### PR TITLE
feat(storage): R2Driver + makeProxyUrlBuilder via questpie/storage

### DIFF
--- a/.changeset/storage-r2-driver-and-proxy-url-helper.md
+++ b/.changeset/storage-r2-driver-and-proxy-url-helper.md
@@ -1,0 +1,40 @@
+---
+"questpie": minor
+---
+
+Add `questpie/storage` entry: `R2Driver` wrapper, `makeProxyUrlBuilder` helper, and re-exports of flydrive's `S3Driver` / `FSDriver` / `GCSDriver`.
+
+**`questpie/storage` — new public entry:**
+
+- **`R2Driver(options)`** — wraps flydrive's `S3Driver` with Cloudflare R2 conventions (`region: "auto"`, `forcePathStyle: true`, `supportsACL: false`) and defaults `urlBuilder` to the QUESTPIE storage proxy. Fixes a long-standing footgun where `new S3Driver({...})` against R2 produced asset URLs pointing at the unsigned S3 endpoint and returned HTTP 400 even with bucket public access on. Optional `publicUrl` opt-out: when set, `generateURL` returns `${publicUrl}/${key}` (CDN / r2.dev / custom domain). Signed URLs always go through the proxy regardless, so visibility-aware access control stays in effect.
+
+- **`makeProxyUrlBuilder(config, { publicUrl? })`** — utility for plugging the QUESTPIE storage proxy into any flydrive driver's `urlBuilder`. Use it with `S3Driver`/`GCSDriver`/`FSDriver` for the same proxy-by-default behaviour. The single source of truth — `createDiskDriver` (default FS) now uses it too.
+
+- **Re-exports** — `S3Driver`, `FSDriver`, `GCSDriver` and their option types are re-exported from `questpie/storage` so a single import is enough to wire any supported backend. Plus `buildStorageFileUrl`, `generateSignedUrlToken`, `verifySignedUrlToken` for users serving files from custom routes.
+
+**`StorageDriverConfig.driver` accepts a factory:**
+
+`storage.driver` now accepts either a `DriverContract` (existing behaviour, unchanged) or a `(config: QuestpieConfig) => DriverContract` factory. The factory form gives the closure access to the resolved `app.url`, `secret`, `storage.basePath`, and `storage.signedUrlExpiration` — that's what makes `R2Driver` and `makeProxyUrlBuilder` work without piping these values into the driver options manually.
+
+```ts
+import { R2Driver } from "questpie/storage";
+
+runtimeConfig({
+  storage: {
+    driver: R2Driver({
+      bucket: process.env.R2_BUCKET!,
+      endpoint: process.env.R2_ENDPOINT!,
+      credentials: { accessKeyId: ..., secretAccessKey: ... },
+      visibility: "public",
+      publicUrl: process.env.R2_PUBLIC_URL, // optional CDN domain
+    }),
+  },
+});
+```
+
+Existing apps importing raw flydrive drivers keep working — wrappers and helpers are purely additive.
+
+**Docs:**
+
+- New page [Storage Flow](/docs/production/storage-flow) — visibility model, proxy lifecycle, signed-token format, `asset.url` computation, perf trade-offs.
+- [Storage](/docs/production/storage) updated with R2/S3/GCS recipes plus a copy-pasteable migration diff for users coming from raw flydrive imports.

--- a/apps/docs/content/docs/extend/custom-adapters/storage.mdx
+++ b/apps/docs/content/docs/extend/custom-adapters/storage.mdx
@@ -5,6 +5,10 @@ description: Implement a custom file storage driver for QUESTPIE using FlyDrive.
 
 Storage in QUESTPIE is backed by [FlyDrive](https://flydrive.dev). To use a custom cloud provider (S3, R2, GCS, Azure Blob, etc.), you provide a FlyDrive `DriverContract` instance. FlyDrive already ships drivers for popular providers -- you only need to write a custom driver if your provider is not supported.
 
+For end-to-end details on how QUESTPIE serves files, signs URLs, and computes
+`asset.url` see [Storage Flow](/docs/production/storage-flow). For provider
+recipes (R2, S3, GCS) see [Storage](/docs/production/storage).
+
 ## Interface
 
 QUESTPIE expects a FlyDrive `DriverContract`. The full interface:
@@ -65,28 +69,20 @@ interface DriverContract {
 
 ## Using an existing FlyDrive driver
 
-For most cloud providers, you do not need to write a driver at all. Install the FlyDrive package for your provider and pass it directly:
+For most cloud providers, you do not need to write a driver at all. Use the
+`questpie/storage` entry, which re-exports FlyDrive's `S3Driver`, `FSDriver`,
+`GCSDriver` and adds:
 
-```ts title="questpie.config.ts"
-import { runtimeConfig } from "questpie";
-import { S3Driver } from "flydrive/drivers/s3";
+- **`R2Driver(options)`** — a wrapper for Cloudflare R2 that applies R2-specific
+  conventions (`region: "auto"`, `forcePathStyle: true`, `supportsACL: false`)
+  and points the storage proxy at your app automatically.
+- **`makeProxyUrlBuilder(config, { publicUrl? })`** — utility that produces
+  `generateURL` / `generateSignedURL` resolvers wired to the QUESTPIE storage
+  proxy. Plug it into any flydrive driver's `urlBuilder`.
 
-export default runtimeConfig({
-	// ...
-	storage: {
-		driver: new S3Driver({
-			credentials: {
-				accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
-				secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
-			},
-			region: process.env.AWS_REGION!,
-			bucket: process.env.S3_BUCKET!,
-		}),
-	},
-});
-```
-
-FlyDrive ships drivers for S3, R2 (Cloudflare), GCS (Google Cloud Storage), and local filesystem. See the [FlyDrive drivers documentation](https://flydrive.dev/docs/drivers) for the full list.
+See the [Storage page](/docs/production/storage) for full recipes. The raw
+flydrive imports also still work (`import { S3Driver } from "flydrive/drivers/s3"`)
+if you want to manage the urlBuilder yourself.
 
 ## Writing a custom driver
 

--- a/apps/docs/content/docs/production/meta.json
+++ b/apps/docs/content/docs/production/meta.json
@@ -5,6 +5,7 @@
 		"migrations",
 		"authentication",
 		"storage",
+		"storage-flow",
 		"email",
 		"queue",
 		"search",

--- a/apps/docs/content/docs/production/storage-flow.mdx
+++ b/apps/docs/content/docs/production/storage-flow.mdx
@@ -1,0 +1,154 @@
+---
+title: Storage Flow
+description: How file storage works end-to-end — visibility, the proxy route, signed tokens, and how asset.url is computed.
+---
+
+This page documents what happens between "user uploads a file" and "browser
+loads `<img src={asset.url}>`". Read it if you are configuring a custom
+storage driver, debugging a 401 on private files, or wondering why `asset.url`
+points at your app and not directly at the bucket.
+
+## Visibility model
+
+Every uploaded file has a visibility — `"public"` or `"private"` — stored on
+the asset record (the `visibility` column added by `.upload()`). When a record
+has no explicit value, the framework falls back to `storage.defaultVisibility`
+in your config (default `"public"`).
+
+| Visibility  | Cache headers                              | Requires token? |
+| ----------- | ------------------------------------------ | --------------- |
+| `"public"`  | `Cache-Control: public, max-age=31536000, immutable` | no    |
+| `"private"` | `Cache-Control: private, no-cache`         | yes (`?token=`) |
+
+The visibility on the record is the source of truth. `setVisibility()` is
+called automatically by the upload `afterChange` hook when you change the
+`visibility` field, so the storage backend (S3 ACL, R2 visibility flag, FS
+metadata) stays in sync.
+
+## The proxy route — `GET /storage/files/:key`
+
+Every file served through QUESTPIE goes through a single route registered at
+`packages/questpie/src/server/modules/core/routes/storage/files/[...key].ts`.
+
+### Request lifecycle
+
+1. **Resolve the upload collection.** The route picks the configured
+   `storage.collection`, or — if there's exactly one collection with
+   `.upload()` — that one. Multiple upload collections without an explicit
+   pick is an error (the route returns 400 with a list of candidates).
+
+2. **Look up the asset record by key.** `findOne({ where: { key } })` on the
+   resolved collection. Visibility is read from `record.visibility`, falling
+   back to `storage.defaultVisibility`.
+
+3. **Verify the signed token if private.** For `"private"` records the route
+   reads `?token=<base64url>`, decodes it, verifies the HMAC-SHA256 signature
+   against `config.secret`, and rejects:
+   - missing token → 401 `upload.tokenRequired`
+   - bad signature → 401 `upload.tokenInvalid`
+   - expired payload → 401 `upload.tokenInvalid`
+   - token's `key` ≠ requested key → 401 `upload.tokenMismatch`
+
+4. **Read bytes from the driver.** `await driver.getBytes(key)` loads the full
+   file into memory as a `Uint8Array`. Metadata (`contentType`) is fetched
+   separately via `driver.getMetaData(key)`.
+
+5. **Respond with bytes + headers.** The route returns:
+
+   | Header                   | Value                                                              |
+   | ------------------------ | ------------------------------------------------------------------ |
+   | `Content-Type`           | from driver metadata, falling back to `record.mimeType`            |
+   | `Content-Length`         | byte length                                                        |
+   | `Accept-Ranges`          | `bytes`                                                            |
+   | `Cache-Control`          | `public, max-age=31536000, immutable` or `private, no-cache`       |
+   | `Content-Disposition`    | `inline; filename="…"` (sanitised) when `record.filename` is set   |
+   | `Content-Security-Policy` | `script-src 'none'` for SVG (defuses embedded `<script>`)         |
+
+   HTTP `Range` requests are honoured: a `Range: bytes=…-…` header makes the
+   route return `206 Partial Content` with `Content-Range`. Useful for video
+   and audio seeking. Out-of-range requests get a `416`.
+
+## Token format
+
+`generateSignedUrlToken(key, secret, expirationSeconds)` produces:
+
+```
+base64url(JSON.stringify({
+  key:     "uploads/abc.pdf",
+  expires: 1717428000,            // unix seconds
+  sig:     base64url(HMAC-SHA256(secret, JSON({key, expires})))
+}))
+```
+
+- `expires` is unix seconds, default `Date.now() + storage.signedUrlExpiration`
+  (defaults to 3600 — one hour).
+- `sig` is computed over the canonical `JSON.stringify({key, expires})` —
+  field ordering matters and must match `verifySignedUrlToken`.
+- `secret` is `config.secret`. **If it's not set, private files cannot be
+  served** — the route returns 500 with a configuration error. Always set
+  `secret` in production.
+
+The token is opaque to the storage backend — verification happens entirely in
+QUESTPIE.
+
+## How `asset.url` is computed
+
+`asset.url` is **not** a stored database column. It's added on-the-fly in the
+upload `afterRead` hook on the collection (see
+`packages/questpie/src/server/collection/builder/collection-builder.ts`).
+Every read recomputes it:
+
+```ts
+// roughly:
+afterRead: ({ data, app }) => {
+  if (data.visibility === "private") {
+    data.url = await app.storage.use().getSignedUrl(data.key);
+  } else {
+    data.url = await app.storage.use().getUrl(data.key);
+  }
+};
+```
+
+Two consequences:
+
+1. **Signed URLs are always fresh.** Tokens carry their own expiration but
+   the URL field never goes stale because it's regenerated on every fetch.
+2. **The driver's `urlBuilder` is the only source of truth for URLs.** Configure
+   it once and every collection that uses `.upload()` produces the right URLs.
+
+## Cost & performance trade-off
+
+The proxy route reads the whole file into memory through `driver.getBytes()`
+before responding — no streaming, no zero-copy.
+
+- **Fine for**: images, PDFs, text, JSON, audio thumbnails, anything under a
+  few megabytes. Memory is bounded by request concurrency × file size, which
+  is usually tiny in practice. Browser cache + a CDN in front of the app
+  push the actual cost close to zero after the first hit.
+- **Bad for**: 50 MB+ video, large archives, anything that benefits from
+  range-streaming under heavy concurrent load. For those, set `publicUrl` on
+  the wrapper drivers (or write a custom `urlBuilder.generateURL`) so public
+  files are served straight from the CDN, bypassing the proxy. Private files
+  still need the proxy regardless — there's no other way to enforce
+  visibility.
+
+The `Cache-Control: immutable` header on public files makes browsers and CDNs
+treat them as forever-cacheable. Pair it with content-hashed keys (which is
+what the upload pipeline does by default) and you'll rarely hit the proxy at
+all in production.
+
+## What lives where
+
+| Concern                              | File                                                                              |
+| ------------------------------------ | --------------------------------------------------------------------------------- |
+| Proxy route handler                  | `packages/questpie/src/server/modules/core/routes/storage/files/[...key].ts`      |
+| Visibility check + token verify      | `packages/questpie/src/server/adapters/routes/storage.ts`                          |
+| Token generation/verification        | `packages/questpie/src/server/modules/core/integrated/storage/signed-url.ts`       |
+| Default FSDriver factory             | `packages/questpie/src/server/modules/core/integrated/storage/create-driver.ts`    |
+| `R2Driver` wrapper, proxy URL helper | `packages/questpie/src/server/modules/core/integrated/storage/drivers/`            |
+| Upload `afterRead` hook              | `packages/questpie/src/server/collection/builder/collection-builder.ts`            |
+
+## Related
+
+- [Storage](/docs/production/storage) — driver configuration recipes
+- [Storage Adapter](/docs/extend/custom-adapters/storage) — writing a custom driver

--- a/apps/docs/content/docs/production/storage.mdx
+++ b/apps/docs/content/docs/production/storage.mdx
@@ -1,9 +1,13 @@
 ---
 title: Storage
-description: File storage with Flydrive — S3, local filesystem, and upload configuration.
+description: File storage with Flydrive — local filesystem, S3, Cloudflare R2, and Google Cloud Storage.
 ---
 
-QUESTPIE uses [Flydrive](https://flydrive.dev/) for file storage. It uses local filesystem storage by default and accepts any custom FlyDrive driver instance for S3, R2, GCS, and other backends.
+QUESTPIE wraps [Flydrive](https://flydrive.dev/) for file storage. Local
+filesystem is the default; for production use one of the recipes below.
+
+For end-to-end details on how files are served, signed, and cached — see
+[Storage Flow](/docs/production/storage-flow).
 
 ## Configuration
 
@@ -11,56 +15,221 @@ QUESTPIE uses [Flydrive](https://flydrive.dev/) for file storage. It uses local 
 export default runtimeConfig({
 	storage: {
 		basePath: "/api",
+		// driver: ...                  // see recipes below
+		// defaultVisibility: "public", // "public" | "private"
+		// signedUrlExpiration: 3600,   // seconds — for private files
 	},
 });
 ```
 
-## Upload Fields
+## Upload fields
 
-Define upload fields on collections:
+Define an upload field on a collection to wire it to your storage:
 
 ```ts
 avatar: f.upload({
-  to: "assets",
-  mimeTypes: ["image/*"],
-  maxSize: 5_000_000,
+	to: "assets",
+	mimeTypes: ["image/*"],
+	maxSize: 5_000_000,
 }),
 ```
 
-## Storage Backends
+## Storage backends
 
-### Local (Development)
+### Local filesystem (default)
 
-Files stored on local filesystem. Default for development.
+No driver needed — QUESTPIE serves from `./uploads` (override with
+`storage.location`). Best for development.
 
-### S3 or S3-Compatible (Production)
+### Cloudflare R2
 
-```ts
-import { S3Driver } from "flydrive/drivers/s3";
+Use the `R2Driver` from `questpie/storage`. It applies R2-specific defaults
+(`region: "auto"`, `forcePathStyle: true`, `supportsACL: false`) and points
+the storage proxy at your app automatically — no `urlBuilder` override
+required.
+
+```ts title="questpie.config.ts"
+import { R2Driver } from "questpie/storage";
 
 export default runtimeConfig({
+	app: { url: process.env.APP_URL! },
+	secret: process.env.SECRET!,
 	storage: {
-		basePath: "/api",
-		driver: new S3Driver({
-			bucket: process.env.S3_BUCKET,
-			region: process.env.S3_REGION,
-			accessKeyId: process.env.S3_ACCESS_KEY,
-			secretAccessKey: process.env.S3_SECRET_KEY,
+		driver: R2Driver({
+			bucket: process.env.R2_BUCKET!,
+			endpoint: process.env.R2_ENDPOINT!,
+			credentials: {
+				accessKeyId: process.env.R2_ACCESS_KEY_ID!,
+				secretAccessKey: process.env.R2_SECRET_ACCESS_KEY!,
+			},
+			visibility: "public",
+			// optional — serve public files from your r2.dev or custom domain,
+			// bypassing the QUESTPIE proxy. Private files still go through the
+			// proxy regardless, so visibility is enforced.
+			publicUrl: process.env.R2_PUBLIC_URL,
 		}),
 	},
 });
 ```
 
-## Client Upload
+#### Why a wrapper for R2 specifically
+
+flydrive's raw `S3Driver` does not apply any of these conventions, and its
+default `getUrl()` returns the S3 API endpoint URL — which on R2 is
+unsigned and not publicly readable, returning HTTP 400 even when the bucket
+has public access enabled. `R2Driver` fixes both problems.
+
+### AWS S3
+
+Use the raw flydrive `S3Driver` with `makeProxyUrlBuilder` from
+`questpie/storage` to point public/signed URLs at the QUESTPIE proxy:
+
+```ts title="questpie.config.ts"
+import { S3Driver, makeProxyUrlBuilder } from "questpie/storage";
+
+export default runtimeConfig({
+	app: { url: process.env.APP_URL! },
+	secret: process.env.SECRET!,
+	storage: {
+		driver: (config) => {
+			const proxy = makeProxyUrlBuilder(config, {
+				// optional CDN/CloudFront domain — public files served directly
+				publicUrl: process.env.S3_PUBLIC_URL,
+			});
+			return new S3Driver({
+				bucket: process.env.S3_BUCKET!,
+				region: process.env.S3_REGION!,
+				credentials: {
+					accessKeyId: process.env.S3_ACCESS_KEY_ID!,
+					secretAccessKey: process.env.S3_SECRET_ACCESS_KEY!,
+				},
+				visibility: "public",
+				urlBuilder: {
+					generateURL: (key) => proxy.generateURL(key),
+					generateSignedURL: (key, _opts, _client, expiresIn) =>
+						proxy.generateSignedURL(key, expiresIn),
+				},
+			});
+		},
+	},
+});
+```
+
+`storage.driver` accepts either a `DriverContract` instance or a factory
+`(config) => DriverContract`. The factory form gives the closure access to
+your resolved app config (`app.url`, `secret`, `storage.basePath`,
+`storage.signedUrlExpiration`) — that's what makes `makeProxyUrlBuilder`
+work without you piping those values around manually.
+
+### Google Cloud Storage
+
+Same shape as S3 — flydrive's GCS `urlBuilder` signature is slightly
+different but the proxy helper covers it:
+
+```ts title="questpie.config.ts"
+import { GCSDriver, makeProxyUrlBuilder } from "questpie/storage";
+
+export default runtimeConfig({
+	app: { url: process.env.APP_URL! },
+	secret: process.env.SECRET!,
+	storage: {
+		driver: (config) => {
+			const proxy = makeProxyUrlBuilder(config, {
+				publicUrl: process.env.GCS_PUBLIC_URL,
+			});
+			return new GCSDriver({
+				bucket: process.env.GCS_BUCKET!,
+				keyFilename: process.env.GCS_KEY_FILE,
+				visibility: "public",
+				urlBuilder: {
+					generateURL: (key) => proxy.generateURL(key),
+					generateSignedURL: (key) => proxy.generateSignedURL(key),
+				},
+			});
+		},
+	},
+});
+```
+
+## Migrating from raw flydrive imports
+
+If you're currently importing flydrive drivers directly:
+
+```diff title="questpie.config.ts"
+- import { S3Driver } from "flydrive/drivers/s3";
++ import { S3Driver, makeProxyUrlBuilder } from "questpie/storage";
+
+  export default runtimeConfig({
++   app:    { url: process.env.APP_URL! },
++   secret: process.env.SECRET!,
+    storage: {
+-     driver: new S3Driver({
+-       bucket: process.env.S3_BUCKET!,
+-       region: process.env.S3_REGION!,
+-       credentials: { ... },
+-       visibility: "public",
+-     }),
++     driver: (config) => {
++       const proxy = makeProxyUrlBuilder(config);
++       return new S3Driver({
++         bucket: process.env.S3_BUCKET!,
++         region: process.env.S3_REGION!,
++         credentials: { ... },
++         visibility: "public",
++         urlBuilder: {
++           generateURL: (key) => proxy.generateURL(key),
++           generateSignedURL: (key, _opts, _client, expiresIn) =>
++             proxy.generateSignedURL(key, expiresIn),
++         },
++       });
++     },
+    },
+  });
+```
+
+For Cloudflare R2 the migration is shorter — drop the manual S3 conventions
+and use `R2Driver` directly:
+
+```diff title="questpie.config.ts"
+- import { S3Driver } from "flydrive/drivers/s3";
++ import { R2Driver } from "questpie/storage";
+
+  export default runtimeConfig({
+    storage: {
+-     driver: new S3Driver({
+-       bucket: process.env.R2_BUCKET!,
+-       endpoint: process.env.R2_ENDPOINT!,
+-       region: "auto",
+-       forcePathStyle: true,
+-       supportsACL: false,
+-       credentials: { ... },
+-       visibility: "public",
+-       urlBuilder: { /* manual proxy override */ },
+-     }),
++     driver: R2Driver({
++       bucket:   process.env.R2_BUCKET!,
++       endpoint: process.env.R2_ENDPOINT!,
++       credentials: { ... },
++       visibility: "public",
++     }),
+    },
+  });
+```
+
+The raw `new S3Driver({ … })` form still works — wrappers and helpers are
+purely additive.
+
+## Client upload
 
 ```ts
-// Upload a file
 const asset = await client.collections.assets.upload(file, {
 	onProgress: (progress) => console.log(`${progress}%`),
 });
 ```
 
-## Related Pages
+## Related pages
 
-- [Media](/docs/workspace/media) — Admin media management
-- [Fields](/docs/backend/data-modeling/fields) — Upload field type
+- [Storage Flow](/docs/production/storage-flow) — proxy lifecycle, tokens, caching
+- [Storage Adapter](/docs/extend/custom-adapters/storage) — write a custom driver
+- [Media](/docs/workspace/media) — admin media management
+- [Fields](/docs/backend/data-modeling/fields) — upload field type

--- a/bun.lock
+++ b/bun.lock
@@ -340,6 +340,8 @@
         "zod": "^4.2.1",
       },
       "devDependencies": {
+        "@aws-sdk/client-s3": "^3.840.0",
+        "@aws-sdk/s3-request-presigner": "^3.840.0",
         "@electric-sql/pglite": "^0.3.14",
         "@types/html-to-text": "^9.0.4",
         "@types/nodemailer": "^7.0.5",
@@ -410,6 +412,90 @@
     "@asamuzakjp/dom-selector": ["@asamuzakjp/dom-selector@6.8.1", "", { "dependencies": { "@asamuzakjp/nwsapi": "^2.3.9", "bidi-js": "^1.0.3", "css-tree": "^3.1.0", "is-potential-custom-element-name": "^1.0.1", "lru-cache": "^11.2.6" } }, "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ=="],
 
     "@asamuzakjp/nwsapi": ["@asamuzakjp/nwsapi@2.3.9", "", {}, "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q=="],
+
+    "@aws-crypto/crc32": ["@aws-crypto/crc32@5.2.0", "", { "dependencies": { "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "tslib": "^2.6.2" } }, "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg=="],
+
+    "@aws-crypto/crc32c": ["@aws-crypto/crc32c@5.2.0", "", { "dependencies": { "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "tslib": "^2.6.2" } }, "sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag=="],
+
+    "@aws-crypto/sha1-browser": ["@aws-crypto/sha1-browser@5.2.0", "", { "dependencies": { "@aws-crypto/supports-web-crypto": "^5.2.0", "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "@aws-sdk/util-locate-window": "^3.0.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg=="],
+
+    "@aws-crypto/sha256-browser": ["@aws-crypto/sha256-browser@5.2.0", "", { "dependencies": { "@aws-crypto/sha256-js": "^5.2.0", "@aws-crypto/supports-web-crypto": "^5.2.0", "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "@aws-sdk/util-locate-window": "^3.0.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw=="],
+
+    "@aws-crypto/sha256-js": ["@aws-crypto/sha256-js@5.2.0", "", { "dependencies": { "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "tslib": "^2.6.2" } }, "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA=="],
+
+    "@aws-crypto/supports-web-crypto": ["@aws-crypto/supports-web-crypto@5.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg=="],
+
+    "@aws-crypto/util": ["@aws-crypto/util@5.2.0", "", { "dependencies": { "@aws-sdk/types": "^3.222.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ=="],
+
+    "@aws-sdk/client-s3": ["@aws-sdk/client-s3@3.1038.0", "", { "dependencies": { "@aws-crypto/sha1-browser": "5.2.0", "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.6", "@aws-sdk/credential-provider-node": "^3.972.37", "@aws-sdk/middleware-bucket-endpoint": "^3.972.10", "@aws-sdk/middleware-expect-continue": "^3.972.10", "@aws-sdk/middleware-flexible-checksums": "^3.974.14", "@aws-sdk/middleware-host-header": "^3.972.10", "@aws-sdk/middleware-location-constraint": "^3.972.10", "@aws-sdk/middleware-logger": "^3.972.10", "@aws-sdk/middleware-recursion-detection": "^3.972.11", "@aws-sdk/middleware-sdk-s3": "^3.972.35", "@aws-sdk/middleware-ssec": "^3.972.10", "@aws-sdk/middleware-user-agent": "^3.972.36", "@aws-sdk/region-config-resolver": "^3.972.13", "@aws-sdk/signature-v4-multi-region": "^3.996.23", "@aws-sdk/types": "^3.973.8", "@aws-sdk/util-endpoints": "^3.996.8", "@aws-sdk/util-user-agent-browser": "^3.972.10", "@aws-sdk/util-user-agent-node": "^3.973.22", "@smithy/config-resolver": "^4.4.17", "@smithy/core": "^3.23.17", "@smithy/eventstream-serde-browser": "^4.2.14", "@smithy/eventstream-serde-config-resolver": "^4.3.14", "@smithy/eventstream-serde-node": "^4.2.14", "@smithy/fetch-http-handler": "^5.3.17", "@smithy/hash-blob-browser": "^4.2.15", "@smithy/hash-node": "^4.2.14", "@smithy/hash-stream-node": "^4.2.14", "@smithy/invalid-dependency": "^4.2.14", "@smithy/md5-js": "^4.2.14", "@smithy/middleware-content-length": "^4.2.14", "@smithy/middleware-endpoint": "^4.4.32", "@smithy/middleware-retry": "^4.5.6", "@smithy/middleware-serde": "^4.2.20", "@smithy/middleware-stack": "^4.2.14", "@smithy/node-config-provider": "^4.3.14", "@smithy/node-http-handler": "^4.6.1", "@smithy/protocol-http": "^5.3.14", "@smithy/smithy-client": "^4.12.13", "@smithy/types": "^4.14.1", "@smithy/url-parser": "^4.2.14", "@smithy/util-base64": "^4.3.2", "@smithy/util-body-length-browser": "^4.2.2", "@smithy/util-body-length-node": "^4.2.3", "@smithy/util-defaults-mode-browser": "^4.3.49", "@smithy/util-defaults-mode-node": "^4.2.54", "@smithy/util-endpoints": "^3.4.2", "@smithy/util-middleware": "^4.2.14", "@smithy/util-retry": "^4.3.5", "@smithy/util-stream": "^4.5.25", "@smithy/util-utf8": "^4.2.2", "@smithy/util-waiter": "^4.3.0", "tslib": "^2.6.2" } }, "sha512-k60qm50bWkaqNfCJe1z28WaqgpztE0wbWVMZw6ZJcTOGfrWFhsJeLCEqtkH8w00iEozKx9GQwdQXz4G0sMGdKA=="],
+
+    "@aws-sdk/core": ["@aws-sdk/core@3.974.6", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@aws-sdk/xml-builder": "^3.972.20", "@smithy/core": "^3.23.17", "@smithy/node-config-provider": "^4.3.14", "@smithy/property-provider": "^4.2.14", "@smithy/protocol-http": "^5.3.14", "@smithy/signature-v4": "^5.3.14", "@smithy/smithy-client": "^4.12.13", "@smithy/types": "^4.14.1", "@smithy/util-base64": "^4.3.2", "@smithy/util-middleware": "^4.2.14", "@smithy/util-retry": "^4.3.5", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-8Vu7zGxu+39ChR/s5J7nXBw3a2kMHAi0OfKT8ohgTVjX0qYed/8mIfdBb638oBmKrWCwwKjYAM5J/4gMJ8nAJA=="],
+
+    "@aws-sdk/crc64-nvme": ["@aws-sdk/crc64-nvme@3.972.7", "", { "dependencies": { "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-QUagVVBbC8gODCF6e1aV0mE2TXWB9Opz4k8EJFdNrujUVQm5R4AjJa1mpOqzwOuROBzqJU9zawzig7M96L8Ejg=="],
+
+    "@aws-sdk/credential-provider-env": ["@aws-sdk/credential-provider-env@3.972.32", "", { "dependencies": { "@aws-sdk/core": "^3.974.6", "@aws-sdk/types": "^3.973.8", "@smithy/property-provider": "^4.2.14", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-7vA4GHg8NSmQxquJHSBcSM3RgB4ZaaRi6u4+zGFKOmOH6aqlgr2Sda46clkZDYzlirgfY96w15Zj0jh6PT48ng=="],
+
+    "@aws-sdk/credential-provider-http": ["@aws-sdk/credential-provider-http@3.972.34", "", { "dependencies": { "@aws-sdk/core": "^3.974.6", "@aws-sdk/types": "^3.973.8", "@smithy/fetch-http-handler": "^5.3.17", "@smithy/node-http-handler": "^4.6.1", "@smithy/property-provider": "^4.2.14", "@smithy/protocol-http": "^5.3.14", "@smithy/smithy-client": "^4.12.13", "@smithy/types": "^4.14.1", "@smithy/util-stream": "^4.5.25", "tslib": "^2.6.2" } }, "sha512-vBrhWujFCLp1u8ptJRWYlipMutzPptb8pDQ00rKVH9q67T7rGd3VTWIj63aKrlLuY6qSsw1Rt5F/D/7wnNgryA=="],
+
+    "@aws-sdk/credential-provider-ini": ["@aws-sdk/credential-provider-ini@3.972.36", "", { "dependencies": { "@aws-sdk/core": "^3.974.6", "@aws-sdk/credential-provider-env": "^3.972.32", "@aws-sdk/credential-provider-http": "^3.972.34", "@aws-sdk/credential-provider-login": "^3.972.36", "@aws-sdk/credential-provider-process": "^3.972.32", "@aws-sdk/credential-provider-sso": "^3.972.36", "@aws-sdk/credential-provider-web-identity": "^3.972.36", "@aws-sdk/nested-clients": "^3.997.4", "@aws-sdk/types": "^3.973.8", "@smithy/credential-provider-imds": "^4.2.14", "@smithy/property-provider": "^4.2.14", "@smithy/shared-ini-file-loader": "^4.4.9", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-FBHyCmV8EB0gUvh1d+CZm87zt2PrdC7OyWexLRoH3I5zWSOUGa+9t58Y5jbxRfwUp3AWpHAFvKY6YzgR845sVA=="],
+
+    "@aws-sdk/credential-provider-login": ["@aws-sdk/credential-provider-login@3.972.36", "", { "dependencies": { "@aws-sdk/core": "^3.974.6", "@aws-sdk/nested-clients": "^3.997.4", "@aws-sdk/types": "^3.973.8", "@smithy/property-provider": "^4.2.14", "@smithy/protocol-http": "^5.3.14", "@smithy/shared-ini-file-loader": "^4.4.9", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-IFap01lJKxQc0C/OHmZwZQr/cKq0DhrcmKedRrdnnl42D+P0SImnnnWQjv07uIPqpEdtqmkPXb9TiPYTU+prxQ=="],
+
+    "@aws-sdk/credential-provider-node": ["@aws-sdk/credential-provider-node@3.972.37", "", { "dependencies": { "@aws-sdk/credential-provider-env": "^3.972.32", "@aws-sdk/credential-provider-http": "^3.972.34", "@aws-sdk/credential-provider-ini": "^3.972.36", "@aws-sdk/credential-provider-process": "^3.972.32", "@aws-sdk/credential-provider-sso": "^3.972.36", "@aws-sdk/credential-provider-web-identity": "^3.972.36", "@aws-sdk/types": "^3.973.8", "@smithy/credential-provider-imds": "^4.2.14", "@smithy/property-provider": "^4.2.14", "@smithy/shared-ini-file-loader": "^4.4.9", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-/WFixFAAiw8WpmjZcI0l4t3DerXLmVinOIfuotmRZnu2qmsFPoqqmstASz0z8bi1pGdFXzeLzf6bwucM3mZcUQ=="],
+
+    "@aws-sdk/credential-provider-process": ["@aws-sdk/credential-provider-process@3.972.32", "", { "dependencies": { "@aws-sdk/core": "^3.974.6", "@aws-sdk/types": "^3.973.8", "@smithy/property-provider": "^4.2.14", "@smithy/shared-ini-file-loader": "^4.4.9", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-uZp4tlGbpczV8QxmtIwOpSkcyGtBRR8/T4BAumRKfAt1nwCig3FSCZvrKl6ARDIDVRYn5p2oRcAsfFR01EgMGA=="],
+
+    "@aws-sdk/credential-provider-sso": ["@aws-sdk/credential-provider-sso@3.972.36", "", { "dependencies": { "@aws-sdk/core": "^3.974.6", "@aws-sdk/nested-clients": "^3.997.4", "@aws-sdk/token-providers": "3.1038.0", "@aws-sdk/types": "^3.973.8", "@smithy/property-provider": "^4.2.14", "@smithy/shared-ini-file-loader": "^4.4.9", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-DsLr0UHMyKzRJKe2bjlwU8q1cfoXg8TIJKV/xwvnalAemiZLOZunFzj/whGnFDZIBVLdnbLiwv5SvRf1+CSwkg=="],
+
+    "@aws-sdk/credential-provider-web-identity": ["@aws-sdk/credential-provider-web-identity@3.972.36", "", { "dependencies": { "@aws-sdk/core": "^3.974.6", "@aws-sdk/nested-clients": "^3.997.4", "@aws-sdk/types": "^3.973.8", "@smithy/property-provider": "^4.2.14", "@smithy/shared-ini-file-loader": "^4.4.9", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-uzrURO7frJhHQVVNR5zBJcCYeMYflmXcWBK1+MiBym2Dfjh6nXATrMixrmGZi+97Q7ETZ+y/4lUwAy0Nfnznjw=="],
+
+    "@aws-sdk/middleware-bucket-endpoint": ["@aws-sdk/middleware-bucket-endpoint@3.972.10", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@aws-sdk/util-arn-parser": "^3.972.3", "@smithy/node-config-provider": "^4.3.14", "@smithy/protocol-http": "^5.3.14", "@smithy/types": "^4.14.1", "@smithy/util-config-provider": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-Vbc2frZH7wXlMNd+ZZSXUEs/l1Sv8Jj4zUnIfwrYF5lwaLdXHZ9xx4U3rjUcaye3HRhFVc+E5DbBxpRAbB16BA=="],
+
+    "@aws-sdk/middleware-expect-continue": ["@aws-sdk/middleware-expect-continue@3.972.10", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@smithy/protocol-http": "^5.3.14", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-2Yn0f1Qiq/DjxYR3wfI3LokXnjOhFM7Ssn4LTdFDIxRMCE6I32MAsVnhPX1cUZsuVA9tiZtwwhlSLAtFGxAZlQ=="],
+
+    "@aws-sdk/middleware-flexible-checksums": ["@aws-sdk/middleware-flexible-checksums@3.974.14", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@aws-crypto/crc32c": "5.2.0", "@aws-crypto/util": "5.2.0", "@aws-sdk/core": "^3.974.6", "@aws-sdk/crc64-nvme": "^3.972.7", "@aws-sdk/types": "^3.973.8", "@smithy/is-array-buffer": "^4.2.2", "@smithy/node-config-provider": "^4.3.14", "@smithy/protocol-http": "^5.3.14", "@smithy/types": "^4.14.1", "@smithy/util-middleware": "^4.2.14", "@smithy/util-stream": "^4.5.25", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-mhTO3amGzYv/DQNbbqZo6UkHquBHlEEVRZwXmjeRqLmy1l9z3xCiFzglPL7n9JpVc2DZc9kjaraAn3JQrueZbw=="],
+
+    "@aws-sdk/middleware-host-header": ["@aws-sdk/middleware-host-header@3.972.10", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@smithy/protocol-http": "^5.3.14", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg=="],
+
+    "@aws-sdk/middleware-location-constraint": ["@aws-sdk/middleware-location-constraint@3.972.10", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-rI3NZvJcEvjoD0+0PI0iUAwlPw2IlSlhyvgBK/3WkKJQE/YiKFedd9dMN2lVacdNxPNhxL/jzQaKQdrGtQagjQ=="],
+
+    "@aws-sdk/middleware-logger": ["@aws-sdk/middleware-logger@3.972.10", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ=="],
+
+    "@aws-sdk/middleware-recursion-detection": ["@aws-sdk/middleware-recursion-detection@3.972.11", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@aws/lambda-invoke-store": "^0.2.2", "@smithy/protocol-http": "^5.3.14", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ=="],
+
+    "@aws-sdk/middleware-sdk-s3": ["@aws-sdk/middleware-sdk-s3@3.972.35", "", { "dependencies": { "@aws-sdk/core": "^3.974.6", "@aws-sdk/types": "^3.973.8", "@aws-sdk/util-arn-parser": "^3.972.3", "@smithy/core": "^3.23.17", "@smithy/node-config-provider": "^4.3.14", "@smithy/protocol-http": "^5.3.14", "@smithy/signature-v4": "^5.3.14", "@smithy/smithy-client": "^4.12.13", "@smithy/types": "^4.14.1", "@smithy/util-config-provider": "^4.2.2", "@smithy/util-middleware": "^4.2.14", "@smithy/util-stream": "^4.5.25", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-lLppaNTAz+wNgLdi4FtHzrlwrGF0ODTnBWHBaFg85SKs0eJ+M+tP5ifrA8f/0lNd+Ak3MC1NGC6RavV3ny4HTg=="],
+
+    "@aws-sdk/middleware-ssec": ["@aws-sdk/middleware-ssec@3.972.10", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-Gli9A0u8EVVb+5bFDGS/QbSVg28w/wpEidg1ggVcSj65BDTdGR6punsOcVjqdiu1i42WHWo51MCvARPIIz9juw=="],
+
+    "@aws-sdk/middleware-user-agent": ["@aws-sdk/middleware-user-agent@3.972.36", "", { "dependencies": { "@aws-sdk/core": "^3.974.6", "@aws-sdk/types": "^3.973.8", "@aws-sdk/util-endpoints": "^3.996.8", "@smithy/core": "^3.23.17", "@smithy/protocol-http": "^5.3.14", "@smithy/types": "^4.14.1", "@smithy/util-retry": "^4.3.5", "tslib": "^2.6.2" } }, "sha512-O2beToxguBvrZFFZ+fFgPbbae8MvyIBjQ6lImee4APHEXXNAD5ZJ2ayLF1mb7rsKw86TM81y5czg82bZncjSjg=="],
+
+    "@aws-sdk/nested-clients": ["@aws-sdk/nested-clients@3.997.4", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.6", "@aws-sdk/middleware-host-header": "^3.972.10", "@aws-sdk/middleware-logger": "^3.972.10", "@aws-sdk/middleware-recursion-detection": "^3.972.11", "@aws-sdk/middleware-user-agent": "^3.972.36", "@aws-sdk/region-config-resolver": "^3.972.13", "@aws-sdk/signature-v4-multi-region": "^3.996.23", "@aws-sdk/types": "^3.973.8", "@aws-sdk/util-endpoints": "^3.996.8", "@aws-sdk/util-user-agent-browser": "^3.972.10", "@aws-sdk/util-user-agent-node": "^3.973.22", "@smithy/config-resolver": "^4.4.17", "@smithy/core": "^3.23.17", "@smithy/fetch-http-handler": "^5.3.17", "@smithy/hash-node": "^4.2.14", "@smithy/invalid-dependency": "^4.2.14", "@smithy/middleware-content-length": "^4.2.14", "@smithy/middleware-endpoint": "^4.4.32", "@smithy/middleware-retry": "^4.5.6", "@smithy/middleware-serde": "^4.2.20", "@smithy/middleware-stack": "^4.2.14", "@smithy/node-config-provider": "^4.3.14", "@smithy/node-http-handler": "^4.6.1", "@smithy/protocol-http": "^5.3.14", "@smithy/smithy-client": "^4.12.13", "@smithy/types": "^4.14.1", "@smithy/url-parser": "^4.2.14", "@smithy/util-base64": "^4.3.2", "@smithy/util-body-length-browser": "^4.2.2", "@smithy/util-body-length-node": "^4.2.3", "@smithy/util-defaults-mode-browser": "^4.3.49", "@smithy/util-defaults-mode-node": "^4.2.54", "@smithy/util-endpoints": "^3.4.2", "@smithy/util-middleware": "^4.2.14", "@smithy/util-retry": "^4.3.5", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-4Sf+WY1lMJzXlw5MiyCMe/UzdILCwvuaHThbqMXS6dfh9gZy3No360I42RXquOI/ULUOhWy2HCyU0Fp20fQGPQ=="],
+
+    "@aws-sdk/region-config-resolver": ["@aws-sdk/region-config-resolver@3.972.13", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@smithy/config-resolver": "^4.4.17", "@smithy/node-config-provider": "^4.3.14", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A=="],
+
+    "@aws-sdk/s3-request-presigner": ["@aws-sdk/s3-request-presigner@3.1038.0", "", { "dependencies": { "@aws-sdk/signature-v4-multi-region": "^3.996.23", "@aws-sdk/types": "^3.973.8", "@aws-sdk/util-format-url": "^3.972.10", "@smithy/middleware-endpoint": "^4.4.32", "@smithy/protocol-http": "^5.3.14", "@smithy/smithy-client": "^4.12.13", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-2PNCm+2Mx8v2GKRREKMS3PavahzRhmMMJjuJxUpLneQV4w3oMs2bpme62oU6l+hip1pyeyPimWHeabjhaURocw=="],
+
+    "@aws-sdk/signature-v4-multi-region": ["@aws-sdk/signature-v4-multi-region@3.996.23", "", { "dependencies": { "@aws-sdk/middleware-sdk-s3": "^3.972.35", "@aws-sdk/types": "^3.973.8", "@smithy/protocol-http": "^5.3.14", "@smithy/signature-v4": "^5.3.14", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-wBbys3Y53Ikly556vyADurKpYQHXS7Jjaskbz+Ga9PZCz7PB/9f3VdKbDlz7dqIzn+xwz7L/a6TR4iXcOi8IRw=="],
+
+    "@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1038.0", "", { "dependencies": { "@aws-sdk/core": "^3.974.6", "@aws-sdk/nested-clients": "^3.997.4", "@aws-sdk/types": "^3.973.8", "@smithy/property-provider": "^4.2.14", "@smithy/shared-ini-file-loader": "^4.4.9", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-Qniru+9oGGb/HNK/gGZWbV3jsD0k71ngE7qMQ/x6gYNYLd2EOwHCS6E2E6jfkaqO4i0d+nNKmfRy8bNcshKdGQ=="],
+
+    "@aws-sdk/types": ["@aws-sdk/types@3.973.8", "", { "dependencies": { "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw=="],
+
+    "@aws-sdk/util-arn-parser": ["@aws-sdk/util-arn-parser@3.972.3", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA=="],
+
+    "@aws-sdk/util-endpoints": ["@aws-sdk/util-endpoints@3.996.8", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@smithy/types": "^4.14.1", "@smithy/url-parser": "^4.2.14", "@smithy/util-endpoints": "^3.4.2", "tslib": "^2.6.2" } }, "sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g=="],
+
+    "@aws-sdk/util-format-url": ["@aws-sdk/util-format-url@3.972.10", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@smithy/querystring-builder": "^4.2.14", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-DEKiHNJVtNxdyTeQspzY+15Po/kHm6sF0Cs4HV9Q2+lplB63+DrvdeiSoOSdWEWAoO2RcY1veoXVDz2tWxWCgQ=="],
+
+    "@aws-sdk/util-locate-window": ["@aws-sdk/util-locate-window@3.965.5", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ=="],
+
+    "@aws-sdk/util-user-agent-browser": ["@aws-sdk/util-user-agent-browser@3.972.10", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@smithy/types": "^4.14.1", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g=="],
+
+    "@aws-sdk/util-user-agent-node": ["@aws-sdk/util-user-agent-node@3.973.22", "", { "dependencies": { "@aws-sdk/middleware-user-agent": "^3.972.36", "@aws-sdk/types": "^3.973.8", "@smithy/node-config-provider": "^4.3.14", "@smithy/types": "^4.14.1", "@smithy/util-config-provider": "^4.2.2", "tslib": "^2.6.2" }, "peerDependencies": { "aws-crt": ">=1.0.0" }, "optionalPeers": ["aws-crt"] }, "sha512-YTYqTmOUrwbm1h99Ee4y/mVYpFRl0oSO/amtP5cc1BZZWdaAVWs9zj3TkyRHWvR9aI/ZS8m3mS6awXtYUlWyaw=="],
+
+    "@aws-sdk/xml-builder": ["@aws-sdk/xml-builder@3.972.21", "", { "dependencies": { "@nodable/entities": "2.1.0", "@smithy/types": "^4.14.1", "fast-xml-parser": "5.7.2", "tslib": "^2.6.2" } }, "sha512-qxNiHUtlrsjTeSlrPWiFkWps7uD6YB4eKzg7eLAFH8jbiHTlt0ePNlo2Xu+WlftP38JIcMaIX4jTUjOlE2ySWw=="],
+
+    "@aws/lambda-invoke-store": ["@aws/lambda-invoke-store@0.2.4", "", {}, "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ=="],
 
     "@azure-rest/core-client": ["@azure-rest/core-client@2.5.1", "", { "dependencies": { "@azure/abort-controller": "^2.1.2", "@azure/core-auth": "^1.10.0", "@azure/core-rest-pipeline": "^1.22.0", "@azure/core-tracing": "^1.3.0", "@typespec/ts-http-runtime": "^0.3.0", "tslib": "^2.6.2" } }, "sha512-EHaOXW0RYDKS5CFffnixdyRPak5ytiCtU7uXDcP/uiY+A6jFRwNGzzJBiznkCzvi5EYpY+YWinieqHb0oY916A=="],
 
@@ -750,6 +836,8 @@
     "@noble/curves": ["@noble/curves@1.9.7", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw=="],
 
     "@noble/hashes": ["@noble/hashes@2.0.1", "", {}, "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw=="],
+
+    "@nodable/entities": ["@nodable/entities@2.1.0", "", {}, "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
@@ -1130,6 +1218,106 @@
     "@sinclair/typebox": ["@sinclair/typebox@0.34.48", "", {}, "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA=="],
 
     "@sindresorhus/merge-streams": ["@sindresorhus/merge-streams@4.0.0", "", {}, "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ=="],
+
+    "@smithy/chunked-blob-reader": ["@smithy/chunked-blob-reader@5.2.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-St+kVicSyayWQca+I1rGitaOEH6uKgE8IUWoYnnEX26SWdWQcL6LvMSD19Lg+vYHKdT9B2Zuu7rd3i6Wnyb/iw=="],
+
+    "@smithy/chunked-blob-reader-native": ["@smithy/chunked-blob-reader-native@4.2.3", "", { "dependencies": { "@smithy/util-base64": "^4.3.2", "tslib": "^2.6.2" } }, "sha512-jA5k5Udn7Y5717L86h4EIv06wIr3xn8GM1qHRi/Nf31annXcXHJjBKvgztnbn2TxH3xWrPBfgwHsOwZf0UmQWw=="],
+
+    "@smithy/config-resolver": ["@smithy/config-resolver@4.4.17", "", { "dependencies": { "@smithy/node-config-provider": "^4.3.14", "@smithy/types": "^4.14.1", "@smithy/util-config-provider": "^4.2.2", "@smithy/util-endpoints": "^3.4.2", "@smithy/util-middleware": "^4.2.14", "tslib": "^2.6.2" } }, "sha512-TzDZcAnhTyAHbXVxWZo7/tEcrIeFq20IBk8So3OLOetWpR8EwY/yEqBMBFaJMeyEiREDq4NfEl+qO3OAUD+vbQ=="],
+
+    "@smithy/core": ["@smithy/core@3.23.17", "", { "dependencies": { "@smithy/protocol-http": "^5.3.14", "@smithy/types": "^4.14.1", "@smithy/url-parser": "^4.2.14", "@smithy/util-base64": "^4.3.2", "@smithy/util-body-length-browser": "^4.2.2", "@smithy/util-middleware": "^4.2.14", "@smithy/util-stream": "^4.5.25", "@smithy/util-utf8": "^4.2.2", "@smithy/uuid": "^1.1.2", "tslib": "^2.6.2" } }, "sha512-x7BlLbUFL8NWCGjMF9C+1N5cVCxcPa7g6Tv9B4A2luWx3be3oU8hQ96wIwxe/s7OhIzvoJH73HAUSg5JXVlEtQ=="],
+
+    "@smithy/credential-provider-imds": ["@smithy/credential-provider-imds@4.2.14", "", { "dependencies": { "@smithy/node-config-provider": "^4.3.14", "@smithy/property-provider": "^4.2.14", "@smithy/types": "^4.14.1", "@smithy/url-parser": "^4.2.14", "tslib": "^2.6.2" } }, "sha512-Au28zBN48ZAoXdooGUHemuVBrkE+Ie6RPmGNIAJsFqj33Vhb6xAgRifUydZ2aY+M+KaMAETAlKk5NC5h1G7wpg=="],
+
+    "@smithy/eventstream-codec": ["@smithy/eventstream-codec@4.2.14", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.1", "@smithy/util-hex-encoding": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-erZq0nOIpzfeZdCyzZjdJb4nVSKLUmSkaQUVkRGQTXs30gyUGeKnrYEg+Xe1W5gE3aReS7IgsvANwVPxSzY6Pw=="],
+
+    "@smithy/eventstream-serde-browser": ["@smithy/eventstream-serde-browser@4.2.14", "", { "dependencies": { "@smithy/eventstream-serde-universal": "^4.2.14", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-8IelTCtTctWRbb+0Dcy+C0aICh1qa0qWXqgjcXDmMuCvPJRnv26hiDZoAau2ILOniki65mCPKqOQs/BaWvO4CQ=="],
+
+    "@smithy/eventstream-serde-config-resolver": ["@smithy/eventstream-serde-config-resolver@4.3.14", "", { "dependencies": { "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-sqHiHpYRYo3FJlaIxD1J8PhbcmJAm7IuM16mVnwSkCToD7g00IBZzKuiLNMGmftULmEUX6/UAz8/NN5uMP8bVA=="],
+
+    "@smithy/eventstream-serde-node": ["@smithy/eventstream-serde-node@4.2.14", "", { "dependencies": { "@smithy/eventstream-serde-universal": "^4.2.14", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-Ht/8BuGlKfFTy0H3+8eEu0vdpwGztCnaLLXtpXNdQqiR7Hj4vFScU3T436vRAjATglOIPjJXronY+1WxxNLSiw=="],
+
+    "@smithy/eventstream-serde-universal": ["@smithy/eventstream-serde-universal@4.2.14", "", { "dependencies": { "@smithy/eventstream-codec": "^4.2.14", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-lWyt4T2XQZUZgK3tQ3Wn0w3XBvZsK/vjTuJl6bXbnGZBHH0ZUSONTYiK9TgjTTzU54xQr3DRFwpjmhp0oLm3gg=="],
+
+    "@smithy/fetch-http-handler": ["@smithy/fetch-http-handler@5.3.17", "", { "dependencies": { "@smithy/protocol-http": "^5.3.14", "@smithy/querystring-builder": "^4.2.14", "@smithy/types": "^4.14.1", "@smithy/util-base64": "^4.3.2", "tslib": "^2.6.2" } }, "sha512-bXOvQzaSm6MnmLaWA1elgfQcAtN4UP3vXqV97bHuoOrHQOJiLT3ds6o9eo5bqd0TJfRFpzdGnDQdW3FACiAVdw=="],
+
+    "@smithy/hash-blob-browser": ["@smithy/hash-blob-browser@4.2.15", "", { "dependencies": { "@smithy/chunked-blob-reader": "^5.2.2", "@smithy/chunked-blob-reader-native": "^4.2.3", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-0PJ4Al3fg2nM4qKrAIxyNcApgqHAXcBkN8FeizOz69z0rb26uZ6lMESYtxegaTlXB5Hj84JfwMPavMrwDMjucA=="],
+
+    "@smithy/hash-node": ["@smithy/hash-node@4.2.14", "", { "dependencies": { "@smithy/types": "^4.14.1", "@smithy/util-buffer-from": "^4.2.2", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-8ZBDY2DD4wr+GGjTpPtiglEsqr0lUP+KHqgZcWczFf6qeZ/YRjMIOoQWVQlmwu7EtxKTd8YXD8lblmYcpBIA1g=="],
+
+    "@smithy/hash-stream-node": ["@smithy/hash-stream-node@4.2.14", "", { "dependencies": { "@smithy/types": "^4.14.1", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-tw4GANWkZPb6+BdD4Fgucqzey2+r73Z/GRo9zklsCdwrnxxumUV83ZIaBDdudV4Ylazw3EPTiJZhpX42105ruQ=="],
+
+    "@smithy/invalid-dependency": ["@smithy/invalid-dependency@4.2.14", "", { "dependencies": { "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-c21qJiTSb25xvvOp+H2TNZzPCngrvl5vIPqPB8zQ/DmJF4QWXO19x1dWfMJZ6wZuuWUPPm0gV8C0cU3+ifcWuw=="],
+
+    "@smithy/is-array-buffer": ["@smithy/is-array-buffer@4.2.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow=="],
+
+    "@smithy/md5-js": ["@smithy/md5-js@4.2.14", "", { "dependencies": { "@smithy/types": "^4.14.1", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-V2v0vx+h0iUSNG1Alt+GNBMSLGCrl9iVsdd+Ap67HPM9PN479x12V8LkuMoKImNZxn3MXeuyUjls+/7ZACZghA=="],
+
+    "@smithy/middleware-content-length": ["@smithy/middleware-content-length@4.2.14", "", { "dependencies": { "@smithy/protocol-http": "^5.3.14", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-xhHq7fX4/3lv5NHxLUk3OeEvl0xZ+Ek3qIbWaCL4f9JwgDZEclPBElljaZCAItdGPQl/kSM4LPMOpy1MYgprpw=="],
+
+    "@smithy/middleware-endpoint": ["@smithy/middleware-endpoint@4.4.32", "", { "dependencies": { "@smithy/core": "^3.23.17", "@smithy/middleware-serde": "^4.2.20", "@smithy/node-config-provider": "^4.3.14", "@smithy/shared-ini-file-loader": "^4.4.9", "@smithy/types": "^4.14.1", "@smithy/url-parser": "^4.2.14", "@smithy/util-middleware": "^4.2.14", "tslib": "^2.6.2" } }, "sha512-ZZkgyjnJppiZbIm6Qbx92pbXYi1uzenIvGhBSCDlc7NwuAkiqSgS75j1czAD25ZLs2FjMjYy1q7gyRVWG6JA0Q=="],
+
+    "@smithy/middleware-retry": ["@smithy/middleware-retry@4.5.6", "", { "dependencies": { "@smithy/core": "^3.23.17", "@smithy/node-config-provider": "^4.3.14", "@smithy/protocol-http": "^5.3.14", "@smithy/service-error-classification": "^4.3.1", "@smithy/smithy-client": "^4.12.13", "@smithy/types": "^4.14.1", "@smithy/util-middleware": "^4.2.14", "@smithy/util-retry": "^4.3.5", "@smithy/uuid": "^1.1.2", "tslib": "^2.6.2" } }, "sha512-5zhmo2AkstmM/RMKYP0NHfmuYWBR+/umlmSuALgajLxf0X0rLE6d17MfzTxpzkILWVhwvCJkCyPH0AfMlbaucQ=="],
+
+    "@smithy/middleware-serde": ["@smithy/middleware-serde@4.2.20", "", { "dependencies": { "@smithy/core": "^3.23.17", "@smithy/protocol-http": "^5.3.14", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-Lx9JMO9vArPtiChE3wbEZ5akMIDQpWQtlu90lhACQmNOXcGXRbaDywMHDzuDZ2OkZzP+9wQfZi3YJT9F67zTQQ=="],
+
+    "@smithy/middleware-stack": ["@smithy/middleware-stack@4.2.14", "", { "dependencies": { "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-2dvkUKLuFdKsCRmOE4Mn63co0Djtsm+JMh0bYZQupN1pJwMeE8FmQmRLLzzEMN0dnNi7CDCYYH8F0EVwWiPBeA=="],
+
+    "@smithy/node-config-provider": ["@smithy/node-config-provider@4.3.14", "", { "dependencies": { "@smithy/property-provider": "^4.2.14", "@smithy/shared-ini-file-loader": "^4.4.9", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-S+gFjyo/weSVL0P1b9Ts8C/CwIfNCgUPikk3sl6QVsfE/uUuO+QsF+NsE/JkpvWqqyz1wg7HFdiaZuj5CoBMRg=="],
+
+    "@smithy/node-http-handler": ["@smithy/node-http-handler@4.6.1", "", { "dependencies": { "@smithy/protocol-http": "^5.3.14", "@smithy/querystring-builder": "^4.2.14", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-iB+orM4x3xrr57X3YaXazfKnntl0LHlZB1kcXSGzMV1Tt0+YwEjGlbjk/44qEGtBzXAz6yFDzkYTKSV6Pj2HUg=="],
+
+    "@smithy/property-provider": ["@smithy/property-provider@4.2.14", "", { "dependencies": { "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-WuM31CgfsnQ/10i7NYr0PyxqknD72Y5uMfUMVSniPjbEPceiTErb4eIqJQ+pdxNEAUEWrewrGjIRjVbVHsxZiQ=="],
+
+    "@smithy/protocol-http": ["@smithy/protocol-http@5.3.14", "", { "dependencies": { "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ=="],
+
+    "@smithy/querystring-builder": ["@smithy/querystring-builder@4.2.14", "", { "dependencies": { "@smithy/types": "^4.14.1", "@smithy/util-uri-escape": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-XYA5Z0IqTeF+5XDdh4BBmSA0HvbgVZIyv4cmOoUheDNR57K1HgBp9ukUMx3Cr3XpDHHpLBnexPE3LAtDsZkj2A=="],
+
+    "@smithy/querystring-parser": ["@smithy/querystring-parser@4.2.14", "", { "dependencies": { "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-hr+YyqBD23GVvRxGGrcc/oOeNlK3PzT5Fu4dzrDXxzS1LpFiuL2PQQqKPs87M79aW7ziMs+nvB3qdw77SqE7Lw=="],
+
+    "@smithy/service-error-classification": ["@smithy/service-error-classification@4.3.1", "", { "dependencies": { "@smithy/types": "^4.14.1" } }, "sha512-aUQuDGh760ts/8MU+APjIZhlLPKhIIfqyzZaJikLEIMrdxFvxuLYD0WxWzaYWpmLbQlXDe9p7EWM3HsBe0K6Gw=="],
+
+    "@smithy/shared-ini-file-loader": ["@smithy/shared-ini-file-loader@4.4.9", "", { "dependencies": { "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-495/V2I15SHgedSJoDPD23JuSfKAp726ZI1V0wtjB07Wh7q/0tri/0e0DLefZCHgxZonrGKt/OCTpAtP1wE1kQ=="],
+
+    "@smithy/signature-v4": ["@smithy/signature-v4@5.3.14", "", { "dependencies": { "@smithy/is-array-buffer": "^4.2.2", "@smithy/protocol-http": "^5.3.14", "@smithy/types": "^4.14.1", "@smithy/util-hex-encoding": "^4.2.2", "@smithy/util-middleware": "^4.2.14", "@smithy/util-uri-escape": "^4.2.2", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA=="],
+
+    "@smithy/smithy-client": ["@smithy/smithy-client@4.12.13", "", { "dependencies": { "@smithy/core": "^3.23.17", "@smithy/middleware-endpoint": "^4.4.32", "@smithy/middleware-stack": "^4.2.14", "@smithy/protocol-http": "^5.3.14", "@smithy/types": "^4.14.1", "@smithy/util-stream": "^4.5.25", "tslib": "^2.6.2" } }, "sha512-y/Pcj1V9+qG98gyu1gvftHB7rDpdh+7kIBIggs55yGm3JdtBV8GT8IFF3a1qxZ79QnaJHX9GXzvBG6tAd+czJA=="],
+
+    "@smithy/types": ["@smithy/types@4.14.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg=="],
+
+    "@smithy/url-parser": ["@smithy/url-parser@4.2.14", "", { "dependencies": { "@smithy/querystring-parser": "^4.2.14", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-p06BiBigJ8bTA3MgnOfCtDUWnAMY0YfedO/GRpmc7p+wg3KW8vbXy1xwSu5ASy0wV7rRYtlfZOIKH4XqfhjSQQ=="],
+
+    "@smithy/util-base64": ["@smithy/util-base64@4.3.2", "", { "dependencies": { "@smithy/util-buffer-from": "^4.2.2", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ=="],
+
+    "@smithy/util-body-length-browser": ["@smithy/util-body-length-browser@4.2.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ=="],
+
+    "@smithy/util-body-length-node": ["@smithy/util-body-length-node@4.2.3", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g=="],
+
+    "@smithy/util-buffer-from": ["@smithy/util-buffer-from@4.2.2", "", { "dependencies": { "@smithy/is-array-buffer": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q=="],
+
+    "@smithy/util-config-provider": ["@smithy/util-config-provider@4.2.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ=="],
+
+    "@smithy/util-defaults-mode-browser": ["@smithy/util-defaults-mode-browser@4.3.49", "", { "dependencies": { "@smithy/property-provider": "^4.2.14", "@smithy/smithy-client": "^4.12.13", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-a5bNrdiONYB/qE2BuKegvUMd/+ZDwdg4vsNuuSzYE8qs2EYAdK9CynL+Rzn29PbPiUqoz/cbpRbcLzD5lEevHw=="],
+
+    "@smithy/util-defaults-mode-node": ["@smithy/util-defaults-mode-node@4.2.54", "", { "dependencies": { "@smithy/config-resolver": "^4.4.17", "@smithy/credential-provider-imds": "^4.2.14", "@smithy/node-config-provider": "^4.3.14", "@smithy/property-provider": "^4.2.14", "@smithy/smithy-client": "^4.12.13", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-g1cvrJvOnzeJgEdf7AE4luI7gp6L8weE0y9a9wQUSGtjb8QRHDbCJYuE4Sy0SD9N8RrnNPFsPltAz/OSoBR9Zw=="],
+
+    "@smithy/util-endpoints": ["@smithy/util-endpoints@3.4.2", "", { "dependencies": { "@smithy/node-config-provider": "^4.3.14", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-a55Tr+3OKld4TTtnT+RhKOQHyPxm3j/xL4OR83WBUhLJaKDS9dnJ7arRMOp3t31dcLhApwG9bgvrRXBHlLdIkg=="],
+
+    "@smithy/util-hex-encoding": ["@smithy/util-hex-encoding@4.2.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg=="],
+
+    "@smithy/util-middleware": ["@smithy/util-middleware@4.2.14", "", { "dependencies": { "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-1Su2vj9RYNDEv/V+2E+jXkkwGsgR7dc4sfHn9Z7ruzQHJIEni9zzw5CauvRXlFJfmgcqYP8fWa0dkh2Q2YaQyw=="],
+
+    "@smithy/util-retry": ["@smithy/util-retry@4.3.5", "", { "dependencies": { "@smithy/service-error-classification": "^4.3.1", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-h1IJsbgMDA+jaTjrco/JsyfWOgHRJBv8myB1y4AEI2fjIzD6ktZ7pFAyTw+gwN9GKIAygvC6db0mq0j8N2rFOg=="],
+
+    "@smithy/util-stream": ["@smithy/util-stream@4.5.25", "", { "dependencies": { "@smithy/fetch-http-handler": "^5.3.17", "@smithy/node-http-handler": "^4.6.1", "@smithy/types": "^4.14.1", "@smithy/util-base64": "^4.3.2", "@smithy/util-buffer-from": "^4.2.2", "@smithy/util-hex-encoding": "^4.2.2", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-/PFpG4k8Ze8Ei+mMKj3oiPICYekthuzePZMgZbCqMiXIHHf4n2aZ4Ps0aSRShycFTGuj/J6XldmC0x0DwednIA=="],
+
+    "@smithy/util-uri-escape": ["@smithy/util-uri-escape@4.2.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw=="],
+
+    "@smithy/util-utf8": ["@smithy/util-utf8@4.2.2", "", { "dependencies": { "@smithy/util-buffer-from": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw=="],
+
+    "@smithy/util-waiter": ["@smithy/util-waiter@4.3.0", "", { "dependencies": { "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-JyjYmLAfS+pdxF92o4yLgEoy0zhayKTw73FU1aofLWwLcJw7iSqIY2exGmMTrl/lmZugP5p/zxdFSippJDfKWA=="],
+
+    "@smithy/uuid": ["@smithy/uuid@1.1.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g=="],
 
     "@solid-primitives/event-listener": ["@solid-primitives/event-listener@2.4.5", "", { "dependencies": { "@solid-primitives/utils": "^6.4.0" }, "peerDependencies": { "solid-js": "^1.6.12" } }, "sha512-nwRV558mIabl4yVAhZKY8cb6G+O1F0M6Z75ttTu5hk+SxdOnKSGj+eetDIu7Oax1P138ZdUU01qnBPR8rnxaEA=="],
 
@@ -1531,6 +1719,8 @@
 
     "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
 
+    "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
+
     "brace-expansion": ["brace-expansion@5.0.4", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
@@ -1868,6 +2058,10 @@
     "fast-safe-stringify": ["fast-safe-stringify@2.1.1", "", {}, "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="],
 
     "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
+
+    "fast-xml-builder": ["fast-xml-builder@1.1.5", "", { "dependencies": { "path-expression-matcher": "^1.1.3" } }, "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA=="],
+
+    "fast-xml-parser": ["fast-xml-parser@5.7.2", "", { "dependencies": { "@nodable/entities": "^2.1.0", "fast-xml-builder": "^1.1.5", "path-expression-matcher": "^1.5.0", "strnum": "^2.2.3" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w=="],
 
     "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
 
@@ -2477,6 +2671,8 @@
 
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
+    "path-expression-matcher": ["path-expression-matcher@1.5.0", "", {}, "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ=="],
+
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
     "path-to-regexp": ["path-to-regexp@8.3.0", "", {}, "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA=="],
@@ -2841,6 +3037,8 @@
 
     "strip-literal": ["strip-literal@3.1.0", "", { "dependencies": { "js-tokens": "^9.0.1" } }, "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg=="],
 
+    "strnum": ["strnum@2.2.3", "", {}, "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg=="],
+
     "strtok3": ["strtok3@10.3.5", "", { "dependencies": { "@tokenizer/token": "^0.3.0" } }, "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA=="],
 
     "style-to-js": ["style-to-js@1.1.21", "", { "dependencies": { "style-to-object": "1.0.14" } }, "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ=="],
@@ -3066,6 +3264,12 @@
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
     "@antfu/ni/package-manager-detector": ["package-manager-detector@1.6.0", "", {}, "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA=="],
+
+    "@aws-crypto/sha1-browser/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
+
+    "@aws-crypto/sha256-browser/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
+
+    "@aws-crypto/util/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
 
     "@azure/identity/open": ["open@10.2.0", "", { "dependencies": { "default-browser": "^5.2.1", "define-lazy-prop": "^3.0.0", "is-inside-container": "^1.0.0", "wsl-utils": "^0.1.0" } }, "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA=="],
 
@@ -3341,6 +3545,12 @@
 
     "yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
+    "@aws-crypto/sha1-browser/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
+
+    "@aws-crypto/sha256-browser/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
+
+    "@aws-crypto/util/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
+
     "@azure/identity/open/wsl-utils": ["wsl-utils@0.1.0", "", { "dependencies": { "is-wsl": "^3.1.0" } }, "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw=="],
 
     "@changesets/get-github-info/node-fetch/whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
@@ -3596,6 +3806,12 @@
     "wrap-ansi/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "@aws-crypto/sha1-browser/@smithy/util-utf8/@smithy/util-buffer-from/@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
+
+    "@aws-crypto/sha256-browser/@smithy/util-utf8/@smithy/util-buffer-from/@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
+
+    "@aws-crypto/util/@smithy/util-utf8/@smithy/util-buffer-from/@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
 
     "@changesets/get-github-info/node-fetch/whatwg-url/tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
 

--- a/packages/questpie/package.json
+++ b/packages/questpie/package.json
@@ -27,6 +27,7 @@
 		"./drizzle": "./src/exports/drizzle.ts",
 		"./drizzle-pg-core": "./src/exports/drizzle-pg-core.ts",
 		"./shared": "./src/exports/shared.ts",
+		"./storage": "./src/exports/storage.ts",
 		"./*": "./*"
 	},
 	"publishConfig": {
@@ -38,6 +39,7 @@
 			"./drizzle": "./dist/drizzle.mjs",
 			"./drizzle-pg-core": "./dist/drizzle-pg-core.mjs",
 			"./shared": "./dist/shared.mjs",
+			"./storage": "./dist/storage.mjs",
 			"./*": "./*"
 		}
 	},
@@ -63,6 +65,8 @@
 		"zod": "^4.2.1"
 	},
 	"devDependencies": {
+		"@aws-sdk/client-s3": "^3.840.0",
+		"@aws-sdk/s3-request-presigner": "^3.840.0",
 		"@electric-sql/pglite": "^0.3.14",
 		"@types/html-to-text": "^9.0.4",
 		"@types/nodemailer": "^7.0.5",

--- a/packages/questpie/src/exports/storage.ts
+++ b/packages/questpie/src/exports/storage.ts
@@ -1,0 +1,57 @@
+/**
+ * questpie/storage — public storage entry point.
+ *
+ * Bundles three things so consumers do not need to mix-and-match imports
+ * from `flydrive` and `questpie`:
+ *
+ *  1. The `R2Driver` factory — wraps flydrive's `S3Driver` with Cloudflare R2
+ *     conventions (region "auto", path-style, no ACL) AND defaults the
+ *     urlBuilder to the questpie storage proxy.
+ *
+ *  2. The `makeProxyUrlBuilder` utility — for users who want to plug the
+ *     questpie storage proxy into a raw flydrive driver themselves
+ *     (S3, GCS, custom). See the storage docs for recipes.
+ *
+ *  3. Re-exports of flydrive's `S3Driver`, `FSDriver`, `GCSDriver` and their
+ *     option types — so a single `from "questpie/storage"` import is enough
+ *     to wire any supported backend.
+ *
+ *  4. Re-exports of the signed-URL helpers (`generateSignedUrlToken`,
+ *     `verifySignedUrlToken`, `buildStorageFileUrl`) — useful when serving
+ *     files from a custom route or generating short-lived URLs by hand.
+ */
+
+// questpie additions
+export { R2Driver, type R2DriverOptions } from "#questpie/server/modules/core/integrated/storage/drivers/r2.js";
+export {
+	makeProxyUrlBuilder,
+	type ProxyUrlOptions,
+} from "#questpie/server/modules/core/integrated/storage/drivers/factory.js";
+export type { StorageDriverFactory } from "#questpie/server/config/types.js";
+
+// signed-URL helpers (also exported from the main `questpie` entry, kept here
+// for discoverability when someone is already importing from `questpie/storage`)
+export {
+	type SignedUrlPayload,
+	type StorageUrlConfig,
+	buildStorageFileUrl,
+	generateFileUrl,
+	generateSignedUrlToken,
+	verifySignedUrlToken,
+} from "#questpie/server/modules/core/integrated/storage/signed-url.js";
+
+// flydrive driver re-exports — single import surface
+export { FSDriver } from "flydrive/drivers/fs";
+export type { FSDriverOptions } from "flydrive/drivers/fs/types";
+export { S3Driver } from "flydrive/drivers/s3";
+export type { S3DriverOptions } from "flydrive/drivers/s3/types";
+export { GCSDriver } from "flydrive/drivers/gcs";
+export type { GCSDriverOptions } from "flydrive/drivers/gcs/types";
+export type {
+	DriverContract,
+	ObjectMetaData,
+	ObjectVisibility,
+	SignedURLOptions,
+	UploadSignedURLOptions,
+	WriteOptions,
+} from "flydrive/types";

--- a/packages/questpie/src/server/config/types.ts
+++ b/packages/questpie/src/server/config/types.ts
@@ -310,20 +310,36 @@ export interface StorageLocalConfig extends StorageBaseConfig {
 }
 
 /**
+ * Factory that produces a flydrive driver from the resolved app config.
+ *
+ * Used by the `questpie/storage` wrapper drivers so they can default
+ * `urlBuilder` to the storage proxy without the user having to pipe
+ * `app.url` / `secret` into the driver options manually.
+ */
+export type StorageDriverFactory = (config: QuestpieConfig) => DriverContract;
+
+/**
  * Custom driver storage configuration (S3, R2, GCS, etc.).
  * Cloud providers serve files directly - no local file serving.
  */
 export interface StorageDriverConfig extends StorageBaseConfig {
 	/**
-	 * Custom FlyDrive driver instance.
+	 * Custom FlyDrive driver instance, or a factory produced by one of the
+	 * wrappers from `questpie/storage`.
 	 *
-	 * @example
+	 * @example raw flydrive driver
 	 * ```ts
 	 * import { S3Driver } from "flydrive/drivers/s3";
 	 * storage: { driver: new S3Driver({ ... }) }
 	 * ```
+	 *
+	 * @example questpie wrapper
+	 * ```ts
+	 * import { R2Driver } from "questpie/storage";
+	 * storage: { driver: R2Driver({ bucket: ..., credentials: ... }) }
+	 * ```
 	 */
-	driver: DriverContract;
+	driver: DriverContract | StorageDriverFactory;
 	location?: never;
 }
 

--- a/packages/questpie/src/server/modules/core/integrated/storage/create-driver.ts
+++ b/packages/questpie/src/server/modules/core/integrated/storage/create-driver.ts
@@ -5,12 +5,8 @@ import type { DriverContract } from "flydrive/types";
 
 import type { QuestpieConfig } from "#questpie/server/config/types.js";
 
-import { buildStorageFileUrl, generateSignedUrlToken } from "./signed-url.js";
+import { makeProxyUrlBuilder } from "./drivers/factory.js";
 
-const DEFAULT_BASE_PATH = "/";
-
-const resolveBasePath = (config: QuestpieConfig) =>
-	config.storage?.basePath || DEFAULT_BASE_PATH;
 const DEFAULT_LOCATION = "./uploads";
 
 /**
@@ -27,43 +23,26 @@ export function getStorageLocation(config: QuestpieConfig): string | null {
 
 /**
  * Creates the storage driver.
- * - Custom `driver` → use it (cloud)
+ * - Custom `driver` (DriverContract or factory) → use it (cloud)
  * - Otherwise → FSDriver with `location` (local)
  */
 export const createDiskDriver = (config: QuestpieConfig): DriverContract => {
 	if (config.storage?.driver) {
-		return config.storage.driver;
+		return typeof config.storage.driver === "function"
+			? config.storage.driver(config)
+			: config.storage.driver;
 	}
 
 	const location = getStorageLocation(config)!;
-	const secret = config.secret || "questpie-default-secret";
-	const expiration = config.storage?.signedUrlExpiration || 3600;
-
-	const basePath = resolveBasePath(config);
+	const proxy = makeProxyUrlBuilder(config);
 
 	return new FSDriver({
 		location,
 		visibility: "public",
 		urlBuilder: {
-			async generateURL(key) {
-				return buildStorageFileUrl(config.app.url, basePath, key);
-			},
-			async generateSignedURL(key, _filePath, options) {
-				const tokenExpiration = options?.expiresIn
-					? Math.floor(
-							(typeof options.expiresIn === "string"
-								? parseInt(options.expiresIn, 10)
-								: options.expiresIn) / 1000,
-						)
-					: expiration;
-
-				const token = await generateSignedUrlToken(
-					key,
-					secret,
-					tokenExpiration,
-				);
-				return buildStorageFileUrl(config.app.url, basePath, key, token);
-			},
+			generateURL: (key) => proxy.generateURL(key),
+			generateSignedURL: (key, _filePath, options) =>
+				proxy.generateSignedURL(key, options?.expiresIn),
 		},
 	});
 };

--- a/packages/questpie/src/server/modules/core/integrated/storage/drivers/factory.ts
+++ b/packages/questpie/src/server/modules/core/integrated/storage/drivers/factory.ts
@@ -1,0 +1,91 @@
+import type { QuestpieConfig } from "#questpie/server/config/types.js";
+
+import {
+	buildStorageFileUrl,
+	generateSignedUrlToken,
+} from "../signed-url.js";
+
+const DEFAULT_BASE_PATH = "/";
+const DEFAULT_SECRET = "questpie-default-secret";
+const DEFAULT_EXPIRATION_SECONDS = 3600;
+
+/**
+ * Options shared by every wrapper driver in `questpie/storage`.
+ */
+export interface ProxyUrlOptions {
+	/**
+	 * Optional public/CDN base URL for serving public files directly,
+	 * bypassing the storage proxy.
+	 *
+	 * When set, `generateURL(key)` returns `${publicUrl}/${key}`.
+	 * Use for:
+	 *  - Cloudflare R2 with `*.r2.dev` or a custom domain on a public bucket
+	 *  - S3/CloudFront distributions
+	 *  - GCS with public bucket + DNS
+	 *
+	 * Signed URLs (private files) ALWAYS go through the questpie proxy
+	 * regardless of this setting, so visibility-aware access control
+	 * stays in effect.
+	 */
+	publicUrl?: string;
+}
+
+/**
+ * Builds a pair of `(key) => string` resolvers that produce questpie proxy URLs
+ * for both public and private (signed) access, using the resolved app config.
+ *
+ * Each driver wires these into its native urlBuilder shape — flydrive passes
+ * different extra arguments per driver (`filePath` for FS, `bucket`/`client`
+ * for S3, `bucket`/`storage` for GCS), but only `key` matters for the proxy.
+ */
+export function makeProxyUrlBuilder(
+	config: QuestpieConfig,
+	options: ProxyUrlOptions = {},
+): {
+	generateURL: (key: string) => Promise<string>;
+	generateSignedURL: (key: string, expiresIn?: number | string) => Promise<string>;
+} {
+	const baseUrl = config.app.url;
+	const basePath = config.storage?.basePath || DEFAULT_BASE_PATH;
+	const secret = config.secret || DEFAULT_SECRET;
+	const defaultExpiration =
+		config.storage?.signedUrlExpiration || DEFAULT_EXPIRATION_SECONDS;
+	const publicUrl = options.publicUrl?.replace(/\/$/, "");
+
+	return {
+		async generateURL(key) {
+			if (publicUrl) {
+				return `${publicUrl}/${key}`;
+			}
+			return buildStorageFileUrl(baseUrl, basePath, key);
+		},
+		async generateSignedURL(key, expiresIn) {
+			const seconds = resolveExpirationSeconds(expiresIn, defaultExpiration);
+			const token = await generateSignedUrlToken(key, secret, seconds);
+			return buildStorageFileUrl(baseUrl, basePath, key, token);
+		},
+	};
+}
+
+/**
+ * flydrive accepts `expiresIn` as either a number of milliseconds or a string
+ * (parsed as ms by flydrive itself). Our token API takes seconds, so we
+ * normalise here. Falls back to the configured default when nothing is
+ * provided or parsing fails.
+ */
+function resolveExpirationSeconds(
+	expiresIn: number | string | undefined,
+	fallbackSeconds: number,
+): number {
+	if (expiresIn === undefined) return fallbackSeconds;
+
+	const ms =
+		typeof expiresIn === "string"
+			? Number.parseInt(expiresIn, 10)
+			: expiresIn;
+
+	if (!Number.isFinite(ms) || ms <= 0) return fallbackSeconds;
+
+	const seconds = Math.floor(ms / 1000);
+	return seconds > 0 ? seconds : fallbackSeconds;
+}

--- a/packages/questpie/src/server/modules/core/integrated/storage/drivers/r2.ts
+++ b/packages/questpie/src/server/modules/core/integrated/storage/drivers/r2.ts
@@ -1,0 +1,100 @@
+import { S3Driver } from "flydrive/drivers/s3";
+import type { S3DriverOptions } from "flydrive/drivers/s3/types";
+import type { DriverContract } from "flydrive/types";
+
+import type {
+	QuestpieConfig,
+	StorageDriverFactory,
+} from "#questpie/server/config/types.js";
+
+import { makeProxyUrlBuilder, type ProxyUrlOptions } from "./factory.js";
+
+/**
+ * Cloudflare R2 conventions that flydrive's raw `S3Driver` does not apply
+ * automatically. Without these, the driver behaves like generic S3 and silently
+ * misconfigures itself against R2:
+ *
+ *  - `region: "auto"` — R2 ignores region but `@aws-sdk/client-s3` rejects undefined.
+ *  - `forcePathStyle: true` — R2 only supports path-style URLs.
+ *  - `supportsACL: false` — R2 has no per-object ACL API; flydrive must skip it
+ *    or every put/getVisibility call errors with "method not allowed".
+ */
+const R2_DEFAULTS = {
+	region: "auto" as const,
+	forcePathStyle: true as const,
+	supportsACL: false as const,
+};
+
+/**
+ * R2Driver options. Same shape as flydrive's `S3DriverOptions` minus the three
+ * R2-required defaults that we apply unconditionally.
+ *
+ * If you need to override one of those defaults (e.g. you're pointing this at
+ * a non-R2 S3-compatible service that does expose ACLs), use the raw flydrive
+ * `S3Driver` directly with the `makeProxyUrlBuilder` utility instead.
+ */
+export type R2DriverOptions = Omit<
+	S3DriverOptions,
+	"region" | "forcePathStyle" | "supportsACL"
+> &
+	ProxyUrlOptions;
+
+/**
+ * Factory for a flydrive `S3Driver` pre-configured for Cloudflare R2.
+ *
+ * Returns a `StorageDriverFactory` so questpie can wire `app.url` / `secret`
+ * into the urlBuilder at app boot. Pass it directly as `storage.driver`:
+ *
+ * ```ts
+ * import { R2Driver } from "questpie/storage";
+ *
+ * runtimeConfig({
+ *   storage: {
+ *     driver: R2Driver({
+ *       bucket: process.env.R2_BUCKET!,
+ *       endpoint: process.env.R2_ENDPOINT!,
+ *       credentials: {
+ *         accessKeyId: process.env.R2_ACCESS_KEY_ID!,
+ *         secretAccessKey: process.env.R2_SECRET_ACCESS_KEY!,
+ *       },
+ *       visibility: "public",
+ *       // optional: serve public files from your r2.dev or custom domain
+ *       publicUrl: "https://cdn.example.com",
+ *     }),
+ *   },
+ * });
+ * ```
+ *
+ * Defaults applied:
+ *  - `urlBuilder.generateURL` → questpie storage proxy (or `publicUrl/<key>` if set)
+ *  - `urlBuilder.generateSignedURL` → questpie proxy + signed token (always)
+ *  - R2-specific: `region: "auto"`, `forcePathStyle: true`, `supportsACL: false`
+ */
+export function R2Driver(options: R2DriverOptions): StorageDriverFactory {
+	const { publicUrl, ...s3Options } = options;
+
+	return (config: QuestpieConfig): DriverContract => {
+		const proxy = makeProxyUrlBuilder(config, { publicUrl });
+
+		// flydrive's S3 urlBuilder signature: (key, ...) — extras (bucket, client,
+		// expiresIn) are ignored except for `expiresIn` on signed URLs.
+		const proxyUrlBuilder: NonNullable<S3DriverOptions["urlBuilder"]> = {
+			generateURL: (key: string) => proxy.generateURL(key),
+			generateSignedURL: (
+				key: string,
+				_options: unknown,
+				_client: unknown,
+				expiresIn?: number | string,
+			) => proxy.generateSignedURL(key, expiresIn),
+		};
+
+		return new S3Driver({
+			...R2_DEFAULTS,
+			...(s3Options as S3DriverOptions),
+			urlBuilder: {
+				...proxyUrlBuilder,
+				...(s3Options.urlBuilder ?? {}),
+			},
+		} as S3DriverOptions);
+	};
+}

--- a/packages/questpie/test/integration/storage-r2-driver.test.ts
+++ b/packages/questpie/test/integration/storage-r2-driver.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Integration test: collection .upload() + R2Driver from `questpie/storage`.
+ *
+ * Verifies the asset.url field that the upload afterRead hook attaches via
+ * `app.storage.use().getUrl(key)` / `getSignedUrl(key)` resolves to the
+ * questpie storage proxy URL when an R2-backed driver is configured — without
+ * the user having to write a urlBuilder override by hand.
+ *
+ * S3/R2 itself is never hit: the upload afterRead hook only exercises the
+ * driver's urlBuilder, which is pure (no network).
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+
+import { collection } from "../../src/exports/index.js";
+import { Questpie } from "../../src/server/config/questpie.js";
+import { R2Driver } from "../../src/server/modules/core/integrated/storage/drivers/r2.js";
+import { verifySignedUrlToken } from "../../src/server/modules/core/integrated/storage/signed-url.js";
+import { buildMockApp } from "../utils/mocks/mock-app-builder";
+import { createTestContext } from "../utils/test-context";
+import { runTestDbMigrations } from "../utils/test-db";
+
+const assets = collection("assets")
+	.options({ timestamps: true })
+	.fields(({ f }) => ({ alt: f.text(500) }))
+	.upload({ visibility: "public" });
+
+const SECRET = "r2-test-secret";
+
+const r2Options = {
+	bucket: "questpie-test",
+	endpoint: "https://example.r2.cloudflarestorage.com",
+	credentials: { accessKeyId: "x", secretAccessKey: "y" },
+	visibility: "public" as const,
+};
+
+describe("R2Driver integration: collection asset.url", () => {
+	let setup: Awaited<ReturnType<typeof buildMockApp>>;
+	let app: (typeof setup)["app"];
+	const ctx = createTestContext();
+
+	const baseUrl = "http://app.test";
+
+	const setupApp = async (driver: ReturnType<typeof R2Driver>) => {
+		setup = await buildMockApp(
+			{ collections: { assets } },
+			{
+				app: { url: baseUrl },
+				secret: SECRET,
+				storage: { driver },
+			},
+		);
+		app = setup.app;
+		await runTestDbMigrations(app);
+		// buildMockApp calls `app.storage.fake()` automatically — restore so the
+		// real R2-backed driver's urlBuilder runs.
+		app.storage.restore(Questpie.__internal.storageDriverServiceName);
+	};
+
+	afterEach(async () => {
+		await setup.cleanup();
+	});
+
+	describe("default (no publicUrl)", () => {
+		beforeEach(async () => {
+			await setupApp(R2Driver(r2Options));
+		});
+
+		it("public asset.url is the questpie proxy URL", async () => {
+			const asset = await app.collections.assets.create(
+				{
+					id: crypto.randomUUID(),
+					key: "uploads/public.png",
+					filename: "public.png",
+					mimeType: "image/png",
+					size: 1234,
+					visibility: "public",
+				},
+				ctx,
+			);
+
+			const fetched = await app.collections.assets.findOne(
+				{ where: { id: asset.id } },
+				ctx,
+			);
+
+			const url = (fetched as any).url as string;
+			expect(url).toBe(`${baseUrl}/storage/files/uploads%2Fpublic.png`);
+			expect(url).not.toContain("?token=");
+		});
+
+		it("private asset.url has ?token= and verifies", async () => {
+			const asset = await app.collections.assets.create(
+				{
+					id: crypto.randomUUID(),
+					key: "uploads/private.pdf",
+					filename: "private.pdf",
+					mimeType: "application/pdf",
+					size: 999,
+					visibility: "private",
+				},
+				ctx,
+			);
+
+			const fetched = await app.collections.assets.findOne(
+				{ where: { id: asset.id } },
+				ctx,
+			);
+
+			const url = (fetched as any).url as string;
+			expect(url).toStartWith(`${baseUrl}/storage/files/uploads%2Fprivate.pdf`);
+			expect(url).toContain("?token=");
+
+			const token = new URL(url).searchParams.get("token")!;
+			const payload = await verifySignedUrlToken(token, SECRET);
+			expect(payload).not.toBeNull();
+			expect(payload?.key).toBe("uploads/private.pdf");
+		});
+	});
+
+	describe("with publicUrl override", () => {
+		const publicUrl = "https://cdn.example.com";
+
+		beforeEach(async () => {
+			await setupApp(R2Driver({ ...r2Options, publicUrl }));
+		});
+
+		it("public asset.url is `${publicUrl}/${key}`", async () => {
+			const asset = await app.collections.assets.create(
+				{
+					id: crypto.randomUUID(),
+					key: "uploads/public.png",
+					filename: "public.png",
+					mimeType: "image/png",
+					size: 1234,
+					visibility: "public",
+				},
+				ctx,
+			);
+
+			const fetched = await app.collections.assets.findOne(
+				{ where: { id: asset.id } },
+				ctx,
+			);
+
+			const url = (fetched as any).url as string;
+			expect(url).toBe(`${publicUrl}/uploads/public.png`);
+		});
+
+		it("private asset.url still goes through the proxy", async () => {
+			const asset = await app.collections.assets.create(
+				{
+					id: crypto.randomUUID(),
+					key: "uploads/secret.pdf",
+					filename: "secret.pdf",
+					mimeType: "application/pdf",
+					size: 999,
+					visibility: "private",
+				},
+				ctx,
+			);
+
+			const fetched = await app.collections.assets.findOne(
+				{ where: { id: asset.id } },
+				ctx,
+			);
+
+			const url = (fetched as any).url as string;
+			// Public override does NOT bypass the access-control proxy for private.
+			expect(url).toStartWith(`${baseUrl}/storage/files/uploads%2Fsecret.pdf`);
+			expect(url).not.toContain("cdn.example.com");
+			expect(url).toContain("?token=");
+		});
+	});
+});

--- a/packages/questpie/test/units/storage-wrapper-drivers.test.ts
+++ b/packages/questpie/test/units/storage-wrapper-drivers.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Tests for `questpie/storage` — R2Driver factory + makeProxyUrlBuilder utility.
+ *
+ * Covers the same surface that storage-driver.test.ts covers for the built-in
+ * FSDriver path, plus R2-specific concerns (R2 conventions applied,
+ * publicUrl override, signed URLs always proxied).
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import type { QuestpieConfig } from "../../src/server/config/types.js";
+import { createDiskDriver } from "../../src/server/modules/core/integrated/storage/create-driver.js";
+import { makeProxyUrlBuilder } from "../../src/server/modules/core/integrated/storage/drivers/factory.js";
+import { R2Driver } from "../../src/server/modules/core/integrated/storage/drivers/r2.js";
+import { verifySignedUrlToken } from "../../src/server/modules/core/integrated/storage/signed-url.js";
+
+const createMockConfig = (
+	overrides: Partial<QuestpieConfig> = {},
+): QuestpieConfig =>
+	({
+		app: { url: "http://localhost:3000", name: "test" },
+		db: { url: "postgres://localhost/test" },
+		secret: "test-secret",
+		...overrides,
+	}) as QuestpieConfig;
+
+describe("makeProxyUrlBuilder", () => {
+	test("generateURL returns proxy URL by default", async () => {
+		const config = createMockConfig();
+		const proxy = makeProxyUrlBuilder(config);
+
+		const url = await proxy.generateURL("avatars/me.png");
+
+		expect(url).toBe(
+			"http://localhost:3000/storage/files/avatars%2Fme.png",
+		);
+	});
+
+	test("generateURL returns publicUrl/<key> when publicUrl is set", async () => {
+		const config = createMockConfig();
+		const proxy = makeProxyUrlBuilder(config, {
+			publicUrl: "https://cdn.example.com",
+		});
+
+		const url = await proxy.generateURL("avatars/me.png");
+
+		expect(url).toBe("https://cdn.example.com/avatars/me.png");
+	});
+
+	test("generateURL trims trailing slash on publicUrl", async () => {
+		const config = createMockConfig();
+		const proxy = makeProxyUrlBuilder(config, {
+			publicUrl: "https://cdn.example.com/",
+		});
+
+		const url = await proxy.generateURL("a.png");
+
+		expect(url).toBe("https://cdn.example.com/a.png");
+	});
+
+	test("generateURL respects basePath", async () => {
+		const config = createMockConfig({
+			storage: { basePath: "/api" },
+		});
+		const proxy = makeProxyUrlBuilder(config);
+
+		const url = await proxy.generateURL("a.png");
+
+		expect(url).toBe("http://localhost:3000/api/storage/files/a.png");
+	});
+
+	test("generateSignedURL returns proxy URL with valid token", async () => {
+		const config = createMockConfig();
+		const proxy = makeProxyUrlBuilder(config);
+
+		const url = await proxy.generateSignedURL("secret.pdf");
+
+		expect(url).toContain("http://localhost:3000/storage/files/secret.pdf");
+		expect(url).toContain("?token=");
+
+		const token = new URL(url).searchParams.get("token");
+		expect(token).toBeTruthy();
+
+		const payload = await verifySignedUrlToken(token!, "test-secret");
+		expect(payload).not.toBeNull();
+		expect(payload?.key).toBe("secret.pdf");
+	});
+
+	test("generateSignedURL ALWAYS uses proxy even when publicUrl is set", async () => {
+		const config = createMockConfig();
+		const proxy = makeProxyUrlBuilder(config, {
+			publicUrl: "https://cdn.example.com",
+		});
+
+		const url = await proxy.generateSignedURL("secret.pdf");
+
+		// publicUrl is for public files only — signed URLs go through the proxy
+		// so visibility-aware access control stays in effect.
+		expect(url).toContain("http://localhost:3000/storage/files/");
+		expect(url).not.toContain("cdn.example.com");
+		expect(url).toContain("?token=");
+	});
+
+	test("generateSignedURL converts flydrive expiresIn (ms) to seconds", async () => {
+		const config = createMockConfig();
+		const proxy = makeProxyUrlBuilder(config);
+
+		// flydrive passes expiresIn in milliseconds; we verify the resulting token
+		// has the expected expiration (60s = 60000ms).
+		const url = await proxy.generateSignedURL("a.pdf", 60_000);
+		const token = new URL(url).searchParams.get("token")!;
+
+		const payload = await verifySignedUrlToken(token, "test-secret");
+		expect(payload).not.toBeNull();
+		const now = Math.floor(Date.now() / 1000);
+		// Allow a few seconds of clock skew.
+		expect(payload!.expires - now).toBeGreaterThanOrEqual(55);
+		expect(payload!.expires - now).toBeLessThanOrEqual(65);
+	});
+
+	test("generateSignedURL falls back to default expiration on bad input", async () => {
+		const config = createMockConfig({
+			storage: { signedUrlExpiration: 7200 },
+		});
+		const proxy = makeProxyUrlBuilder(config);
+
+		const url = await proxy.generateSignedURL("a.pdf", "not-a-number");
+		const token = new URL(url).searchParams.get("token")!;
+
+		const payload = await verifySignedUrlToken(token, "test-secret");
+		const now = Math.floor(Date.now() / 1000);
+		expect(payload!.expires - now).toBeGreaterThan(7000);
+	});
+});
+
+describe("R2Driver", () => {
+	test("returns a StorageDriverFactory (not a DriverContract)", () => {
+		const factory = R2Driver({
+			bucket: "my-bucket",
+			endpoint: "https://r2.example.com",
+			credentials: { accessKeyId: "x", secretAccessKey: "y" },
+			visibility: "public",
+		});
+
+		expect(typeof factory).toBe("function");
+	});
+
+	test("produces a flydrive driver with R2 conventions applied", () => {
+		const factory = R2Driver({
+			bucket: "my-bucket",
+			endpoint: "https://r2.example.com",
+			credentials: { accessKeyId: "x", secretAccessKey: "y" },
+			visibility: "public",
+		});
+		const config = createMockConfig();
+		const driver = factory(config);
+
+		// We can't introspect S3Driver's constructor args directly, but we can
+		// verify the resulting driver exposes the standard contract.
+		expect(typeof driver.getUrl).toBe("function");
+		expect(typeof driver.getSignedUrl).toBe("function");
+		expect(typeof driver.put).toBe("function");
+
+		// And that the options object on the driver carries the conventions.
+		const opts = (driver as unknown as { options: Record<string, unknown> })
+			.options;
+		expect(opts.region).toBe("auto");
+		expect(opts.forcePathStyle).toBe(true);
+		expect(opts.supportsACL).toBe(false);
+	});
+
+	test("getUrl returns proxy URL by default", async () => {
+		const factory = R2Driver({
+			bucket: "my-bucket",
+			endpoint: "https://r2.example.com",
+			credentials: { accessKeyId: "x", secretAccessKey: "y" },
+			visibility: "public",
+		});
+		const driver = factory(createMockConfig());
+
+		const url = await driver.getUrl("photos/a.jpg");
+
+		expect(url).toBe("http://localhost:3000/storage/files/photos%2Fa.jpg");
+	});
+
+	test("getUrl returns publicUrl/<key> when publicUrl is set", async () => {
+		const factory = R2Driver({
+			bucket: "my-bucket",
+			endpoint: "https://r2.example.com",
+			credentials: { accessKeyId: "x", secretAccessKey: "y" },
+			visibility: "public",
+			publicUrl: "https://pub-abc123.r2.dev",
+		});
+		const driver = factory(createMockConfig());
+
+		const url = await driver.getUrl("photos/a.jpg");
+
+		expect(url).toBe("https://pub-abc123.r2.dev/photos/a.jpg");
+	});
+
+	test("getSignedUrl uses proxy + token even when publicUrl is set", async () => {
+		const factory = R2Driver({
+			bucket: "my-bucket",
+			endpoint: "https://r2.example.com",
+			credentials: { accessKeyId: "x", secretAccessKey: "y" },
+			visibility: "private",
+			publicUrl: "https://pub-abc123.r2.dev",
+		});
+		const driver = factory(createMockConfig());
+
+		const url = await driver.getSignedUrl("private.pdf");
+
+		expect(url).toContain("http://localhost:3000/storage/files/private.pdf");
+		expect(url).not.toContain("r2.dev");
+		expect(url).toContain("?token=");
+	});
+
+	test("user-supplied urlBuilder overrides override the proxy defaults", async () => {
+		const factory = R2Driver({
+			bucket: "my-bucket",
+			endpoint: "https://r2.example.com",
+			credentials: { accessKeyId: "x", secretAccessKey: "y" },
+			visibility: "public",
+			urlBuilder: {
+				generateURL: async (key) => `https://manual.example.com/${key}`,
+			},
+		});
+		const driver = factory(createMockConfig());
+
+		const url = await driver.getUrl("a.png");
+
+		expect(url).toBe("https://manual.example.com/a.png");
+	});
+});
+
+describe("createDiskDriver — driver factory variant", () => {
+	test("invokes factory function with config", () => {
+		const factory = R2Driver({
+			bucket: "my-bucket",
+			endpoint: "https://r2.example.com",
+			credentials: { accessKeyId: "x", secretAccessKey: "y" },
+			visibility: "public",
+		});
+		const config = createMockConfig({ storage: { driver: factory } });
+
+		const driver = createDiskDriver(config);
+
+		expect(typeof driver.put).toBe("function");
+		expect(typeof driver.getUrl).toBe("function");
+	});
+
+	test("backwards-compat: still accepts a raw DriverContract", () => {
+		const mockDriver = {
+			put: () => {},
+			get: () => {},
+			delete: () => {},
+			exists: () => {},
+			getUrl: () => {},
+			getSignedUrl: () => {},
+		} as any;
+		const config = createMockConfig({ storage: { driver: mockDriver } });
+
+		const driver = createDiskDriver(config);
+
+		expect(driver).toBe(mockDriver);
+	});
+});


### PR DESCRIPTION
## Summary

- New `questpie/storage` entry: **`R2Driver`** wrapper, **`makeProxyUrlBuilder`** utility, plus re-exports of flydrive's `S3Driver`/`FSDriver`/`GCSDriver` and the signed-URL helpers — one import surface for every supported backend.
- `StorageDriverConfig.driver` accepts a `(config) => DriverContract` factory in addition to a raw `DriverContract`, so wrappers can read the resolved `app.url`/`secret`/`storage.basePath`/`signedUrlExpiration` without users threading them through. Raw flydrive imports keep working.
- Fixes the long-standing R2 footgun: `new S3Driver({...})` against R2 returns an unsigned S3 endpoint URL from `getUrl()` and 400s on public reads. `R2Driver` applies the three required R2 conventions (`region:"auto"`, `forcePathStyle:true`, `supportsACL:false`) and defaults the urlBuilder to the questpie proxy. Optional `publicUrl` opt-out (CDN / r2.dev / custom domain); private/signed URLs always go through the proxy regardless so visibility-aware access control stays in effect.
- `makeProxyUrlBuilder` is the single source of truth — `createDiskDriver` (default FS) now uses it too, dropping a duplicate copy of the proxy URL/token logic.
- Docs: new [Storage Flow](apps/docs/content/docs/production/storage-flow.mdx) page covers visibility, proxy lifecycle, token format, `asset.url` computation, and the buffered-read perf trade-off. [Storage](apps/docs/content/docs/production/storage.mdx) rewritten with R2/S3/GCS recipes and a copy-pasteable migration diff from raw flydrive imports.

Backwards-compat: purely additive. Existing apps importing raw flydrive drivers are untouched. Changeset is `questpie: minor`.

## Test plan

- [x] Unit tests: `bun test test/units/storage-wrapper-drivers.test.ts` — 16 pass (proxy URL, `publicUrl` override, signed URL ms→s conversion, R2 conventions applied, BC with raw `DriverContract`)
- [x] Integration test: `bun test test/integration/storage-r2-driver.test.ts` — 4 pass (collection `.upload()` + `findOne` → `asset.url` is proxy URL for public, `?token=` for private, `${publicUrl}/${key}` with override, private still proxied with override set)
- [x] Existing storage tests still pass (`storage-driver.test.ts`, `collection-upload.test.ts`)
- [x] Full `bun test` for `packages/questpie` — 1678 pass, 0 fail
- [x] `bunx tsc --noEmit -p tsconfig.json` clean
- [x] `oxlint` on changed files — 0 warnings, 0 errors