### PR TITLE
fix(crud, queue): race-free global auto-create, jsonb input normalization, pg-boss v10+ shape

### DIFF
--- a/.changeset/crud-race-jsonb-pgboss-fixes.md
+++ b/.changeset/crud-race-jsonb-pgboss-fixes.md
@@ -1,0 +1,13 @@
+---
+"questpie": patch
+---
+
+Fix three independent bugs in the CRUD + queue layer.
+
+**Race in `globals.<name>.get` auto-create.** Two concurrent `get(...)` calls against a fresh global both saw zero rows under READ COMMITTED and each inserted a "default-valued" auto-created row, leaving the database with two singletons. Auto-create now takes a transaction-scoped `pg_advisory_xact_lock(hashtext('questpie:global:<name>'))` and re-checks existence inside the locked transaction before inserting. Applied to both the workflow-versions branch and the plain branch. Schema-free — no migration. Backends without `pg_advisory_xact_lock` log a warning and fall back to the existence re-check.
+
+**Pre-stringified jsonb values stored as jsonb strings.** When upstream code (legacy seeds, RPC layers, custom hooks) handed an already-`JSON.stringify`'d array or object to `globals.<name>.update(...)` or `collections.<name>.create/update(...)`, Drizzle's jsonb `mapToDriverValue` stringified it a second time and Postgres stored a jsonb string instead of the intended array/object. The framework now normalizes input for jsonb-backed fields (`f.json()`, `f.object()`, `f.<x>().array()`, `f.blocks()`) before validation, hooks, and write — pre-stringified arrays/objects are decoded back to their plain JS values. Field input hooks always observe decoded values.
+
+**`pgBossAdapter` ignored pg-boss v10+ array callback shape.** pg-boss v10+ calls `work()` callbacks with `Job<T>[]` regardless of `batchSize`. The adapter destructured `job.id` / `job.data` straight off the array → both `undefined` → registered handlers received `payload: undefined` and every job failed Zod validation upstream. `listen()` now iterates the array, dispatches each job to the handler, and reports per-item failures via `boss.fail(jobName, id, …)` so siblings in the same batch still complete and the failed job retries independently. `runOnce()` already handled the array shape correctly via `fetch()` and is unchanged.
+
+All three fixes are backwards-compatible. No public API changes, no schema migrations.

--- a/packages/questpie/src/server/collection/crud/crud-generator.ts
+++ b/packages/questpie/src/server/collection/crud/crud-generator.ts
@@ -66,6 +66,7 @@ import {
 	getDb,
 	mergeI18nRows,
 	normalizeContext,
+	normalizeJsonbInput,
 	resolveFieldKey,
 	splitLocalizedFields,
 	withTransaction,
@@ -1399,6 +1400,13 @@ export class CRUDGenerator<TState extends CollectionBuilderState> {
 						nestedRelations,
 					));
 
+					// Decode any pre-stringified jsonb values before any hook or write
+					// path observes them — see normalizeJsonbInput.
+					regularFields = normalizeJsonbInput(
+						regularFields,
+						this.state.fieldDefinitions,
+					);
+
 					// Validate field-level write access (on regular fields only)
 					await this.validateFieldWriteAccess(
 						regularFields,
@@ -1692,6 +1700,16 @@ export class CRUDGenerator<TState extends CollectionBuilderState> {
 		// This prevents the validation schema from stripping relation fields
 		let { regularFields, nestedRelations } =
 			this.separateNestedRelationsInternal(data);
+
+		// Decode any pre-stringified jsonb values before any hook or write
+		// path observes them. Drizzle stringifies jsonb values itself; if a
+		// caller (legacy seed, RPC, etc.) passes an already-encoded JSON
+		// string for a jsonb column, double-encoding stores a jsonb string
+		// instead of the intended array/object.
+		regularFields = normalizeJsonbInput(
+			regularFields,
+			this.state.fieldDefinitions,
+		);
 
 		// 4. Global Validation (Zod)
 		if (this.state.validation?.updateSchema) {

--- a/packages/questpie/src/server/collection/crud/shared/index.ts
+++ b/packages/questpie/src/server/collection/crud/shared/index.ts
@@ -39,6 +39,7 @@ export {
 	createHookContext,
 	executeHooks,
 } from "./hooks.js";
+export { isJsonbBackedField, normalizeJsonbInput } from "./jsonb-input.js";
 export {
 	hasI18nPrefixedColumns,
 	I18N_CURRENT_PREFIX,

--- a/packages/questpie/src/server/collection/crud/shared/jsonb-input.ts
+++ b/packages/questpie/src/server/collection/crud/shared/jsonb-input.ts
@@ -1,0 +1,109 @@
+/**
+ * JSONB input normalization.
+ *
+ * Drizzle's pg `jsonb` column already serializes JS values to JSON via
+ * `mapToDriverValue`. If the framework (or upstream caller — e.g. a seed
+ * script, an RPC layer, a custom hook) hands Drizzle a value that is *already*
+ * a JSON-encoded string, Drizzle stringifies it a second time and the column
+ * stores the encoded string as a jsonb string instead of the intended array
+ * or object. Reads then return strings to clients, breaking any consumer
+ * that iterates the value as an array.
+ *
+ * This helper normalizes the input *before* it reaches Drizzle's `set(...)` /
+ * `values(...)`. For every field that is backed by a jsonb column, if the
+ * value is a string that parses as a JSON array or object, it is replaced
+ * with the parsed value. Non-jsonb fields are left untouched so that
+ * legitimate text-column strings are preserved.
+ */
+
+import type { FieldState } from "#questpie/server/fields/field-class-types.js";
+import type { Field } from "#questpie/server/fields/field-class.js";
+
+/**
+ * Drizzle column types that store as PostgreSQL jsonb.
+ *
+ * `array` is the result of any `.array()` call — `Field.array()` overrides the
+ * column factory to `jsonb(name)` regardless of the inner field's type.
+ * `json` defaults to `mode: "jsonb"` (the `mode: "json"` variant is mapped
+ * the same way by Drizzle, so the same normalization applies).
+ */
+const JSONB_FIELD_TYPES = new Set([
+	"array",
+	"object",
+	"json",
+	"blocks",
+]);
+
+/**
+ * True if `fieldDef` is stored as a jsonb column.
+ */
+export function isJsonbBackedField(fieldDef: Field<FieldState>): boolean {
+	if (fieldDef._state.isArray) return true;
+	return JSONB_FIELD_TYPES.has(fieldDef.getType());
+}
+
+/**
+ * Decode a value that was accidentally pre-stringified for a jsonb column.
+ * Only string inputs that parse as a JSON array or object are decoded —
+ * primitive jsonb values (number / boolean / quoted string) and unparseable
+ * strings are returned untouched, since `jsonb` legitimately accepts those.
+ */
+function decodePreStringifiedJsonb(value: unknown): unknown {
+	if (typeof value !== "string") return value;
+
+	// Cheap shape check first — avoids paying for JSON.parse on every plain
+	// string we might encounter (description fields, etc.).
+	const trimmed = value.trim();
+	const first = trimmed.charCodeAt(0);
+	const ARRAY_OPEN = 0x5b; // [
+	const OBJECT_OPEN = 0x7b; // {
+	if (first !== ARRAY_OPEN && first !== OBJECT_OPEN) return value;
+
+	try {
+		const parsed = JSON.parse(value);
+		if (
+			parsed !== null &&
+			(Array.isArray(parsed) || typeof parsed === "object")
+		) {
+			return parsed;
+		}
+	} catch {
+		// Not valid JSON — leave the string as-is. Drizzle will stringify it
+		// once and Postgres will store it as a jsonb string, which is
+		// presumably what the caller intended.
+	}
+	return value;
+}
+
+/**
+ * Normalize input data for jsonb-backed fields by decoding any
+ * accidentally-stringified array/object values back into plain JS.
+ *
+ * Runs before field input hooks so that hooks (`beforeChange`, etc.) always
+ * see decoded values, never JSON strings.
+ *
+ * @param data - Input data being prepared for write
+ * @param fieldDefinitions - Field definitions for the collection / global
+ * @returns A new object with jsonb fields normalized; other fields untouched
+ */
+export function normalizeJsonbInput(
+	data: Record<string, unknown>,
+	fieldDefinitions: Record<string, Field<FieldState>> | undefined,
+): Record<string, unknown> {
+	if (!fieldDefinitions) return data;
+
+	let result: Record<string, unknown> | null = null;
+
+	for (const [key, value] of Object.entries(data)) {
+		const fieldDef = fieldDefinitions[key];
+		if (!fieldDef || !isJsonbBackedField(fieldDef)) continue;
+
+		const normalized = decodePreStringifiedJsonb(value);
+		if (normalized !== value) {
+			if (result === null) result = { ...data };
+			result[key] = normalized;
+		}
+	}
+
+	return result ?? data;
+}

--- a/packages/questpie/src/server/global/crud/global-crud-generator.ts
+++ b/packages/questpie/src/server/global/crud/global-crud-generator.ts
@@ -18,6 +18,7 @@ import {
 	getRestrictedReadFields,
 	mergeI18nRows,
 	normalizeContext,
+	normalizeJsonbInput,
 	onAfterCommit,
 	splitLocalizedFields,
 	withTransaction,
@@ -348,6 +349,33 @@ export class GlobalCRUDGenerator<TState extends GlobalBuilderState> {
 		return rows[0] || null;
 	}
 
+	/**
+	 * Acquire a transaction-scoped Postgres advisory lock keyed on the global's
+	 * table name. Serializes auto-create attempts across concurrent processes so
+	 * we never end up with two singleton rows for the same global.
+	 *
+	 * Released automatically on COMMIT/ROLLBACK. No-op (with a warning) on DBs
+	 * that do not implement `pg_advisory_xact_lock` — the subsequent existence
+	 * re-check is the actual correctness guard.
+	 */
+	private async acquireAutoCreateLock(tx: any): Promise<void> {
+		const lockKey = `questpie:global:${this.state.name}`;
+		try {
+			await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${lockKey}))`);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			// Only swallow the "function does not exist" case — anything else
+			// (permission errors, connection errors, …) must surface so we don't
+			// silently mask a broken DB configuration in production.
+			if (!/pg_advisory_xact_lock|does not exist/i.test(message)) {
+				throw error;
+			}
+			console.warn(
+				`[questpie] pg_advisory_xact_lock unavailable; auto-create for global "${this.state.name}" falls back to existence re-check only. Underlying error: ${message}`,
+			);
+		}
+	}
+
 	private createGet() {
 		return async (
 			options: GlobalGetOptions = {},
@@ -395,6 +423,16 @@ export class GlobalCRUDGenerator<TState extends GlobalBuilderState> {
 
 				if (!baseRow) {
 					baseRow = await withTransaction(db, async (tx: any) => {
+						// Serialize concurrent auto-creates: take the lock first, then
+						// re-check existence inside the locked transaction. Without this
+						// two boot-time fetches can both see "0 rows" and both INSERT.
+						await this.acquireAutoCreateLock(tx);
+
+						const existingAfterLock = await this.getCurrentRow(tx, normalized);
+						if (existingAfterLock) {
+							return existingAfterLock;
+						}
+
 						const insertValues: Record<string, any> = {};
 						if (isScoped) {
 							insertValues.scopeId = scopeId ?? null;
@@ -469,21 +507,34 @@ export class GlobalCRUDGenerator<TState extends GlobalBuilderState> {
 
 				if (!row) {
 					row = await withTransaction(db, async (tx: any) => {
-						// Auto-create with scope_id if scoped
-						const insertValues: Record<string, any> = {};
-						if (isScoped) {
-							insertValues.scopeId = scopeId ?? null;
-						}
+						// Serialize concurrent auto-creates: take the lock first, then
+						// re-check existence inside the locked transaction. Without this
+						// two boot-time fetches can both see "0 rows" and both INSERT.
+						await this.acquireAutoCreateLock(tx);
 
-						const [inserted] = await tx
-							.insert(this.table)
-							.values(insertValues)
-							.returning();
-						if (!inserted) {
-							throw ApiError.internal("Failed to auto-create global record");
-						}
+						const existingAfterLock = await this.getCurrentRow(tx, normalized);
 
-						await this.createVersion(tx, inserted, "create", normalized);
+						let baseRecord = existingAfterLock;
+						if (!baseRecord) {
+							// Auto-create with scope_id if scoped
+							const insertValues: Record<string, any> = {};
+							if (isScoped) {
+								insertValues.scopeId = scopeId ?? null;
+							}
+
+							const [inserted] = await tx
+								.insert(this.table)
+								.values(insertValues)
+								.returning();
+							if (!inserted) {
+								throw ApiError.internal(
+									"Failed to auto-create global record",
+								);
+							}
+
+							await this.createVersion(tx, inserted, "create", normalized);
+							baseRecord = inserted;
+						}
 
 						const {
 							query: createdQuery,
@@ -491,7 +542,7 @@ export class GlobalCRUDGenerator<TState extends GlobalBuilderState> {
 							needsFallback: createdNeedsFallback,
 						} = this.buildSelectQuery(tx, normalized, options.columns);
 						let createdRows = await createdQuery
-							.where(eq((this.table as any).id, inserted.id))
+							.where(eq((this.table as any).id, baseRecord.id))
 							.limit(1);
 
 						// Application-side i18n merge
@@ -506,7 +557,7 @@ export class GlobalCRUDGenerator<TState extends GlobalBuilderState> {
 							});
 						}
 
-						return createdRows[0] || inserted;
+						return createdRows[0] || baseRecord;
 					});
 				}
 			}
@@ -615,6 +666,16 @@ export class GlobalCRUDGenerator<TState extends GlobalBuilderState> {
 			// Separate nested relation operations from regular fields
 			let { regularFields, nestedRelations } =
 				this.separateNestedRelationsInternal(data);
+
+			// Decode any pre-stringified jsonb values before any hook or write
+			// path observes them. Drizzle stringifies jsonb values itself; if a
+			// caller (legacy seed, RPC, etc.) passes an already-encoded JSON
+			// string for a jsonb column, double-encoding stores a jsonb string
+			// instead of the intended array/object.
+			regularFields = normalizeJsonbInput(
+				regularFields,
+				this.state.fieldDefinitions,
+			);
 
 			// Validate field-level write access
 			await this.validateFieldWriteAccess(

--- a/packages/questpie/src/server/modules/core/integrated/queue/adapters/pg-boss.ts
+++ b/packages/questpie/src/server/modules/core/integrated/queue/adapters/pg-boss.ts
@@ -88,8 +88,39 @@ export class PgBossAdapter implements QueueAdapter {
 			const handler = handlers[jobName];
 			if (!handler) continue;
 
-			await this.boss.work(jobName, options as any, async (job: any) => {
-				await handler({ id: job.id, data: job.data });
+			// pg-boss v10+ always passes an array to work() callbacks, regardless
+			// of batchSize. Iterating jobs serially keeps the existing teamSize/
+			// batchSize semantics (one batch per worker callback). Per-item
+			// failures are reported to pg-boss via boss.fail(jobName, id, …) so
+			// they retry independently while siblings in the same batch still
+			// complete.
+			await this.boss.work(jobName, options as any, async (jobs: any) => {
+				const arr: any[] = Array.isArray(jobs) ? jobs : jobs ? [jobs] : [];
+				for (const j of arr) {
+					try {
+						await handler({ id: String(j.id), data: j.data });
+					} catch (error) {
+						const err =
+							error instanceof Error
+								? error
+								: new Error(typeof error === "string" ? error : String(error));
+						try {
+							await this.boss.fail(jobName, String(j.id), {
+								message: err.message,
+								stack: err.stack,
+							});
+						} catch (failError) {
+							// If reporting the failure itself fails, surface the
+							// original handler error so pg-boss's own timeout/retry
+							// path can take over.
+							console.error(
+								`[questpie:pg-boss] failed to mark job ${j.id} as failed`,
+								failError,
+							);
+							throw err;
+						}
+					}
+				}
 			});
 		}
 	}

--- a/packages/questpie/test/global/global-auto-create-race.test.ts
+++ b/packages/questpie/test/global/global-auto-create-race.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Regression test for the race condition where two concurrent
+ * `globals.<name>.get(...)` calls each saw zero rows and each inserted a
+ * fresh "auto-created" singleton, leaving the database with two rows for
+ * a global that is supposed to have exactly one.
+ *
+ * The fix takes a Postgres transaction-scoped advisory lock keyed on the
+ * table name, then re-checks existence inside the locked transaction
+ * before inserting. See `acquireAutoCreateLock` in
+ * `packages/questpie/src/server/global/crud/global-crud-generator.ts`.
+ */
+
+import { sql } from "drizzle-orm";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+
+import { global } from "../../src/exports/index.js";
+import { buildMockApp } from "../utils/mocks/mock-app-builder";
+import { createTestContext } from "../utils/test-context";
+import { runTestDbMigrations } from "../utils/test-db";
+
+const header_settings = global("header_settings").fields(({ f }) => ({
+	title: f.text().default("Header"),
+}));
+
+const versioned_settings = global("versioned_settings")
+	.fields(({ f }) => ({
+		title: f.text().default("Versioned"),
+	}))
+	.options({ versioning: { enabled: true } });
+
+describe("globals auto-create race condition", () => {
+	let setup: Awaited<ReturnType<typeof buildMockApp>>;
+	let app: any;
+
+	beforeEach(async () => {
+		setup = await buildMockApp({
+			globals: { header_settings, versioned_settings },
+		});
+		app = setup.app;
+		await runTestDbMigrations(app);
+	});
+
+	afterEach(async () => {
+		await setup.cleanup();
+	});
+
+	it("produces exactly one row under N concurrent get() calls (plain branch)", async () => {
+		const ctx = createTestContext({ accessMode: "system" });
+
+		const results = await Promise.all(
+			Array.from({ length: 20 }, () => app.globals.header_settings.get({}, ctx)),
+		);
+
+		// All callers see the auto-created row
+		expect(results.every((r) => r != null)).toBe(true);
+
+		const countResult = await app.db.execute(
+			sql`SELECT COUNT(*)::int AS c FROM header_settings`,
+		);
+		const row = (countResult.rows ?? countResult)[0];
+		expect(row.c).toBe(1);
+	});
+
+	it("produces exactly one row under N concurrent get() calls (versioned branch)", async () => {
+		const ctx = createTestContext({ accessMode: "system" });
+
+		const results = await Promise.all(
+			Array.from({ length: 20 }, () =>
+				app.globals.versioned_settings.get({}, ctx),
+			),
+		);
+
+		expect(results.every((r) => r != null)).toBe(true);
+
+		const countResult = await app.db.execute(
+			sql`SELECT COUNT(*)::int AS c FROM versioned_settings`,
+		);
+		const row = (countResult.rows ?? countResult)[0];
+		expect(row.c).toBe(1);
+
+		// And exactly one initial version
+		const versionsResult = await app.db.execute(
+			sql`SELECT COUNT(*)::int AS c FROM versioned_settings_versions`,
+		);
+		const versionsRow = (versionsResult.rows ?? versionsResult)[0];
+		expect(versionsRow.c).toBe(1);
+	});
+});

--- a/packages/questpie/test/units/global-jsonb-encoding.test.ts
+++ b/packages/questpie/test/units/global-jsonb-encoding.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Regression test for the jsonb double-encoding bug where calling
+ * `globals.<name>.update({ field: [...] })` stored the array as a
+ * JSON-encoded string in the jsonb column instead of a jsonb array.
+ *
+ * Reads via Drizzle were then strings, breaking any consumer that iterated
+ * the value as an array.
+ */
+
+import { sql } from "drizzle-orm";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+
+import { global } from "../../src/exports/index.js";
+import { buildMockApp } from "../utils/mocks/mock-app-builder";
+import { createTestContext } from "../utils/test-context";
+import { runTestDbMigrations } from "../utils/test-db";
+
+describe("globals jsonb encoding", () => {
+	describe("plain global with jsonb array field", () => {
+		const header_settings = global("header_settings").fields(({ f }) => ({
+			menuItems: f
+				.object({
+					label: f.text().required(),
+					link: f.text().required(),
+					isExternal: f.boolean(),
+				})
+				.array()
+				.default([] as any),
+		}));
+
+		let setup: Awaited<ReturnType<typeof buildMockApp>>;
+		let app: any;
+
+		beforeEach(async () => {
+			setup = await buildMockApp({ globals: { header_settings } });
+			app = setup.app;
+			await runTestDbMigrations(app);
+		});
+
+		afterEach(async () => {
+			await setup.cleanup();
+		});
+
+		it("stores jsonb array values as arrays — not as JSON-encoded strings", async () => {
+			const ctx = createTestContext({ accessMode: "system" });
+
+			await app.globals.header_settings.update(
+				{
+					menuItems: [
+						{ label: "O nás", link: "/about", isExternal: false },
+						{ label: "Kontakt", link: "/contact", isExternal: false },
+					],
+				},
+				ctx,
+			);
+
+			const result = await app.db.execute(
+				sql`SELECT "menuItems", jsonb_typeof("menuItems") AS t FROM header_settings LIMIT 1`,
+			);
+			const row = (result.rows ?? result)[0];
+
+			expect(row.t).toBe("array");
+			expect(Array.isArray(row.menuItems)).toBe(true);
+			expect(row.menuItems).toHaveLength(2);
+			expect(row.menuItems[0].label).toBe("O nás");
+		});
+
+		it("stores jsonb array values correctly even when the input is a stringified JSON array", async () => {
+			// Defensive guarantee: if upstream code (e.g. legacy seed scripts,
+			// custom hooks, RPC layers) accidentally passes a JSON-encoded
+			// string for a jsonb column, the framework should normalize it
+			// rather than store the value as a jsonb string.
+			const ctx = createTestContext({ accessMode: "system" });
+
+			const items = [
+				{ label: "X", link: "/x", isExternal: false },
+				{ label: "Y", link: "/y", isExternal: true },
+			];
+			await app.globals.header_settings.update(
+				{ menuItems: JSON.stringify(items) as any },
+				ctx,
+			);
+
+			const result = await app.db.execute(
+				sql`SELECT "menuItems", jsonb_typeof("menuItems") AS t FROM header_settings LIMIT 1`,
+			);
+			const row = (result.rows ?? result)[0];
+
+			expect(row.t).toBe("array");
+			expect(Array.isArray(row.menuItems)).toBe(true);
+			expect(row.menuItems).toHaveLength(2);
+			expect(row.menuItems[1].label).toBe("Y");
+		});
+	});
+
+	describe("hooks see decoded values", () => {
+		it("input hooks (beforeChange, beforeUpdate) receive the array, never a JSON string", async () => {
+			const seenTypes: string[] = [];
+			const seenValues: unknown[] = [];
+
+			const config_with_hook = global("config_with_hook").fields(({ f }) => ({
+				items: f
+					.json()
+					.default([] as any)
+					.hooks({
+						beforeChange: (value: unknown) => {
+							seenTypes.push(
+								Array.isArray(value)
+									? "array"
+									: value === null
+										? "null"
+										: typeof value,
+							);
+							seenValues.push(value);
+							return value;
+						},
+					}),
+			}));
+
+			const setup = await buildMockApp({ globals: { config_with_hook } });
+			const app = setup.app as any;
+			await runTestDbMigrations(app);
+			try {
+				const ctx = createTestContext({ accessMode: "system" });
+
+				// Plain array input — hook must see an array
+				await app.globals.config_with_hook.update(
+					{ items: [{ a: 1 }, { a: 2 }] },
+					ctx,
+				);
+
+				// Stringified-array input — hook must STILL see an array
+				await app.globals.config_with_hook.update(
+					{ items: JSON.stringify([{ a: 3 }]) as any },
+					ctx,
+				);
+
+				expect(seenTypes).toEqual(["array", "array"]);
+				expect(seenValues[0]).toEqual([{ a: 1 }, { a: 2 }]);
+				expect(seenValues[1]).toEqual([{ a: 3 }]);
+			} finally {
+				await setup.cleanup();
+			}
+		});
+	});
+});

--- a/packages/questpie/test/units/queue-pg-boss-adapter.test.ts
+++ b/packages/questpie/test/units/queue-pg-boss-adapter.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Regression test for the pg-boss adapter's v10+ compatibility.
+ *
+ * pg-boss v10+ (and the v12 we depend on) calls the work() callback with
+ * `Job<T>[]` regardless of batchSize. The adapter previously destructured
+ * `job.id` / `job.data` directly off the array → both undefined → the
+ * downstream Zod-validated handler always saw `undefined` and rejected
+ * every job before reaching user code.
+ *
+ * The fix iterates the array, dispatches each item to the registered
+ * handler, and reports per-item failures via `boss.fail(jobName, id, …)`
+ * so siblings in the same batch can still complete.
+ */
+
+import { describe, expect, it, mock } from "bun:test";
+
+import { z } from "zod";
+
+import { PgBossAdapter } from "../../src/server/modules/core/integrated/queue/adapters/pg-boss.js";
+
+// ---------------------------------------------------------------------------
+// Minimal pg-boss double: captures the work() callback so the test can fire
+// a v12-style array-shaped invocation through the adapter without spinning
+// up a real Postgres / pg-boss instance.
+// ---------------------------------------------------------------------------
+
+type WorkCallback = (jobs: any) => Promise<unknown>;
+
+class FakePgBoss {
+	public started = false;
+	public createdQueues: string[] = [];
+	public failCalls: Array<{ name: string; id: string; data: unknown }> = [];
+	public workCallbacks = new Map<string, WorkCallback>();
+
+	async start(): Promise<void> {
+		this.started = true;
+	}
+	async stop(): Promise<void> {
+		this.started = false;
+	}
+	async createQueue(name: string): Promise<void> {
+		this.createdQueues.push(name);
+	}
+	async send(): Promise<string> {
+		return "fake-id";
+	}
+	async work(
+		name: string,
+		_options: unknown,
+		callback: WorkCallback,
+	): Promise<string> {
+		this.workCallbacks.set(name, callback);
+		return `worker-${name}`;
+	}
+	async fail(name: string, id: string, data: unknown): Promise<void> {
+		this.failCalls.push({ name, id, data });
+	}
+}
+
+function makeAdapter() {
+	const fake = new FakePgBoss();
+	const adapter = new PgBossAdapter({} as any);
+	// Replace the real PgBoss instance with our double — the adapter only
+	// touches the methods we stub.
+	(adapter as any).boss = fake;
+	return { adapter, fake };
+}
+
+describe("PgBossAdapter — v10+ work() callback receives Job[]", () => {
+	it("dispatches each job in the array to the handler with the correct payload", async () => {
+		const { adapter, fake } = makeAdapter();
+
+		const schema = z.object({ value: z.string() });
+		const seen: Array<{ id: string; value: string }> = [];
+
+		await adapter.listen({
+			echo: async ({ id, data }) => {
+				const parsed = schema.parse(data);
+				seen.push({ id, value: parsed.value });
+			},
+		});
+
+		const callback = fake.workCallbacks.get("echo");
+		expect(callback).toBeDefined();
+
+		// Simulate pg-boss firing the worker with a batch of 5 jobs — the v12
+		// shape is always `Job<T>[]`, even when batchSize === 1.
+		await callback!([
+			{ id: "j-1", data: { value: "one" } },
+			{ id: "j-2", data: { value: "two" } },
+			{ id: "j-3", data: { value: "three" } },
+			{ id: "j-4", data: { value: "four" } },
+			{ id: "j-5", data: { value: "five" } },
+		]);
+
+		expect(seen).toEqual([
+			{ id: "j-1", value: "one" },
+			{ id: "j-2", value: "two" },
+			{ id: "j-3", value: "three" },
+			{ id: "j-4", value: "four" },
+			{ id: "j-5", value: "five" },
+		]);
+		// All jobs handled successfully → nothing was reported as failed.
+		expect(fake.failCalls).toEqual([]);
+	});
+
+	it("handler is never called with undefined payload (array vs single object)", async () => {
+		const { adapter, fake } = makeAdapter();
+
+		const handler = mock(async () => {});
+		await adapter.listen({ echo: handler });
+
+		const callback = fake.workCallbacks.get("echo")!;
+
+		// Pre-fix bug: destructuring off the array yielded `undefined` for both
+		// `id` and `data`, which then failed Zod parse upstream. The fix must
+		// always pass through the underlying job object.
+		await callback([{ id: "a", data: { value: "x" } }]);
+		expect(handler).toHaveBeenCalledTimes(1);
+		expect(handler.mock.calls[0]?.[0]).toEqual({
+			id: "a",
+			data: { value: "x" },
+		});
+
+		// Defensive: even if a future pg-boss version reverts to a single
+		// object (or hands us undefined), the adapter must not blow up and
+		// must not call the handler with garbage.
+		handler.mockClear();
+		await callback({ id: "b", data: { value: "y" } });
+		expect(handler).toHaveBeenCalledTimes(1);
+		expect(handler.mock.calls[0]?.[0]).toEqual({
+			id: "b",
+			data: { value: "y" },
+		});
+	});
+
+	it("reports per-item handler failures via boss.fail and keeps processing siblings", async () => {
+		const { adapter, fake } = makeAdapter();
+
+		const seen: string[] = [];
+		await adapter.listen({
+			echo: async ({ id, data }) => {
+				if ((data as any).value === "boom") {
+					throw new Error(`handler exploded on ${id}`);
+				}
+				seen.push(id);
+			},
+		});
+
+		const callback = fake.workCallbacks.get("echo")!;
+
+		await callback([
+			{ id: "ok-1", data: { value: "one" } },
+			{ id: "bad-2", data: { value: "boom" } },
+			{ id: "ok-3", data: { value: "three" } },
+		]);
+
+		// Siblings of the failing job still completed.
+		expect(seen).toEqual(["ok-1", "ok-3"]);
+		// The failing job was reported to pg-boss for retry — siblings were not.
+		expect(fake.failCalls).toHaveLength(1);
+		const failed = fake.failCalls[0]!;
+		expect(failed.name).toBe("echo");
+		expect(failed.id).toBe("bad-2");
+		expect((failed.data as { message: string }).message).toBe(
+			"handler exploded on bad-2",
+		);
+	});
+});


### PR DESCRIPTION
## Summary

Three independent bugs in the CRUD + queue layer, all surfaced from the same investigation and shipped together in one patch changeset.

### 1. Race in `globals.<name>.get` auto-create
Two concurrent `get(...)` calls against a fresh global both saw zero rows under READ COMMITTED and each inserted a default-valued auto-created row, leaving the database with two singletons (subsequent reads/writes flipped non-deterministically between them).

**Fix:** Auto-create takes a transaction-scoped `pg_advisory_xact_lock(hashtext('questpie:global:<name>'))` and re-checks existence inside the locked transaction before inserting. Applied to both the workflow-versions branch and the plain branch in `createGet`. Schema-free — no migration. Backends without `pg_advisory_xact_lock` log a warning and fall back to the existence re-check.

### 2. Pre-stringified jsonb values stored as jsonb strings
When upstream code (legacy seeds, RPC layers, custom hooks) handed an already-`JSON.stringify`'d array/object to `globals.<name>.update` or `collections.<name>.create/update`, Drizzle's jsonb `mapToDriverValue` stringified it a second time and Postgres stored a jsonb string instead of the intended array/object. Reads via Drizzle then returned strings, breaking any consumer that iterated as an array.

**Fix:** New shared helper `normalizeJsonbInput(data, fieldDefs)` walks the data and, for fields backed by jsonb columns (`f.json()`, `f.object()`, `f.<x>().array()`, `f.blocks()`), decodes pre-stringified JSON array/object values back to plain JS. Non-jsonb columns and non-JSON strings pass through unchanged. Applied at the very start of the input pipeline so `beforeChange` / `beforeUpdate` / `validate` hooks always observe decoded values.

### 3. `pgBossAdapter` ignored pg-boss v10+ `Job[]` callback shape
pg-boss v10+ (we depend on v12) calls `work()` callbacks with `Job<T>[]` regardless of `batchSize`. The adapter destructured `job.id` / `job.data` straight off the array → both `undefined` → registered handlers received `payload: undefined` and every job failed Zod validation upstream before reaching user code.

**Fix:** `listen()` iterates the array, dispatches each job to the handler, and reports per-item failures via `boss.fail(jobName, id, …)` so siblings in the same batch still complete and the failed job retries independently. `runOnce()` already handled the array shape correctly via `fetch()` and is unchanged.

All three fixes are backwards-compatible. No public API changes, no schema migrations.

## Test plan

- [x] 20 concurrent `get()` calls produce exactly 1 row + 1 initial version (both auto-create branches) — verified failing on `main` (20 rows), passing with the fix
- [x] `update` with plain array → jsonb array stored
- [x] `update` with stringified array → jsonb array stored (defensive)
- [x] Input hooks always see arrays regardless of input shape
- [x] v12-style `Job[]` of 5 → all 5 handler invocations receive the correct payload (not `undefined`) — verified failing on `main`, passing with the fix
- [x] One handler throw triggers exactly one `boss.fail()` call while siblings continue
- [x] `bun test` → 1684 pass / 0 fail (full suite)
- [x] `bun lint` clean on all touched files