### PR TITLE
feat: multi-export factory discovery + RuntimeConfig extensibility

### DIFF
--- a/packages/admin/src/server/plugin.ts
+++ b/packages/admin/src/server/plugin.ts
@@ -52,6 +52,7 @@ export function adminPlugin(): CodegenPlugin {
 					views: {
 						dirs: ["views"],
 						prefix: "view",
+						factoryFunctions: ["view"],
 						registryKey: true,
 						placeholder: "$VIEW_NAMES",
 						includeInAppState: true,
@@ -81,6 +82,7 @@ export function adminPlugin(): CodegenPlugin {
 					components: {
 						dirs: ["components"],
 						prefix: "comp",
+						factoryFunctions: ["component"],
 						registryKey: true,
 						placeholder: "$COMPONENT_NAMES",
 						recordPlaceholder: "$COMPONENTS",
@@ -95,6 +97,7 @@ export function adminPlugin(): CodegenPlugin {
 					blocks: {
 						dirs: ["blocks"],
 						prefix: "bloc",
+						factoryFunctions: ["block"],
 						registryKey: true,
 						includeInAppState: true,
 						extractFromModules: true,
@@ -159,11 +162,11 @@ export function adminPlugin(): CodegenPlugin {
 							isCallback: true,
 							callbackContextParams: ["v", "f", "a"],
 							defaults: {
-							view: "collection-table",
-							showSearch: true,
-							showFilters: true,
-							showToolbar: true,
-						},
+								view: "collection-table",
+								showSearch: true,
+								showFilters: true,
+								showToolbar: true,
+							},
 						},
 						form: {
 							stateKey: "adminForm",
@@ -182,9 +185,9 @@ export function adminPlugin(): CodegenPlugin {
 							isCallback: true,
 							callbackContextParams: ["v", "f"],
 							defaults: {
-							view: "collection-form",
-							showMeta: true,
-						},
+								view: "collection-form",
+								showMeta: true,
+							},
 						},
 						preview: {
 							stateKey: "adminPreview",
@@ -249,9 +252,9 @@ export function adminPlugin(): CodegenPlugin {
 							isCallback: true,
 							callbackContextParams: ["v", "f"],
 							defaults: {
-							view: "global-form",
-							showMeta: true,
-						},
+								view: "global-form",
+								showMeta: true,
+							},
 						},
 					},
 					singletonFactories: {
@@ -432,8 +435,8 @@ export function adminPlugin(): CodegenPlugin {
 
 					// Add per-block server type imports and build the map entries
 					const entries: string[] = [];
-					for (const [key, file] of [...blockFiles.entries()].sort(
-						([a], [b]) => a.localeCompare(b),
+					for (const [key, file] of [...blockFiles.entries()].sort(([a], [b]) =>
+						a.localeCompare(b),
 					)) {
 						const varName = `${key}Block`;
 						// Derive kebab-case filename from the client import path
@@ -456,9 +459,7 @@ export function adminPlugin(): CodegenPlugin {
 					ctx.addTypeDeclaration(
 						'\tInferBlockValues<_ServerBlocks[T]["state"]>,',
 					);
-					ctx.addTypeDeclaration(
-						"\tInferBlockData<_ServerBlocks[T]>",
-					);
+					ctx.addTypeDeclaration("\tInferBlockData<_ServerBlocks[T]>");
 					ctx.addTypeDeclaration(">;");
 				},
 

--- a/packages/questpie/src/cli/codegen/discover.ts
+++ b/packages/questpie/src/cli/codegen/discover.ts
@@ -125,6 +125,8 @@ interface DiscoveryCategory {
 	prefix: string;
 	/** Key separator for recursive categories. */
 	keySeparator?: "." | "/";
+	/** Factory function names for multi-export discovery. */
+	factoryFunctions?: string[];
 }
 
 /**
@@ -141,6 +143,7 @@ function toDiscoveryCategory(
 		recursive: decl.recursive ?? false,
 		prefix: decl.prefix,
 		keySeparator: decl.keySeparator,
+		factoryFunctions: decl.factoryFunctions,
 	};
 }
 
@@ -231,23 +234,32 @@ export async function discoverFiles(
 				const scanPath = join(rootDir, dir);
 				const files = await scanDir(scanPath, scanPath, category.recursive);
 				for (const relFile of files) {
-					const file = await processFile(
+					const discovered = await processFile(
 						rootDir,
 						outDir,
 						join(dir, relFile),
 						category,
 					);
-					checkConflict(map, file, category.category);
-					map.set(file.key, file);
+					for (const file of discovered) {
+						checkConflict(map, file, category.category);
+						map.set(file.key, file);
+					}
 				}
 			}
 
 			// Scan by-feature layout
 			const featureFiles = await discoverFeatures(rootDir, category);
 			for (const { relPath } of featureFiles) {
-				const file = await processFile(rootDir, outDir, relPath, category);
-				checkConflict(map, file, category.category);
-				map.set(file.key, file);
+				const discovered = await processFile(
+					rootDir,
+					outDir,
+					relPath,
+					category,
+				);
+				for (const file of discovered) {
+					checkConflict(map, file, category.category);
+					map.set(file.key, file);
+				}
 			}
 
 			result.categories.set(name, map);
@@ -513,14 +525,16 @@ async function discoverDirectoryPattern(
 	const scanPath = join(rootDir, baseDir);
 	const files = await scanDir(scanPath, scanPath, recursive);
 	for (const relFile of files) {
-		const file = await processFile(
+		const discovered = await processFile(
 			rootDir,
 			outDir,
 			join(baseDir, relFile),
 			category,
 		);
-		checkConflict(pluginMap, file, stateKey);
-		pluginMap.set(file.key, file);
+		for (const file of discovered) {
+			checkConflict(pluginMap, file, stateKey);
+			pluginMap.set(file.key, file);
+		}
 	}
 
 	// By-feature scan
@@ -543,14 +557,16 @@ async function discoverDirectoryPattern(
 			recursive,
 		);
 		for (const relFile of featureFiles) {
-			const file = await processFile(
+			const discovered = await processFile(
 				rootDir,
 				outDir,
 				join("features", fDirName, baseDir, relFile),
 				category,
 			);
-			checkConflict(pluginMap, file, stateKey);
-			pluginMap.set(file.key, file);
+			for (const file of discovered) {
+				checkConflict(pluginMap, file, stateKey);
+				pluginMap.set(file.key, file);
+			}
 		}
 	}
 }
@@ -560,20 +576,11 @@ async function discoverDirectoryPattern(
 // ============================================================================
 
 /**
- * Process a discovered file into a DiscoveredFile object.
- * Detects export type (default vs named) for import generation.
+ * Derive the filename-based key for a file in a category.
+ * Handles recursive categories (functions/routes use path segments as keys)
+ * and simple categories (filename → camelCase).
  */
-async function processFile(
-	rootDir: string,
-	outDir: string,
-	relPath: string,
-	category: DiscoveryCategory,
-): Promise<DiscoveredFile> {
-	const absolutePath = join(rootDir, relPath);
-	const importPath = relativeImport(outDir, absolutePath);
-
-	// Derive key based on category
-	let key: string;
+function deriveFileKey(relPath: string, category: DiscoveryCategory): string {
 	if (category.recursive) {
 		// Functions/routes: path segments become nested keys
 		// functions/admin/stats.ts → "admin.stats"
@@ -590,35 +597,109 @@ async function processFile(
 
 		if (category.category === "routes") {
 			// Routes use slash-separated keys to match URL paths
-			key = innerPath.replace(/\.(ts|tsx|mts|mjs|js|jsx)$/, "");
-		} else {
-			// Functions use dot-separated keys
-			const segments = innerPath
-				.replace(/\.(ts|tsx|mts|mjs|js|jsx)$/, "")
-				.split("/")
-				.map(kebabToCamelCase);
-			key = segments.join(".");
+			return innerPath.replace(/\.(ts|tsx|mts|mjs|js|jsx)$/, "");
 		}
-	} else {
-		// Simple: filename → camelCase key
-		key = kebabToCamelCase(basename(relPath));
+		// Functions use dot-separated keys
+		const segments = innerPath
+			.replace(/\.(ts|tsx|mts|mjs|js|jsx)$/, "")
+			.split("/")
+			.map(kebabToCamelCase);
+		return segments.join(".");
+	}
+	// Simple: filename → camelCase key
+	return kebabToCamelCase(basename(relPath));
+}
+
+/**
+ * Process a discovered file into one or more DiscoveredFile objects.
+ *
+ * When the category declares `factoryFunctions`, uses two-pass regex
+ * detection to find all exported factory calls. Each match becomes
+ * a separate DiscoveredFile. Files without matching factory calls
+ * are skipped (returns empty array) — this filters out utility files.
+ *
+ * When `factoryFunctions` is not set, falls back to single-entity
+ * detection (backward compatible).
+ */
+async function processFile(
+	rootDir: string,
+	outDir: string,
+	relPath: string,
+	category: DiscoveryCategory,
+): Promise<DiscoveredFile[]> {
+	const absolutePath = join(rootDir, relPath);
+	const importPath = relativeImport(outDir, absolutePath);
+
+	// Read file content once — used by both factory and legacy detection
+	let content: string;
+	try {
+		content = await readFile(absolutePath, "utf-8");
+	} catch {
+		return [];
 	}
 
-	const varName = toVarName(category.prefix, key);
+	// ── Multi-export mode (factory-aware) ───────────────────────
+	if (category.factoryFunctions && category.factoryFunctions.length > 0) {
+		const matches = detectFactoryExports(content, category.factoryFunctions);
+		if (matches.length === 0) {
+			// No factory calls found → skip file (utility/types file)
+			return [];
+		}
 
-	// Detect export type
-	const exportInfo = await detectExportType(absolutePath);
+		const results: DiscoveredFile[] = [];
+		const namedMatches = matches.filter((m) => !m.isDefault);
+		const defaultMatch = matches.find((m) => m.isDefault);
 
-	return {
-		absolutePath,
-		key,
-		importPath,
-		varName,
-		source: relPath,
-		exportType: exportInfo.type,
-		namedExportName: exportInfo.namedExportName,
-		isBundle: exportInfo.isBundle,
-	};
+		if (namedMatches.length > 0) {
+			// Named factory exports found — each becomes a separate entity
+			for (const m of namedMatches) {
+				const key = m.entityKey
+					? kebabToCamelCase(`${m.entityKey}.ts`)
+					: m.exportName;
+				results.push({
+					absolutePath,
+					key,
+					importPath,
+					varName: toVarName(category.prefix, key),
+					source: relPath,
+					exportType: "named",
+					namedExportName: m.exportName,
+				});
+			}
+		} else if (defaultMatch) {
+			// Only a default factory export — single entity
+			const key = defaultMatch.entityKey
+				? kebabToCamelCase(`${defaultMatch.entityKey}.ts`)
+				: deriveFileKey(relPath, category);
+			results.push({
+				absolutePath,
+				key,
+				importPath,
+				varName: toVarName(category.prefix, key),
+				source: relPath,
+				exportType: "default",
+			});
+		}
+
+		return results;
+	}
+
+	// ── Legacy single-entity mode ───────────────────────────────
+	const key = deriveFileKey(relPath, category);
+	const exportInfo = detectExportTypeFromContent(content);
+
+	return [
+		{
+			absolutePath,
+			key,
+			importPath,
+			varName: toVarName(category.prefix, key),
+			source: relPath,
+			exportType: exportInfo.type,
+			namedExportName: exportInfo.namedExportName,
+			isBundle: exportInfo.isBundle,
+		},
+	];
 }
 
 /**
@@ -654,8 +735,8 @@ export interface ExportDetection {
 }
 
 /**
- * Detect what kind of export a TypeScript file has.
- * Reads the file and checks for `export default` vs named exports.
+ * Detect what kind of export a TypeScript file has from its content string.
+ * Pure function — no I/O.
  *
  * Detection priority:
  * 1. `export default` → default export (no bundle check)
@@ -666,16 +747,7 @@ export interface ExportDetection {
  * - `export const bundle = {` (object literal value) → isBundle: true
  * - `export const myFn = fn({` (function call) → isBundle: false
  */
-export async function detectExportType(
-	absolutePath: string,
-): Promise<ExportDetection> {
-	let content: string;
-	try {
-		content = await readFile(absolutePath, "utf-8");
-	} catch {
-		return { type: "unknown" };
-	}
-
+export function detectExportTypeFromContent(content: string): ExportDetection {
 	// Check for default export patterns:
 	// - export default ...
 	// - export { X as default }
@@ -716,6 +788,177 @@ export async function detectExportType(
 	}
 
 	return { type: "unknown" };
+}
+
+/**
+ * Detect what kind of export a TypeScript file has.
+ * Reads the file and delegates to `detectExportTypeFromContent`.
+ */
+export async function detectExportType(
+	absolutePath: string,
+): Promise<ExportDetection> {
+	let content: string;
+	try {
+		content = await readFile(absolutePath, "utf-8");
+	} catch {
+		return { type: "unknown" };
+	}
+	return detectExportTypeFromContent(content);
+}
+
+// ============================================================================
+// Factory export detection (multi-export discovery)
+// ============================================================================
+
+/**
+ * Result of a factory export match in a file.
+ */
+interface FactoryExportMatch {
+	/** Export name used in the export statement (for import generation). */
+	exportName: string;
+	/** Which factory function was called. */
+	factoryName: string;
+	/** Entity key extracted from the factory's first string argument, or null. */
+	entityKey: string | null;
+	/** Whether this is a default export. */
+	isDefault: boolean;
+}
+
+/**
+ * Detect all exported factory function calls in a file's content.
+ *
+ * Uses a two-pass regex approach (no AST parsing):
+ *
+ * **Pass 1** — Build a map of all variable assignments that call a factory function.
+ * Matches both exported and non-exported assignments:
+ * `const hero = block("hero")`, `export const hero = block("hero")`
+ *
+ * **Pass 2** — Cross-reference with export statements to find which
+ * factory variables are actually exported:
+ * - `export const X` → direct export
+ * - `export { X }` or `export { X as Y }` → re-export (excluding `from "..."`)
+ * - `export default X` → default re-export of factory variable
+ * - `export default factory(...)` → inline default factory call
+ *
+ * @param content — File content string
+ * @param factoryFunctions — Factory function names to match (e.g. ["block", "view"])
+ * @returns Array of matched factory exports. Empty if no factory calls found.
+ */
+export function detectFactoryExports(
+	content: string,
+	factoryFunctions: string[],
+): FactoryExportMatch[] {
+	if (factoryFunctions.length === 0) return [];
+
+	const factoryAlt = factoryFunctions
+		.map((f) => f.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
+		.join("|");
+
+	// ── Pass 1: Build factory variable map ──────────────────────
+	// Matches: [export] const/let/var X = factory(...) or factory<T>(...)
+	// Captures: [1] varName, [2] factoryName, [3] first string arg (optional)
+	const assignRe = new RegExp(
+		`(?:const|let|var)\\s+([a-zA-Z_$][a-zA-Z0-9_$]*)\\s*=\\s*(${factoryAlt})\\s*(?:<[^>]*>)?\\s*\\(\\s*(?:["']([^"']+)["'])?`,
+		"gm",
+	);
+
+	const factoryVars = new Map<
+		string,
+		{ factoryName: string; entityKey: string | null }
+	>();
+	let match: RegExpExecArray | null;
+	while ((match = assignRe.exec(content)) !== null) {
+		factoryVars.set(match[1], {
+			factoryName: match[2],
+			entityKey: match[3] ?? null,
+		});
+	}
+
+	// ── Pass 2: Cross-reference with export statements ──────────
+	const results: FactoryExportMatch[] = [];
+	const seen = new Set<string>(); // avoid duplicates
+
+	// 2a. Direct exports: export const/let/var X
+	const directExportRe =
+		/\bexport\s+(?:const|let|var)\s+([a-zA-Z_$][a-zA-Z0-9_$]*)/gm;
+	while ((match = directExportRe.exec(content)) !== null) {
+		const name = match[1];
+		const info = factoryVars.get(name);
+		if (info && !seen.has(name)) {
+			seen.add(name);
+			results.push({
+				exportName: name,
+				factoryName: info.factoryName,
+				entityKey: info.entityKey,
+				isDefault: false,
+			});
+		}
+	}
+
+	// 2b. Re-exports: export { X } or export { X as Y }
+	// Exclude re-exports from other modules: export { X } from "..."
+	const reExportBlockRe = /\bexport\s*\{([^}]+)\}(?!\s*from\s)/gm;
+	while ((match = reExportBlockRe.exec(content)) !== null) {
+		const specifiers = match[1];
+		// Parse individual specifiers: "X" or "X as Y"
+		const specRe =
+			/([a-zA-Z_$][a-zA-Z0-9_$]*)(?:\s+as\s+([a-zA-Z_$][a-zA-Z0-9_$]*))?/g;
+		let specMatch: RegExpExecArray | null;
+		while ((specMatch = specRe.exec(specifiers)) !== null) {
+			const localName = specMatch[1];
+			const exportedAs = specMatch[2]; // may be undefined
+			// Skip "as default" — handled separately
+			if (exportedAs === "default") continue;
+			const info = factoryVars.get(localName);
+			if (info) {
+				const name = exportedAs ?? localName;
+				if (!seen.has(name)) {
+					seen.add(name);
+					results.push({
+						exportName: name,
+						factoryName: info.factoryName,
+						entityKey: info.entityKey,
+						isDefault: false,
+					});
+				}
+			}
+		}
+	}
+
+	// 2c. Default re-export of a factory variable: export default X
+	const defaultVarRe =
+		/\bexport\s+default\s+([a-zA-Z_$][a-zA-Z0-9_$]*)\s*[;\n]/m;
+	const defaultVarMatch = content.match(defaultVarRe);
+	if (defaultVarMatch) {
+		const name = defaultVarMatch[1];
+		const info = factoryVars.get(name);
+		if (info && !seen.has(`default:${name}`)) {
+			seen.add(`default:${name}`);
+			results.push({
+				exportName: name,
+				factoryName: info.factoryName,
+				entityKey: info.entityKey,
+				isDefault: true,
+			});
+		}
+	}
+
+	// 2d. Inline default: export default factory(...)
+	const inlineDefaultRe = new RegExp(
+		`\\bexport\\s+default\\s+(${factoryAlt})\\s*(?:<[^>]*>)?\\s*\\(\\s*(?:["']([^"']+)["'])?`,
+		"m",
+	);
+	const inlineMatch = content.match(inlineDefaultRe);
+	if (inlineMatch && !defaultVarMatch) {
+		results.push({
+			exportName: "",
+			factoryName: inlineMatch[1],
+			entityKey: inlineMatch[2] ?? null,
+			isDefault: true,
+		});
+	}
+
+	return results;
 }
 
 /**

--- a/packages/questpie/src/cli/codegen/index.ts
+++ b/packages/questpie/src/cli/codegen/index.ts
@@ -53,6 +53,7 @@ export function coreCodegenPlugin(): CodegenPlugin {
 					collections: {
 						dirs: ["collections"],
 						prefix: "coll",
+						factoryFunctions: ["collection"],
 						registryKey: true,
 						includeInAppState: true,
 						extractFromModules: true,
@@ -60,6 +61,7 @@ export function coreCodegenPlugin(): CodegenPlugin {
 					globals: {
 						dirs: ["globals"],
 						prefix: "glob",
+						factoryFunctions: ["global"],
 						registryKey: true,
 						includeInAppState: true,
 						extractFromModules: true,
@@ -435,20 +437,30 @@ export async function runCodegen(
 	});
 
 	// 2b. Warn about files with named exports (not default)
-	const allFiles: import("./types.js").DiscoveredFile[] = [];
-	for (const catMap of discovered.categories.values()) {
+	// Skip warnings for categories with factoryFunctions — named exports are expected there.
+	const factoryCategories = new Set<string>();
+	for (const [catName, decl] of Object.entries(target.categories)) {
+		if (decl.factoryFunctions && decl.factoryFunctions.length > 0) {
+			factoryCategories.add(catName);
+		}
+	}
+
+	for (const [catName, catMap] of discovered.categories) {
+		if (factoryCategories.has(catName)) continue;
 		for (const file of catMap.values()) {
-			allFiles.push(file);
+			if (file.exportType === "named") {
+				console.warn(
+					`⚠  ${file.source}: no default export found, using named export "${file.namedExportName}". ` +
+						`Consider: export default ${file.namedExportName};`,
+				);
+			}
 		}
 	}
 	for (const singleFile of discovered.singles.values()) {
-		allFiles.push(singleFile);
-	}
-	for (const file of allFiles) {
-		if (file.exportType === "named") {
+		if (singleFile.exportType === "named") {
 			console.warn(
-				`⚠  ${file.source}: no default export found, using named export "${file.namedExportName}". ` +
-					`Consider: export default ${file.namedExportName};`,
+				`⚠  ${singleFile.source}: no default export found, using named export "${singleFile.namedExportName}". ` +
+					`Consider: export default ${singleFile.namedExportName};`,
 			);
 		}
 	}

--- a/packages/questpie/src/cli/codegen/types.ts
+++ b/packages/questpie/src/cli/codegen/types.ts
@@ -272,6 +272,38 @@ export interface CategoryDeclaration {
 	 */
 	keyFromProperty?: string;
 
+	// ── Multi-export discovery ────────────────────────────────
+
+	/**
+	 * Factory function names that identify entities in this category.
+	 * Enables multi-export discovery: each matching export becomes
+	 * a separate `DiscoveredFile` entry.
+	 *
+	 * When set:
+	 * - Files are scanned for exports calling these factory functions
+	 * - Multiple entities can be discovered from a single file
+	 * - Files without any matching factory calls are automatically skipped
+	 *   (utility files, type-only files)
+	 *
+	 * When NOT set:
+	 * - Current one-file-one-entity behavior is preserved (backward compatible)
+	 *
+	 * Uses a two-pass regex approach (no AST parsing):
+	 * 1. Scan all `const/let/var X = factory(...)` assignments
+	 * 2. Cross-reference with export statements (`export const`, `export { }`,
+	 *    `export default`)
+	 *
+	 * Entity key derivation priority:
+	 * 1. Factory call's first string argument: `block("hero")` → `"hero"`
+	 * 2. Fallback to export name: `export const heroBlock = block(var)` → `"heroBlock"`
+	 * 3. For default exports, fallback to filename
+	 *
+	 * @example ["collection"] — for collections category
+	 * @example ["block"] — for blocks category
+	 * @example ["view", "listView"] — multiple factory names
+	 */
+	factoryFunctions?: string[];
+
 	// ── Registry / factory type integration ─────────────────────
 
 	/**

--- a/packages/questpie/src/server/config/create-app.ts
+++ b/packages/questpie/src/server/config/create-app.ts
@@ -242,6 +242,30 @@ const MERGE_FNS = new Map<string, MergeFn>([
 const STRUCTURAL_KEYS = new Set(["name", "modules"]);
 
 /**
+ * Known infrastructure keys on RuntimeConfig that should NOT be forwarded
+ * to `instance.state`. Only truly unknown extension keys pass through.
+ *
+ * @see RuntimeConfig in module-types.ts for the full list.
+ */
+const RUNTIME_CONSUMED_KEYS = new Set([
+	"plugins",
+	"app",
+	"db",
+	"secret",
+	"storage",
+	"email",
+	"queue",
+	"search",
+	"realtime",
+	"logger",
+	"kv",
+	"translations",
+	"autoMigrate",
+	"autoSeed",
+	"cli",
+]);
+
+/**
  * Keys consumed by QuestpieConfig construction or definition metadata.
  * Everything NOT in this set flows to `instance.state` for plugins to read
  * (e.g., admin reads sidebar, dashboard, branding, blocks, views, components).
@@ -394,6 +418,27 @@ function buildExtensionState(
 	return extensionState;
 }
 
+/**
+ * Extract unknown extension keys from RuntimeConfig.
+ * Filters out known infrastructure keys so only truly unknown
+ * plugin-contributed keys (e.g. `channels`, `workflows`) flow through
+ * to `instance.state`.
+ */
+function extractRuntimeExtensions(
+	runtime: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+	if (!runtime) return undefined;
+	const extensions: Record<string, unknown> = {};
+	let hasAny = false;
+	for (const [key, value] of Object.entries(runtime)) {
+		if (!RUNTIME_CONSUMED_KEYS.has(key) && value !== undefined) {
+			extensions[key] = value;
+			hasAny = true;
+		}
+	}
+	return hasAny ? extensions : undefined;
+}
+
 // ============================================================================
 // createApp() — the main entry point
 // ============================================================================
@@ -542,7 +587,12 @@ function createAppFromDefinition(
 	const instance = new Questpie(cmsConfig);
 
 	// 7. Store plugin extension state (sidebar, dashboard, branding, blocks, views, etc.)
-	const extensionState = buildExtensionState(merged);
+	// Also forward unknown RuntimeConfig extension keys (e.g. channels, workflows)
+	// — same mechanism as legacy createAppLegacy() uses via configOverrides.
+	const runtimeExtensions = extractRuntimeExtensions(
+		runtime as Record<string, unknown>,
+	);
+	const extensionState = buildExtensionState(merged, runtimeExtensions);
 	if (Object.keys(extensionState).length > 0) {
 		instance.state = extensionState;
 	}

--- a/packages/questpie/test/codegen/discover.test.ts
+++ b/packages/questpie/test/codegen/discover.test.ts
@@ -13,6 +13,8 @@ import { join } from "node:path";
 import type { DiscoverFilesOptions } from "../../src/cli/codegen/discover.js";
 import {
 	detectExportType,
+	detectExportTypeFromContent,
+	detectFactoryExports,
 	discoverFiles,
 	kebabToCamelCase,
 } from "../../src/cli/codegen/discover.js";
@@ -224,8 +226,8 @@ describe("discoverFiles", () => {
 	// ── Collections ───────────────────────────────────────────────────────────
 
 	it("discovers collections with camelCase keys", async () => {
-		await write("collections/posts.ts", "export const posts = {};");
-		await write("collections/blog-posts.ts", "export const blogPosts = {};");
+		await write("collections/posts.ts", "export const posts = collection('posts');");
+		await write("collections/blog-posts.ts", "export const blogPosts = collection('blog-posts');");
 
 		const result = await discoverFiles(rootDir, outDir, coreDiscoverOptions());
 		const collections = cat(result, "collections");
@@ -235,7 +237,7 @@ describe("discoverFiles", () => {
 	});
 
 	it("sets correct varName and importPath for collections", async () => {
-		await write("collections/posts.ts", "export const posts = {};");
+		await write("collections/posts.ts", "export const posts = collection('posts');");
 
 		const result = await discoverFiles(rootDir, outDir, coreDiscoverOptions());
 		const file = cat(result, "collections").get("posts")!;
@@ -247,7 +249,7 @@ describe("discoverFiles", () => {
 
 	it("ignores index.ts in collections", async () => {
 		await write("collections/index.ts", "export * from './posts';");
-		await write("collections/posts.ts", "export const posts = {};");
+		await write("collections/posts.ts", "export const posts = collection('posts');");
 
 		const result = await discoverFiles(rootDir, outDir, coreDiscoverOptions());
 		const collections = cat(result, "collections");
@@ -257,7 +259,7 @@ describe("discoverFiles", () => {
 
 	it("ignores private files starting with _ in collections", async () => {
 		await write("collections/_utils.ts", "export const util = {};");
-		await write("collections/posts.ts", "export const posts = {};");
+		await write("collections/posts.ts", "export const posts = collection('posts');");
 
 		const result = await discoverFiles(rootDir, outDir, coreDiscoverOptions());
 		const collections = cat(result, "collections");
@@ -268,7 +270,7 @@ describe("discoverFiles", () => {
 	// ── Globals ───────────────────────────────────────────────────────────────
 
 	it("discovers globals", async () => {
-		await write("globals/site-settings.ts", "export const siteSettings = {};");
+		await write("globals/site-settings.ts", "export const siteSettings = global('site-settings');");
 
 		const result = await discoverFiles(rootDir, outDir, coreDiscoverOptions());
 		const globals = cat(result, "globals");
@@ -358,7 +360,7 @@ describe("discoverFiles", () => {
 
 	it("does not treat auth.ts as a collection/job/etc.", async () => {
 		await write("auth.ts", "export default {};");
-		await write("collections/posts.ts", "export const posts = {};");
+		await write("collections/posts.ts", "export const posts = collection('posts');");
 
 		const result = await discoverFiles(rootDir, outDir, coreDiscoverOptions());
 		expect(cat(result, "collections").size).toBe(1);
@@ -403,7 +405,7 @@ describe("discoverFiles", () => {
 	it("discovers collections from features/ layout", async () => {
 		await write(
 			"features/blog/collections/articles.ts",
-			"export const articles = {};",
+			"export const articles = collection('articles');",
 		);
 
 		const result = await discoverFiles(rootDir, outDir, coreDiscoverOptions());
@@ -411,10 +413,10 @@ describe("discoverFiles", () => {
 	});
 
 	it("merges by-type and by-feature layout collections", async () => {
-		await write("collections/posts.ts", "export const posts = {};");
+		await write("collections/posts.ts", "export const posts = collection('posts');");
 		await write(
 			"features/blog/collections/articles.ts",
-			"export const articles = {};",
+			"export const articles = collection('articles');",
 		);
 
 		const result = await discoverFiles(rootDir, outDir, coreDiscoverOptions());
@@ -427,10 +429,10 @@ describe("discoverFiles", () => {
 	// ── Conflict detection ────────────────────────────────────────────────────
 
 	it("throws on duplicate keys from by-type and by-feature layout", async () => {
-		await write("collections/posts.ts", "export const posts = {};");
+		await write("collections/posts.ts", "export const posts = collection('posts');");
 		await write(
 			"features/blog/collections/posts.ts",
-			"export const posts = {};",
+			"export const posts = collection('posts');",
 		);
 
 		await expect(
@@ -591,5 +593,359 @@ describe("discoverFiles — mergeStrategy spread", () => {
 		const [file] = result.spreads.get("sidebar")!;
 
 		expect(file.importPath).toBe("../features/admin/sidebar");
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// detectFactoryExports — unit tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("detectFactoryExports", () => {
+	it("detects a single exported factory call", () => {
+		const matches = detectFactoryExports(
+			`export const hero = block("hero");`,
+			["block"],
+		);
+		expect(matches).toHaveLength(1);
+		expect(matches[0].exportName).toBe("hero");
+		expect(matches[0].factoryName).toBe("block");
+		expect(matches[0].entityKey).toBe("hero");
+		expect(matches[0].isDefault).toBe(false);
+	});
+
+	it("detects multiple exported factory calls", () => {
+		const matches = detectFactoryExports(
+			`export const hero = block("hero");\nexport const cta = block("cta");`,
+			["block"],
+		);
+		expect(matches).toHaveLength(2);
+		expect(matches[0].exportName).toBe("hero");
+		expect(matches[1].exportName).toBe("cta");
+	});
+
+	it("extracts entity key from factory string argument", () => {
+		const matches = detectFactoryExports(
+			`export const x = block("hero-banner");`,
+			["block"],
+		);
+		expect(matches[0].entityKey).toBe("hero-banner");
+	});
+
+	it("returns null entityKey when factory arg is not a string literal", () => {
+		const matches = detectFactoryExports(
+			`export const heroBlock = block(dynamicVar);`,
+			["block"],
+		);
+		expect(matches[0].entityKey).toBeNull();
+		expect(matches[0].exportName).toBe("heroBlock");
+	});
+
+	it("detects inline default factory export", () => {
+		const matches = detectFactoryExports(
+			`export default block("hero");`,
+			["block"],
+		);
+		expect(matches).toHaveLength(1);
+		expect(matches[0].isDefault).toBe(true);
+		expect(matches[0].entityKey).toBe("hero");
+	});
+
+	it("detects inline default factory without string arg", () => {
+		const matches = detectFactoryExports(
+			`export default block(dynamicVar);`,
+			["block"],
+		);
+		expect(matches).toHaveLength(1);
+		expect(matches[0].isDefault).toBe(true);
+		expect(matches[0].entityKey).toBeNull();
+	});
+
+	it("returns empty for files with no factory calls", () => {
+		const matches = detectFactoryExports(
+			`export const helper = () => {};\nexport type Foo = string;`,
+			["block"],
+		);
+		expect(matches).toHaveLength(0);
+	});
+
+	it("detects re-export pattern: export { X }", () => {
+		const matches = detectFactoryExports(
+			`const hero = block("hero");\nexport { hero };`,
+			["block"],
+		);
+		expect(matches).toHaveLength(1);
+		expect(matches[0].exportName).toBe("hero");
+		expect(matches[0].entityKey).toBe("hero");
+		expect(matches[0].isDefault).toBe(false);
+	});
+
+	it("detects aliased re-export: export { X as Y }", () => {
+		const matches = detectFactoryExports(
+			`const hero = block("hero");\nexport { hero as myHero };`,
+			["block"],
+		);
+		expect(matches).toHaveLength(1);
+		expect(matches[0].exportName).toBe("myHero");
+		expect(matches[0].entityKey).toBe("hero");
+	});
+
+	it("detects default re-export of factory variable", () => {
+		const matches = detectFactoryExports(
+			`const hero = block("hero");\nexport default hero;\n`,
+			["block"],
+		);
+		expect(matches).toHaveLength(1);
+		expect(matches[0].isDefault).toBe(true);
+		expect(matches[0].exportName).toBe("hero");
+		expect(matches[0].entityKey).toBe("hero");
+	});
+
+	it("handles generic type parameters on factory", () => {
+		const matches = detectFactoryExports(
+			`export const posts = collection<PostConfig>("posts");`,
+			["collection"],
+		);
+		expect(matches).toHaveLength(1);
+		expect(matches[0].entityKey).toBe("posts");
+	});
+
+	it("matches multiple factory function names", () => {
+		const matches = detectFactoryExports(
+			`export const a = view("list");\nexport const b = listView("grid");`,
+			["view", "listView"],
+		);
+		expect(matches).toHaveLength(2);
+		expect(matches[0].factoryName).toBe("view");
+		expect(matches[1].factoryName).toBe("listView");
+	});
+
+	it("returns empty when factoryFunctions is empty", () => {
+		const matches = detectFactoryExports(
+			`export const hero = block("hero");`,
+			[],
+		);
+		expect(matches).toHaveLength(0);
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// detectExportTypeFromContent — backward compatibility
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("detectExportTypeFromContent", () => {
+	it("detects default export", () => {
+		expect(detectExportTypeFromContent("export default {};")).toEqual({
+			type: "default",
+		});
+	});
+
+	it("detects export { X as default }", () => {
+		expect(
+			detectExportTypeFromContent("export { X as default };"),
+		).toEqual({ type: "default" });
+	});
+
+	it("detects named const export", () => {
+		const result = detectExportTypeFromContent(
+			"export const posts = collection('posts');",
+		);
+		expect(result.type).toBe("named");
+		expect(result.namedExportName).toBe("posts");
+	});
+
+	it("detects bundle export (object literal)", () => {
+		const result = detectExportTypeFromContent("export const fns = {\n  fn1,\n  fn2,\n};");
+		expect(result.type).toBe("named");
+		expect(result.namedExportName).toBe("fns");
+		expect(result.isBundle).toBe(true);
+	});
+
+	it("does not mark function call as bundle", () => {
+		const result = detectExportTypeFromContent(
+			"export const x = collection('x');",
+		);
+		// collection('x') matches `export const X = <something>` — but the regex
+		// for bundle requires `= {` directly, which doesn't match `= collection(`
+		expect(result.isBundle).toBeUndefined();
+	});
+
+	it("detects named re-export", () => {
+		const result = detectExportTypeFromContent("export { foo };");
+		expect(result.type).toBe("named");
+		expect(result.namedExportName).toBe("foo");
+	});
+
+	it("returns unknown for no exports", () => {
+		expect(detectExportTypeFromContent("const x = 1;")).toEqual({
+			type: "unknown",
+		});
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// multi-export factory discovery (integration)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("multi-export factory discovery", () => {
+	let rootDir: string;
+	let outDir: string;
+
+	beforeEach(async () => {
+		rootDir = await mkdtemp(join(tmpdir(), "questpie-factory-"));
+		outDir = join(rootDir, ".generated");
+		await mkdir(outDir, { recursive: true });
+	});
+
+	afterEach(async () => {
+		await rm(rootDir, { recursive: true, force: true });
+	});
+
+	async function write(
+		relPath: string,
+		content: string,
+	): Promise<void> {
+		const full = join(rootDir, relPath);
+		await mkdir(join(full, ".."), { recursive: true });
+		await writeFile(full, content, "utf-8");
+	}
+
+	/** Custom options with a blocks category using factoryFunctions */
+	const factoryOpts: DiscoverFilesOptions = {
+		categories: {
+			blocks: {
+				dirs: ["blocks"],
+				prefix: "bloc",
+				factoryFunctions: ["block"],
+			},
+		},
+	};
+
+	it("discovers two named factory exports from one file", async () => {
+		await write(
+			"blocks/layout.ts",
+			'export const hero = block("hero");\nexport const cta = block("cta");',
+		);
+
+		const result = await discoverFiles(rootDir, outDir, factoryOpts);
+		const blocks = result.categories.get("blocks")!;
+		expect(blocks.size).toBe(2);
+		expect(blocks.has("hero")).toBe(true);
+		expect(blocks.has("cta")).toBe(true);
+
+		const heroFile = blocks.get("hero")!;
+		expect(heroFile.exportType).toBe("named");
+		expect(heroFile.namedExportName).toBe("hero");
+		expect(heroFile.varName).toBe("_bloc_hero");
+
+		const ctaFile = blocks.get("cta")!;
+		expect(ctaFile.namedExportName).toBe("cta");
+	});
+
+	it("derives key from factory string arg (kebab-case)", async () => {
+		await write(
+			"blocks/banner.ts",
+			'export const x = block("hero-banner");',
+		);
+
+		const result = await discoverFiles(rootDir, outDir, factoryOpts);
+		const blocks = result.categories.get("blocks")!;
+		expect(blocks.has("heroBanner")).toBe(true);
+	});
+
+	it("falls back to export name when factory arg is not a string", async () => {
+		await write(
+			"blocks/dynamic.ts",
+			"export const heroBlock = block(dynamicVar);",
+		);
+
+		const result = await discoverFiles(rootDir, outDir, factoryOpts);
+		const blocks = result.categories.get("blocks")!;
+		expect(blocks.has("heroBlock")).toBe(true);
+	});
+
+	it("discovers default inline factory export", async () => {
+		await write("blocks/hero.ts", 'export default block("hero");');
+
+		const result = await discoverFiles(rootDir, outDir, factoryOpts);
+		const blocks = result.categories.get("blocks")!;
+		expect(blocks.has("hero")).toBe(true);
+		expect(blocks.get("hero")!.exportType).toBe("default");
+	});
+
+	it("falls back to filename for default with non-string arg", async () => {
+		await write("blocks/hero-banner.ts", "export default block(dynamicVar);");
+
+		const result = await discoverFiles(rootDir, outDir, factoryOpts);
+		const blocks = result.categories.get("blocks")!;
+		expect(blocks.has("heroBanner")).toBe(true);
+	});
+
+	it("skips utility files with no factory calls", async () => {
+		await write(
+			"blocks/helpers.ts",
+			"export const helper = () => {};\nexport type Foo = string;",
+		);
+
+		const result = await discoverFiles(rootDir, outDir, factoryOpts);
+		const blocks = result.categories.get("blocks") ?? new Map();
+		expect(blocks.size).toBe(0);
+	});
+
+	it("detects re-export pattern: export { X }", async () => {
+		await write(
+			"blocks/hero.ts",
+			'const hero = block("hero");\nexport { hero };',
+		);
+
+		const result = await discoverFiles(rootDir, outDir, factoryOpts);
+		const blocks = result.categories.get("blocks")!;
+		expect(blocks.has("hero")).toBe(true);
+		expect(blocks.get("hero")!.exportType).toBe("named");
+	});
+
+	it("detects aliased re-export: export { X as Y }", async () => {
+		await write(
+			"blocks/hero.ts",
+			'const hero = block("hero");\nexport { hero as myHero };',
+		);
+
+		const result = await discoverFiles(rootDir, outDir, factoryOpts);
+		const blocks = result.categories.get("blocks")!;
+		expect(blocks.has("hero")).toBe(true);
+		expect(blocks.get("hero")!.namedExportName).toBe("myHero");
+	});
+
+	it("detects default re-export of factory variable", async () => {
+		await write(
+			"blocks/hero.ts",
+			'const hero = block("hero");\nexport default hero;\n',
+		);
+
+		const result = await discoverFiles(rootDir, outDir, factoryOpts);
+		const blocks = result.categories.get("blocks")!;
+		expect(blocks.has("hero")).toBe(true);
+		expect(blocks.get("hero")!.exportType).toBe("default");
+	});
+
+	it("detects conflict with multi-export across files", async () => {
+		await write("blocks/file1.ts", 'export const hero = block("hero");');
+		await write("blocks/file2.ts", 'export const hero2 = block("hero");');
+
+		await expect(
+			discoverFiles(rootDir, outDir, factoryOpts),
+		).rejects.toThrow(/duplicate blocks key "hero"/);
+	});
+
+	it("both import paths point to same file for multi-export", async () => {
+		await write(
+			"blocks/layout.ts",
+			'export const hero = block("hero");\nexport const cta = block("cta");',
+		);
+
+		const result = await discoverFiles(rootDir, outDir, factoryOpts);
+		const blocks = result.categories.get("blocks")!;
+		expect(blocks.get("hero")!.importPath).toBe(
+			blocks.get("cta")!.importPath,
+		);
 	});
 });


### PR DESCRIPTION
## Summary
- **QUE-20**: Add `factoryFunctions` field to `CategoryDeclaration` enabling multi-export discovery from single files. `detectFactoryExports()` uses a two-pass regex approach to find all exported factory calls (direct exports, re-exports, aliased re-exports, default re-exports, inline default). `processFile()` now returns `DiscoveredFile[]` — each factory match becomes a separate entry, while categories without `factoryFunctions` retain backward-compatible single-entity behavior.
- **QUE-159**: Add `RUNTIME_CONSUMED_KEYS` set and `extractRuntimeExtensions()` function to `create-app.ts`, wired into `createAppFromDefinition()` for runtime config extensibility via `buildExtensionState()`.
- Updated test fixtures to use factory calls for collections/globals categories, and added comprehensive new test suites for `detectFactoryExports`, `detectExportTypeFromContent`, and multi-export integration tests (78 tests in discover.test.ts, 1162 total passing).

## Test plan
- [x] All 78 discover.test.ts tests pass (was 47, 31 new)
- [x] Full test suite: 1162 tests across 66 files, 0 failures
- [x] Manual verification: run `bun questpie codegen` on a project with multi-export block/view files

Closes QUE-20
Closes QUE-159