### PR TITLE
Fix stale export referencing deleted file.

### DIFF
--- a/packages/questpie/src/server/index.ts
+++ b/packages/questpie/src/server/index.ts
@@ -61,7 +61,6 @@ export type {
 } from "./config/extensions.js";
 export * from "./config/global-hooks-types.js";
 export * from "./config/questpie.js";
-export * from "./config/register.js";
 export * from "./config/types.js";
 export * from "./fields/index.js";
 export * from "./functions/index.js";


### PR DESCRIPTION
This removes an export referencing a file that was previously deleted,
which caused a module resolution error.