### PR TITLE
feat(core)!: lazy service context + namespace placement + async createApp (QUE-161)

### DIFF
--- a/examples/city-portal/.generated/index.ts
+++ b/examples/city-portal/.generated/index.ts
@@ -87,7 +87,7 @@ export interface App extends AppContext {
 // RUNTIME — create the app instance
 // ════════════════════════════════════════════════════════════
 
-export const app = createApp(_runtime, {
+export const app = await createApp(_runtime, {
 }) as unknown as App;
 
 // ── createContext — typed context for scripts ──────────────
@@ -115,4 +115,3 @@ export async function createContext(options?: {
 	});
 	return { ...services, locale: reqCtx.locale } as AppContext;
 }
-

--- a/examples/city-portal/src/questpie/server/.generated/index.ts
+++ b/examples/city-portal/src/questpie/server/.generated/index.ts
@@ -215,7 +215,7 @@ export type AppConfig = {
 // RUNTIME — create the app instance
 // ════════════════════════════════════════════════════════════
 
-export const app = createApp(
+export const app = await createApp(
 	{
 		modules: _modules as any,
 		collections: {

--- a/packages/create-questpie/templates/tanstack-start/src/questpie/server/.generated/index.ts
+++ b/packages/create-questpie/templates/tanstack-start/src/questpie/server/.generated/index.ts
@@ -115,7 +115,7 @@ export type App = _AppInternal;
 // RUNTIME — create the app instance
 // ════════════════════════════════════════════════════════════
 
-export const app = createApp(
+export const app = await createApp(
 	{
 		modules: _modules as any,
 		collections: {
@@ -145,4 +145,3 @@ export const app = createApp(
  * ```
  */
 export const createContext = createContextFactory(app);
-

--- a/packages/questpie/src/cli/codegen/index.ts
+++ b/packages/questpie/src/cli/codegen/index.ts
@@ -208,7 +208,7 @@ export function coreCodegenPlugin(): CodegenPlugin {
 						dir: "services",
 						description: "Service definition",
 						template: ({ camel }) =>
-							`import { service } from "questpie";\n\nexport const ${camel}Service = service({\n\tsetup: async ({ ctx }) => {\n\t\treturn {};\n\t},\n});\n`,
+							`import { service } from "questpie";\n\nexport const ${camel}Service = service()\n\t.lifecycle("singleton")\n\t.create(() => {\n\t\treturn {};\n\t});\n`,
 					},
 					email: {
 						dir: "emails",

--- a/packages/questpie/src/cli/codegen/index.ts
+++ b/packages/questpie/src/cli/codegen/index.ts
@@ -105,9 +105,6 @@ export function coreCodegenPlugin(): CodegenPlugin {
 						dirs: ["services"],
 						prefix: "svc",
 						typeEmit: "services",
-						extraTypeImports: [
-							'import type { ServiceInstanceOf } from "questpie";',
-						],
 						registryKey: true,
 						includeInAppState: true,
 						extractFromModules: true,

--- a/packages/questpie/src/cli/codegen/template.ts
+++ b/packages/questpie/src/cli/codegen/template.ts
@@ -17,8 +17,8 @@
 
 import type {
 	CategoryDeclaration,
-	DiscoverPattern,
 	DiscoveredFile,
+	DiscoverPattern,
 	DiscoveryResult,
 	SingletonFactory,
 } from "./types.js";
@@ -202,9 +202,7 @@ export function generateTemplate(options: TemplateOptions): string {
 	lines.push("// ════════════════════════════════════════════════════════════");
 	lines.push("");
 
-	lines.push(
-		'import type { UnionToIntersection } from "questpie";',
-	);
+	lines.push('import type { UnionToIntersection } from "questpie";');
 	lines.push(`type _Module = (typeof ${modulesFile.varName})[number];`);
 	lines.push(
 		"type _MPRaw<K extends string> = UnionToIntersection<_Module extends infer M ? M extends Record<K, infer V> ? V : never : never>;",
@@ -237,7 +235,8 @@ export function generateTemplate(options: TemplateOptions): string {
 		const registryCatNames: Array<{ catName: string; regKey: string }> = [];
 		for (const [catName, decl] of allDecls) {
 			if (!decl.registryKey) continue;
-			const regKey = typeof decl.registryKey === "string" ? decl.registryKey : catName;
+			const regKey =
+				typeof decl.registryKey === "string" ? decl.registryKey : catName;
 			registryCatNames.push({ catName, regKey });
 		}
 
@@ -256,14 +255,15 @@ export function generateTemplate(options: TemplateOptions): string {
 	// Unlike _MP<> (top-level only), this recurses into sub-modules because
 	// each module contributes its own field types (not merged into parent).
 	{
-		const tildeKeys = collectTildeRegistryKeys(discoverPatterns, discovered.singles);
+		const tildeKeys = collectTildeRegistryKeys(
+			discoverPatterns,
+			discovered.singles,
+		);
 		if (tildeKeys.length > 0) {
 			lines.push(
 				"// Recursive module property extraction (for fields contributed at each level)",
 			);
-			lines.push(
-				'import type { ExtractModuleProp } from "questpie";',
-			);
+			lines.push('import type { ExtractModuleProp } from "questpie";');
 			lines.push("");
 
 			for (const { singleName, registryKey } of tildeKeys) {
@@ -455,7 +455,7 @@ export function generateTemplate(options: TemplateOptions): string {
 			);
 		}
 
-		// Services — namespaced under `services` (matches extractAppServices runtime)
+		// Services — default namespace under `services`
 		if (hasServices) {
 			lines.push("");
 			lines.push("\t\t\t// User services");
@@ -463,6 +463,8 @@ export function generateTemplate(options: TemplateOptions): string {
 		}
 
 		lines.push("\t\t}");
+		lines.push("");
+		lines.push("\t\tinterface ServiceCreateContext extends AppContext {}");
 
 		// Registry — ALL registryKey categories + ~-prefixed singles augmented centrally.
 		// This is the SINGLE place that augments Registry. Modules never augment it.
@@ -472,13 +474,17 @@ export function generateTemplate(options: TemplateOptions): string {
 			// Category registryKeys (views, components, blocks, listViews, etc.)
 			for (const [catName, decl] of allDecls) {
 				if (!decl.registryKey) continue;
-				const regKey = typeof decl.registryKey === "string" ? decl.registryKey : catName;
+				const regKey =
+					typeof decl.registryKey === "string" ? decl.registryKey : catName;
 				const typeName = `_Registry_${capitalize(catName)}`;
 				registryEntries.push(`\t\t\t${safeKey(regKey)}: ${typeName};`);
 			}
 
 			// ~-prefixed registryKeys from singles (e.g. ~fieldTypes)
-			const tildeKeys = collectTildeRegistryKeys(discoverPatterns, discovered.singles);
+			const tildeKeys = collectTildeRegistryKeys(
+				discoverPatterns,
+				discovered.singles,
+			);
 			for (const { singleName, registryKey } of tildeKeys) {
 				const typeName = `_AllModule${capitalize(singleName)}`;
 				registryEntries.push(`\t\t\t${safeKey(registryKey)}: ${typeName};`);
@@ -554,7 +560,9 @@ export function generateTemplate(options: TemplateOptions): string {
 	lines.push("");
 
 	// Factories are available via #questpie/factories (separate entry to avoid circular deps)
-	lines.push("// Factories: import { collection, global, ... } from '#questpie/factories';");
+	lines.push(
+		"// Factories: import { collection, global, ... } from '#questpie/factories';",
+	);
 	lines.push("");
 
 	// Extra runtime code from plugins
@@ -591,7 +599,7 @@ function emitNewArchitectureRuntime(
 	}
 	const coreSingles = getCategorizedSingles(discovered.singles, allDecls);
 
-	lines.push("export const app = createApp(");
+	lines.push("export const app = await createApp(");
 	lines.push("\t{");
 
 	// Modules
@@ -610,7 +618,9 @@ function emitNewArchitectureRuntime(
 				lines.push(`\t\t${safeKey(createAppKey)}: {`);
 				for (const file of sortedValues(fileMap)) {
 					if (decl?.keyFromProperty) {
-						lines.push(`\t\t\t[${file.varName}.${decl.keyFromProperty}]: ${file.varName},`);
+						lines.push(
+							`\t\t\t[${file.varName}.${decl.keyFromProperty}]: ${file.varName},`,
+						);
 					} else {
 						lines.push(`\t\t\t${safeKey(file.key)}: ${file.varName},`);
 					}

--- a/packages/questpie/src/cli/codegen/template.ts
+++ b/packages/questpie/src/cli/codegen/template.ts
@@ -202,7 +202,9 @@ export function generateTemplate(options: TemplateOptions): string {
 	lines.push("// ════════════════════════════════════════════════════════════");
 	lines.push("");
 
-	lines.push('import type { UnionToIntersection } from "questpie";');
+	lines.push(
+		'import type { ServiceCustomNamespaceInstances, ServiceInstanceOf, ServiceInstancesInNamespace, ServiceTopLevelInstances, UnionToIntersection } from "questpie";',
+	);
 	lines.push(`type _Module = (typeof ${modulesFile.varName})[number];`);
 	lines.push(
 		"type _MPRaw<K extends string> = UnionToIntersection<_Module extends infer M ? M extends Record<K, infer V> ? V : never : never>;",
@@ -314,19 +316,35 @@ export function generateTemplate(options: TemplateOptions): string {
 			case "services": {
 				const hasUser = fileMap.size > 0;
 				lines.push(
-					"/** All services in the app (modules + user, user overrides). Values are service instances. */",
+					"/** All service definitions in the app (modules + user, user overrides). */",
 				);
 				if (hasUser) {
-					lines.push(`export type ${appTypeName} = ${moduleTypeName} & {`);
+					lines.push(`type _AppServiceDefinitions = ${moduleTypeName} & {`);
 					for (const file of sortedValues(fileMap)) {
-						lines.push(
-							`\t${safeKey(file.key)}: ServiceInstanceOf<typeof ${file.varName}>;`,
-						);
+						lines.push(`\t${safeKey(file.key)}: typeof ${file.varName};`);
 					}
 					lines.push("};");
 				} else {
-					lines.push(`export type ${appTypeName} = ${moduleTypeName};`);
+					lines.push(`type _AppServiceDefinitions = ${moduleTypeName};`);
 				}
+				lines.push("");
+				lines.push(
+					"/** All services in the app as resolved service instances. */",
+				);
+				lines.push(`export type ${appTypeName} = {`);
+				lines.push(
+					"\t[K in keyof _AppServiceDefinitions]: ServiceInstanceOf<_AppServiceDefinitions[K]>;",
+				);
+				lines.push("};");
+				lines.push(
+					'type _AppDefaultServices = ServiceInstancesInNamespace<_AppServiceDefinitions, "services">;',
+				);
+				lines.push(
+					"type _AppTopLevelServices = ServiceTopLevelInstances<_AppServiceDefinitions>;",
+				);
+				lines.push(
+					"type _AppCustomServiceNamespaces = ServiceCustomNamespaceInstances<_AppServiceDefinitions>;",
+				);
 				lines.push("");
 				break;
 			}
@@ -414,14 +432,20 @@ export function generateTemplate(options: TemplateOptions): string {
 		const hasMessages = messagesCat && messagesCat.size > 0;
 
 		const servicesCat = discovered.categories.get("services");
-		const hasServices = servicesCat && servicesCat.size > 0;
+		const hasServices = !!servicesCat;
 
 		lines.push(
 			"// ── AppContext augmentation — auto-types ALL handlers ──────",
 		);
 		lines.push("declare global {");
 		lines.push("\tnamespace Questpie {");
-		lines.push("\t\tinterface AppContext {");
+		if (hasServices) {
+			lines.push(
+				"\t\tinterface AppContext extends _AppTopLevelServices, _AppCustomServiceNamespaces {",
+			);
+		} else {
+			lines.push("\t\tinterface AppContext {");
+		}
 		lines.push("\t\t\t// Infrastructure");
 		lines.push("\t\t\tdb: _AppInternal['db'];");
 		if (hasEmails) {
@@ -459,7 +483,7 @@ export function generateTemplate(options: TemplateOptions): string {
 		if (hasServices) {
 			lines.push("");
 			lines.push("\t\t\t// User services");
-			lines.push("\t\t\tservices: AppServices;");
+			lines.push("\t\t\tservices: _AppDefaultServices;");
 		}
 
 		lines.push("\t\t}");

--- a/packages/questpie/src/exports/index.ts
+++ b/packages/questpie/src/exports/index.ts
@@ -52,6 +52,16 @@ export {
 	CLOUD_ENV,
 	isQuestpieCloud,
 } from "#questpie/server/config/cloud-env.js";
+export type {
+	ExtractModuleProp,
+	ExtractModulePropArr,
+	RegistryProp,
+	ServiceCustomNamespaceInstances,
+	ServiceDefinitionsInNamespace,
+	ServiceInstancesInNamespace,
+	ServiceTopLevelInstances,
+	UnionToIntersection,
+} from "#questpie/server/config/codegen-type-utils.js";
 // Re-export type safety helpers (getContext, etc. exported via context.js)
 export type {
 	InferAppFromApp,
@@ -66,6 +76,7 @@ export {
 	module,
 	runtimeConfig,
 } from "#questpie/server/config/create-app.js";
+export { createContextFactory } from "#questpie/server/config/create-context-factory.js";
 export * from "#questpie/server/config/global-hooks-types.js";
 export * from "#questpie/server/config/module-types.js";
 export * from "#questpie/server/config/questpie.js";
@@ -100,13 +111,6 @@ export { service } from "#questpie/server/services/define-service.js";
 export * from "#questpie/server/utils/builder-extensions.js";
 export * from "#questpie/server/utils/callback-proxies.js";
 export * from "#questpie/server/utils/drizzle-to-zod.js";
-export type {
-	ExtractModuleProp,
-	ExtractModulePropArr,
-	RegistryProp,
-	UnionToIntersection,
-} from "#questpie/server/config/codegen-type-utils.js";
-export { createContextFactory } from "#questpie/server/config/create-context-factory.js";
 export type {
 	CollectionInfer,
 	CollectionInsert,

--- a/packages/questpie/src/server/config/app-context.ts
+++ b/packages/questpie/src/server/config/app-context.ts
@@ -15,8 +15,10 @@
  *   }
  *   → ({ channels }) available in every hook, function, job, etc.
  *
- * User services are namespaced under `services`:
- *   ({ services }) => services.blog.computeReadingTime(text)
+ * User services support namespace placement:
+ *   ({ services }) => services.blog.computeReadingTime(text) // default
+ *   ({ workflows }) => workflows.run(...)                    // namespace: null
+ *   ({ analytics }) => analytics.tracker.track(...)          // namespace: "analytics"
  *
  * @see RFC-CONTEXT-FIRST.md §2
  */
@@ -133,17 +135,43 @@ export function extractAppServices(
 		t: app.t,
 	};
 
-	// Resolve user-defined services — namespaced under `services`
-	const serviceDefs = app.config?.services;
+	const serviceDefs = app._serviceDefs ?? app.config?.services;
 	if (serviceDefs) {
 		const services: Record<string, unknown> = {};
-		for (const name of Object.keys(serviceDefs)) {
-			services[name] = app.resolveService(name, {
+
+		for (const [name, input] of Object.entries(serviceDefs as Record<string, any>)) {
+			const instance = app.resolveService(name, {
 				db: result.db,
 				session: result.session,
+				locale: overrides?.locale,
 			});
+
+			const state =
+				input && typeof input === "object" && "state" in input
+					? (input.state as Record<string, unknown>)
+					: (input as Record<string, unknown>);
+			const namespace = state?.namespace as string | null | undefined;
+
+			if (namespace === undefined || namespace === "services") {
+				services[name] = instance;
+				continue;
+			}
+
+			if (namespace === null) {
+				result[name] = instance;
+				continue;
+			}
+
+			if (!(namespace in result) || typeof result[namespace] !== "object") {
+				result[namespace] = {};
+			}
+
+			(result[namespace] as Record<string, unknown>)[name] = instance;
 		}
-		result.services = services;
+
+		if (Object.keys(services).length > 0) {
+			result.services = services;
+		}
 	}
 
 	return result;

--- a/packages/questpie/src/server/config/app-context.ts
+++ b/packages/questpie/src/server/config/app-context.ts
@@ -123,6 +123,7 @@ export function extractAppServices(
 		app,
 		db: overrides?.db ?? app.db,
 		session: overrides?.session ?? null,
+		services: {},
 		queue: app.queue,
 		email: app.email,
 		storage: app.storage,
@@ -139,7 +140,9 @@ export function extractAppServices(
 	if (serviceDefs) {
 		const services: Record<string, unknown> = {};
 
-		for (const [name, input] of Object.entries(serviceDefs as Record<string, any>)) {
+		for (const [name, input] of Object.entries(
+			serviceDefs as Record<string, any>,
+		)) {
 			const instance = app.resolveService(name, {
 				db: result.db,
 				session: result.session,
@@ -169,9 +172,7 @@ export function extractAppServices(
 			(result[namespace] as Record<string, unknown>)[name] = instance;
 		}
 
-		if (Object.keys(services).length > 0) {
-			result.services = services;
-		}
+		result.services = services;
 	}
 
 	return result;

--- a/packages/questpie/src/server/config/codegen-type-utils.ts
+++ b/packages/questpie/src/server/config/codegen-type-utils.ts
@@ -8,6 +8,11 @@
  * @see QUE-163 — Codegen Simplification
  */
 
+import type {
+	ServiceInstanceOf,
+	ServiceNamespace,
+	ServiceNamespaceOf,
+} from "#questpie/server/services/define-service.js";
 import type { Registry } from "./app-context.js";
 
 /**
@@ -17,9 +22,11 @@ import type { Registry } from "./app-context.js";
  * `_U2I<ModuleUnion extends ... ? V : never>` collapses into an intersection.
  */
 // biome-ignore lint/suspicious/noExplicitAny: Required for distributive conditional type
-export type UnionToIntersection<U> = (U extends any ? (x: U) => void : never) extends (
-	x: infer I,
-) => void
+export type UnionToIntersection<U> = (
+	U extends any
+		? (x: U) => void
+		: never
+) extends (x: infer I) => void
 	? I
 	: never;
 
@@ -29,9 +36,8 @@ export type UnionToIntersection<U> = (U extends any ? (x: U) => void : never) ex
  * Used in generated factories.ts to derive view/component type aliases
  * from the globally augmented Registry without importing modules directly.
  */
-export type RegistryProp<K extends string> = Registry extends Record<K, infer V>
-	? V
-	: Record<string, unknown>;
+export type RegistryProp<K extends string> =
+	Registry extends Record<K, infer V> ? V : Record<string, unknown>;
 
 /**
  * Recursively extract a named property from a module tree.
@@ -56,9 +62,76 @@ export type ExtractModuleProp<M, K extends string> = (M extends {
  * Array companion for ExtractModuleProp — recurses over a readonly tuple of modules.
  */
 // biome-ignore lint/suspicious/noExplicitAny: Required for generic module shape matching
-export type ExtractModulePropArr<A extends readonly any[], K extends string> =
-	// biome-ignore lint/suspicious/noExplicitAny: Required for generic module shape matching
-	A extends readonly [infer H, ...infer T extends readonly any[]]
-		? ExtractModuleProp<H, K> & ExtractModulePropArr<T, K>
-		: // biome-ignore lint/complexity/noBannedTypes: Empty object is correct base case
-			{};
+export type ExtractModulePropArr<
+	A extends readonly any[],
+	K extends string,
+> = // biome-ignore lint/suspicious/noExplicitAny: Required for generic module shape matching
+A extends readonly [infer H, ...infer T extends readonly any[]]
+	? ExtractModuleProp<H, K> & ExtractModulePropArr<T, K>
+	: // biome-ignore lint/complexity/noBannedTypes: Empty object is correct base case
+		{};
+
+/**
+ * Normalize a service namespace to its runtime placement namespace.
+ *
+ * - `undefined` and `"services"` are both default namespace (`services.*`)
+ * - `null` is top-level
+ * - any other string is custom namespace (`ctx.<namespace>.<name>`)
+ */
+export type NormalizeServiceNamespace<TNamespace> = TNamespace extends
+	| undefined
+	| "services"
+	? "services"
+	: TNamespace extends ServiceNamespace
+		? TNamespace
+		: "services";
+
+/**
+ * Extract service definitions that belong to a specific namespace.
+ */
+export type ServiceDefinitionsInNamespace<
+	TServices,
+	TNamespace extends string | null,
+> = {
+	[K in keyof TServices as NormalizeServiceNamespace<
+		ServiceNamespaceOf<TServices[K]>
+	> extends TNamespace
+		? K
+		: never]: TServices[K];
+};
+
+/**
+ * Convert service definitions in a namespace into instance types.
+ */
+export type ServiceInstancesInNamespace<
+	TServices,
+	TNamespace extends string | null,
+> = {
+	[K in keyof ServiceDefinitionsInNamespace<
+		TServices,
+		TNamespace
+	>]: ServiceInstanceOf<
+		ServiceDefinitionsInNamespace<TServices, TNamespace>[K]
+	>;
+};
+
+/**
+ * Top-level namespace (`namespace: null`) service instances keyed by service name.
+ */
+export type ServiceTopLevelInstances<TServices> = ServiceInstancesInNamespace<
+	TServices,
+	null
+>;
+
+/**
+ * Custom namespace map: `{ analytics: { tracker: Tracker } }`.
+ */
+export type ServiceCustomNamespaceInstances<TServices> = {
+	[TNamespace in Exclude<
+		Extract<
+			NormalizeServiceNamespace<ServiceNamespaceOf<TServices[keyof TServices]>>,
+			string
+		>,
+		"services"
+	>]: ServiceInstancesInNamespace<TServices, TNamespace>;
+};

--- a/packages/questpie/src/server/config/create-app.ts
+++ b/packages/questpie/src/server/config/create-app.ts
@@ -481,10 +481,10 @@ function isRuntimeConfig(arg: unknown): arg is RuntimeConfig {
  *
  * @see RFC-MODULE-ARCHITECTURE §9.1 (Root App — .generated/index.ts)
  */
-export function createApp(
+export async function createApp(
 	configOrDefinition: AppConfig | AppDefinition,
 	entitiesOrRuntime?: AppEntities | RuntimeConfig,
-) {
+): Promise<Questpie<QuestpieConfig>> {
 	// Detect new vs legacy signature
 	if (isRuntimeConfig(entitiesOrRuntime)) {
 		return createAppFromDefinition(
@@ -509,10 +509,10 @@ export function createApp(
  *
  * @see RFC-MODULE-ARCHITECTURE §9.1
  */
-function createAppFromDefinition(
+async function createAppFromDefinition(
 	definition: AppDefinition,
 	runtime: RuntimeConfig,
-) {
+): Promise<Questpie<QuestpieConfig>> {
 	// 1. Resolve modules depth-first
 	const flatModules = resolveModules(definition.modules ?? []);
 
@@ -593,9 +593,9 @@ function createAppFromDefinition(
 		runtime as Record<string, unknown>,
 	);
 	const extensionState = buildExtensionState(merged, runtimeExtensions);
-	if (Object.keys(extensionState).length > 0) {
-		instance.state = extensionState;
-	}
+	instance.state = extensionState;
+
+	await instance._initServices();
 
 	return instance;
 }
@@ -607,7 +607,10 @@ function createAppFromDefinition(
 /**
  * Legacy createApp — takes mixed config + optional entities.
  */
-function createAppLegacy(appConfig: AppConfig, entities?: AppEntities) {
+async function createAppLegacy(
+	appConfig: AppConfig,
+	entities?: AppEntities,
+): Promise<Questpie<QuestpieConfig>> {
 	// 1. Resolve modules depth-first
 	const flatModules = resolveModules(appConfig.modules ?? []);
 
@@ -672,6 +675,8 @@ function createAppLegacy(appConfig: AppConfig, entities?: AppEntities) {
 		contextResolver: appConfig.contextResolver,
 		globalHooks: mergeGlobalHooks(merged.hooks, appConfig.hooks),
 		defaultAccess: appConfig.defaultAccess ?? merged.defaultAccess,
+		services:
+			Object.keys(merged.services).length > 0 ? merged.services : undefined,
 	};
 
 	// 6. Create Questpie instance
@@ -682,9 +687,9 @@ function createAppLegacy(appConfig: AppConfig, entities?: AppEntities) {
 		merged,
 		appConfig as Record<string, unknown>,
 	);
-	if (Object.keys(extensionState).length > 0) {
-		instance.state = extensionState;
-	}
+	instance.state = extensionState;
+
+	await instance._initServices();
 
 	return instance;
 }

--- a/packages/questpie/src/server/config/module-types.ts
+++ b/packages/questpie/src/server/config/module-types.ts
@@ -114,10 +114,7 @@ export interface ModuleDefinition {
 	/** Services this module contributes. Keyed by service name. */
 	services?: Record<
 		string,
-		import("#questpie/server/services/define-service.js").ServiceDefinition<
-			any,
-			any
-		>
+		import("#questpie/server/services/define-service.js").ServiceBuilder<any>
 	>;
 
 	/** Partial auth config — deep-merged with other modules and user config. */
@@ -330,10 +327,7 @@ export interface AppDefinition {
 	/** Services discovered from `services/` directory. */
 	services?: Record<
 		string,
-		import("#questpie/server/services/define-service.js").ServiceDefinition<
-			any,
-			any
-		>
+		import("#questpie/server/services/define-service.js").ServiceBuilder<any>
 	>;
 
 	/** Email templates discovered from `emails/` directory. */

--- a/packages/questpie/src/server/config/questpie.ts
+++ b/packages/questpie/src/server/config/questpie.ts
@@ -51,6 +51,10 @@ import {
 	type SearchServiceWrapper,
 } from "#questpie/server/integrated/search/index.js";
 import { createDiskDriver } from "#questpie/server/integrated/storage/create-driver.js";
+import {
+	ServiceBuilder,
+	type ServiceLifecycle,
+} from "#questpie/server/services/define-service.js";
 import { resolveAutoSeedCategories } from "#questpie/server/seed/types.js";
 import { DEFAULT_LOCALE } from "#questpie/shared/constants.js";
 import type {
@@ -62,6 +66,15 @@ import type { FunctionsTree } from "../functions/types.js";
 import type { GlobalHooksState } from "./global-hooks-types.js";
 import type { GetMessageKeys, QuestpieConfig } from "./types.js";
 
+interface ResolvedServiceDefinition {
+	lifecycle: ServiceLifecycle;
+	create: (
+		ctx: Questpie.ServiceCreateContext,
+	) => unknown | Promise<unknown>;
+	dispose?: (instance: unknown) => void | Promise<void>;
+	namespace: string | null;
+}
+
 export class Questpie<TConfig extends QuestpieConfig = QuestpieConfig> {
 	static readonly __internal = {
 		storageDriverServiceName: "appDefault",
@@ -70,6 +83,8 @@ export class Questpie<TConfig extends QuestpieConfig = QuestpieConfig> {
 	private _collections: Record<string, Collection<AnyCollectionState>> = {};
 	private _globals: Record<string, AnyGlobal> = {};
 	private _singletonServices: Record<string, any> = {};
+	private _serviceDefs: Record<string, ResolvedServiceDefinition> = {};
+	private _customServiceNamespaces = new Set<string>();
 	public readonly config: TConfig;
 	private resolvedLocales: Locale[] | null = null;
 	private pgConnectionString?: string;
@@ -292,14 +307,7 @@ export class Questpie<TConfig extends QuestpieConfig = QuestpieConfig> {
 		this.migrations = new QuestpieMigrationsAPI(this);
 		this.seeds = new QuestpieSeedsAPI(this);
 		this.api = new QuestpieAPI(this) as QuestpieApi<TConfig>;
-
-		// Initialize singleton services
-		this._initSingletonServices();
-
-		// Auto-init if configured (autoMigrate / autoSeed)
-		if (config.autoMigrate || config.autoSeed) {
-			this._initPromise = this._autoInit();
-		}
+		this._resolveServiceDefs();
 
 		// In development, track this instance in globalThis so that HMR module
 		// re-evaluations automatically close the previous instance's connection
@@ -352,20 +360,22 @@ export class Questpie<TConfig extends QuestpieConfig = QuestpieConfig> {
 	 * ```
 	 */
 	async destroy(): Promise<void> {
-		// Dispose singleton services
-		const serviceDefs = this.config.services;
-		if (serviceDefs) {
-			const disposals: Promise<void>[] = [];
-			for (const [name, def] of Object.entries(serviceDefs)) {
-				if (def.dispose && this._singletonServices[name] !== undefined) {
-					const result = def.dispose(this._singletonServices[name]);
-					if (result instanceof Promise) disposals.push(result);
-				}
-			}
-			if (disposals.length > 0) {
-				await Promise.allSettled(disposals);
+		const disposals: Promise<void>[] = [];
+		for (const [name, def] of Object.entries(this._serviceDefs)) {
+			if (def.lifecycle !== "singleton") continue;
+			if (!def.dispose) continue;
+			if (this._singletonServices[name] === undefined) continue;
+
+			const result = def.dispose(this._singletonServices[name]);
+			if (result instanceof Promise) {
+				disposals.push(result);
 			}
 		}
+
+		if (disposals.length > 0) {
+			await Promise.allSettled(disposals);
+		}
+
 		this._singletonServices = {};
 
 		await Promise.allSettled([
@@ -390,41 +400,316 @@ export class Questpie<TConfig extends QuestpieConfig = QuestpieConfig> {
 		}
 	}
 
-	/**
-	 * Initialize all singleton-lifecycle services.
-	 * Creates service instances and stores them for injection.
-	 */
-	private _initSingletonServices(): void {
-		const serviceDefs = this.config.services;
-		if (!serviceDefs) return;
+	private _normalizeServiceNamespace(
+		namespace: string | null | undefined,
+	): string | null {
+		if (namespace === undefined || namespace === "services") {
+			return "services";
+		}
 
-		// Build a deps bag with infrastructure services
-		const infraDeps: Record<string, any> = {
-			db: this.db,
-			email: this.email,
+		if (namespace === "") {
+			throw new Error(
+				"[QuestPie] Service namespace cannot be an empty string.",
+			);
+		}
+
+		return namespace;
+	}
+
+	private _resolveServiceDefs(): void {
+		this._serviceDefs = {};
+		this._customServiceNamespaces.clear();
+
+		if (!this.config.services) return;
+
+		for (const [name, input] of Object.entries(this.config.services)) {
+			const state =
+				input instanceof ServiceBuilder
+					? input.state
+					: ((input as { state?: unknown }).state as
+							| Record<string, unknown>
+							| undefined) ??
+						(input as Record<string, unknown>);
+
+			if (!state || typeof state !== "object") {
+				throw new Error(
+					`[QuestPie] Service "${name}" is invalid. Use service().create(...) or service({ create: ... }).`,
+				);
+			}
+
+			if (typeof state.create !== "function") {
+				throw new Error(
+					`[QuestPie] Service "${name}" must define create().`,
+				);
+			}
+
+			const lifecycle = (state.lifecycle ?? "singleton") as ServiceLifecycle;
+			if (lifecycle !== "singleton" && lifecycle !== "request") {
+				throw new Error(
+					`[QuestPie] Service "${name}" has invalid lifecycle "${String(state.lifecycle)}".`,
+				);
+			}
+
+			const namespace = this._normalizeServiceNamespace(
+				state.namespace as string | null | undefined,
+			);
+
+			if (lifecycle === "request" && namespace !== "services") {
+				const formattedNamespace = namespace === null ? "null" : namespace;
+				throw new Error(
+					`[QuestPie] Service "${name}" uses namespace "${formattedNamespace}" but only singleton services may use non-default namespaces.`,
+				);
+			}
+
+			this._serviceDefs[name] = {
+				lifecycle,
+				create: state.create as (
+					ctx: Questpie.ServiceCreateContext,
+				) => unknown | Promise<unknown>,
+				dispose: state.dispose as
+					| ((instance: unknown) => void | Promise<void>)
+					| undefined,
+				namespace,
+			};
+
+			if (namespace !== "services" && namespace !== null) {
+				this._customServiceNamespaces.add(namespace);
+			}
+		}
+	}
+
+	async _initServices(): Promise<void> {
+		for (const [name, def] of Object.entries(this._serviceDefs)) {
+			if (def.lifecycle !== "singleton") continue;
+
+			await this._resolveSingletonService(name, {
+				stack: [],
+				lazyTriggered: false,
+				allowAsync: true,
+			});
+		}
+
+		if (!this._initPromise && (this.config.autoMigrate || this.config.autoSeed)) {
+			this._initPromise = this._autoInit();
+		}
+	}
+
+	private _createServiceContext(options: {
+		requestDeps?: Record<string, any>;
+		stack: string[];
+	}): Questpie.ServiceCreateContext {
+		const namespaceProxyCache = new Map<string, Record<string, unknown>>();
+		const { requestDeps, stack } = options;
+
+		const resolveFromProxy = (serviceName: string): unknown => {
+			return this._resolveServiceFromProxy(serviceName, {
+				requestDeps,
+				stack,
+			});
+		};
+
+		const getNamespaceProxy = (namespace: string): Record<string, unknown> => {
+			const existing = namespaceProxyCache.get(namespace);
+			if (existing) return existing;
+
+			const proxy = new Proxy<Record<string, unknown>>(
+				{},
+				{
+					get: (_target, prop) => {
+						if (typeof prop !== "string") return undefined;
+						const def = this._serviceDefs[prop];
+						if (!def || def.namespace !== namespace) return undefined;
+						return resolveFromProxy(prop);
+					},
+					has: (_target, prop) => {
+						if (typeof prop !== "string") return false;
+						const def = this._serviceDefs[prop];
+						return !!def && def.namespace === namespace;
+					},
+				},
+			);
+
+			namespaceProxyCache.set(namespace, proxy);
+			return proxy;
+		};
+
+		const context = {
+			...requestDeps,
+			db: requestDeps?.db ?? this.db,
 			queue: this.queue,
 			storage: this.storage,
 			kv: this.kv,
 			logger: this.logger,
 			search: this.search,
 			realtime: this.realtime,
+			email: this.email,
 			auth: this.auth,
+			app: this,
+			collections: this.api?.collections,
+			globals: this.api?.globals,
+			t: this.t,
+		} as Record<string, unknown>;
+
+		return new Proxy(context, {
+			get: (target, prop, receiver) => {
+				if (typeof prop !== "string") {
+					return Reflect.get(target, prop, receiver);
+				}
+
+				if (Object.prototype.hasOwnProperty.call(target, prop)) {
+					return target[prop];
+				}
+
+				const topLevelDef = this._serviceDefs[prop];
+				if (topLevelDef?.namespace === null) {
+					return resolveFromProxy(prop);
+				}
+
+				if (this._customServiceNamespaces.has(prop)) {
+					return getNamespaceProxy(prop);
+				}
+
+				if (prop === "services") {
+					return getNamespaceProxy("services");
+				}
+
+				return undefined;
+			},
+			has: (target, prop) => {
+				if (typeof prop !== "string") return false;
+				if (Object.prototype.hasOwnProperty.call(target, prop)) return true;
+				if (prop === "services") return true;
+				if (this._customServiceNamespaces.has(prop)) return true;
+				const topLevelDef = this._serviceDefs[prop];
+				return !!topLevelDef && topLevelDef.namespace === null;
+			},
+		}) as Questpie.ServiceCreateContext;
+	}
+
+	private _resolveServiceFromProxy(
+		name: string,
+		options: { requestDeps?: Record<string, any>; stack: string[] },
+	): unknown {
+		const def = this._serviceDefs[name];
+		if (!def) return undefined;
+
+		if (def.lifecycle === "singleton") {
+			return this._resolveSingletonService(name, {
+				requestDeps: options.requestDeps,
+				stack: options.stack,
+				lazyTriggered: true,
+				allowAsync: false,
+			});
+		}
+
+		return this._createServiceInstance(name, def, {
+			requestDeps: options.requestDeps,
+			stack: options.stack,
+			cacheSingleton: false,
+			lazyTriggered: true,
+			allowAsync: false,
+		});
+	}
+
+	private _resolveSingletonService(
+		name: string,
+		options: {
+			requestDeps?: Record<string, any>;
+			stack: string[];
+			lazyTriggered: boolean;
+			allowAsync: boolean;
+		},
+	): unknown | Promise<unknown> {
+		if (this._singletonServices[name] !== undefined) {
+			return this._singletonServices[name];
+		}
+
+		const def = this._serviceDefs[name];
+		if (!def) return undefined;
+
+		return this._createServiceInstance(name, def, {
+			requestDeps: options.requestDeps,
+			stack: options.stack,
+			cacheSingleton: true,
+			lazyTriggered: options.lazyTriggered,
+			allowAsync: options.allowAsync,
+		});
+	}
+
+	private _createServiceInstance(
+		name: string,
+		def: ResolvedServiceDefinition,
+		options: {
+			requestDeps?: Record<string, any>;
+			stack: string[];
+			cacheSingleton: boolean;
+			lazyTriggered: boolean;
+			allowAsync: boolean;
+		},
+	): unknown | Promise<unknown> {
+		this._assertNoCircularServiceDependency(name, options.stack);
+		options.stack.push(name);
+
+		const popIfCurrent = () => {
+			if (options.stack[options.stack.length - 1] === name) {
+				options.stack.pop();
+			}
 		};
 
-		for (const [name, def] of Object.entries(serviceDefs)) {
-			if (def.lifecycle === "request") continue;
+		try {
+			const context = this._createServiceContext({
+				requestDeps: options.requestDeps,
+				stack: options.stack,
+			});
+			const created = def.create(context);
 
-			// Resolve deps
-			const deps: Record<string, any> = {};
-			if (def.deps) {
-				for (const depName of def.deps) {
-					// Check infra first, then already-created singleton services
-					deps[depName] = infraDeps[depName] ?? this._singletonServices[depName];
+			if (created instanceof Promise) {
+				if (!options.allowAsync) {
+					popIfCurrent();
+					if (options.lazyTriggered) {
+						throw new Error(
+							`[QuestPie] Service "${name}" has async create() but was lazily triggered. Reorder services so "${name}" initializes first.`,
+						);
+					}
+
+					throw new Error(
+						`[QuestPie] Service "${name}" has async create() but this resolution path is synchronous.`,
+					);
 				}
+
+				return created
+					.then((instance) => {
+						if (options.cacheSingleton) {
+							this._singletonServices[name] = instance;
+						}
+						return instance;
+					})
+					.finally(() => {
+						popIfCurrent();
+					});
 			}
 
-			this._singletonServices[name] = def.create(deps);
+			if (options.cacheSingleton) {
+				this._singletonServices[name] = created;
+			}
+
+			popIfCurrent();
+			return created;
+		} catch (error) {
+			popIfCurrent();
+			throw error;
 		}
+	}
+
+	private _assertNoCircularServiceDependency(
+		name: string,
+		stack: string[],
+	): void {
+		const existingIndex = stack.indexOf(name);
+		if (existingIndex === -1) return;
+
+		const cycle = [...stack.slice(existingIndex), name].join(" -> ");
+		throw new Error(`[QuestPie] Circular service dependency detected: ${cycle}`);
 	}
 
 	/**
@@ -432,36 +717,25 @@ export class Questpie<TConfig extends QuestpieConfig = QuestpieConfig> {
 	 * @internal Used by context creation for flat service injection.
 	 */
 	resolveService(name: string, requestDeps?: Record<string, any>): any {
-		// Check singleton cache first
-		if (this._singletonServices[name] !== undefined) {
+		const def = this._serviceDefs[name];
+		if (!def) return undefined;
+
+		if (def.lifecycle === "singleton") {
+			if (this._singletonServices[name] === undefined) {
+				throw new Error(
+					`[QuestPie] Singleton service "${name}" is not initialized. Await createApp() before accessing services.`,
+				);
+			}
 			return this._singletonServices[name];
 		}
 
-		// Create request-scoped service
-		const def = this.config.services?.[name];
-		if (!def) return undefined;
-
-		const deps: Record<string, any> = {};
-		if (def.deps) {
-			const infraDeps: Record<string, any> = {
-				db: this.db,
-				email: this.email,
-				queue: this.queue,
-				storage: this.storage,
-				kv: this.kv,
-				logger: this.logger,
-				search: this.search,
-				realtime: this.realtime,
-				auth: this.auth,
-				...this._singletonServices,
-				...requestDeps,
-			};
-			for (const depName of def.deps) {
-				deps[depName] = infraDeps[depName];
-			}
-		}
-
-		return def.create(deps);
+		return this._createServiceInstance(name, def, {
+			requestDeps,
+			stack: [],
+			cacheSingleton: false,
+			lazyTriggered: false,
+			allowAsync: false,
+		});
 	}
 
 	private registerCollections(

--- a/packages/questpie/src/server/config/types.ts
+++ b/packages/questpie/src/server/config/types.ts
@@ -544,10 +544,7 @@ export interface QuestpieConfig {
 	 */
 	services?: Record<
 		string,
-		import("#questpie/server/services/define-service.js").ServiceDefinition<
-			any,
-			any
-		>
+		import("#questpie/server/services/define-service.js").ServiceBuilder<any>
 	>;
 
 	/**

--- a/packages/questpie/src/server/services/define-service.ts
+++ b/packages/questpie/src/server/services/define-service.ts
@@ -1,142 +1,90 @@
 /**
- * Service Definition
- *
- * First-class convention for user services (Stripe, geocoding, email templates, etc.).
- * Services are discovered from `services/*.ts` by codegen and auto-injected into AppContext.
- *
- * @see RFC-CONTEXT-FIRST §5 (Services Convention)
- */
-
-// ============================================================================
-// Service Lifecycle
-// ============================================================================
-
-/**
  * Service lifecycle determines when a service is created and destroyed.
- *
- * - `singleton` — Created once at app startup, destroyed at app shutdown.
- *   Use for external clients, connection pools, SDK instances.
- *
- * - `request` — Created fresh per request, disposed at end of request.
- *   Use for tenant-scoped DB, user-specific config, request-scoped caches.
  */
 export type ServiceLifecycle = "singleton" | "request";
 
-// ============================================================================
-// Service Definition
-// ============================================================================
+declare global {
+	namespace Questpie {
+		interface ServiceCreateContext {
+			[key: string]: any;
+		}
+	}
+}
 
-/**
- * Service definition — describes how to create and manage a service instance.
- *
- * @example
- * ```ts
- * // services/stripe.ts
- * import { defineService } from "questpie";
- * import Stripe from "stripe";
- *
- * export default defineService({
- *   lifecycle: "singleton",
- *   deps: ["logger"] as const,
- *   create: ({ logger }) => {
- *     logger.info("Stripe initialized");
- *     return new Stripe(process.env.STRIPE_SECRET_KEY!);
- *   },
- * });
- * ```
- *
- * @example
- * ```ts
- * // services/tenant-db.ts — request-scoped
- * export default defineService({
- *   lifecycle: "request",
- *   deps: ["db", "session"] as const,
- *   create: ({ db, session }) => {
- *     return createScopedDb(db, session?.user?.tenantId);
- *   },
- * });
- * ```
- */
-export interface ServiceDefinition<
-	TDeps extends readonly string[] = readonly string[],
-	TInstance = unknown,
-> {
-	/**
-	 * Service lifecycle.
-	 * @default "singleton"
-	 */
+export interface ServiceBuilderState<TInstance = unknown> {
 	lifecycle?: ServiceLifecycle;
-
-	/**
-	 * Dependencies — names of other services or infrastructure this service needs.
-	 * These are resolved from AppContext before calling `create()`.
-	 *
-	 * Use `as const` for type-safe dependency injection:
-	 * ```ts
-	 * deps: ["db", "logger"] as const,
-	 * ```
-	 */
-	deps?: TDeps;
-
-	/**
-	 * Factory function that creates the service instance.
-	 * Receives resolved dependencies as an object.
-	 */
-	create: (deps: Record<TDeps[number], any>) => TInstance;
-
-	/**
-	 * Optional cleanup function called when the service is destroyed.
-	 * Only meaningful for singleton services (called at app shutdown)
-	 * or request services (called at end of request).
-	 */
+	create?: (
+		ctx: Questpie.ServiceCreateContext,
+	) => TInstance | Promise<TInstance>;
 	dispose?: (instance: TInstance) => void | Promise<void>;
+	namespace?: string | null;
 }
 
-/**
- * Define a service with type-safe dependency injection.
- *
- * Services are first-class citizens in QuestPie — discovered from `services/*.ts`
- * by codegen and automatically available in hook/function context.
- *
- * @param definition - Service definition with lifecycle, deps, and create factory.
- * @returns The service definition (identity function for type inference).
- *
- * @example
- * ```ts
- * // services/stripe.ts
- * import { defineService } from "questpie";
- * import Stripe from "stripe";
- *
- * export default defineService({
- *   lifecycle: "singleton",
- *   create: () => new Stripe(process.env.STRIPE_SECRET_KEY!),
- * });
- * ```
- */
-export function service<
-	const TDeps extends readonly string[],
-	TInstance,
->(
-	definition: ServiceDefinition<TDeps, TInstance>,
-): ServiceDefinition<TDeps, TInstance> {
-	return definition;
+export class ServiceBuilder<TInstance = unknown> {
+	readonly state: ServiceBuilderState<TInstance>;
+
+	constructor(state: ServiceBuilderState<TInstance> = {}) {
+		this.state = state;
+	}
+
+	create<T>(
+		factory: (ctx: Questpie.ServiceCreateContext) => T | Promise<T>,
+	): ServiceBuilder<T> {
+		return new ServiceBuilder<T>({
+			...(this.state as unknown as ServiceBuilderState<T>),
+			create: factory,
+		});
+	}
+
+	dispose(
+		fn: (instance: TInstance) => void | Promise<void>,
+	): ServiceBuilder<TInstance> {
+		return new ServiceBuilder<TInstance>({
+			...this.state,
+			dispose: fn,
+		});
+	}
+
+	lifecycle(lifecycle: ServiceLifecycle): ServiceBuilder<TInstance> {
+		return new ServiceBuilder<TInstance>({
+			...this.state,
+			lifecycle,
+		});
+	}
+
+	namespace(namespace: string | null): ServiceBuilder<TInstance> {
+		return new ServiceBuilder<TInstance>({
+			...this.state,
+			namespace,
+		});
+	}
 }
 
-/** @deprecated Use service() instead */
-export const defineService = service;
+export function service(): ServiceBuilder<unknown>;
+export function service<TInstance>(state: {
+	create: (
+		ctx: Questpie.ServiceCreateContext,
+	) => TInstance | Promise<TInstance>;
+	lifecycle?: ServiceLifecycle;
+	dispose?: (instance: TInstance) => void | Promise<void>;
+	namespace?: string | null;
+}): ServiceBuilder<TInstance>;
+export function service<TInstance>(state?: {
+	create?: (
+		ctx: Questpie.ServiceCreateContext,
+	) => TInstance | Promise<TInstance>;
+	lifecycle?: ServiceLifecycle;
+	dispose?: (instance: TInstance) => void | Promise<void>;
+	namespace?: string | null;
+}): ServiceBuilder<TInstance | unknown> {
+	return new ServiceBuilder<TInstance | unknown>(
+		(state ?? {}) as ServiceBuilderState<TInstance | unknown>,
+	);
+}
 
-/**
- * Extract the instance type from a service definition.
- * Used by codegen to generate typed AppContext.
- *
- * @example
- * ```ts
- * type StripeInstance = ServiceInstanceOf<typeof stripeService>;
- * // Stripe
- * ```
- */
-export type ServiceInstanceOf<T> = T extends ServiceDefinition<any, infer I>
-	? I
-	: T extends { create: (...args: any[]) => infer I }
+export type ServiceInstanceOf<T> =
+	T extends ServiceBuilder<infer I>
 		? I
-		: unknown;
+		: T extends { create: (...args: any[]) => infer I }
+			? I
+			: unknown;

--- a/packages/questpie/src/server/services/define-service.ts
+++ b/packages/questpie/src/server/services/define-service.ts
@@ -3,6 +3,8 @@
  */
 export type ServiceLifecycle = "singleton" | "request";
 
+export type ServiceNamespace = string | null | undefined;
+
 declare global {
 	namespace Questpie {
 		interface ServiceCreateContext {
@@ -11,49 +13,67 @@ declare global {
 	}
 }
 
-export interface ServiceBuilderState<TInstance = unknown> {
-	lifecycle?: ServiceLifecycle;
+export interface ServiceBuilderState<
+	TInstance = unknown,
+	TNamespace extends ServiceNamespace = undefined,
+	TLifecycle extends ServiceLifecycle | undefined = undefined,
+> {
+	lifecycle?: TLifecycle;
 	create?: (
 		ctx: Questpie.ServiceCreateContext,
 	) => TInstance | Promise<TInstance>;
 	dispose?: (instance: TInstance) => void | Promise<void>;
-	namespace?: string | null;
+	namespace?: TNamespace;
 }
 
-export class ServiceBuilder<TInstance = unknown> {
-	readonly state: ServiceBuilderState<TInstance>;
+export class ServiceBuilder<
+	TInstance = unknown,
+	TNamespace extends ServiceNamespace = undefined,
+	TLifecycle extends ServiceLifecycle | undefined = undefined,
+> {
+	readonly state: ServiceBuilderState<TInstance, TNamespace, TLifecycle>;
 
-	constructor(state: ServiceBuilderState<TInstance> = {}) {
+	constructor(
+		state: ServiceBuilderState<TInstance, TNamespace, TLifecycle> = {},
+	) {
 		this.state = state;
 	}
 
 	create<T>(
 		factory: (ctx: Questpie.ServiceCreateContext) => T | Promise<T>,
-	): ServiceBuilder<T> {
-		return new ServiceBuilder<T>({
-			...(this.state as unknown as ServiceBuilderState<T>),
+	): ServiceBuilder<T, TNamespace, TLifecycle> {
+		return new ServiceBuilder<T, TNamespace, TLifecycle>({
+			...(this.state as unknown as ServiceBuilderState<
+				T,
+				TNamespace,
+				TLifecycle
+			>),
 			create: factory,
 		});
 	}
 
 	dispose(
 		fn: (instance: TInstance) => void | Promise<void>,
-	): ServiceBuilder<TInstance> {
-		return new ServiceBuilder<TInstance>({
+	): ServiceBuilder<TInstance, TNamespace, TLifecycle> {
+		return new ServiceBuilder<TInstance, TNamespace, TLifecycle>({
 			...this.state,
 			dispose: fn,
 		});
 	}
 
-	lifecycle(lifecycle: ServiceLifecycle): ServiceBuilder<TInstance> {
-		return new ServiceBuilder<TInstance>({
+	lifecycle<TNextLifecycle extends ServiceLifecycle>(
+		lifecycle: TNextLifecycle,
+	): ServiceBuilder<TInstance, TNamespace, TNextLifecycle> {
+		return new ServiceBuilder<TInstance, TNamespace, TNextLifecycle>({
 			...this.state,
 			lifecycle,
 		});
 	}
 
-	namespace(namespace: string | null): ServiceBuilder<TInstance> {
-		return new ServiceBuilder<TInstance>({
+	namespace<TNextNamespace extends string | null>(
+		namespace: TNextNamespace,
+	): ServiceBuilder<TInstance, TNextNamespace, TLifecycle> {
+		return new ServiceBuilder<TInstance, TNextNamespace, TLifecycle>({
 			...this.state,
 			namespace,
 		});
@@ -61,21 +81,25 @@ export class ServiceBuilder<TInstance = unknown> {
 }
 
 export function service(): ServiceBuilder<unknown>;
-export function service<TInstance>(state: {
+export function service<
+	TInstance,
+	TNamespace extends ServiceNamespace,
+	TLifecycle extends ServiceLifecycle,
+>(state: {
 	create: (
 		ctx: Questpie.ServiceCreateContext,
 	) => TInstance | Promise<TInstance>;
-	lifecycle?: ServiceLifecycle;
+	lifecycle?: TLifecycle;
 	dispose?: (instance: TInstance) => void | Promise<void>;
-	namespace?: string | null;
-}): ServiceBuilder<TInstance>;
+	namespace?: TNamespace;
+}): ServiceBuilder<TInstance, TNamespace, TLifecycle>;
 export function service<TInstance>(state?: {
 	create?: (
 		ctx: Questpie.ServiceCreateContext,
 	) => TInstance | Promise<TInstance>;
 	lifecycle?: ServiceLifecycle;
 	dispose?: (instance: TInstance) => void | Promise<void>;
-	namespace?: string | null;
+	namespace?: ServiceNamespace;
 }): ServiceBuilder<TInstance | unknown> {
 	return new ServiceBuilder<TInstance | unknown>(
 		(state ?? {}) as ServiceBuilderState<TInstance | unknown>,
@@ -83,8 +107,17 @@ export function service<TInstance>(state?: {
 }
 
 export type ServiceInstanceOf<T> =
-	T extends ServiceBuilder<infer I>
+	T extends ServiceBuilder<infer I, any, any>
 		? I
 		: T extends { create: (...args: any[]) => infer I }
 			? I
 			: unknown;
+
+export type ServiceNamespaceOf<T> =
+	T extends ServiceBuilder<any, infer TNamespace, any>
+		? TNamespace
+		: T extends { state: { namespace?: infer TNamespace } }
+			? TNamespace
+			: T extends { namespace?: infer TNamespace }
+				? TNamespace
+				: undefined;

--- a/packages/questpie/test/codegen/template.test.ts
+++ b/packages/questpie/test/codegen/template.test.ts
@@ -201,7 +201,7 @@ describe("generateTemplate — minimal (modules.ts only)", () => {
 	});
 
 	it("emits createApp call with modules", () => {
-		expect(code).toContain("export const app = createApp(");
+		expect(code).toContain("export const app = await createApp(");
 		expect(code).toContain("modules: _modules as any");
 	});
 

--- a/packages/questpie/test/codegen/template.test.ts
+++ b/packages/questpie/test/codegen/template.test.ts
@@ -206,7 +206,9 @@ describe("generateTemplate — minimal (modules.ts only)", () => {
 	});
 
 	it("emits createContext helper", () => {
-		expect(code).toContain("export const createContext = createContextFactory(app);");
+		expect(code).toContain(
+			"export const createContext = createContextFactory(app);",
+		);
 	});
 
 	it("emits factory comment", () => {
@@ -469,7 +471,7 @@ describe("generateTemplate — seeds", () => {
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe("generateTemplate — services", () => {
-	it("emits ServiceInstanceOf import when services exist", () => {
+	it("imports ServiceInstanceOf type utility", () => {
 		const result = minimalResult();
 		cat(result, "services").set(
 			"stripe",
@@ -487,7 +489,7 @@ describe("generateTemplate — services", () => {
 			singletonFactories: coreSingletonFactories(),
 		});
 
-		expect(code).toContain('import type { ServiceInstanceOf } from "questpie"');
+		expect(code).toContain("ServiceInstanceOf");
 	});
 
 	it("emits services in AppServices type", () => {
@@ -508,10 +510,14 @@ describe("generateTemplate — services", () => {
 			singletonFactories: coreSingletonFactories(),
 		});
 
-		expect(code).toContain("stripe: ServiceInstanceOf<typeof _svc_stripe>;");
+		expect(code).toContain("type _AppServiceDefinitions = _ModuleServices & {");
+		expect(code).toContain("stripe: typeof _svc_stripe;");
+		expect(code).toContain(
+			"[K in keyof _AppServiceDefinitions]: ServiceInstanceOf<_AppServiceDefinitions[K]>;",
+		);
 	});
 
-	it("exposes services flat on AppContext", () => {
+	it("emits namespace-aware service context helpers", () => {
 		const result = minimalResult();
 		cat(result, "services").set(
 			"stripe",
@@ -529,8 +535,19 @@ describe("generateTemplate — services", () => {
 			singletonFactories: coreSingletonFactories(),
 		});
 
-		// Should appear inside declare module "questpie" { interface AppContext
-		expect(code).toContain("stripe: ServiceInstanceOf<typeof _svc_stripe>;");
+		expect(code).toContain(
+			"type _AppTopLevelServices = ServiceTopLevelInstances<_AppServiceDefinitions>;",
+		);
+		expect(code).toContain(
+			"type _AppCustomServiceNamespaces = ServiceCustomNamespaceInstances<_AppServiceDefinitions>;",
+		);
+		expect(code).toContain(
+			"interface AppContext extends _AppTopLevelServices, _AppCustomServiceNamespaces {",
+		);
+		expect(code).toContain("services: _AppDefaultServices;");
+		expect(code).toContain(
+			"interface ServiceCreateContext extends AppContext {}",
+		);
 	});
 });
 

--- a/packages/questpie/test/migration/migrations.test.ts
+++ b/packages/questpie/test/migration/migrations.test.ts
@@ -40,7 +40,7 @@ describe("Migration System - Programmatic", () => {
 			collections: { posts },
 		});
 
-		app = createApp(def, {
+		app = await createApp(def, {
 			app: { url: "http://localhost:3000" },
 			db: { pglite: pgClient },
 			email: { adapter: new MockMailAdapter() },
@@ -277,7 +277,7 @@ describe("Migration System - DrizzleMigrationGenerator", () => {
 		}));
 
 		const def = module({ name: "test-app", collections: { posts } });
-		const app = createApp(def, {
+		const app = await createApp(def, {
 			app: { url: "http://localhost:3000" },
 			db: { pglite: pgClient },
 			email: { adapter: new MockMailAdapter() },
@@ -316,7 +316,7 @@ describe("Migration System - DrizzleMigrationGenerator", () => {
 		}));
 
 		const def = module({ name: "test-app", collections: { posts } });
-		const app = createApp(def, {
+		const app = await createApp(def, {
 			app: { url: "http://localhost:3000" },
 			db: { pglite: pgClient },
 			email: { adapter: new MockMailAdapter() },

--- a/packages/questpie/test/unit/services/service-system.test.ts
+++ b/packages/questpie/test/unit/services/service-system.test.ts
@@ -1,0 +1,265 @@
+import { describe, expect, it } from "bun:test";
+import {
+	ServiceBuilder,
+	createApp,
+	extractAppServices,
+	module,
+	service,
+	type ServiceInstanceOf,
+} from "../../../src/exports/index.js";
+import { MockKVAdapter } from "../../utils/mocks/kv.adapter.js";
+import { MockLogger } from "../../utils/mocks/logger.adapter.js";
+import { MockMailAdapter } from "../../utils/mocks/mailer.adapter.js";
+import { MockQueueAdapter } from "../../utils/mocks/queue.adapter.js";
+import { createTestDb } from "../../utils/test-db.js";
+
+async function createServiceApp(
+	services: Record<string, ServiceBuilder<any>>,
+): Promise<{ app: any; cleanup: () => Promise<void> }> {
+	const db = await createTestDb();
+
+	try {
+		const app = await createApp(
+			module({
+				name: "service-test",
+				services,
+			}),
+			{
+				app: { url: "http://localhost:3000" },
+				db: { pglite: db },
+				email: { adapter: new MockMailAdapter() },
+				queue: { adapter: new MockQueueAdapter() },
+				kv: { adapter: new MockKVAdapter() },
+				logger: { adapter: new MockLogger() },
+			},
+		);
+
+		return {
+			app,
+			cleanup: async () => {
+				await app.destroy();
+				await db.close();
+			},
+		};
+	} catch (error) {
+		await db.close();
+		throw error;
+	}
+}
+
+describe("service system", () => {
+	it("builds immutable ServiceBuilder chains without .build()", () => {
+		const base = service();
+		const withLifecycle = base.lifecycle("singleton");
+		const withCreate = withLifecycle.create(() => ({ ok: true }));
+		const withDispose = withCreate.dispose(() => {});
+		const withNamespace = withDispose.namespace("analytics");
+
+		expect(base).toBeInstanceOf(ServiceBuilder);
+		expect(base).not.toBe(withLifecycle);
+		expect(withLifecycle).not.toBe(withCreate);
+		expect(withCreate).not.toBe(withDispose);
+		expect(withDispose).not.toBe(withNamespace);
+
+		expect(base.state.lifecycle).toBeUndefined();
+		expect(withLifecycle.state.lifecycle).toBe("singleton");
+		expect(typeof withCreate.state.create).toBe("function");
+		expect(typeof withDispose.state.dispose).toBe("function");
+		expect(withNamespace.state.namespace).toBe("analytics");
+		expect("build" in withNamespace).toBe(false);
+	});
+
+	it("wraps plain object services into ServiceBuilder", () => {
+		const wrapped = service({
+			lifecycle: "singleton",
+			namespace: null,
+			create: () => ({ ok: true }),
+		});
+
+		expect(wrapped).toBeInstanceOf(ServiceBuilder);
+		expect(wrapped.state.lifecycle).toBe("singleton");
+		expect(wrapped.state.namespace).toBeNull();
+		expect((wrapped.state.create as (ctx: any) => { ok: boolean })({}).ok).toBe(
+			true,
+		);
+	});
+
+	it("extracts ServiceInstanceOf from builders and plain create() fallback", () => {
+		const typedBuilder = service().create(() => ({ ping: () => "pong" }));
+
+		type BuilderInstance = ServiceInstanceOf<typeof typedBuilder>;
+		const builderInstance: BuilderInstance = { ping: () => "pong" };
+		expect(builderInstance.ping()).toBe("pong");
+
+		type PlainInstance = ServiceInstanceOf<{ create: () => number }>;
+		const plainInstance: PlainInstance = 7;
+		expect(plainInstance).toBe(7);
+	});
+
+	it("initializes singleton services with lazy proxy context", async () => {
+		const creationOrder: string[] = [];
+
+		const alpha = service().create(() => {
+			creationOrder.push("alpha");
+			return { value: 40 };
+		});
+
+		const beta = service().create(({ services }) => {
+			creationOrder.push("beta:start");
+			const value = services.alpha.value + 2;
+			creationOrder.push("beta:end");
+			return { value };
+		});
+
+		const { app, cleanup } = await createServiceApp({ beta, alpha });
+		try {
+			const ctx = extractAppServices(app);
+			expect((ctx.services as any).beta.value).toBe(42);
+			expect(creationOrder).toEqual(["beta:start", "alpha", "beta:end"]);
+		} finally {
+			await cleanup();
+		}
+	});
+
+	it("throws on circular singleton dependencies", async () => {
+		const alpha = service().create(({ services }) => ({
+			value: services.beta.value + 1,
+		}));
+
+		const beta = service().create(({ services }) => ({
+			value: services.alpha.value + 1,
+		}));
+
+		await expect(createServiceApp({ alpha, beta })).rejects.toThrow(
+			"Circular service dependency detected",
+		);
+	});
+
+	it("awaits async singleton create() during app initialization", async () => {
+		const asyncService = service().create(async () => {
+			await Promise.resolve();
+			return { ready: true };
+		});
+
+		const consumer = service().create(({ services }) => ({
+			ready: services.asyncService.ready,
+		}));
+
+		const { app, cleanup } = await createServiceApp({ asyncService, consumer });
+		try {
+			const ctx = extractAppServices(app);
+			expect((ctx.services as any).consumer.ready).toBe(true);
+		} finally {
+			await cleanup();
+		}
+	});
+
+	it("throws when async create() is lazily triggered", async () => {
+		const asyncService = service().create(async () => ({ ready: true }));
+		const consumer = service().create(({ services }) => ({
+			ready: services.asyncService.ready,
+		}));
+
+		await expect(createServiceApp({ consumer, asyncService })).rejects.toThrow(
+			'Service "asyncService" has async create() but was lazily triggered',
+		);
+	});
+
+	it("places services by namespace in extracted AppContext", async () => {
+		const blog = service().create(() => ({ kind: "blog" }));
+		const workflows = service().namespace(null).create(() => ({ kind: "workflows" }));
+		const tracker = service()
+			.namespace("analytics")
+			.create(() => ({ kind: "tracker" }));
+
+		const { app, cleanup } = await createServiceApp({
+			blog,
+			workflows,
+			tracker,
+		});
+		try {
+			const ctx = extractAppServices(app);
+			expect((ctx.services as any).blog.kind).toBe("blog");
+			expect((ctx as any).workflows.kind).toBe("workflows");
+			expect((ctx as any).analytics.tracker.kind).toBe("tracker");
+			expect((ctx.services as any).workflows).toBeUndefined();
+		} finally {
+			await cleanup();
+		}
+	});
+
+	it("throws when request-scoped service uses non-default namespace", async () => {
+		const invalid = service()
+			.lifecycle("request")
+			.namespace("analytics")
+			.create(() => ({}));
+
+		await expect(createServiceApp({ invalid })).rejects.toThrow(
+			"only singleton services may use non-default namespaces",
+		);
+	});
+
+	it("creates request-scoped services per context extraction", async () => {
+		let sequence = 0;
+
+		const requestOnly = service()
+			.lifecycle("request")
+			.create(({ session }) => ({
+				id: ++sequence,
+				userId: session?.user?.id ?? null,
+			}));
+
+		const { app, cleanup } = await createServiceApp({ requestOnly });
+		try {
+			const ctxA = extractAppServices(app, {
+				session: { user: { id: "user-a" }, session: {} } as any,
+			});
+			const ctxB = extractAppServices(app, {
+				session: { user: { id: "user-b" }, session: {} } as any,
+			});
+
+			expect((ctxA.services as any).requestOnly.id).toBe(1);
+			expect((ctxB.services as any).requestOnly.id).toBe(2);
+			expect((ctxA.services as any).requestOnly.userId).toBe("user-a");
+			expect((ctxB.services as any).requestOnly.userId).toBe("user-b");
+		} finally {
+			await cleanup();
+		}
+	});
+
+	it("disposes all singleton services on destroy", async () => {
+		const disposed: string[] = [];
+
+		const blog = service()
+			.create(() => ({ ok: true }))
+			.dispose(() => {
+				disposed.push("blog");
+			});
+
+		const workflows = service()
+			.namespace(null)
+			.create(() => ({ ok: true }))
+			.dispose(() => {
+				disposed.push("workflows");
+			});
+
+		const requestOnly = service()
+			.lifecycle("request")
+			.create(() => ({ ok: true }))
+			.dispose(() => {
+				disposed.push("request-only");
+			});
+
+		const { app, cleanup } = await createServiceApp({
+			blog,
+			workflows,
+			requestOnly,
+		});
+		try {
+			await app.destroy();
+			expect(disposed.sort()).toEqual(["blog", "workflows"]);
+		} finally {
+			await cleanup();
+		}
+	});
+});

--- a/packages/questpie/test/utils/mocks/mock-app-builder.ts
+++ b/packages/questpie/test/utils/mocks/mock-app-builder.ts
@@ -70,7 +70,7 @@ export async function buildMockApp(
 	const { locale, contextResolver, ...moduleDef } = definition as any;
 	const normalizedDef = module({ name: "test", ...moduleDef });
 
-	const app = createApp(
+	const app = await createApp(
 		{ modules: [normalizedDef], locale, contextResolver },
 		{
 			app: runtimeOverrides.app ?? { url: "http://localhost:3000" },


### PR DESCRIPTION
## Summary
- replace `ServiceDefinition`/`deps` with immutable `ServiceBuilder` (`create`, `dispose`, `lifecycle`, `namespace`) and add global `Questpie.ServiceCreateContext`
- refactor service runtime to resolve builder state once, initialize singletons after `app.state`, and inject lazy proxy context with circular-dependency + async lazy-trigger guards
- make `createApp` async in both definition and legacy flows, update codegen/templates to emit `await createApp(...)`, and update existing tests/call sites
- add namespace-aware context extraction (`services.*`, top-level for `namespace: null`, custom namespace objects) and a new comprehensive service-system unit suite

## Validation
- `bun test` (1337 pass)
- `bun run check-types` in `packages/questpie`
- `bun run check-types` in `packages/create-questpie`

## Follow-ups
- runtime is now ready for package-level services needed by workflows/channels; dynamic AppContext namespace typing remains tracked in `QUE-169`