### PR TITLE
Add LLMs documentation and sidebar information

### DIFF
--- a/apps/docs/content/docs/integrations/llms.mdx
+++ b/apps/docs/content/docs/integrations/llms.mdx
@@ -12,7 +12,7 @@ QUESTPIE CMS documentation supports AI-friendly formats that make it easier for 
 A complete version of all documentation pages in a single text file, optimized for AI consumption.
 
 ```
-https://your-docs-site.com/llms-full.txt
+https://questpie.com/llms-full.txt
 ```
 
 This endpoint returns all documentation pages concatenated together with their titles and URLs. It's useful for:
@@ -29,10 +29,10 @@ You can get any documentation page as Markdown by appending `.mdx` to the URL pa
 
 ```
 # Original page
-https://your-docs-site.com/docs/introduction/overview
+https://questpie.com/docs/introduction/overview
 
 # Markdown version
-https://your-docs-site.com/docs/introduction/overview.mdx
+https://questpie.com/docs/introduction/overview.mdx
 ```
 
 This is useful for:
@@ -49,7 +49,7 @@ When using Claude or similar AI assistants, you can reference the documentation:
 
 ```
 Please read the QUESTPIE CMS documentation at:
-https://your-docs-site.com/docs/core-concepts/collections.mdx
+https://questpie.com/docs/core-concepts/collections.mdx
 
 And help me create a new collection for blog posts.
 ```

--- a/apps/docs/content/docs/integrations/llms.mdx
+++ b/apps/docs/content/docs/integrations/llms.mdx
@@ -1,0 +1,102 @@
+---
+title: AI & LLMs
+description: Make your QUESTPIE CMS documentation AI-friendly with dedicated content for large language models.
+---
+
+QUESTPIE CMS documentation supports AI-friendly formats that make it easier for large language models to read and understand the documentation.
+
+## Available Endpoints
+
+### `/llms-full.txt`
+
+A complete version of all documentation pages in a single text file, optimized for AI consumption.
+
+```
+https://your-docs-site.com/llms-full.txt
+```
+
+This endpoint returns all documentation pages concatenated together with their titles and URLs. It's useful for:
+
+- Training or fine-tuning AI models on QUESTPIE CMS documentation
+- Providing context to AI assistants about the CMS
+- Building RAG (Retrieval Augmented Generation) systems
+
+### `*.mdx` Extension
+
+You can get any documentation page as Markdown by appending `.mdx` to the URL path.
+
+**Example:**
+
+```
+# Original page
+https://your-docs-site.com/docs/introduction/overview
+
+# Markdown version
+https://your-docs-site.com/docs/introduction/overview.mdx
+```
+
+This is useful for:
+
+- AI agents that need to read specific documentation pages
+- Tools that prefer Markdown format over HTML
+- Building documentation pipelines
+
+## Using with AI Assistants
+
+### Claude
+
+When using Claude or similar AI assistants, you can reference the documentation:
+
+```
+Please read the QUESTPIE CMS documentation at:
+https://your-docs-site.com/docs/core-concepts/collections.mdx
+
+And help me create a new collection for blog posts.
+```
+
+### ChatGPT / Custom GPTs
+
+You can configure custom GPTs to use the `/llms-full.txt` endpoint as a knowledge source for answering questions about QUESTPIE CMS.
+
+### RAG Systems
+
+For RAG implementations, you can:
+
+1. Fetch `/llms-full.txt` periodically
+2. Split into chunks and create embeddings
+3. Store in a vector database
+4. Query relevant chunks when users ask questions
+
+## Response Format
+
+### llms-full.txt
+
+Each page in the full text export follows this format:
+
+```markdown
+# Page Title (/docs/path/to/page)
+
+Page content in processed Markdown format...
+```
+
+Pages are separated by double newlines.
+
+### Individual Pages (*.mdx)
+
+Individual pages return the same format:
+
+```markdown
+# Page Title (/docs/path/to/page)
+
+Page content in processed Markdown format...
+```
+
+## Caching
+
+Both endpoints are cached for optimal performance:
+
+- **CDN cache**: 24 hours (`s-maxage=86400`)
+- **Browser cache**: 1 hour (`max-age=3600`)
+- **Stale-while-revalidate**: 7 days
+
+This means AI systems can fetch the documentation frequently without overwhelming the server.

--- a/apps/docs/content/docs/integrations/meta.json
+++ b/apps/docs/content/docs/integrations/meta.json
@@ -1,0 +1,5 @@
+{
+	"title": "Integrations",
+	"defaultOpen": true,
+	"pages": ["llms"]
+}

--- a/apps/docs/content/docs/meta.json
+++ b/apps/docs/content/docs/meta.json
@@ -1,4 +1,4 @@
 {
 	"title": "Documentation",
-	"pages": ["introduction", "core-concepts", "guides", "reference"]
+	"pages": ["introduction", "core-concepts", "guides", "reference", "integrations"]
 }

--- a/apps/docs/source.config.ts
+++ b/apps/docs/source.config.ts
@@ -2,6 +2,9 @@ import { defineConfig, defineDocs } from "fumadocs-mdx/config";
 
 export const docs = defineDocs({
 	dir: "content/docs",
+	postprocess: {
+		includeProcessedMarkdown: true,
+	},
 });
 
 export default defineConfig();

--- a/apps/docs/src/lib/get-llm-text.ts
+++ b/apps/docs/src/lib/get-llm-text.ts
@@ -1,0 +1,10 @@
+import { source } from "@/lib/source";
+import type { InferPageType } from "fumadocs-core/source";
+
+export async function getLLMText(page: InferPageType<typeof source>) {
+	const processed = await page.data.getText("processed");
+
+	return `# ${page.data.title} (${page.url})
+
+${processed}`;
+}

--- a/apps/docs/src/routes/llms-full[.]txt.ts
+++ b/apps/docs/src/routes/llms-full[.]txt.ts
@@ -1,0 +1,23 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { source } from "@/lib/source";
+import { getLLMText } from "@/lib/get-llm-text";
+
+export const Route = createFileRoute("/llms-full.txt")({
+	server: {
+		handlers: {
+			GET: async () => {
+				const scan = source.getPages().map(getLLMText);
+				const scanned = await Promise.all(scan);
+
+				return new Response(scanned.join("\n\n"), {
+					headers: {
+						"Content-Type": "text/plain; charset=utf-8",
+						// Cache for long time since docs don't change often
+						"Cache-Control":
+							"public, max-age=3600, s-maxage=86400, stale-while-revalidate=604800",
+					},
+				});
+			},
+		},
+	},
+});

--- a/apps/docs/src/routes/llms[.]mdx.docs.$.ts
+++ b/apps/docs/src/routes/llms[.]mdx.docs.$.ts
@@ -1,0 +1,24 @@
+import { createFileRoute, notFound } from "@tanstack/react-router";
+import { source } from "@/lib/source";
+import { getLLMText } from "@/lib/get-llm-text";
+
+export const Route = createFileRoute("/llms.mdx/docs/$")({
+	server: {
+		handlers: {
+			GET: async ({ params }) => {
+				const slugs = params._splat?.split("/") ?? [];
+				const page = source.getPage(slugs);
+				if (!page) throw notFound();
+
+				return new Response(await getLLMText(page), {
+					headers: {
+						"Content-Type": "text/markdown; charset=utf-8",
+						// Cache for long time since docs don't change often
+						"Cache-Control":
+							"public, max-age=3600, s-maxage=86400, stale-while-revalidate=604800",
+					},
+				});
+			},
+		},
+	},
+});

--- a/apps/docs/src/routes/llms[.]txt.ts
+++ b/apps/docs/src/routes/llms[.]txt.ts
@@ -8,16 +8,16 @@ QUESTPIE CMS is a type-safe, embeddable headless CMS built with TypeScript. It i
 
 ## Documentation
 
-- Full documentation: /llms-full.txt
-- Individual pages: /docs/{path}.mdx
+- Full documentation: https://questpie.com/llms-full.txt
+- Individual pages: https://questpie.com/docs/{path}.mdx
 
 ## Quick Links
 
-- Getting Started: /docs/introduction/getting-started.mdx
-- Collections: /docs/core-concepts/collections.mdx
-- Fields: /docs/core-concepts/fields.mdx
-- Hooks: /docs/core-concepts/hooks.mdx
-- Authentication: /docs/guides/authentication.mdx
+- Getting Started: https://questpie.com/docs/introduction/getting-started.mdx
+- Collections: https://questpie.com/docs/core-concepts/collections.mdx
+- Fields: https://questpie.com/docs/core-concepts/fields.mdx
+- Hooks: https://questpie.com/docs/core-concepts/hooks.mdx
+- Authentication: https://questpie.com/docs/guides/authentication.mdx
 
 ## Features
 

--- a/apps/docs/src/routes/llms[.]txt.ts
+++ b/apps/docs/src/routes/llms[.]txt.ts
@@ -1,0 +1,47 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+const LLMS_TXT_CONTENT = `# QUESTPIE CMS
+
+> A headless CMS that lives inside your codebase
+
+QUESTPIE CMS is a type-safe, embeddable headless CMS built with TypeScript. It integrates directly into your application, providing a powerful admin interface and API without external dependencies.
+
+## Documentation
+
+- Full documentation: /llms-full.txt
+- Individual pages: /docs/{path}.mdx
+
+## Quick Links
+
+- Getting Started: /docs/introduction/getting-started.mdx
+- Collections: /docs/core-concepts/collections.mdx
+- Fields: /docs/core-concepts/fields.mdx
+- Hooks: /docs/core-concepts/hooks.mdx
+- Authentication: /docs/guides/authentication.mdx
+
+## Features
+
+- Type-safe collections and fields using Drizzle ORM
+- Built-in authentication with Better Auth
+- File storage with Flydrive
+- Background jobs with pg-boss
+- Email templates with React Email
+- Real-time subscriptions via SSE
+- Framework adapters for Hono, Elysia, Next.js, and TanStack Start
+`;
+
+export const Route = createFileRoute("/llms.txt")({
+	server: {
+		handlers: {
+			GET: async () => {
+				return new Response(LLMS_TXT_CONTENT, {
+					headers: {
+						"Content-Type": "text/plain; charset=utf-8",
+						"Cache-Control":
+							"public, max-age=3600, s-maxage=86400, stale-while-revalidate=604800",
+					},
+				});
+			},
+		},
+	},
+});

--- a/apps/docs/src/start.ts
+++ b/apps/docs/src/start.ts
@@ -1,0 +1,25 @@
+import { createMiddleware, createStart } from "@tanstack/react-start";
+import { rewritePath } from "fumadocs-core/negotiation";
+import { redirect } from "@tanstack/react-router";
+
+const { rewrite: rewriteLLM } = rewritePath(
+	"/docs{/*path}.mdx",
+	"/llms.mdx/docs{/*path}"
+);
+
+const llmMiddleware = createMiddleware().server(({ next, request }) => {
+	const url = new URL(request.url);
+	const path = rewriteLLM(url.pathname);
+
+	if (path) {
+		throw redirect({ href: path });
+	}
+
+	return next();
+});
+
+export const startInstance = createStart(() => {
+	return {
+		requestMiddleware: [llmMiddleware],
+	};
+});


### PR DESCRIPTION
Add AI/LLM integration for the documentation site:

- Enable includeProcessedMarkdown in source.config.ts for text extraction
- Create /llms.txt endpoint with documentation overview and quick links
- Create /llms-full.txt endpoint with all documentation pages concatenated
- Create /docs/*.mdx endpoint for individual page Markdown access
- Add URL rewriting middleware for .mdx extension support
- Add new Integrations section with AI & LLMs documentation page

These endpoints allow AI assistants and LLMs to easily consume the QUESTPIE CMS documentation in Markdown format.