### PR TITLE
fix(docs): build vite-plugin-iconify before docs build in Docker

### DIFF
--- a/apps/docs/Dockerfile
+++ b/apps/docs/Dockerfile
@@ -31,6 +31,9 @@ COPY --from=pruner /app/out/full/ .
 # Install dependencies
 RUN bun install --frozen-lockfile
 
+# Build workspace dependencies first (vite-plugin-iconify dist/ is gitignored)
+RUN bun run --filter @questpie/vite-plugin-iconify build
+
 # Build docs app
 WORKDIR /app/apps/docs
 ENV DISABLE_PRERENDER=true


### PR DESCRIPTION
## Summary
- Pipeline #64 (and #62, #61, #59) failed in `build-docs`: `Failed to resolve entry for package "@questpie/vite-plugin-iconify"`.
- Root cause: `packages/vite-plugin-iconify/dist/` is gitignored, so `turbo prune --docker` ships only sources. After `bun install` the workspace package has no built entry, and `vite.config.ts` (which imports `iconifyPreload`) fails to load.
- Fix: build the workspace package after install, before the docs build.

## Test plan
- [ ] Woodpecker pipeline on this branch / after merge passes the `build-docs` step
- [ ] Docs deployment rolls out new version