### PR TITLE
Implement Incremental Static Regeneration

### DIFF
--- a/apps/docs/src/routes/api/search.ts
+++ b/apps/docs/src/routes/api/search.ts
@@ -7,10 +7,24 @@ const server = createFromSource(source, {
   language: 'english',
 });
 
-export const Route = createFileRoute('/api/search')({
-  server: {
-    handlers: {
-      GET: async ({ request }) => server.GET(request),
-    },
-  },
+export const Route = createFileRoute("/api/search")({
+	server: {
+		handlers: {
+			GET: async ({ request }) => {
+				const response = await server.GET(request);
+				// Clone response to add ISR headers
+				const headers = new Headers(response.headers);
+				// Cache search results for 5 minutes, stale for 1 hour
+				headers.set(
+					"Cache-Control",
+					"public, max-age=300, s-maxage=300, stale-while-revalidate=3600"
+				);
+				return new Response(response.body, {
+					status: response.status,
+					statusText: response.statusText,
+					headers,
+				});
+			},
+		},
+	},
 });

--- a/apps/docs/src/routes/docs/$.tsx
+++ b/apps/docs/src/routes/docs/$.tsx
@@ -21,6 +21,14 @@ export const Route = createFileRoute("/docs/$")({
 		await clientLoader.preload(data.path);
 		return data;
 	},
+	// ISR: Cache docs pages for 1 hour, allow stale content for 7 days
+	headers: () => ({
+		"Cache-Control":
+			"public, max-age=3600, s-maxage=3600, stale-while-revalidate=604800",
+	}),
+	// Client-side: Consider data fresh for 5 minutes
+	staleTime: 5 * 60_000,
+	gcTime: 10 * 60_000,
 });
 
 const serverLoader = createServerFn({

--- a/apps/docs/src/routes/index.tsx
+++ b/apps/docs/src/routes/index.tsx
@@ -31,6 +31,14 @@ export const Route = createFileRoute("/")({
 			headlineIndex: getRandomHeadlineIndex(),
 		};
 	},
+	// ISR: Cache landing page for 24 hours, allow stale for 7 days
+	headers: () => ({
+		"Cache-Control":
+			"public, max-age=86400, s-maxage=86400, stale-while-revalidate=604800",
+	}),
+	// Client-side: Consider data fresh for 1 hour
+	staleTime: 60 * 60_000,
+	gcTime: 2 * 60 * 60_000,
 });
 
 function Home() {

--- a/apps/docs/vite.config.ts
+++ b/apps/docs/vite.config.ts
@@ -19,6 +19,10 @@ export default defineConfig({
 		tanstackStart({
 			prerender: {
 				enabled: process.env.DISABLE_PRERENDER !== "true",
+				// Prerender landing page and docs routes for ISR
+				routes: ["/", "/docs/*"],
+				// Crawl links to discover all documentation pages
+				crawlLinks: true,
 			},
 		}),
 		nitro({ preset: "bun" }),


### PR DESCRIPTION
Add Cache-Control headers for efficient CDN caching with stale-while-revalidate:
- Landing page: 24h cache, 7 day stale period
- Docs pages: 1h cache, 7 day stale period
- Search API: 5min cache, 1h stale period

Also enable static prerendering with crawlLinks for automatic route discovery.