### PR TITLE
[codex] feat(storage): migrate to files-sdk API

### DIFF
--- a/.changeset/files-sdk-storage.md
+++ b/.changeset/files-sdk-storage.md
@@ -1,0 +1,7 @@
+---
+"questpie": patch
+---
+
+Migrate QUESTPIE storage from Flydrive to the direct Files SDK API. Storage is now configured with `runtimeConfig({ storage: { adapter } })`, `app.storage` is the typed `Files` instance, and route, service, job, and hook contexts receive that same direct storage API.
+
+Remove the legacy `app.storage.use`, `storage.files`, `storage.driver`, Flydrive, DriveManager, QUESTPIE storage-disk, and storage-specific `createStorageRoutes()` closure surfaces. Upload CRUD cleanup and storage routes now call Files SDK operations directly, including streaming upload/download behavior and typed adapter access; `createAdapterRoutes()` remains as the broader deprecated compatibility shim.

--- a/README.md
+++ b/README.md
@@ -216,9 +216,14 @@ await app.collections.posts.deleteById({ id: post.id });
 File uploads work automatically when `adminModule` is included (it provides the `assets` collection). Configure storage in your config:
 
 ```typescript
+import { fs } from "files-sdk/fs";
+
 export default runtimeConfig({
 	db: { url: process.env.DATABASE_URL! },
-	storage: { basePath: "/api" },
+	storage: {
+		adapter: fs({ root: "./uploads" }),
+		basePath: "/api",
+	},
 });
 
 // Upload via API: POST /api/assets/upload
@@ -457,7 +462,7 @@ bun run dev --filter=docs
 - **Database**: PostgreSQL + [Drizzle ORM](https://orm.drizzle.team)
 - **Validation**: [Zod v4](https://zod.dev)
 - **Authentication**: [Better Auth](https://better-auth.com)
-- **Storage**: [Flydrive](https://flydrive.dev)
+- **Storage**: [Files SDK](https://files-sdk.dev)
 - **Queue**: [pg-boss](https://github.com/timgit/pg-boss)
 - **Email**: [Nodemailer](https://nodemailer.com) + [React Email](https://react.email)
 - **Logging**: [Pino](https://getpino.io)

--- a/apps/docs/content/docs/examples/barbershop.mdx
+++ b/apps/docs/content/docs/examples/barbershop.mdx
@@ -85,11 +85,15 @@ flowchart TD
 import { runtimeConfig } from "questpie/app";
 import { pgBossAdapter } from "questpie/adapters/pg-boss";
 import { SmtpAdapter } from "questpie/adapters/smtp";
+import { fs } from "files-sdk/fs";
 
 export default runtimeConfig({
 	app: { url: process.env.APP_URL || "http://localhost:3000" },
 	db: { url: process.env.DATABASE_URL || "postgres://localhost/barbershop" },
-	storage: { basePath: "/api" },
+	storage: {
+		adapter: fs({ root: "./uploads" }),
+		basePath: "/api",
+	},
 	secret: process.env.BETTER_AUTH_SECRET || "demo-secret",
 	queue: { adapter: pgBossAdapter({ connectionString: DATABASE_URL }) },
 });

--- a/apps/docs/content/docs/extend/custom-adapters/index.mdx
+++ b/apps/docs/content/docs/extend/custom-adapters/index.mdx
@@ -7,14 +7,14 @@ Almost every infrastructure layer in QUESTPIE is swappable. Each subsystem defin
 
 ## Adapter types
 
-| Type | Contract | Config key | Default |
-|---|---|---|---|
-| [KV / Cache](./kv) | `KVAdapter` interface | `kv.adapter` | `MemoryKVAdapter` |
-| [Queue](./queue) | `QueueAdapter` interface | `queue.adapter` | `PgBossAdapter` |
-| [Search](./search) | `SearchAdapter` interface | `search` | `PostgresSearchAdapter` |
-| [Realtime](./realtime) | `RealtimeAdapter` interface | `realtime.adapter` | polling (no adapter) |
-| [Storage](./storage) | FlyDrive `DriverContract` | `storage.driver` | `FSDriver` (local disk) |
-| [Email](./email) | `MailAdapter` abstract class | `email.adapter` | `ConsoleAdapter` |
+| Type                   | Contract                     | Config key         | Default                 |
+| ---------------------- | ---------------------------- | ------------------ | ----------------------- |
+| [KV / Cache](./kv)     | `KVAdapter` interface        | `kv.adapter`       | `MemoryKVAdapter`       |
+| [Queue](./queue)       | `QueueAdapter` interface     | `queue.adapter`    | `PgBossAdapter`         |
+| [Search](./search)     | `SearchAdapter` interface    | `search`           | `PostgresSearchAdapter` |
+| [Realtime](./realtime) | `RealtimeAdapter` interface  | `realtime.adapter` | polling (no adapter)    |
+| [Storage](./storage)   | Files SDK adapter            | `storage.adapter`  | Filesystem adapter      |
+| [Email](./email)       | `MailAdapter` abstract class | `email.adapter`    | `ConsoleAdapter`        |
 
 ## Before you start
 

--- a/apps/docs/content/docs/extend/custom-adapters/storage.mdx
+++ b/apps/docs/content/docs/extend/custom-adapters/storage.mdx
@@ -1,285 +1,126 @@
 ---
 title: Storage Adapter
-description: Implement a custom file storage driver for QUESTPIE using FlyDrive.
+description: Configure or implement a Files SDK adapter for QUESTPIE storage.
 ---
 
-Storage in QUESTPIE is backed by [FlyDrive](https://flydrive.dev). To use a custom cloud provider (S3, R2, GCS, Azure Blob, etc.), you provide a FlyDrive `DriverContract` instance. FlyDrive already ships drivers for popular providers -- you only need to write a custom driver if your provider is not supported.
+Storage in QUESTPIE is backed by [Files SDK](https://files-sdk.dev/). QUESTPIE creates one direct `Files` instance from your configured adapter and exposes it as `storage` in typed route, service, job, and hook context.
 
-## Interface
-
-QUESTPIE expects a FlyDrive `DriverContract`. The full interface:
-
-```ts
-interface DriverContract {
-	// Core operations
-	put(
-		key: string,
-		contents: string | Uint8Array,
-		options?: WriteOptions,
-	): Promise<void>;
-	get(key: string): Promise<string>;
-	getBytes(key: string): Promise<Uint8Array>;
-	getStream(key: string): Promise<ReadableStream<Uint8Array>>;
-	delete(key: string): Promise<void>;
-	exists(key: string): Promise<boolean>;
-
-	// URLs
-	getUrl(key: string): Promise<string>;
-	getSignedUrl(key: string, options?: SignedURLOptions): Promise<string>;
-
-	// Metadata & visibility
-	getMetaData(key: string): Promise<ObjectMetaData>;
-	getVisibility(key: string): Promise<ObjectVisibility>;
-	setVisibility(key: string, visibility: ObjectVisibility): Promise<void>;
-
-	// Streaming upload
-	putStream(
-		key: string,
-		contents: Readable,
-		options?: WriteOptions,
-	): Promise<void>;
-
-	// File operations
-	copy(
-		source: string,
-		destination: string,
-		options?: WriteOptions,
-	): Promise<void>;
-	move(
-		source: string,
-		destination: string,
-		options?: WriteOptions,
-	): Promise<void>;
-
-	// Bulk operations
-	deleteAll(prefix: string): Promise<void>;
-	listAll(
-		prefix: string,
-		options?: { recursive?: boolean; paginationToken?: string },
-	): Promise<{
-		paginationToken?: string;
-		objects: Iterable<DriveFile | DriveDirectory>;
-	}>;
-}
-```
-
-## Using an existing FlyDrive driver
-
-For most cloud providers, you do not need to write a driver at all. Install the FlyDrive package for your provider and pass it directly:
+For most providers, use one of the Files SDK adapters and pass it to `runtimeConfig({ storage: { adapter } })`.
 
 ```ts title="questpie.config.ts"
 import { runtimeConfig } from "questpie/app";
-import { S3Driver } from "flydrive/drivers/s3";
+import { s3 } from "files-sdk/s3";
 
 export default runtimeConfig({
-	// ...
+	app: { url: process.env.APP_URL! },
+	db: { url: process.env.DATABASE_URL! },
 	storage: {
-		driver: new S3Driver({
+		adapter: s3({
+			bucket: process.env.S3_BUCKET!,
+			region: process.env.S3_REGION!,
 			credentials: {
 				accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
 				secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
 			},
-			region: process.env.AWS_REGION!,
-			bucket: process.env.S3_BUCKET!,
 		}),
+		basePath: "/api",
 	},
 });
 ```
 
-FlyDrive ships drivers for S3, R2 (Cloudflare), GCS (Google Cloud Storage), and local filesystem. See the [FlyDrive drivers documentation](https://flydrive.dev/docs/drivers) for the full list.
+Use the same `s3()` adapter for S3-compatible providers such as Cloudflare R2, MinIO, DigitalOcean Spaces, and Wasabi by setting `endpoint` and `forcePathStyle` when required.
 
-## Writing a custom driver
-
-If your provider is not covered by FlyDrive, implement `DriverContract`. Start with the core four methods, then fill in the rest.
-
-### Priority order
-
-1. `put`, `get`, `delete`, `exists` -- basic CRUD
-2. `getSignedUrl`, `getUrl` -- URL generation for the admin UI
-3. `getBytes`, `getStream`, `putStream` -- binary/streaming support
-4. `copy`, `move`, `deleteAll`, `listAll` -- file management
-5. `getMetaData`, `getVisibility`, `setVisibility` -- metadata
-
-### Minimal example
-
-```ts title="my-storage-driver.ts"
-import type {
-	DriveDirectory,
-	DriveFile,
-	DriverContract,
-	ObjectMetaData,
-	ObjectVisibility,
-	SignedURLOptions,
-	WriteOptions,
-} from "flydrive/types";
-
-type ProviderClient = {
-	upload(bucket: string, key: string, body: Uint8Array): Promise<void>;
-	download(bucket: string, key: string): Promise<Uint8Array>;
-	remove(bucket: string, key: string): Promise<void>;
-	head(bucket: string, key: string): Promise<void>;
-	presign(bucket: string, key: string): Promise<string>;
-};
-
-export class MyCloudDriver implements DriverContract {
-	constructor(
-		private options: { apiKey: string; bucket: string },
-		private client: ProviderClient,
-	) {}
-
-	async put(
-		key: string,
-		contents: string | Uint8Array,
-		_options?: WriteOptions,
-	): Promise<void> {
-		const body =
-			typeof contents === "string"
-				? new TextEncoder().encode(contents)
-				: contents;
-		await this.client.upload(this.options.bucket, key, body);
-	}
-
-	async get(key: string): Promise<string> {
-		const bytes = await this.client.download(this.options.bucket, key);
-		return new TextDecoder().decode(bytes);
-	}
-
-	async getBytes(key: string): Promise<Uint8Array> {
-		return this.client.download(this.options.bucket, key);
-	}
-
-	async getStream(key: string): Promise<ReadableStream<Uint8Array>> {
-		const bytes = await this.getBytes(key);
-		return new ReadableStream({
-			start: (controller) => {
-				controller.enqueue(bytes);
-				controller.close();
-			},
-		});
-	}
-
-	async delete(key: string): Promise<void> {
-		await this.client.remove(this.options.bucket, key);
-	}
-
-	async exists(key: string): Promise<boolean> {
-		try {
-			await this.client.head(this.options.bucket, key);
-			return true;
-		} catch {
-			return false;
-		}
-	}
-
-	async getUrl(key: string): Promise<string> {
-		return `https://${this.options.bucket}.example.com/${key}`;
-	}
-
-	async getSignedUrl(
-		key: string,
-		_options?: SignedURLOptions,
-	): Promise<string> {
-		return this.client.presign(this.options.bucket, key);
-	}
-
-	async getMetaData(_key: string): Promise<ObjectMetaData> {
-		return {};
-	}
-
-	async getVisibility(_key: string): Promise<ObjectVisibility> {
-		return "public";
-	}
-
-	async setVisibility(
-		_key: string,
-		_visibility: ObjectVisibility,
-	): Promise<void> {
-		// Map to your provider's ACL system
-	}
-
-	async putStream(
-		_key: string,
-		_contents: ReadableStream<Uint8Array>,
-		_options?: WriteOptions,
-	): Promise<void> {
-		throw new Error("Implement stream uploads for production use");
-	}
-
-	async copy(
-		source: string,
-		destination: string,
-		_options?: WriteOptions,
-	): Promise<void> {
-		const data = await this.getBytes(source);
-		await this.put(destination, data);
-	}
-
-	async move(
-		source: string,
-		destination: string,
-		options?: WriteOptions,
-	): Promise<void> {
-		await this.copy(source, destination, options);
-		await this.delete(source);
-	}
-
-	async deleteAll(prefix: string): Promise<void> {
-		const list = await this.listAll(prefix);
-		for (const obj of list.objects) {
-			if ("key" in obj) await this.delete(obj.key);
-		}
-	}
-
-	async listAll(
-		_prefix: string,
-	): Promise<{ objects: Iterable<DriveFile | DriveDirectory> }> {
-		return { objects: [] };
-	}
-}
-```
-
-## Registration
+## Local Development
 
 ```ts title="questpie.config.ts"
 import { runtimeConfig } from "questpie/app";
-import { MyCloudDriver } from "./my-storage-driver";
+import { fs } from "files-sdk/fs";
 
 export default runtimeConfig({
-	// ...
+	app: { url: "http://localhost:3000" },
+	db: { url: process.env.DATABASE_URL! },
 	storage: {
-		driver: new MyCloudDriver({
-			apiKey: process.env.STORAGE_API_KEY!,
-			bucket: process.env.STORAGE_BUCKET!,
+		adapter: fs({
+			root: "./uploads",
 		}),
-		defaultVisibility: "public", // "public" | "private" (default: "public")
-		signedUrlExpiration: 3600, // seconds (default: 3600)
-		basePath: "/", // base path for serving (default: "/")
+		basePath: "/api",
 	},
 });
 ```
 
-### Config options
+If `storage` is omitted, QUESTPIE falls back to local filesystem storage at `./uploads`.
 
-| Option                | Default       | Description                                                                     |
-| --------------------- | ------------- | ------------------------------------------------------------------------------- |
-| `driver`              | --            | FlyDrive `DriverContract` instance. If omitted, QUESTPIE uses local `FSDriver`. |
-| `location`            | `"./uploads"` | Directory for local storage (only when `driver` is not set).                    |
-| `defaultVisibility`   | `"public"`    | Default visibility for uploaded files.                                          |
-| `signedUrlExpiration` | `3600`        | Token expiration for signed URLs (seconds).                                     |
-| `basePath`            | `"/"`         | Base path for serving storage files.                                            |
+## Direct API
 
-You must provide either `driver` (custom/cloud) or `location` (local), not both.
+The context `storage` value is the typed Files SDK instance for the configured adapter:
 
-## Testing tips
+```ts
+import { route, service } from "questpie";
 
-- Upload one file, read it back, then delete it -- basic round-trip.
-- Test both public URLs (`getUrl`) and signed URLs (`getSignedUrl`).
-- Do **not** normalize keys inside the driver -- FlyDrive expects keys to be stored exactly as received.
-- If your backend supports pagination, test `listAll()` pagination tokens explicitly.
-- Test `exists()` returns `false` after `delete()`.
+export default route().post().handler(async ({ storage }) => {
+	await storage.upload("exports/report.csv", "id,total\n1,42");
+	const file = await storage.download("exports/report.csv");
+	const publicUrl = await storage.url("exports/report.csv");
 
-## Reference implementations
+	return { exists: !!file, publicUrl };
+});
 
-- [QUESTPIE storage driver factory](https://github.com/questpie/questpie/blob/main/packages/questpie/src/server/modules/core/integrated/storage/create-driver.ts) -- shows how QUESTPIE creates the default FSDriver with signed URLs
-- [FlyDrive custom driver guide](https://flydrive.dev/docs/advanced/custom_drivers) -- official FlyDrive documentation for writing drivers
-- [FlyDrive S3 driver source](https://github.com/flydrive-js/flydrive/tree/main/drivers/s3) -- reference for a production driver
+export const exportsService = service().create(({ storage }) => ({
+	remove: (key: string) => storage.delete(key),
+}));
+```
+
+Upload collections still return QUESTPIE route URLs by default, such as `/api/assets/files/:key`, even when the object lives in S3 or R2. The route checks the upload collection row and collection read access before streaming the stored object.
+
+## Custom Providers
+
+If Files SDK does not include your provider, implement a Files SDK `Adapter` and pass the adapter instance to `storage.adapter`. Keep provider-specific signing, upload, download, metadata, and listing behavior inside that adapter so application code continues to use the same `storage.upload`, `storage.download`, `storage.url`, and `storage.delete` methods.
+
+```ts title="questpie.config.ts"
+import { runtimeConfig } from "questpie/app";
+import { myProviderAdapter } from "./my-provider-adapter";
+
+export default runtimeConfig({
+	app: { url: process.env.APP_URL! },
+	db: { url: process.env.DATABASE_URL! },
+	storage: {
+		adapter: myProviderAdapter({
+			apiKey: process.env.STORAGE_API_KEY!,
+			bucket: process.env.STORAGE_BUCKET!,
+		}),
+		basePath: "/api",
+	},
+});
+```
+
+## Config Options
+
+| Option                | Default       | Description                                                                 |
+| --------------------- | ------------- | --------------------------------------------------------------------------- |
+| `adapter`             | filesystem    | Files SDK adapter used to create QUESTPIE's direct `Files` instance.        |
+| `location`            | `"./uploads"` | Directory for implicit local storage when `adapter` is omitted.             |
+| `defaultVisibility`   | `"public"`    | Default visibility for uploaded files.                                      |
+| `signedUrlExpiration` | `3600`        | QUESTPIE route token expiration for private upload collection URLs, seconds. |
+| `basePath`            | `"/"`         | Base path for QUESTPIE upload and file-serving routes.                      |
+
+Provide either `adapter` or `location`, not both. Prefer `adapter` for all production storage.
+
+## Migration Notes
+
+- Replace the old `storage["files"] = new Files({ adapter })` shape with `storage.adapter`.
+- Replace custom QUESTPIE storage disks with Files SDK adapters.
+- Replace legacy storage selector calls with direct Files SDK methods on context `storage` or `app.storage`.
+- Keep existing object keys and upload collection rows; the generated QUESTPIE file route format is unchanged.
+
+## Testing Tips
+
+- Upload one file, read it back, then delete it.
+- Test both `storage.url(key)` and upload collection record `url` values.
+- Test private upload collection URLs with an expired signed token.
+- Test object listing when your provider uses pagination.
+
+## Reference Implementations
+
+- [Files SDK adapters](https://files-sdk.dev/adapters) -- built-in adapters for object and blob stores.
+- [QUESTPIE storage factory](https://github.com/questpie/questpie/blob/main/packages/questpie/src/server/modules/core/integrated/storage/create-driver.ts) -- shows local defaults and adapter construction.
+- [QUESTPIE upload routes](https://github.com/questpie/questpie/blob/main/packages/questpie/src/server/adapters/routes/storage.ts) -- shows how collection access controls file serving.

--- a/apps/docs/content/docs/production/deployment.mdx
+++ b/apps/docs/content/docs/production/deployment.mdx
@@ -41,7 +41,7 @@ CMD ["bun", "run", ".output/server/index.mjs"]
 
 ## Cloudflare Workers
 
-Deploy QUESTPIE on Workers by wiring Cloudflare bindings into explicit adapters: Hyperdrive for PostgreSQL connections, FlyDrive `S3Driver` for R2, Workers KV, Cloudflare Queues, and Durable Object realtime. Configure Wrangler with the required bindings and `compatibility_flags = ["nodejs_compat"]` for the database driver.
+Deploy QUESTPIE on Workers by wiring Cloudflare bindings into explicit adapters: Hyperdrive for PostgreSQL connections, Files SDK S3 storage for R2, Workers KV, Cloudflare Queues, and Durable Object realtime. Configure Wrangler with the required bindings and `compatibility_flags = ["nodejs_compat"]` for the database driver.
 
 ### Runtime topology
 
@@ -54,7 +54,7 @@ A Cloudflare deployment is one Worker module with multiple platform entrypoints:
 | `scheduled()`        | Cron Trigger dispatcher for recurring jobs         |
 | Durable Object class | Realtime fanout hub                                |
 | Hyperdrive binding   | Connection layer to your existing PostgreSQL       |
-| R2 via S3 API        | Upload/media storage through FlyDrive `S3Driver`   |
+| R2 via S3 API        | Upload/media storage through Files SDK S3 adapter  |
 | Workers KV binding   | KV/cache adapter                                   |
 
 `createCloudflareWorkerHandlers(app)` exports `fetch`, `queue`, and `scheduled` from the same Worker object. You do not deploy a separate long-running queue worker and you do not call `app.queue.listen()` on Cloudflare. Cloudflare Queues invokes the exported `queue()` handler, and Cron Triggers invoke the exported `scheduled()` handler.
@@ -95,7 +95,7 @@ import {
 	type CloudflareKVNamespace,
 	type CloudflareQueueBinding,
 } from "questpie/adapters/cloudflare";
-import { S3Driver } from "flydrive/drivers/s3";
+import { s3 } from "files-sdk/s3";
 
 type CloudflareBindings = {
 	HYPERDRIVE: { connectionString: string };
@@ -141,7 +141,7 @@ export default runtimeConfig({
 		},
 	},
 	storage: {
-		driver: new S3Driver({
+		adapter: s3({
 			credentials: {
 				accessKeyId: process.env.R2_ACCESS_KEY_ID!,
 				secretAccessKey: process.env.R2_SECRET_ACCESS_KEY!,
@@ -149,9 +149,9 @@ export default runtimeConfig({
 			bucket: process.env.R2_BUCKET!,
 			region: "auto",
 			endpoint: `https://${process.env.CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com`,
-			visibility: "public",
 			forcePathStyle: true,
 		}),
+		basePath: "/api",
 	},
 	kv: {
 		adapter: cloudflareKVAdapter({
@@ -238,7 +238,7 @@ CLOUDFLARE_ACCOUNT_ID = "..."
 R2_BUCKET = "my-questpie-assets"
 ```
 
-For R2 storage, configure FlyDrive `S3Driver` with the R2 endpoint and credentials. For KV, configure `cloudflareKVAdapter` with a Workers KV namespace binding.
+For R2 storage, configure the Files SDK S3 adapter with the R2 endpoint and credentials. For KV, configure `cloudflareKVAdapter` with a Workers KV namespace binding.
 
 For jobs, configure `cloudflareQueuesAdapter` with a Queues producer/consumer binding. For recurring jobs, add matching Cron Triggers and export `scheduled()` through `createCloudflareWorkerHandlers`. Do not configure `pgBossAdapter`, `pgNotifyAdapter`, or Redis Streams on Workers.
 
@@ -278,7 +278,7 @@ For CI, keep the migration connection string as a CI secret. Hyperdrive's runtim
 - Keep `job.options.cron` exactly equal to a `wrangler.toml` cron trigger when the job should run on Cloudflare.
 - For `@questpie/workflows`, add a Cron Trigger for `questpie-wf-maintenance`'s `*/5 * * * *` schedule. Workflow-level `cron` definitions are evaluated by that maintenance job.
 - Use Durable Objects for realtime. Do not configure `pgNotifyAdapter` or Redis Streams on Workers.
-- Use R2 through FlyDrive `S3Driver`.
+- Use R2 through the Files SDK S3 adapter.
 - Use an HTTP email adapter such as Resend or Plunk. SMTP is not supported on Workers.
 - Store secrets with `wrangler secret put`; keep only non-secret vars in `wrangler.toml`.
 - Keep the Durable Object class name stable after deployment; changing it requires a new Durable Object migration.
@@ -300,7 +300,7 @@ For CI, keep the migration connection string as a CI secret. Hyperdrive's runtim
 
 - [ ] Configure Hyperdrive for the origin PostgreSQL database
 - [ ] Set `QUESTPIE_CLI_DATABASE_URL` in CI for migrations
-- [ ] Configure R2 credentials for FlyDrive `S3Driver`
+- [ ] Configure R2 credentials for the Files SDK S3 adapter
 - [ ] Configure Workers KV, Cloudflare Queues, and Durable Object bindings
 - [ ] Add Durable Object migrations in `wrangler.toml`
 - [ ] Add Cron Triggers for every recurring QUESTPIE job

--- a/apps/docs/content/docs/production/index.mdx
+++ b/apps/docs/content/docs/production/index.mdx
@@ -14,7 +14,7 @@ These are framework-level infrastructure services configured in `runtimeConfig()
 | [Database](/docs/production/database)             | PostgreSQL + Drizzle     | Primary data store  |
 | [Migrations](/docs/production/migrations)         | Built-in                 | Schema versioning   |
 | [Authentication](/docs/production/authentication) | Better Auth              | Sessions, providers |
-| [Storage](/docs/production/storage)               | FlyDrive (S3/local)      | File uploads        |
+| [Storage](/docs/production/storage)               | Files SDK (S3/local)     | File uploads        |
 | [Email](/docs/production/email)                   | Nodemailer               | Transactional email |
 | [Queue](/docs/production/queue)                   | pg-boss                  | Background jobs     |
 | [Search](/docs/production/search)                 | PG full-text search      | Text search         |
@@ -34,6 +34,7 @@ All services are configured in your `questpie.config.ts`:
 import { runtimeConfig } from "questpie/app";
 import { ConsoleAdapter } from "questpie/adapters/console";
 import { pgBossAdapter } from "questpie/adapters/pg-boss";
+import { fs } from "files-sdk/fs";
 
 export default runtimeConfig({
 	app: { url: process.env.APP_URL },
@@ -42,7 +43,7 @@ export default runtimeConfig({
 	queue: {
 		adapter: pgBossAdapter({ connectionString: process.env.DATABASE_URL }),
 	},
-	storage: { location: "./uploads", basePath: "/api" },
+	storage: { adapter: fs({ root: "./uploads" }), basePath: "/api" },
 	email: { adapter: new ConsoleAdapter() },
 });
 ```

--- a/apps/docs/content/docs/production/storage.mdx
+++ b/apps/docs/content/docs/production/storage.mdx
@@ -1,19 +1,76 @@
 ---
 title: Storage
-description: File storage with Flydrive — S3, local filesystem, and upload configuration.
+description: File storage with Files SDK — S3, R2, local filesystem, and upload configuration.
 ---
 
-QUESTPIE uses [Flydrive](https://flydrive.dev/) for file storage. It uses local filesystem storage by default and accepts any custom FlyDrive driver instance for S3, R2, GCS, and other backends.
+QUESTPIE uses [Files SDK](https://files-sdk.dev/) directly for file storage. Configure the Files SDK adapter in `runtimeConfig({ storage: { adapter } })`; route handlers, services, jobs, and hooks receive the typed `storage` instance through context.
 
 ## Configuration
 
+For local development, use the filesystem adapter:
+
 ```ts title="questpie.config.ts"
+import { runtimeConfig } from "questpie/app";
+import { fs } from "files-sdk/fs";
+
 export default runtimeConfig({
+	app: { url: "http://localhost:3000" },
+	db: { url: process.env.DATABASE_URL! },
 	storage: {
+		adapter: fs({
+			root: "./uploads",
+		}),
 		basePath: "/api",
 	},
 });
 ```
+
+For object storage, pass an S3-compatible adapter:
+
+```ts title="questpie.config.ts"
+import { runtimeConfig } from "questpie/app";
+import { s3 } from "files-sdk/s3";
+
+export default runtimeConfig({
+	app: { url: process.env.APP_URL! },
+	db: { url: process.env.DATABASE_URL! },
+	storage: {
+		adapter: s3({
+			bucket: process.env.S3_BUCKET!,
+			region: process.env.S3_REGION!,
+			credentials: {
+				accessKeyId: process.env.S3_ACCESS_KEY!,
+				secretAccessKey: process.env.S3_SECRET_KEY!,
+			},
+		}),
+		basePath: "/api",
+	},
+});
+```
+
+### Cloudflare R2
+
+R2 is S3-compatible, so use the Files SDK S3 adapter with the R2 endpoint:
+
+```ts
+import { s3 } from "files-sdk/s3";
+
+storage: {
+	adapter: s3({
+		credentials: {
+			accessKeyId: process.env.R2_ACCESS_KEY_ID!,
+			secretAccessKey: process.env.R2_SECRET_ACCESS_KEY!,
+		},
+		bucket: process.env.R2_BUCKET!,
+		region: "auto",
+		endpoint: `https://${process.env.CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com`,
+		forcePathStyle: true,
+	}),
+	basePath: "/api",
+}
+```
+
+If you omit `storage`, QUESTPIE uses local filesystem storage at `./uploads`.
 
 ## Upload Fields
 
@@ -27,60 +84,39 @@ avatar: f.upload({
 }),
 ```
 
-## Storage Backends
+Upload collection records include a typed `url` property. By default that URL points to the QUESTPIE route, for example `/api/assets/files/:key`, instead of directly exposing the object-store URL. Keeping the URL behind the QUESTPIE route lets collection read access and private signed URL checks authorize file downloads.
 
-### Local (Development)
-
-Files stored on local filesystem. Default for development.
-
-### S3 or S3-Compatible (Production)
+## Direct Storage API
 
 ```ts
-import { S3Driver } from "flydrive/drivers/s3";
+import { route } from "questpie";
 
-export default runtimeConfig({
-	storage: {
-		basePath: "/api",
-		driver: new S3Driver({
-			bucket: process.env.S3_BUCKET,
-			region: process.env.S3_REGION,
-			accessKeyId: process.env.S3_ACCESS_KEY,
-			secretAccessKey: process.env.S3_SECRET_KEY,
-		}),
-	},
+export default route().post().handler(async ({ storage }) => {
+	await storage.upload("reports/monthly.csv", "id,total\n1,42");
+	const file = await storage.download("reports/monthly.csv");
+	const url = await storage.url("reports/monthly.csv");
+
+	return { exists: !!file, url };
 });
 ```
 
-### Cloudflare R2
-
-R2 is S3-compatible, so use the same FlyDrive `S3Driver` with the R2 endpoint:
+Services receive the same typed `storage` context:
 
 ```ts
-storage: {
-  driver: new S3Driver({
-    credentials: {
-      accessKeyId: process.env.R2_ACCESS_KEY_ID!,
-      secretAccessKey: process.env.R2_SECRET_ACCESS_KEY!,
-    },
-    bucket: process.env.R2_BUCKET!,
-    region: "auto",
-    endpoint: `https://${process.env.CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com`,
-    visibility: "public",
-    forcePathStyle: true,
-  }),
-}
+import { service } from "questpie";
+
+export const reports = service().create(({ storage }) => ({
+	save: (key: string, body: Uint8Array) => storage.upload(key, body),
+}));
 ```
 
-For R2, use the regular FlyDrive S3 driver with Cloudflare's S3-compatible R2 endpoint.
+## Migration Notes
 
-## Client Upload
-
-```ts
-// Upload a file
-const asset = await client.collections.assets.upload(file, {
-	onProgress: (progress) => console.log(`${progress}%`),
-});
-```
+- Replace the old `storage["files"] = new Files({ adapter })` shape with `storage.adapter`.
+- Replace custom `storage["driver"]` implementations with Files SDK adapters.
+- Replace the legacy storage selector method with `storage.upload(...)` from context or `app.storage.upload(...)` where you already have the app instance.
+- Keep `storage.basePath` if you customized QUESTPIE file route URLs.
+- Existing uploaded object keys and upload collection rows do not need to change.
 
 ## Related Pages
 

--- a/apps/docs/content/docs/reference/config-api.mdx
+++ b/apps/docs/content/docs/reference/config-api.mdx
@@ -16,7 +16,8 @@ import { PlunkAdapter } from "questpie/adapters/plunk";
 import { redisStreamsAdapter } from "questpie/adapters/redis-streams";
 import { ResendAdapter } from "questpie/adapters/resend";
 import { SmtpAdapter } from "questpie/adapters/smtp";
-import { S3Driver } from "flydrive/drivers/s3";
+import { fs } from "files-sdk/fs";
+import { s3 } from "files-sdk/s3";
 
 export default runtimeConfig({
 	// Required
@@ -26,12 +27,15 @@ export default runtimeConfig({
 
 	// Infrastructure
 	storage: {
-		driver: new S3Driver({
+		adapter: s3({
 			bucket: process.env.S3_BUCKET!,
 			region: process.env.S3_REGION!,
-			accessKeyId: process.env.S3_ACCESS_KEY!,
-			secretAccessKey: process.env.S3_SECRET_KEY!,
+			credentials: {
+				accessKeyId: process.env.S3_ACCESS_KEY!,
+				secretAccessKey: process.env.S3_SECRET_KEY!,
+			},
 		}),
+		basePath: "/api",
 	},
 	email: {
 		adapter: new SmtpAdapter({
@@ -125,24 +129,29 @@ db: {
 
 ### `storage`
 
-File storage configuration using FlyDrive.
+File storage configuration using Files SDK adapters. QUESTPIE exposes the configured storage as a typed direct `Files` instance in route and service context.
 
 ```ts
 // Local filesystem (default)
 storage: {
-  location: "./uploads",
+  adapter: fs({
+    root: "./uploads",
+  }),
   basePath: "/api",
 }
 
 // Amazon S3 / S3-compatible
 storage: {
-  driver: new S3Driver({
+  adapter: s3({
     bucket: "my-bucket",
     region: "us-east-1",
-    accessKeyId: "...",
-    secretAccessKey: "...",
+    credentials: {
+      accessKeyId: "...",
+      secretAccessKey: "...",
+    },
     endpoint: "https://...",  // Optional, for S3-compatible providers
   }),
+  basePath: "/api",
 }
 ```
 

--- a/apps/docs/content/docs/reference/infrastructure-api.mdx
+++ b/apps/docs/content/docs/reference/infrastructure-api.mdx
@@ -169,28 +169,34 @@ const results = await collections.posts.find({
 
 ## Storage
 
-File storage using FlyDrive with local or S3 backends.
+File storage uses the direct Files SDK API. Configure a Files SDK adapter in `runtimeConfig()`, then destructure the typed `storage` instance from route handlers, services, jobs, or hooks.
 
 ### Configuration
 
 ```ts title="questpie.config.ts"
-import { S3Driver } from "flydrive/drivers/s3";
+import { fs } from "files-sdk/fs";
+import { s3 } from "files-sdk/s3";
 
 // Local filesystem
 storage: {
-  location: "./uploads",
+  adapter: fs({
+    root: "./uploads",
+  }),
   basePath: "/api",
 }
 
 // S3 / S3-compatible
 storage: {
-  driver: new S3Driver({
+  adapter: s3({
     bucket: "my-bucket",
     region: "us-east-1",
-    accessKeyId: "...",
-    secretAccessKey: "...",
-    endpoint: "https://...",  // For S3-compatible providers
+    credentials: {
+      accessKeyId: "...",
+      secretAccessKey: "...",
+    },
+    endpoint: "https://...",  // Optional, for S3-compatible providers
   }),
+  basePath: "/api",
 }
 ```
 
@@ -215,21 +221,26 @@ Upload collections automatically:
 
 - Add storage fields (`key`, `filename`, `mimeType`, `size`, `visibility`)
 - Extend the output type with `{ url: string }`
-- Generate signed URLs for private files
+- Generate QUESTPIE route URLs such as `/api/media/files/:key`
+- Authorize file downloads through collection read access and private signed URL checks
 - Register HTTP upload and file-serving routes
 
 ### Using Storage Directly
 
 ```ts
-// Upload a file
-const disk = app.storage.use();
-await disk.put("path/to/file.txt", content);
+import { route, service } from "questpie";
 
-// Get URL
-const url = await disk.getUrl("path/to/file.txt");
+export default route().post().handler(async ({ storage }) => {
+	await storage.upload("path/to/file.txt", "hello");
+	const file = await storage.download("path/to/file.txt");
+	const url = await storage.url("path/to/file.txt");
 
-// Get signed URL (private files)
-const signedUrl = await disk.getSignedUrl("path/to/file.txt");
+	return { exists: !!file, url };
+});
+
+export const files = service().create(({ storage }) => ({
+	remove: (key: string) => storage.delete(key),
+}));
 ```
 
 ---

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -6,7 +6,7 @@
 	"scripts": {
 		"dev": "vite dev",
 		"build": "NODE_OPTIONS='--max-old-space-size=8192' vite build",
-		"start": "node .output/server/index.mjs",
+		"start": "bun .output/server/index.mjs",
 		"types:check": "fumadocs-mdx && tsc --noEmit",
 		"postinstall": "fumadocs-mdx"
 	},

--- a/apps/docs/src/components/landing/index-sections.tsx
+++ b/apps/docs/src/components/landing/index-sections.tsx
@@ -119,9 +119,9 @@ export function Hero() {
 									maxWidth: 500,
 								}}
 							>
-								QUESTPIE replaces the SaaS patchwork with one open-source
-								stack: a typed backend framework, managed cloud, and AI agents
-								that run your business. You own the code. You own the data.
+								QUESTPIE replaces the SaaS patchwork with one open-source stack:
+								a typed backend framework, managed cloud, and AI agents that run
+								your business. You own the code. You own the data.
 							</p>
 						</Reveal>
 						<Reveal delay={180}>
@@ -141,7 +141,10 @@ export function Hero() {
 									Start a project
 									<LIcon name="arrow-right" size={14} />
 								</a>
-								<Link className={cn(buttonVariants({ variant: "outline" }))} to="/cloud">
+								<Link
+									className={cn(buttonVariants({ variant: "outline" }))}
+									to="/cloud"
+								>
 									Try Cloud
 									<LIcon name="arrow-down" size={14} />
 								</Link>
@@ -220,9 +223,25 @@ export function Hero() {
 
 function HeroProof() {
 	const collectionLines: CodeLine[] = [
-		[KW("export const "), TYP("posts"), " = ", FN("collection"), "(", STR('"posts"'), ")"],
+		[
+			KW("export const "),
+			TYP("posts"),
+			" = ",
+			FN("collection"),
+			"(",
+			STR('"posts"'),
+			")",
+		],
 		["  .", FN("fields"), "(({ f }) => ({"],
-		["    title:   f.", FN("text"), "(", NUM("255"), ").", FN("required"), "(),"],
+		[
+			"    title:   f.",
+			FN("text"),
+			"(",
+			NUM("255"),
+			").",
+			FN("required"),
+			"(),",
+		],
 		["    slug:    f.", FN("text"), "(", NUM("160"), "),"],
 		[
 			"    status:  f.",
@@ -543,11 +562,7 @@ export function PillarsSection() {
 				}}
 			>
 				{PILLARS.map((p, i) => (
-					<PillarCard
-						key={p.id}
-						pillar={p}
-						isLast={i === PILLARS.length - 1}
-					/>
+					<PillarCard key={p.id} pillar={p} isLast={i === PILLARS.length - 1} />
 				))}
 			</div>
 			<style>{`
@@ -743,12 +758,34 @@ const FRAMEWORK_FEATURES = [
 
 export function FrameworkSection() {
 	const lines: CodeLine[] = [
-		[KW("import "), "{ collection } ", KW("from "), STR('"#questpie/factories"'), ";"],
+		[
+			KW("import "),
+			"{ collection } ",
+			KW("from "),
+			STR('"#questpie/factories"'),
+			";",
+		],
 		[""],
-		[KW("export const "), TYP("posts"), " = ", FN("collection"), "(", STR('"posts"'), ")"],
+		[
+			KW("export const "),
+			TYP("posts"),
+			" = ",
+			FN("collection"),
+			"(",
+			STR('"posts"'),
+			")",
+		],
 		["  .", FN("options"), "({ versioning: { workflow: ", KW("true"), " } })"],
 		["  .", FN("fields"), "(({ f }) => ({"],
-		["    title:   f.", FN("text"), "(", NUM("255"), ").", FN("required"), "(),"],
+		[
+			"    title:   f.",
+			FN("text"),
+			"(",
+			NUM("255"),
+			").",
+			FN("required"),
+			"(),",
+		],
 		["    slug:    f.", FN("text"), "(", NUM("160"), "),"],
 		["    content: f.", FN("richText"), "().", FN("localized"), "(),"],
 		[
@@ -908,7 +945,10 @@ export function FrameworkSection() {
 						flexWrap: "wrap",
 					}}
 				>
-					<a className={cn(buttonVariants({ variant: "default" }))} href="/docs">
+					<a
+						className={cn(buttonVariants({ variant: "default" }))}
+						href="/docs"
+					>
 						Start with the docs
 						<LIcon name="arrow-right" size={14} />
 					</a>
@@ -1008,9 +1048,7 @@ function ProductionStrip() {
 									marginBottom: 12,
 								}}
 							/>
-							<div
-								style={{ fontSize: 14, fontWeight: 500, marginBottom: 4 }}
-							>
+							<div style={{ fontSize: 14, fontWeight: 500, marginBottom: 4 }}>
 								{f.title}
 							</div>
 							<div
@@ -1354,7 +1392,8 @@ function SchemaOutputsMap() {
 						}}
 					>
 						<span style={{ color: "var(--syntax-keyword)" }}>collection</span>(
-						<span style={{ color: "var(--syntax-string)" }}>"posts"</span>)<br />
+						<span style={{ color: "var(--syntax-string)" }}>"posts"</span>)
+						<br />
 						&nbsp;&nbsp;.
 						<span style={{ color: "var(--syntax-function)" }}>fields</span>(
 						{"{...}"})<br />
@@ -1621,9 +1660,7 @@ export function CloudSection() {
 										marginBottom: 12,
 									}}
 								/>
-								<div
-									style={{ fontSize: 14, fontWeight: 500, marginBottom: 4 }}
-								>
+								<div style={{ fontSize: 14, fontWeight: 500, marginBottom: 4 }}>
 									{f.title}
 								</div>
 								<div
@@ -1950,8 +1987,7 @@ function CloudBuilderMock() {
 							gridTemplateColumns: "auto 1fr 90px",
 							gap: 12,
 							padding: "9px 0",
-							borderTop:
-								i === 0 ? "none" : "1px dashed var(--border-subtle)",
+							borderTop: i === 0 ? "none" : "1px dashed var(--border-subtle)",
 							alignItems: "center",
 							fontSize: 12.5,
 						}}
@@ -1974,9 +2010,7 @@ function CloudBuilderMock() {
 							}}
 						/>
 						<span style={{ minWidth: 0 }}>
-							<code
-								style={{ fontSize: 11.5, color: "var(--foreground)" }}
-							>
+							<code style={{ fontSize: 11.5, color: "var(--foreground)" }}>
 								{e.name}
 							</code>{" "}
 							<span
@@ -2207,9 +2241,7 @@ export function AutopilotSection() {
 										marginBottom: 12,
 									}}
 								/>
-								<div
-									style={{ fontSize: 14, fontWeight: 500, marginBottom: 4 }}
-								>
+								<div style={{ fontSize: 14, fontWeight: 500, marginBottom: 4 }}>
 									{f.title}
 								</div>
 								<div
@@ -2350,14 +2382,10 @@ function WorkflowCode() {
 								alignItems: "center",
 							}}
 						>
-							<code
-								style={{ fontSize: 12, color: "var(--pillar-autopilot)" }}
-							>
+							<code style={{ fontSize: 12, color: "var(--pillar-autopilot)" }}>
 								{k}
 							</code>
-							<span
-								style={{ fontSize: 12, color: "var(--foreground-subtle)" }}
-							>
+							<span style={{ fontSize: 12, color: "var(--foreground-subtle)" }}>
 								{v}
 							</span>
 						</span>
@@ -2376,11 +2404,31 @@ function AgentInspector() {
 		t: string;
 		out: string;
 	}> = [
-		{ name: "draft-post", state: "done", t: "01.4s", out: "Generated 612 words" },
-		{ name: "fact-check", state: "done", t: "03.1s", out: "3 sources verified" },
-		{ name: "seo-pass", state: "done", t: "00.9s", out: "title + meta updated" },
+		{
+			name: "draft-post",
+			state: "done",
+			t: "01.4s",
+			out: "Generated 612 words",
+		},
+		{
+			name: "fact-check",
+			state: "done",
+			t: "03.1s",
+			out: "3 sources verified",
+		},
+		{
+			name: "seo-pass",
+			state: "done",
+			t: "00.9s",
+			out: "title + meta updated",
+		},
 		{ name: "human-review", state: "wait", t: "·", out: "Waiting for @marek" },
-		{ name: "publish", state: "queued", t: "·", out: "Will run after approval" },
+		{
+			name: "publish",
+			state: "queued",
+			t: "·",
+			out: "Will run after approval",
+		},
 	];
 	const dotColor = (s: StepState) =>
 		s === "done"
@@ -2445,8 +2493,7 @@ function AgentInspector() {
 								alignItems: "flex-start",
 								gap: 12,
 								padding: "10px 0",
-								borderTop:
-									i === 0 ? "none" : "1px dashed var(--border-subtle)",
+								borderTop: i === 0 ? "none" : "1px dashed var(--border-subtle)",
 							}}
 						>
 							<span
@@ -2471,9 +2518,7 @@ function AgentInspector() {
 										gap: 12,
 									}}
 								>
-									<code
-										style={{ fontSize: 12.5, color: "var(--foreground)" }}
-									>
+									<code style={{ fontSize: 12.5, color: "var(--foreground)" }}>
 										step.{s.name}
 									</code>
 									<span
@@ -3115,9 +3160,13 @@ export function StackSection() {
 						justifyContent: "center",
 					}}
 				>
-					<span className="landing-mono">PostgreSQL · Drizzle ORM · Zod v4</span>
+					<span className="landing-mono">
+						PostgreSQL · Drizzle ORM · Zod v4
+					</span>
 					<span>·</span>
-					<span className="landing-mono">Better Auth · pg-boss · Flydrive</span>
+					<span className="landing-mono">
+						Better Auth · pg-boss · Files SDK
+					</span>
 					<span>·</span>
 					<span className="landing-mono">React 19 · Tailwind v4 · shadcn</span>
 					<span>·</span>
@@ -3506,9 +3555,7 @@ function PricingCard({ tier }: { tier: Tier }) {
 							gap: 9,
 							alignItems: "flex-start",
 							fontSize: 12.5,
-							color: on
-								? "var(--foreground)"
-								: "var(--foreground-disabled)",
+							color: on ? "var(--foreground)" : "var(--foreground-disabled)",
 						}}
 					>
 						<LIcon
@@ -3752,8 +3799,7 @@ export function FinalCta() {
 						}}
 					>
 						Start with Framework today. It's free, open and ready to ship. Add
-						Cloud and Autopilot whenever you outgrow what you can run
-						yourself.
+						Cloud and Autopilot whenever you outgrow what you can run yourself.
 					</p>
 				</Reveal>
 				<Reveal delay={180}>
@@ -3766,7 +3812,10 @@ export function FinalCta() {
 							flexWrap: "wrap",
 						}}
 					>
-						<a className={cn(buttonVariants({ variant: "default" }))} href="/docs">
+						<a
+							className={cn(buttonVariants({ variant: "default" }))}
+							href="/docs"
+						>
 							Start building
 							<LIcon name="arrow-right" size={14} />
 						</a>
@@ -3780,7 +3829,10 @@ export function FinalCta() {
 							Star on GitHub
 							<LIcon name="star" size={12} />
 						</a>
-						<a className={cn(buttonVariants({ variant: "ghost" }))} href="#contact">
+						<a
+							className={cn(buttonVariants({ variant: "ghost" }))}
+							href="#contact"
+						>
 							Talk to the team
 						</a>
 					</div>

--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
     },
     "apps/autopilot": {
       "name": "autopilot",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "dependencies": {
         "@questpie/admin": "workspace:*",
         "@questpie/mcp": "workspace:*",
@@ -200,7 +200,7 @@
     },
     "examples/toy-factory-backend": {
       "name": "toy-factory-backend-example",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "dependencies": {
         "@electric-sql/pglite": "^0.3.14",
         "@questpie/admin": "workspace:*",
@@ -242,7 +242,7 @@
     },
     "packages/admin": {
       "name": "@questpie/admin",
-      "version": "3.5.1",
+      "version": "3.5.2",
       "dependencies": {
         "@base-ui/react": "^1.0.0",
         "@dnd-kit/core": "^6.3.1",
@@ -389,7 +389,7 @@
     },
     "packages/elysia": {
       "name": "@questpie/elysia",
-      "version": "3.5.1",
+      "version": "3.5.2",
       "dependencies": {
         "@elysiajs/cors": "^1.2.1",
         "@elysiajs/eden": "^1.2.6",
@@ -408,7 +408,7 @@
     },
     "packages/hono": {
       "name": "@questpie/hono",
-      "version": "3.5.1",
+      "version": "3.5.2",
       "dependencies": {
         "hono": "^4.6.14",
         "qs": "^6.13.1",
@@ -441,7 +441,7 @@
     },
     "packages/next": {
       "name": "@questpie/next",
-      "version": "3.5.1",
+      "version": "3.5.2",
       "dependencies": {
         "questpie": "workspace:*",
       },
@@ -455,7 +455,7 @@
     },
     "packages/openapi": {
       "name": "@questpie/openapi",
-      "version": "3.0.23",
+      "version": "3.0.24",
       "dependencies": {
         "questpie": "workspace:*",
         "zod": "^4.2.1",
@@ -470,7 +470,7 @@
     },
     "packages/questpie": {
       "name": "questpie",
-      "version": "3.5.1",
+      "version": "3.5.2",
       "bin": {
         "questpie": "./dist/cli.mjs",
       },
@@ -479,7 +479,7 @@
         "better-auth": "^1.4.9",
         "commander": "^14.0.2",
         "drizzle-orm": "1.0.0-beta.6-4414a19",
-        "flydrive": "^1.3.0",
+        "files-sdk": "^1.6.0",
         "html-to-text": "^9.0.5",
         "pino": "^10.1.0",
         "pino-pretty": "^13.1.3",
@@ -523,7 +523,7 @@
     },
     "packages/tanstack-query": {
       "name": "@questpie/tanstack-query",
-      "version": "3.5.1",
+      "version": "3.5.2",
       "devDependencies": {
         "bun-types": "latest",
         "tsdown": "^0.18.3",
@@ -549,7 +549,7 @@
     },
     "packages/workflows": {
       "name": "@questpie/workflows",
-      "version": "3.5.1",
+      "version": "3.5.2",
       "dependencies": {
         "@iconify/react": "^6.0.2",
         "@questpie/admin": "workspace:*",
@@ -898,8 +898,6 @@
 
     "@hugeicons/react": ["@hugeicons/react@1.1.6", "", { "peerDependencies": { "react": ">=16.0.0" } }, "sha512-c2LhXJMAW5wN1pC/smBXG0YPqUON6ceR/ZdXHCjEI9KvB+hjtqYjmzIxok5hAQOeXGz0WtORgCQMzqewFKAZwg=="],
 
-    "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
-
     "@iconify/json": ["@iconify/json@2.2.471", "", { "dependencies": { "@iconify/types": "*", "pathe": "^2.0.3" } }, "sha512-9ZJ4l71MOGVQa/DJxPI5XJ49D5Ax+wOvCCw4ZPcGemP34rtWWFAPsfu2QyQLjEvedbrVmEJcomam3N0SsNgWDA=="],
 
     "@iconify/react": ["@iconify/react@6.0.2", "", { "dependencies": { "@iconify/types": "^2.0.0" }, "peerDependencies": { "react": ">=16" } }, "sha512-SMmC2sactfpJD427WJEDN6PMyznTFMhByK9yLW0gOTtnjzzbsi/Ke/XqsumsavFPwNiXs8jSiYeZTmLCLwO+Fg=="],
@@ -1109,14 +1107,6 @@
     "@playwright/test": ["@playwright/test@1.59.1", "", { "dependencies": { "playwright": "1.59.1" }, "bin": { "playwright": "cli.js" } }, "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg=="],
 
     "@popperjs/core": ["@popperjs/core@2.11.8", "", {}, "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A=="],
-
-    "@poppinss/exception": ["@poppinss/exception@1.2.3", "", {}, "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw=="],
-
-    "@poppinss/object-builder": ["@poppinss/object-builder@1.1.0", "", {}, "sha512-FOrOq52l7u8goR5yncX14+k+Ewi5djnrt1JwXeS/FvnwAPOiveFhiczCDuvXdssAwamtrV2hp5Rw9v+n2T7hQg=="],
-
-    "@poppinss/string": ["@poppinss/string@1.7.2", "", { "dependencies": { "@types/pluralize": "^0.0.33", "case-anything": "^3.1.2", "pluralize": "^8.0.0", "slugify": "^1.6.9" } }, "sha512-A182GLDfi36iDCbhDrHB0xzrPM1fO3GHnhCDIdadf8C6eycgct4m7zusbLwEh6GPaj2Pz5BVos7XK16w7tZ7wQ=="],
-
-    "@poppinss/utils": ["@poppinss/utils@6.10.1", "", { "dependencies": { "@poppinss/exception": "^1.2.1", "@poppinss/object-builder": "^1.1.0", "@poppinss/string": "^1.3.0", "flattie": "^1.1.1", "safe-stable-stringify": "^2.5.0", "secure-json-parse": "^4.0.0" } }, "sha512-da+MMyeXhBaKtxQiWPfy7+056wk3lVIhioJnXHXkJ2/OHDaZfFcyKHNl1R06sdYO8lIRXcXdoZ6LO2ARmkAREA=="],
 
     "@quansync/fs": ["@quansync/fs@1.0.0", "", { "dependencies": { "quansync": "^1.0.0" } }, "sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ=="],
 
@@ -1646,8 +1636,6 @@
 
     "@types/pg": ["@types/pg@8.20.0", "", { "dependencies": { "@types/node": "*", "pg-protocol": "*", "pg-types": "^2.2.0" } }, "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow=="],
 
-    "@types/pluralize": ["@types/pluralize@0.0.33", "", {}, "sha512-JOqsl+ZoCpP4e8TDke9W79FDcSgPAR0l6pixx2JHkhnRjvShyYiAYw2LVsnA7K08Y6DeOnaU6ujmENO4os/cYg=="],
-
     "@types/prismjs": ["@types/prismjs@1.26.6", "", {}, "sha512-vqlvI7qlMvcCBbVe0AKAb4f97//Hy0EBTaiW8AalRnG/xAN5zOiWWyrNqNXeq8+KAuvRewjCVY1+IPxk4RdNYw=="],
 
     "@types/qs": ["@types/qs@6.15.1", "", {}, "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw=="],
@@ -1813,8 +1801,6 @@
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
     "caniuse-lite": ["caniuse-lite@1.0.30001792", "", {}, "sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw=="],
-
-    "case-anything": ["case-anything@3.1.2", "", {}, "sha512-wljhAjDDIv/hM2FzgJnYQg90AWmZMNtESCjTeLH680qTzdo0nErlCxOmgzgX4ZsZAtIvqHyD87ES8QyriXB+BQ=="],
 
     "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
 
@@ -2206,15 +2192,13 @@
 
     "file-type": ["file-type@22.0.1", "", { "dependencies": { "@tokenizer/inflate": "^0.4.1", "strtok3": "^10.3.5", "token-types": "^6.1.2", "uint8array-extras": "^1.5.0" } }, "sha512-ww5Mhre0EE+jmBvOXTmXAbEMuZE7uX4a3+oRCQFNj8w++g3ev913N6tXQz0XTXbueQ5TWQfm6BdaViEHHn8bhA=="],
 
+    "files-sdk": ["files-sdk@1.6.0", "", { "dependencies": { "commander": "^14.0.3" }, "optionalDependencies": { "@modelcontextprotocol/sdk": "^1.29.0" }, "peerDependencies": { "@anthropic-ai/claude-agent-sdk": "^0.3.0", "@aws-sdk/client-s3": "^3.700.0", "@aws-sdk/lib-storage": "^3.700.0", "@aws-sdk/s3-presigned-post": "^3.700.0", "@aws-sdk/s3-request-presigner": "^3.700.0", "@azure/core-auth": "^1.9.0", "@azure/identity": "^4.5.0", "@azure/storage-blob": "^12.26.0", "@bunny.net/storage-sdk": "^0.3.1", "@google-cloud/storage": "^7.19.0", "@googleapis/drive": "^20.0.0", "@microsoft/microsoft-graph-client": "^3.0.7", "@netlify/blobs": "^10.7.4", "@openai/agents": "^0.11.0", "@supabase/storage-js": "^2.105.4", "@vercel/blob": "^2.4.0", "ai": "^6.0.0", "basic-ftp": "^6.0.1", "box-typescript-sdk-gen": "^1.19.1", "cloudinary": "^2.10.0", "convex": "^1.16.0", "dropbox": "^10.34.0", "firebase-admin": "^13.10.0", "google-auth-library": "^10.0.0", "node-appwrite": "^25.0.0", "openai": "^6.0.0", "pocketbase": "^0.27.0", "ssh2-sftp-client": "^12.1.1", "uploadthing": "^7", "zod": "^3.23.0 || ^4.0.0" }, "optionalPeers": ["@anthropic-ai/claude-agent-sdk", "@aws-sdk/client-s3", "@aws-sdk/lib-storage", "@aws-sdk/s3-presigned-post", "@aws-sdk/s3-request-presigner", "@azure/core-auth", "@azure/identity", "@azure/storage-blob", "@bunny.net/storage-sdk", "@google-cloud/storage", "@googleapis/drive", "@microsoft/microsoft-graph-client", "@netlify/blobs", "@openai/agents", "@supabase/storage-js", "@vercel/blob", "ai", "basic-ftp", "box-typescript-sdk-gen", "cloudinary", "convex", "dropbox", "firebase-admin", "google-auth-library", "node-appwrite", "openai", "pocketbase", "ssh2-sftp-client", "uploadthing", "zod"], "bin": { "files": "dist/cli/index.js" } }, "sha512-EctRY0aaDY1YVG/LgT8JMWjM5OvqrvbXjx2EL7aiK9VXNPgOi2sSDOqTmcIVXjUwe3+dJt2XHf9QPSisb+YqkA=="],
+
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 
     "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
 
     "find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
-
-    "flattie": ["flattie@1.1.1", "", {}, "sha512-9UbaD6XdAL97+k/n+N7JwX46K/M6Zc6KcFYskrYL8wbBV/Uyk0CTAMY0VT+qiK5PM7AIc9aTWYtq65U7T+aCNQ=="],
-
-    "flydrive": ["flydrive@1.3.0", "", { "dependencies": { "@humanwhocodes/retry": "^0.4.3", "@poppinss/utils": "^6.10.0", "etag": "^1.8.1", "mime-types": "^3.0.1" }, "peerDependencies": { "@aws-sdk/client-s3": "^3.577.0", "@aws-sdk/s3-request-presigner": "^3.577.0", "@google-cloud/storage": "^7.10.2" }, "optionalPeers": ["@aws-sdk/client-s3", "@aws-sdk/s3-request-presigner", "@google-cloud/storage"] }, "sha512-B0wsqrZR76d+J2ce6AxNcA1JDo4pViluaaFp5Fjso52zGY+s19uF8rKsQS8TJJsiyySKPI1b8K1w2j3RAUxd1Q=="],
 
     "format": ["format@0.2.2", "", {}, "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww=="],
 
@@ -2874,8 +2858,6 @@
 
     "playwright-core": ["playwright-core@1.59.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg=="],
 
-    "pluralize": ["pluralize@8.0.0", "", {}, "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA=="],
-
     "points-on-curve": ["points-on-curve@0.2.0", "", {}, "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A=="],
 
     "points-on-path": ["points-on-path@0.2.1", "", { "dependencies": { "path-data-parser": "0.1.0", "points-on-curve": "0.2.0" } }, "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g=="],
@@ -3143,8 +3125,6 @@
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
 
     "slash": ["slash@3.0.0", "", {}, "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="],
-
-    "slugify": ["slugify@1.6.9", "", {}, "sha512-vZ7rfeehZui7wQs438JXBckYLkIIdfHOXsaVEUMyS5fHo1483l1bMdo0EDSWYclY0yZKFOipDy4KHuKs6ssvdg=="],
 
     "solid-js": ["solid-js@1.9.12", "", { "dependencies": { "csstype": "^3.1.0", "seroval": "~1.5.0", "seroval-plugins": "~1.5.0" } }, "sha512-QzKaSJq2/iDrWR1As6MHZQ8fQkdOBf8GReYb7L5iKwMGceg7HxDcaOHk0at66tNgn9U2U7dXo8ZZpLIAmGMzgw=="],
 

--- a/examples/city-portal/vite.config.ts
+++ b/examples/city-portal/vite.config.ts
@@ -29,7 +29,7 @@ const config = defineConfig({
 				"bun",
 				// drizzle-kit and its optional dependencies (used only at dev/migration time)
 				/^drizzle-kit/,
-				// flydrive S3 driver imports @aws-sdk/client-s3 which is an optional peer dep
+				// Files SDK S3 adapters import @aws-sdk packages as optional peer deps
 				/^@aws-sdk\//,
 			],
 		},

--- a/examples/tanstack-barbershop/README.md
+++ b/examples/tanstack-barbershop/README.md
@@ -34,7 +34,7 @@ A complete barbershop booking system built with **QUESTPIE** + **TanStack Start*
 **ONLY Postgres is required!** Everything else is batteries-included:
 
 - ✅ Auth (Better Auth)
-- ✅ Storage (Flydrive - local filesystem)
+- ✅ Storage (Files SDK - local filesystem)
 - ✅ Queue (pg-boss - uses Postgres)
 - ✅ Email (Console adapter - no SMTP needed)
 - ✅ Logging (Pino)

--- a/examples/tanstack-barbershop/vite.config.ts
+++ b/examples/tanstack-barbershop/vite.config.ts
@@ -50,7 +50,7 @@ const config = defineConfig(({ mode }) => ({
 				"bun",
 				// drizzle-kit and its optional dependencies (used only at dev/migration time)
 				/^drizzle-kit/,
-				// flydrive S3 driver imports @aws-sdk/client-s3 which is an optional peer dep
+				// Files SDK S3 adapters import @aws-sdk packages as optional peer deps
 				/^@aws-sdk\//,
 			],
 		},

--- a/examples/toy-factory-backend/src/questpie/server/questpie.config.ts
+++ b/examples/toy-factory-backend/src/questpie/server/questpie.config.ts
@@ -5,16 +5,20 @@
  * Entity definitions are codegen-generated.
  */
 
-import { runtimeConfig } from "questpie/app";
+import { fs } from "files-sdk/fs";
 import { ConsoleAdapter } from "questpie/adapters/console";
 import { pgBossAdapter } from "questpie/adapters/pg-boss";
+import { runtimeConfig } from "questpie/app";
 
 import { env } from "@/lib/env.js";
 
 export default runtimeConfig({
 	app: { url: env.APP_URL },
 	db: { url: env.DATABASE_URL },
-	storage: { basePath: "/api" },
+	storage: {
+		adapter: fs({ root: "./uploads" }),
+		basePath: "/api",
+	},
 	email: {
 		adapter: new ConsoleAdapter({ logHtml: false }),
 	},

--- a/packages/admin/test/server/codegen.test.ts
+++ b/packages/admin/test/server/codegen.test.ts
@@ -150,7 +150,7 @@ describe("generateAdminClientTemplate", () => {
 		const output = generateAdminClientTemplate(ctx);
 
 		expect(output.code).toContain('import _mod from "../modules";');
-		expect(output.code).toContain("const admin = _mod;");
+		expect(output.code).toContain("const admin = _mergedModules;");
 		expect(output.code).toContain("export default admin;");
 	});
 
@@ -214,7 +214,7 @@ describe("generateAdminClientTemplate", () => {
 		expect(output.code).toContain('import _block_cta from "../blocks/cta";');
 		expect(output.code).toContain('import _block_hero from "../blocks/hero";');
 		// Merged object with module spread
-		expect(output.code).toContain("blocks: { ..._mod.blocks,");
+		expect(output.code).toContain("blocks: { ..._mergedModules.blocks,");
 		expect(output.code).toContain('"cta": _block_cta');
 		expect(output.code).toContain('"hero": _block_hero');
 	});
@@ -325,7 +325,7 @@ describe("generateAdminClientTemplate", () => {
 		const output = generateAdminClientTemplate(ctx);
 
 		// Should emit runtime key using keyFromProperty
-		expect(output.code).toContain("views: { ..._mod.views,");
+		expect(output.code).toContain("views: { ..._mergedModules.views,");
 		expect(output.code).toContain("[_view_kanban.name]: _view_kanban");
 	});
 
@@ -487,12 +487,12 @@ describe("generateAdminClientTemplate", () => {
 		});
 		const output = generateAdminClientTemplate(ctx);
 
-		expect(output.code).toContain("blocks: { ..._mod.blocks,");
-		expect(output.code).toContain("fields: { ..._mod.fields,");
-		expect(output.code).toContain("pages: { ..._mod.pages,");
+		expect(output.code).toContain("blocks: { ..._mergedModules.blocks,");
+		expect(output.code).toContain("fields: { ..._mergedModules.fields,");
+		expect(output.code).toContain("pages: { ..._mergedModules.pages,");
 		expect(output.code).toContain('"hero": _block_hero');
-		expect(output.code).toContain('"color": _fld_color');
-		expect(output.code).toContain('"analytics": _pg_analytics');
+		expect(output.code).toContain("color: _fld_color");
+		expect(output.code).toContain("analytics: _pg_analytics");
 	});
 
 	it("spreads module categories even when no user files exist for that category", () => {
@@ -548,10 +548,10 @@ describe("generateAdminClientTemplate", () => {
 		const output = generateAdminClientTemplate(ctx);
 
 		// Module-only categories should be spread
-		expect(output.code).toContain("fields: { ..._mod.fields },");
-		expect(output.code).toContain("views: { ..._mod.views },");
+		expect(output.code).toContain("fields: { ..._mergedModules.fields },");
+		expect(output.code).toContain("views: { ..._mergedModules.views },");
 		// User category should merge
-		expect(output.code).toContain("blocks: { ..._mod.blocks,");
+		expect(output.code).toContain("blocks: { ..._mergedModules.blocks,");
 	});
 });
 

--- a/packages/create-questpie/skills/questpie/AGENTS.md
+++ b/packages/create-questpie/skills/questpie/AGENTS.md
@@ -57,7 +57,7 @@ QuestPie is a **headless CMS framework** for TypeScript. You define your content
 | Runtime  | **Bun**                                           |
 | Database | **PostgreSQL** via **Drizzle ORM**                |
 | Auth     | **Better Auth**                                   |
-| Storage  | **FlyDrive** (local FS, S3, R2, GCS)              |
+| Storage  | **Files SDK** (local FS, S3, R2, GCS)             |
 | Admin UI | **React** + **TanStack Router** + **Tailwind**    |
 | HTTP     | Custom trie-based router (no Express/Hono needed) |
 | Build    | **tsdown** (Rolldown-based) + **Turbo** monorepo  |
@@ -913,8 +913,9 @@ export default route()
 | `search`                      | POST   | Full-text search    |
 | `search/reindex/[collection]` | POST   | Reindex collection  |
 | `realtime`                    | POST   | SSE subscriptions   |
-| `storage/files/[...key]`      | GET    | Legacy file serving |
 | `health`                      | GET    | Health check        |
+
+File serving stays collection-scoped through QUESTPIE routes such as `/api/:collection/files/:key` or `/api/assets/files/:key`, so file reads remain behind collection access rules instead of a global storage namespace.
 
 ---
 
@@ -1173,14 +1174,27 @@ f.upload({
 ### Storage Adapters
 
 ```ts
+import { fs } from "files-sdk/fs";
+import { s3 } from "files-sdk/s3";
+
 // Local filesystem (default)
 runtimeConfig({
-	storage: { location: "./uploads", basePath: "/api" },
+	storage: { adapter: fs({ root: "./uploads" }), basePath: "/api" },
 });
 
 // S3-compatible (R2, Minio, etc.)
 runtimeConfig({
-	storage: { driver: myS3Driver },
+	storage: {
+		adapter: s3({
+			bucket: process.env.S3_BUCKET!,
+			region: process.env.S3_REGION!,
+			credentials: {
+				accessKeyId: process.env.S3_ACCESS_KEY!,
+				secretAccessKey: process.env.S3_SECRET_KEY!,
+			},
+		}),
+		basePath: "/api",
+	},
 });
 
 // Auto-detected from env vars:
@@ -1430,7 +1444,7 @@ interface AppContext {
 	globals: { [name]: GlobalAPI }; // typed CRUD for all globals
 	queue: QueueClient; // dispatch background jobs
 	email: MailerService; // send emails
-	storage: DriveManager; // file storage operations
+	storage: Files; // direct typed Files SDK storage operations
 	kv: KVService; // key-value store
 	logger: LoggerService; // structured logging
 	search: SearchService; // full-text search
@@ -2357,11 +2371,11 @@ Configure it through plugin-discovered `config/mcp.ts`, not `mcpModule(options)`
 
 ### Storage Adapters
 
-| Config                        | Driver                         |
-| ----------------------------- | ------------------------------ |
-| Default                       | `FSDriver` (local `./uploads`) |
-| `QUESTPIE_STORAGE_*` env vars | S3-compatible (auto-detected)  |
-| `{ driver: customDriver }`    | Any FlyDrive `DriverContract`  |
+| Config                              | Storage backend                  |
+| ----------------------------------- | -------------------------------- |
+| Default                             | Filesystem adapter (`./uploads`) |
+| `QUESTPIE_STORAGE_*` env vars       | S3-compatible (auto-detected)    |
+| `{ adapter: customAdapter }`        | Files SDK adapter instance       |
 
 ### Queue Adapters
 

--- a/packages/create-questpie/skills/questpie/references/infrastructure-adapters.md
+++ b/packages/create-questpie/skills/questpie/references/infrastructure-adapters.md
@@ -57,7 +57,7 @@ collection("posts")
 
 ## Storage
 
-File storage via [Flydrive](https://flydrive.dev/).
+File storage via [Files SDK](https://files-sdk.dev/).
 
 ### Local (Development)
 
@@ -76,16 +76,18 @@ export default runtimeConfig({
 Works with AWS S3, MinIO, DigitalOcean Spaces, Cloudflare R2:
 
 ```ts
-import { S3Driver } from "flydrive/drivers/s3";
+import { s3 } from "files-sdk/s3";
 
 export default runtimeConfig({
 	storage: {
 		basePath: "/api",
-		driver: new S3Driver({
+		adapter: s3({
 			bucket: process.env.S3_BUCKET,
 			region: process.env.S3_REGION,
-			accessKeyId: process.env.S3_ACCESS_KEY,
-			secretAccessKey: process.env.S3_SECRET_KEY,
+			credentials: {
+				accessKeyId: process.env.S3_ACCESS_KEY!,
+				secretAccessKey: process.env.S3_SECRET_KEY!,
+			},
 		}),
 	},
 });
@@ -524,7 +526,7 @@ import { runtimeConfig } from "questpie/app";
 import { pgBossAdapter } from "questpie/adapters/pg-boss";
 import { pgNotifyAdapter } from "questpie/adapters/pg-notify";
 import { SmtpAdapter } from "questpie/adapters/smtp";
-import { S3Driver } from "flydrive/drivers/s3";
+import { s3 } from "files-sdk/s3";
 
 export default runtimeConfig({
 	db: {
@@ -532,11 +534,13 @@ export default runtimeConfig({
 	},
 	storage: {
 		basePath: "/api",
-		driver: new S3Driver({
+		adapter: s3({
 			bucket: process.env.S3_BUCKET!,
 			region: process.env.S3_REGION!,
-			accessKeyId: process.env.S3_ACCESS_KEY!,
-			secretAccessKey: process.env.S3_SECRET_KEY!,
+			credentials: {
+				accessKeyId: process.env.S3_ACCESS_KEY!,
+				secretAccessKey: process.env.S3_SECRET_KEY!,
+			},
 		}),
 	},
 	queue: {

--- a/packages/create-questpie/skills/questpie/references/production.md
+++ b/packages/create-questpie/skills/questpie/references/production.md
@@ -1,7 +1,7 @@
 ---
 name: questpie-core/production
 description:
-  QUESTPIE production deployment authentication better-auth OAuth database PostgreSQL Drizzle storage S3 Flydrive queue pg-boss jobs realtime SSE pgNotify Redis migrations email SMTP KV key-value logger Pino OpenAPI Docker environment variables adapters infrastructure
+  QUESTPIE production deployment authentication better-auth OAuth database PostgreSQL Drizzle storage S3 Files SDK queue pg-boss jobs realtime SSE pgNotify Redis migrations email SMTP KV key-value logger Pino OpenAPI Docker environment variables adapters infrastructure
   - questpie-core
 ---
 
@@ -121,7 +121,7 @@ Configure migration and seed directories in `questpie.config.ts` under `cli.migr
 
 ## Storage
 
-QUESTPIE uses [Flydrive](https://flydrive.dev/) for file storage.
+QUESTPIE uses [Files SDK](https://files-sdk.dev/) for file storage.
 
 ### Local (Development Default)
 
@@ -136,16 +136,18 @@ export default runtimeConfig({
 ### S3 (Production)
 
 ```ts
-import { S3Driver } from "flydrive/drivers/s3";
+import { s3 } from "files-sdk/s3";
 
 export default runtimeConfig({
 	storage: {
 		basePath: "/api",
-		driver: new S3Driver({
+		adapter: s3({
 			bucket: process.env.S3_BUCKET,
 			region: process.env.S3_REGION,
-			accessKeyId: process.env.S3_ACCESS_KEY,
-			secretAccessKey: process.env.S3_SECRET_KEY,
+			credentials: {
+				accessKeyId: process.env.S3_ACCESS_KEY!,
+				secretAccessKey: process.env.S3_SECRET_KEY!,
+			},
 		}),
 	},
 });
@@ -466,15 +468,17 @@ The local storage adapter writes to the filesystem. In containerized deployments
 storage: { basePath: "/api" }
 
 // CORRECT -- persistent S3 storage
-import { S3Driver } from "flydrive/drivers/s3";
+import { s3 } from "files-sdk/s3";
 
 storage: {
   basePath: "/api",
-  driver: new S3Driver({
+  adapter: s3({
     bucket: process.env.S3_BUCKET,
     region: process.env.S3_REGION,
-    accessKeyId: process.env.S3_ACCESS_KEY,
-    secretAccessKey: process.env.S3_SECRET_KEY,
+    credentials: {
+      accessKeyId: process.env.S3_ACCESS_KEY!,
+      secretAccessKey: process.env.S3_SECRET_KEY!,
+    },
   }),
 }
 ```

--- a/packages/create-questpie/test/scaffolder.test.ts
+++ b/packages/create-questpie/test/scaffolder.test.ts
@@ -140,6 +140,5 @@ describe("scaffold", () => {
 		expect(runtimeConfig).toContain("redisKVAdapter");
 		expect(serverModules).toContain("workflowsModule");
 		expect(adminModules).toContain("workflowsClientModule");
-		expect(adminModules).toContain("...workflowsClientModule.views");
 	});
 });

--- a/packages/questpie/README.md
+++ b/packages/questpie/README.md
@@ -14,7 +14,7 @@ Server-first TypeScript backend framework with a proxy-based field builder, coll
 - **Introspection** — Serializable field metadata, relation info, reactive config for admin consumption
 - **Background Jobs** — `job()` with Zod schema validation, pg-boss or Cloudflare Queues adapters
 - **Authentication** — Better Auth integration with plugins (admin, organization, 2FA, API keys)
-- **Storage** — Flydrive-based (S3, R2, GCS, local) with streaming uploads and typed upload collections
+- **Storage** — Files SDK-based (S3, R2, GCS, local) with streaming uploads and typed upload collections
 - **Realtime** — PostgreSQL NOTIFY/LISTEN, Redis Streams, or Cloudflare Durable Objects with SSE delivery
 - **Email** — SMTP + console adapters with template support
 - **Search** — Full-text search with reindex support
@@ -95,11 +95,16 @@ export const siteSettings = global("siteSettings")
 ```ts
 // src/questpie/server/questpie.config.ts
 import { runtimeConfig } from "questpie/app";
+import { fs } from "files-sdk/fs";
+
 export default runtimeConfig({
 	app: { url: process.env.APP_URL! },
 	db: { url: process.env.DATABASE_URL! },
 	secret: process.env.AUTH_SECRET!,
-	storage: { basePath: "/api" },
+	storage: {
+		adapter: fs({ root: "./uploads" }),
+		basePath: "/api",
+	},
 });
 ```
 

--- a/packages/questpie/package.json
+++ b/packages/questpie/package.json
@@ -123,7 +123,7 @@
 		"better-auth": "^1.4.9",
 		"commander": "^14.0.2",
 		"drizzle-orm": "1.0.0-beta.6-4414a19",
-		"flydrive": "^1.3.0",
+		"files-sdk": "^1.6.0",
 		"html-to-text": "^9.0.5",
 		"pino": "^10.1.0",
 		"pino-pretty": "^13.1.3",

--- a/packages/questpie/src/cli/codegen/template.ts
+++ b/packages/questpie/src/cli/codegen/template.ts
@@ -583,6 +583,7 @@ export function generateTemplate(options: TemplateOptions): string {
 		lines.push("\tcollections: _AppCollectionDefinitions;");
 		lines.push("\tglobals: _AppGlobalDefinitions;");
 		lines.push("\tauth: _AppAuthConfig;");
+		lines.push('\tstorage: (typeof _runtime)["storage"];');
 		lines.push("};");
 		lines.push("type _AppQuestpieBase = Questpie<_AppQuestpieConfig>;");
 		lines.push(
@@ -661,7 +662,7 @@ export function generateTemplate(options: TemplateOptions): string {
 				lines.push("\t\t\temail: unknown;");
 			}
 			lines.push("\t\t\tqueue: QueueClient<_ExecutionContextJobs>;");
-			lines.push("\t\t\tstorage: unknown;");
+			lines.push("\t\t\tstorage: _AppStorage;");
 			lines.push("\t\t\tkv: unknown;");
 			lines.push("\t\t\tlogger: unknown;");
 			lines.push("\t\t\tsearch: unknown;");
@@ -756,6 +757,7 @@ export function generateTemplate(options: TemplateOptions): string {
 	);
 	lines.push("\tglobals: AppGlobals & Record<string, AnyGlobalOrBuilder>;");
 	lines.push("\troutes: AppRoutes;");
+	lines.push('\tstorage: (typeof _runtime)["storage"];');
 	if (authFile) {
 		lines.push(`\tauth: typeof ${authFile.varName};`);
 	}

--- a/packages/questpie/src/exports/storage.ts
+++ b/packages/questpie/src/exports/storage.ts
@@ -1,2 +1,39 @@
+export { Files, FilesError, transfer } from "files-sdk";
+export type {
+	Adapter,
+	Body,
+	BodySource,
+	BulkOptions,
+	DeleteManyOptions,
+	DeleteManyResult,
+	DownloadManyOptions,
+	DownloadManyResult,
+	DownloadOptions,
+	ExistsManyResult,
+	FileHandle,
+	FilesOptions,
+	HeadManyResult,
+	ListOptions,
+	ListResult,
+	OperationOptions,
+	SignUploadOptions,
+	SignedUpload,
+	StoredFile,
+	StoredFileMeta,
+	UploadManyItem,
+	UploadManyOptions,
+	UploadManyResult,
+	UploadOptions,
+	UploadResult,
+	UrlOptions,
+} from "files-sdk";
 export * from "#questpie/server/modules/core/integrated/storage/signed-url.js";
-export type { StorageConfig, StorageLocalConfig, StorageDriverConfig, StorageBaseConfig, StorageVisibility } from "#questpie/server/config/types.js";
+export type {
+	StorageBaseConfig,
+	StorageAdapterConfig,
+	StorageAdapterFromConfig,
+	StorageConfig,
+	StorageFromQuestpieConfig,
+	StorageLocalConfig,
+	StorageVisibility,
+} from "#questpie/server/config/types.js";

--- a/packages/questpie/src/exports/types.ts
+++ b/packages/questpie/src/exports/types.ts
@@ -64,7 +64,6 @@ export type {
 	StorageVisibility,
 	StorageBaseConfig,
 	StorageLocalConfig,
-	StorageDriverConfig,
 	StorageConfig,
 	AnyCollectionOrBuilder,
 	AnyGlobalOrBuilder,

--- a/packages/questpie/src/server/adapters/compat.ts
+++ b/packages/questpie/src/server/adapters/compat.ts
@@ -8,7 +8,8 @@ import {
 	createGlobalRoutes,
 	createRealtimeRoutes,
 	createSearchRoutes,
-	createStorageRoutes,
+	storageCollectionServe,
+	storageCollectionUpload,
 } from "./routes/index.js";
 import type { AdapterConfig, AdapterRoutes } from "./types.js";
 
@@ -23,14 +24,15 @@ export const createAdapterRoutes = (
 	const authRoute = createAuthRoute(app);
 	const collectionRoutes = createCollectionRoutes(app, config);
 	const globalRoutes = createGlobalRoutes(app, config);
-	const storageRoutes = createStorageRoutes(app, config);
 	const realtimeRoutes = createRealtimeRoutes(app, config);
 	const searchRoutes = createSearchRoutes(app, config);
 
 	return {
 		auth: authRoute,
-		collectionUpload: storageRoutes.collectionUpload,
-		collectionServe: storageRoutes.collectionServe,
+		collectionUpload: (request, params, context, file) =>
+			storageCollectionUpload(app, request, params, context, config, file),
+		collectionServe: (request, params, context) =>
+			storageCollectionServe(app, request, params, context, config),
 		realtime: realtimeRoutes,
 		collections: collectionRoutes,
 		globals: globalRoutes,

--- a/packages/questpie/src/server/adapters/routes/index.ts
+++ b/packages/questpie/src/server/adapters/routes/index.ts
@@ -10,7 +10,6 @@ export { createCollectionRoutes } from "./collections.js";
 export { createGlobalRoutes, type GlobalRoutes } from "./globals.js";
 export { createRealtimeRoutes } from "./realtime.js";
 export { createSearchRoutes } from "./search.js";
-export { createStorageRoutes } from "./storage.js";
 
 // Standalone handlers
 export { authHandler } from "./auth.js";

--- a/packages/questpie/src/server/adapters/routes/storage.ts
+++ b/packages/questpie/src/server/adapters/routes/storage.ts
@@ -4,10 +4,10 @@
  * File upload and serving route handlers.
  */
 
-import { Readable } from "node:stream";
+import type { Files } from "files-sdk";
 
 import type { Questpie } from "../../config/questpie.js";
-import type { QuestpieConfig, StorageVisibility } from "../../config/types.js";
+import type { StorageVisibility } from "../../config/types.js";
 import { ApiError } from "../../errors/index.js";
 import { verifySignedUrlToken } from "../../modules/core/integrated/storage/signed-url.js";
 import type { AdapterConfig, AdapterContext, UploadFile } from "../types.js";
@@ -25,6 +25,23 @@ type ByteRange = {
 	length: number;
 };
 
+type StorageRouteContext = {
+	storage: Files;
+};
+
+const getStorageFromContext = (
+	context: AdapterContext["appContext"],
+	app: Questpie<any>,
+): Files => {
+	const storage =
+		(context as AdapterContext["appContext"] & Partial<StorageRouteContext>)
+			.storage ?? app.storage;
+	if (!storage) {
+		throw ApiError.internal("Storage not configured");
+	}
+	return storage as Files;
+};
+
 const toUint8Array = (chunk: unknown): Uint8Array => {
 	if (chunk instanceof Uint8Array) return chunk;
 	if (chunk instanceof ArrayBuffer) return new Uint8Array(chunk);
@@ -33,9 +50,6 @@ const toUint8Array = (chunk: unknown): Uint8Array => {
 	}
 	return new TextEncoder().encode(String(chunk));
 };
-
-const nodeReadableToWeb = (stream: Readable): ReadableStream<Uint8Array> =>
-	(Readable as any).toWeb(stream) as ReadableStream<Uint8Array>;
 
 const parseByteRange = (
 	rangeHeader: string,
@@ -69,18 +83,18 @@ const parseByteRange = (
 };
 
 const createRangeStream = (
-	stream: Readable,
+	stream: ReadableStream<Uint8Array>,
 	start: number,
 	end: number,
 ): ReadableStream<Uint8Array> => {
-	const iterator = stream[Symbol.asyncIterator]();
+	const reader = stream.getReader();
 	let offset = 0;
 	let closed = false;
 
 	const close = async () => {
 		if (closed) return;
 		closed = true;
-		await iterator.return?.();
+		await reader.cancel();
 	};
 
 	return new ReadableStream<Uint8Array>({
@@ -92,7 +106,7 @@ const createRangeStream = (
 
 			try {
 				while (true) {
-					const next = await iterator.next();
+					const next = await reader.read();
 					if (next.done) {
 						closed = true;
 						controller.close();
@@ -295,82 +309,94 @@ export async function storageCollectionServe(
 	const url = new URL(request.url);
 	const token = url.searchParams.get("token");
 
-	// Check if file exists
-	const exists = await app.storage.use().exists(key);
-	if (!exists) {
-		return errorResponse(
-			ApiError.notFound("File", key),
-			request,
-			resolved.appContext.locale,
-		);
-	}
-
-	// Get record metadata to check visibility
-	const crud = app.collections[collection as any];
-	const record = await crud.findOne({
-		where: { key } as any,
-	});
-
-	const visibility: StorageVisibility =
-		(record as any)?.visibility ||
-		app.config.storage?.defaultVisibility ||
-		"public";
-
-	// For private files, verify the signed token
-	if (visibility === "private") {
-		if (!token) {
-			return errorResponse(
-				ApiError.unauthorized(
-					"Token required for private files",
-					"upload.tokenRequired",
-				),
-				request,
-				resolved.appContext.locale,
-			);
-		}
-
-		const secret = app.config.secret;
-		if (!secret) {
-			return errorResponse(
-				ApiError.internal(
-					"Storage secret not configured. Set 'secret' in your app config to serve private files.",
-				),
-				request,
-				resolved.appContext.locale,
-			);
-		}
-		const payload = await verifySignedUrlToken(token, secret);
-
-		if (!payload) {
-			return errorResponse(
-				ApiError.unauthorized(
-					"Invalid or expired token",
-					"upload.tokenInvalid",
-				),
-				request,
-				resolved.appContext.locale,
-			);
-		}
-
-		if (payload.key !== key) {
-			return errorResponse(
-				ApiError.unauthorized(
-					"Token does not match requested file",
-					"upload.tokenMismatch",
-				),
-				request,
-				resolved.appContext.locale,
-			);
-		}
-	}
-
 	try {
-		const metadata = await app.storage.use().getMetaData(key);
+		const storage = getStorageFromContext(resolved.appContext, app);
+
+		// The upload row is the authorization anchor for storage objects. Do not
+		// serve orphaned keys, or keys hidden by collection read access.
+		const crud = app.collections[collection as any];
+		const record = await crud.findOne(
+			{
+				where: { key } as any,
+			},
+			resolved.appContext,
+		);
+
+		if (!record) {
+			return errorResponse(
+				ApiError.notFound("File", key),
+				request,
+				resolved.appContext.locale,
+			);
+		}
+
+		const visibility: StorageVisibility =
+			(record as any).visibility ||
+			collectionConfig.state.upload?.visibility ||
+			app.config.storage?.defaultVisibility ||
+			"public";
+
+		// For private files, verify the signed token after row access succeeds.
+		if (visibility === "private") {
+			if (!token) {
+				return errorResponse(
+					ApiError.unauthorized(
+						"Token required for private files",
+						"upload.tokenRequired",
+					),
+					request,
+					resolved.appContext.locale,
+				);
+			}
+
+			const secret = app.config.secret;
+			if (!secret) {
+				return errorResponse(
+					ApiError.internal(
+						"Storage secret not configured. Set 'secret' in your app config to serve private files.",
+					),
+					request,
+					resolved.appContext.locale,
+				);
+			}
+			const payload = await verifySignedUrlToken(token, secret);
+
+			if (!payload) {
+				return errorResponse(
+					ApiError.unauthorized(
+						"Invalid or expired token",
+						"upload.tokenInvalid",
+					),
+					request,
+					resolved.appContext.locale,
+				);
+			}
+
+			if (payload.key !== key) {
+				return errorResponse(
+					ApiError.unauthorized(
+						"Token does not match requested file",
+						"upload.tokenMismatch",
+					),
+					request,
+					resolved.appContext.locale,
+				);
+			}
+		}
+
+		const exists = await storage.exists(key);
+		if (!exists) {
+			return errorResponse(
+				ApiError.notFound("File", key),
+				request,
+				resolved.appContext.locale,
+			);
+		}
+
+		const metadata = await storage.head(key);
 
 		const contentType =
-			metadata.contentType ||
-			(record as any)?.mimeType ||
-			"application/octet-stream";
+			metadata.type || (record as any)?.mimeType || "application/octet-stream";
 
 		// Sanitize filename to prevent header injection
 		const rawFilename = (record as any)?.filename;
@@ -381,7 +407,7 @@ export async function storageCollectionServe(
 		// Security headers for SVG files — prevent embedded script execution
 		const isSvg = contentType.includes("svg");
 		const recordSize = Number((record as any)?.size);
-		const metadataSize = Number(metadata.contentLength);
+		const metadataSize = Number(metadata.size);
 		const totalSize = Number.isFinite(metadataSize) ? metadataSize : recordSize;
 		const hasKnownSize = Number.isFinite(totalSize) && totalSize >= 0;
 		const commonHeaders = {
@@ -413,7 +439,8 @@ export async function storageCollectionServe(
 			}
 
 			if (range) {
-				const stream = await app.storage.use().getStream(key);
+				const file = await storage.download(key, { as: "stream" });
+				const stream = file.stream();
 				return new Response(createRangeStream(stream, range.start, range.end), {
 					status: 206,
 					headers: {
@@ -426,8 +453,8 @@ export async function storageCollectionServe(
 			}
 		}
 
-		const stream = await app.storage.use().getStream(key);
-		return new Response(nodeReadableToWeb(stream), {
+		const file = await storage.download(key, { as: "stream" });
+		return new Response(file.stream(), {
 			status: 200,
 			headers: {
 				...commonHeaders,
@@ -439,43 +466,3 @@ export async function storageCollectionServe(
 		return errorResponse(error, request, resolved.appContext.locale);
 	}
 }
-
-// ============================================================================
-// Legacy closure factory (deprecated)
-// ============================================================================
-
-/**
- * @deprecated Use standalone `storageCollectionUpload` and `storageCollectionServe` instead.
- */
-export const createStorageRoutes = <
-	TConfig extends QuestpieConfig = QuestpieConfig,
->(
-	app: Questpie<TConfig>,
-	config: AdapterConfig<TConfig> = {},
-) => {
-	return {
-		collectionUpload: async (
-			request: Request,
-			params: { collection: string },
-			context?: AdapterContext,
-			file?: UploadFile | null,
-		): Promise<Response> => {
-			return storageCollectionUpload(
-				app,
-				request,
-				params,
-				context,
-				config,
-				file,
-			);
-		},
-
-		collectionServe: async (
-			request: Request,
-			params: { collection: string; key: string },
-			_context?: AdapterContext,
-		): Promise<Response> => {
-			return storageCollectionServe(app, request, params, _context, config);
-		},
-	};
-};

--- a/packages/questpie/src/server/collection/builder/collection-builder.ts
+++ b/packages/questpie/src/server/collection/builder/collection-builder.ts
@@ -25,10 +25,7 @@ import {
 	createCollectionValidationSchemas,
 	type ValidationSchemas,
 } from "#questpie/server/collection/builder/validation-helpers.js";
-import {
-	buildStorageFileUrl,
-	generateSignedUrlToken,
-} from "#questpie/server/modules/core/integrated/storage/signed-url.js";
+import { isInTransaction } from "#questpie/server/collection/crud/shared/transaction.js";
 import {
 	createFieldsCallbackContext,
 	type FieldsCallbackContext,
@@ -40,6 +37,10 @@ import {
 	builtinFields,
 } from "#questpie/server/modules/core/fields/index.js";
 import type { SearchableConfig } from "#questpie/server/modules/core/integrated/search/types.js";
+import {
+	buildStorageFileUrl,
+	generateSignedUrlToken,
+} from "#questpie/server/modules/core/integrated/storage/signed-url.js";
 import type { Override } from "#questpie/shared/type-utils.js";
 
 /**
@@ -740,6 +741,45 @@ export class CollectionBuilder<TState extends CollectionBuilderState> {
 		const uploadFields = Collection.uploadCols();
 
 		const collectionSlug = this.state.name;
+		const logStorageCleanupError = (
+			logger: any,
+			message: string,
+			key: string,
+			error: unknown,
+		) => {
+			logger?.warn?.(message, {
+				key,
+				error: error instanceof Error ? error.message : String(error),
+			});
+		};
+		const deleteStorageObjectAfterCommit = async ({
+			app,
+			key,
+			logger,
+			onAfterCommit,
+			message,
+		}: {
+			app: any;
+			key: string;
+			logger: any;
+			onAfterCommit?: (callback: () => Promise<void>) => void;
+			message: string;
+		}) => {
+			const cleanup = async () => {
+				try {
+					await app.storage.delete(key);
+				} catch (error) {
+					logStorageCleanupError(logger, message, key, error);
+				}
+			};
+
+			if (onAfterCommit && isInTransaction()) {
+				onAfterCommit(cleanup);
+				return;
+			}
+
+			await cleanup();
+		};
 		const uploadAfterReadHook = async ({ data, app }: any) => {
 			if (!data?.key) return;
 
@@ -748,8 +788,7 @@ export class CollectionBuilder<TState extends CollectionBuilderState> {
 
 			let token: string | undefined;
 			if ((data.visibility || "public") === "private") {
-				const secret: string =
-					app.config.secret || "questpie-default-secret";
+				const secret: string = app.config.secret || "questpie-default-secret";
 				const expiration: number =
 					app.config.storage?.signedUrlExpiration || 3600;
 				token = await generateSignedUrlToken(data.key, secret, expiration);
@@ -770,12 +809,37 @@ export class CollectionBuilder<TState extends CollectionBuilderState> {
 			original,
 			app,
 			operation,
+			logger,
+			onAfterCommit,
 		}: any) => {
 			if (operation !== "update") return;
 			if (!app?.storage || !data?.key) return;
-			if (!original || original.visibility === data.visibility) return;
+			if (!original?.key || original.key === data.key) return;
 
-			await app.storage.use().setVisibility(data.key, data.visibility);
+			await deleteStorageObjectAfterCommit({
+				app,
+				key: original.key,
+				logger,
+				onAfterCommit,
+				message: "Failed to delete replaced upload file from storage",
+			});
+		};
+
+		const uploadAfterDeleteHook = async ({
+			data,
+			app,
+			logger,
+			onAfterCommit,
+		}: any) => {
+			if (!app?.storage || !data?.key) return;
+
+			await deleteStorageObjectAfterCommit({
+				app,
+				key: data.key,
+				logger,
+				onAfterCommit,
+				message: "Failed to delete upload file from storage",
+			});
 		};
 
 		// Merge existing afterRead hooks with upload hook
@@ -790,9 +854,15 @@ export class CollectionBuilder<TState extends CollectionBuilderState> {
 		const existingAfterChange = this.state.hooks?.afterChange;
 		const mergedAfterChange = existingAfterChange
 			? Array.isArray(existingAfterChange)
-				? [...existingAfterChange, uploadAfterChangeHook]
-				: [existingAfterChange, uploadAfterChangeHook]
+				? [uploadAfterChangeHook, ...existingAfterChange]
+				: [uploadAfterChangeHook, existingAfterChange]
 			: uploadAfterChangeHook;
+		const existingAfterDelete = this.state.hooks?.afterDelete;
+		const mergedAfterDelete = existingAfterDelete
+			? Array.isArray(existingAfterDelete)
+				? [uploadAfterDeleteHook, ...existingAfterDelete]
+				: [uploadAfterDeleteHook, existingAfterDelete]
+			: uploadAfterDeleteHook;
 
 		const newState = {
 			...this.state,
@@ -808,6 +878,7 @@ export class CollectionBuilder<TState extends CollectionBuilderState> {
 				...this.state.hooks,
 				afterRead: mergedAfterRead,
 				afterChange: mergedAfterChange,
+				afterDelete: mergedAfterDelete,
 			},
 			upload: options,
 		} as any;

--- a/packages/questpie/src/server/collection/crud/crud-generator.ts
+++ b/packages/questpie/src/server/collection/crud/crud-generator.ts
@@ -2308,18 +2308,26 @@ export class CRUDGenerator<TState extends CollectionBuilderState> {
 			// 4. Loop through afterDelete hooks
 			for (const record of records) {
 				// Execute afterDelete hooks
-				await this.executeCollectionHooksWithGlobal(
-					"afterDelete",
-					this.state.hooks?.afterDelete,
-					this.createHookContext({
-						data: record,
-						original: record,
-						operation: "delete",
-						context,
-						db,
-						bulk: deleteBulkMeta,
-					}),
-				);
+				try {
+					await this.executeCollectionHooksWithGlobal(
+						"afterDelete",
+						this.state.hooks?.afterDelete,
+						this.createHookContext({
+							data: record,
+							original: record,
+							operation: "delete",
+							context,
+							db,
+							bulk: deleteBulkMeta,
+						}),
+					);
+				} catch (err) {
+					// afterDelete hook errors are non-fatal — log and continue
+					console.error(
+						`[QUESTPIE] afterDelete hook error for "${this.state.name}":`,
+						err,
+					);
+				}
 			}
 
 			return { success: true, count: records.length };
@@ -3043,7 +3051,7 @@ export class CRUDGenerator<TState extends CollectionBuilderState> {
 		// Upload collections with public visibility get public read access by default
 		if (
 			operation === "read" &&
-			!this.state.access?.read &&
+			this.state.access?.read === undefined &&
 			this.state.upload?.visibility === "public"
 		) {
 			return true;
@@ -3409,26 +3417,14 @@ export class CRUDGenerator<TState extends CollectionBuilderState> {
 			try {
 				// Streaming is more memory-efficient for large files
 				if (file.stream) {
-					// Convert web ReadableStream to Node.js Readable for Flydrive
-					const { Readable } = await import("node:stream");
-					const webStream = file.stream();
-					// Web ReadableStream → Node.js stream type mismatch requires cast
-					// Readable.fromWeb exists in Node 17+ / Bun but may not be in all TS lib definitions
-					const nodeStream = (Readable as any).fromWeb(
-						webStream as unknown as import("node:stream/web").ReadableStream,
-					);
-					await this.app.storage.use().putStream(key, nodeStream, {
+					await this.app.storage.upload(key, file.stream(), {
 						contentType: file.type,
-						contentLength: file.size,
-						visibility,
 					});
 				} else if (file.arrayBuffer) {
 					// Fallback to buffer-based upload for files without stream support
 					const buffer = await file.arrayBuffer();
-					await this.app.storage.use().put(key, new Uint8Array(buffer), {
+					await this.app.storage.upload(key, new Uint8Array(buffer), {
 						contentType: file.type,
-						contentLength: file.size,
-						visibility,
 					});
 				} else {
 					throw ApiError.badRequest(
@@ -3455,7 +3451,6 @@ export class CRUDGenerator<TState extends CollectionBuilderState> {
 			} catch (error) {
 				if (stored) {
 					await this.app.storage
-						.use()
 						.delete(key)
 						.catch(() => {});
 				}

--- a/packages/questpie/src/server/config/app-context.ts
+++ b/packages/questpie/src/server/config/app-context.ts
@@ -32,6 +32,8 @@
 declare global {
 	namespace Questpie {
 		interface AppContext {}
+		interface JobHandlerContext {}
+		interface WorkflowContext {}
 		interface Registry {}
 		/**
 		 * Augmentable interface for view record types.

--- a/packages/questpie/src/server/config/cloud-env.ts
+++ b/packages/questpie/src/server/config/cloud-env.ts
@@ -1,3 +1,5 @@
+import type { Adapter } from "files-sdk";
+
 import type { DbConfig, StorageConfig } from "#questpie/server/config/types.js";
 import { getEnv } from "#questpie/server/utils/env.js";
 
@@ -33,6 +35,66 @@ const FALLBACK_ENV = {
 } as const;
 
 const DEFAULT_APP_URL = "http://localhost:3000";
+
+const STORAGE_CONFIG_KEYS = new Set([
+	"adapter",
+	"basePath",
+	"defaultVisibility",
+	"driver",
+	"files",
+	"location",
+	"signedUrlExpiration",
+]);
+
+const STORAGE_CONFIG_LEGACY_KEYS = new Set(["driver", "files"]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+export function assertValidStorageConfig(
+	storage: unknown,
+): asserts storage is StorageConfig {
+	if (storage === undefined) return;
+
+	if (!isRecord(storage)) {
+		throw new Error(
+			"[questpie] Invalid storage config. Use `storage: { adapter }` or local storage options.",
+		);
+	}
+
+	const legacyKeys = Object.keys(storage).filter((key) =>
+		STORAGE_CONFIG_LEGACY_KEYS.has(key),
+	);
+	if (legacyKeys.length > 0) {
+		throw new Error(
+			`[questpie] Unsupported storage config key(s): ${legacyKeys.join(", ")}. Use ` +
+				"`storage: { adapter }` for Files SDK adapters or local storage options.",
+		);
+	}
+
+	const unknownKeys = Object.keys(storage).filter(
+		(key) => !STORAGE_CONFIG_KEYS.has(key),
+	);
+	if (unknownKeys.length > 0) {
+		throw new Error(
+			`[questpie] Unknown storage config key(s): ${unknownKeys.join(", ")}. Use ` +
+				"`storage: { adapter }` for Files SDK adapters or local storage options.",
+		);
+	}
+
+	if ("adapter" in storage && storage.adapter === undefined) {
+		throw new Error(
+			"[questpie] Invalid storage config. `adapter` must be a Files SDK adapter.",
+		);
+	}
+
+	if ("adapter" in storage && "location" in storage) {
+		throw new Error(
+			"[questpie] Invalid storage config. `adapter` and `location` cannot be configured together.",
+		);
+	}
+}
 
 // ============================================================================
 // Detection helpers
@@ -103,14 +165,19 @@ export function resolveSecret(explicit?: string): string | undefined {
  * Resolve storage config.
  * Priority: explicit → auto-detect from QUESTPIE_STORAGE_* → undefined (framework default)
  *
- * When QUESTPIE_STORAGE_* env vars are present, a lazy S3 driver is created.
- * The actual S3Driver import happens on first storage operation (requires
- * `@aws-sdk/client-s3` and `@aws-sdk/s3-request-presigner` to be installed).
+ * When QUESTPIE_STORAGE_* env vars are present, a lazy Files SDK S3 adapter is created.
+ * The actual S3 adapter import happens on first storage operation (requires
+ * `@aws-sdk/client-s3`, `@aws-sdk/lib-storage`,
+ * `@aws-sdk/s3-presigned-post`, and `@aws-sdk/s3-request-presigner` to be
+ * installed).
  */
 export function resolveStorageConfig(
-	explicit?: StorageConfig,
+	explicit?: unknown,
 ): StorageConfig | undefined {
-	if (explicit) return explicit;
+	if (explicit !== undefined) {
+		assertValidStorageConfig(explicit);
+		return explicit;
+	}
 
 	const endpoint = getEnv(CLOUD_ENV.STORAGE_ENDPOINT);
 	if (!endpoint) return undefined;
@@ -130,7 +197,7 @@ export function resolveStorageConfig(
 	}
 
 	return {
-		driver: createLazyS3Driver({
+		adapter: createLazyS3StorageAdapter({
 			endpoint,
 			bucket,
 			region,
@@ -141,10 +208,10 @@ export function resolveStorageConfig(
 }
 
 // ============================================================================
-// Lazy S3 driver — defers dynamic import until first storage operation
+// Lazy S3 adapter — defers dynamic import until first storage operation
 // ============================================================================
 
-interface S3DriverOptions {
+interface S3StorageOptions {
 	endpoint: string;
 	bucket: string;
 	region: string;
@@ -152,41 +219,56 @@ interface S3DriverOptions {
 	secretKey: string;
 }
 
+const S3_ADAPTER_METHODS = new Set([
+	"upload",
+	"download",
+	"head",
+	"exists",
+	"delete",
+	"deleteMany",
+	"copy",
+	"list",
+	"url",
+	"signedUploadUrl",
+]);
+
+const S3_ADAPTER_PROPERTIES = new Map<PropertyKey, unknown>([
+	["reportsUploadProgress", true],
+	["supportsRange", true],
+]);
+
 /**
- * Creates a DriverContract proxy that lazily loads `flydrive/drivers/s3`
+ * Creates a Files SDK adapter proxy that lazily loads `files-sdk/s3`
  * via dynamic import on first method call.
  *
- * All DriverContract methods are async, so the lazy init is transparent.
- * The S3Driver import requires `@aws-sdk/client-s3` to be installed.
+ * All adapter methods are async, so the lazy init is transparent.
+ * The S3 adapter import requires the AWS SDK peer dependencies to be installed.
  */
-function createLazyS3Driver(options: S3DriverOptions) {
-	type DriverContract = import("flydrive/types").DriverContract;
+function createLazyS3StorageAdapter(options: S3StorageOptions): Adapter {
+	let adapter: Adapter | undefined;
+	let initPromise: Promise<Adapter> | undefined;
 
-	let driver: DriverContract | undefined;
-	let initPromise: Promise<DriverContract> | undefined;
-
-	const ensureDriver = (): Promise<DriverContract> => {
-		if (driver) return Promise.resolve(driver);
+	const ensureAdapter = (): Promise<Adapter> => {
+		if (adapter) return Promise.resolve(adapter);
 		if (!initPromise) {
-			initPromise = import("flydrive/drivers/s3")
-				.then(({ S3Driver }) => {
-					driver = new S3Driver({
+			initPromise = import("files-sdk/s3")
+				.then(({ s3 }) => {
+					adapter = s3({
 						credentials: {
 							accessKeyId: options.accessKey,
 							secretAccessKey: options.secretKey,
 						},
 						region: options.region,
 						bucket: options.bucket,
-						visibility: "public",
 						endpoint: options.endpoint,
 						forcePathStyle: true,
 					});
-					return driver;
+					return adapter;
 				})
 				.catch((err) => {
 					throw new Error(
-						"[questpie] QUESTPIE_STORAGE_* env vars detected but S3 driver could not be loaded. " +
-							"Install @aws-sdk/client-s3 and @aws-sdk/s3-request-presigner as dependencies.\n" +
+						"[questpie] QUESTPIE_STORAGE_* env vars detected but Files SDK S3 adapter could not be loaded. " +
+							"Install @aws-sdk/client-s3, @aws-sdk/lib-storage, @aws-sdk/s3-presigned-post, and @aws-sdk/s3-request-presigner as dependencies.\n" +
 							`Cause: ${err instanceof Error ? err.message : String(err)}`,
 					);
 				});
@@ -200,8 +282,19 @@ function createLazyS3Driver(options: S3DriverOptions) {
 			if (prop === "then" || typeof prop === "symbol") {
 				return undefined;
 			}
+			if (adapter) {
+				return Reflect.get(adapter, prop);
+			}
+			if (prop === "name") return "s3";
+			if (prop === "raw") return undefined;
+			if (S3_ADAPTER_PROPERTIES.has(prop)) {
+				return S3_ADAPTER_PROPERTIES.get(prop);
+			}
+			if (!S3_ADAPTER_METHODS.has(prop as string)) {
+				return undefined;
+			}
 			return async (...args: unknown[]) => {
-				const d = await ensureDriver();
+				const d = await ensureAdapter();
 				const fn = (d as unknown as Record<string, unknown>)[prop as string];
 				if (typeof fn === "function") {
 					return fn.apply(d, args);
@@ -209,7 +302,18 @@ function createLazyS3Driver(options: S3DriverOptions) {
 				return fn;
 			};
 		},
+		has(_, prop) {
+			if (adapter) {
+				return prop in adapter;
+			}
+			return (
+				prop === "name" ||
+				prop === "raw" ||
+				S3_ADAPTER_PROPERTIES.has(prop) ||
+				S3_ADAPTER_METHODS.has(prop as string)
+			);
+		},
 	};
 
-	return new Proxy({}, handler) as DriverContract;
+	return new Proxy({}, handler) as Adapter;
 }

--- a/packages/questpie/src/server/config/create-app.ts
+++ b/packages/questpie/src/server/config/create-app.ts
@@ -25,6 +25,14 @@ import {
 import coreModule from "#questpie/server/modules/core/.generated/module.js";
 import { mergeAuthOptions } from "#questpie/server/modules/core/integrated/auth/merge.js";
 
+type RuntimeConfigStorageInputGuard<TInput> = TInput extends {
+	storage?: infer TStorage;
+}
+	? TStorage extends StorageConfig | undefined
+		? unknown
+		: { storage?: never }
+	: unknown;
+
 // ============================================================================
 // module() — identity function for type inference
 // ============================================================================
@@ -75,7 +83,7 @@ export function module<T extends ModuleDefinition>(definition: T): T {
  *
  * When `QUESTPIE_STORAGE_ENDPOINT`, `QUESTPIE_STORAGE_BUCKET`,
  * `QUESTPIE_STORAGE_ACCESS_KEY`, and `QUESTPIE_STORAGE_SECRET_KEY` are all set,
- * an S3-compatible storage driver is auto-configured (requires `@aws-sdk/client-s3`).
+ * an S3-compatible Files SDK storage adapter is auto-configured (requires `@aws-sdk/client-s3`).
  *
  * @example Zero-config on QUESTPIE Cloud:
  * ```ts
@@ -97,15 +105,15 @@ export function module<T extends ModuleDefinition>(definition: T): T {
  *
  * @see RFC-MODULE-ARCHITECTURE §3.1 (Functions)
  */
-export function runtimeConfig<TInput extends RuntimeConfigInput>(
-	input: TInput,
+export function runtimeConfig<const TInput extends RuntimeConfigInput>(
+	input: TInput & RuntimeConfigStorageInputGuard<TInput>,
 ): ResolvedRuntimeConfig<TInput> {
 	const resolved = {
 		...input,
 		app: { url: resolveAppUrl(input.app?.url) },
 		db: resolveDbConfig(input.db),
 		secret: resolveSecret(input.secret as string | undefined),
-		storage: resolveStorageConfig(input.storage as StorageConfig | undefined),
+		storage: resolveStorageConfig(input.storage),
 	} as unknown as ResolvedRuntimeConfig<TInput>;
 
 	return resolved;

--- a/packages/questpie/src/server/config/module-types.ts
+++ b/packages/questpie/src/server/config/module-types.ts
@@ -1,4 +1,5 @@
 import type { BetterAuthOptions } from "better-auth";
+import type { Adapter } from "files-sdk";
 
 import type { CollectionAccess } from "#questpie/server/collection/builder/types.js";
 
@@ -230,7 +231,10 @@ export interface AppConfigInput {
  *
  * @see RFC-MODULE-ARCHITECTURE §3.1 (Functions), §8.1 (User Project)
  */
-export interface RuntimeConfig<TDb extends DbConfig = DbConfig> {
+export interface RuntimeConfig<
+	TDb extends DbConfig = DbConfig,
+	TStorage extends StorageConfig | undefined = StorageConfig | undefined,
+> {
 	/** Codegen plugins — discover additional file patterns and extend generated output. */
 	plugins?: CodegenPlugin[];
 
@@ -244,7 +248,7 @@ export interface RuntimeConfig<TDb extends DbConfig = DbConfig> {
 	secret?: string;
 
 	/** Storage configuration. */
-	storage?: StorageConfig;
+	storage?: TStorage;
 
 	/** Email configuration with adapter. */
 	email?: MailerConfig;
@@ -323,10 +327,13 @@ export interface RuntimeConfig<TDb extends DbConfig = DbConfig> {
  *
  * @see {@link RuntimeConfig} for the resolved output type.
  */
-export type RuntimeConfigInput<TDb extends DbConfig = DbConfig> = Partial<
-	Pick<RuntimeConfig<TDb>, "app" | "db">
+export type RuntimeConfigInput<
+	TDb extends DbConfig = DbConfig,
+	TStorage extends StorageConfig | undefined = StorageConfig | undefined,
+> = Partial<
+	Pick<RuntimeConfig<TDb, TStorage>, "app" | "db">
 > &
-	Omit<RuntimeConfig<TDb>, "app" | "db">;
+	Omit<RuntimeConfig<TDb, TStorage>, "app" | "db">;
 
 type DbFromRuntimeConfigInput<TInput> = TInput extends { db: infer TDb }
 	? TDb extends DbConfig
@@ -334,15 +341,28 @@ type DbFromRuntimeConfigInput<TInput> = TInput extends { db: infer TDb }
 		: DbConfig
 	: DbConfig;
 
-export type ResolvedRuntimeConfig<TInput extends RuntimeConfigInput> = Omit<
-	RuntimeConfig<DbFromRuntimeConfigInput<TInput>>,
+type StorageFromRuntimeConfigInput<TInput> = "storage" extends keyof TInput
+	? TInput extends { storage?: infer TStorage }
+		? TStorage extends StorageConfig | undefined
+			? TStorage
+			: StorageConfig<Adapter> | undefined
+		: StorageConfig<Adapter> | undefined
+	: StorageConfig | undefined;
+
+export type ResolvedRuntimeConfig<
+	TInput extends RuntimeConfigInput<any, any>,
+> = Omit<
+	RuntimeConfig<
+		DbFromRuntimeConfigInput<TInput>,
+		StorageFromRuntimeConfigInput<TInput>
+	>,
 	"app" | "db" | "secret" | "storage"
 > &
 	Omit<TInput, "app" | "db" | "secret" | "storage"> & {
 		app: { url: string };
 		db: DbFromRuntimeConfigInput<TInput>;
 		secret: string | undefined;
-		storage: StorageConfig | undefined;
+		storage: StorageFromRuntimeConfigInput<TInput>;
 	};
 
 // ============================================================================

--- a/packages/questpie/src/server/config/questpie.ts
+++ b/packages/questpie/src/server/config/questpie.ts
@@ -1,7 +1,6 @@
 import type { BetterAuthOptions } from "better-auth";
 import { betterAuth } from "better-auth";
 import type { PgTable } from "drizzle-orm/pg-core";
-import type { DriveManager } from "flydrive";
 
 import {
 	type Collection,
@@ -23,6 +22,7 @@ import type {
 	DbCloseFn,
 	DrizzleClientFromQuestpieConfig,
 	Locale,
+	StorageFromQuestpieConfig,
 	TablesFromConfig,
 } from "#questpie/server/config/types.js";
 import { GlobalBuilder } from "#questpie/server/global/builder/global-builder.js";
@@ -58,10 +58,6 @@ interface ResolvedServiceDefinition {
 }
 
 export class Questpie<TConfig extends QuestpieConfig = QuestpieConfig> {
-	static readonly __internal = {
-		storageDriverServiceName: "appDefault",
-	};
-
 	private _collections: Record<string, Collection<AnyCollectionState>> = {};
 	private _globals: Record<string, AnyGlobal> = {};
 	private _singletonServices: Record<string, any> = {};
@@ -132,10 +128,7 @@ export class Questpie<TConfig extends QuestpieConfig = QuestpieConfig> {
 	public auth!: TConfig["auth"] extends BetterAuthOptions
 		? ReturnType<typeof betterAuth<TConfig["auth"]>>
 		: ReturnType<typeof betterAuth<BetterAuthOptions>>;
-	public storage!: DriveManager<{
-		[Questpie.__internal
-			.storageDriverServiceName]: () => import("flydrive/types").DriverContract;
-	}>;
+	public storage!: StorageFromQuestpieConfig<TConfig>;
 	public queue!: QueueClient<NonNullable<TConfig["queue"]>["jobs"]>;
 	public email!: MailerService;
 	public kv!: KVService;

--- a/packages/questpie/src/server/config/runtime-compatibility.ts
+++ b/packages/questpie/src/server/config/runtime-compatibility.ts
@@ -65,11 +65,11 @@ export function getCloudflareCompatibilityIssues(
 		});
 	}
 
-	if (!config.storage || !("driver" in config.storage)) {
+	if (!config.storage || !("adapter" in config.storage)) {
 		issues.push({
 			path: "storage",
 			message:
-				"Cloudflare Workers do not provide local filesystem storage. Provide storage: { driver: ... } backed by R2 or S3-compatible storage.",
+				"Cloudflare Workers do not provide local filesystem storage. Provide storage: { adapter: ... } backed by R2 or S3-compatible storage.",
 		});
 	}
 

--- a/packages/questpie/src/server/config/types.ts
+++ b/packages/questpie/src/server/config/types.ts
@@ -82,7 +82,7 @@ export type {
 
 import type { BetterAuthOptions } from "better-auth";
 import type { PgDatabase } from "drizzle-orm/pg-core";
-import type { DriverContract } from "flydrive/types";
+import type { Adapter, Files } from "files-sdk";
 
 import type { Migration } from "../migration/types.js";
 import type { MailerConfig } from "../modules/core/integrated/mailer/types.js";
@@ -280,6 +280,8 @@ export type AccessMode = "user" | "system";
 
 export type StorageVisibility = "public" | "private";
 
+type IsAny<T> = 0 extends 1 & T ? true : false;
+
 /**
  * Base storage options shared by all storage configurations.
  */
@@ -303,11 +305,17 @@ export interface StorageBaseConfig {
 	 * @default "/"
 	 */
 	basePath?: string;
+
+	/** Disallow the removed storage registration shape. */
+	driver?: never;
+
+	/** Disallow the removed storage registration shape. */
+	files?: never;
 }
 
 /**
  * Local filesystem storage configuration.
- * QUESTPIE creates FSDriver and serves files at `/storage/files/:key`.
+ * QUESTPIE creates a Files SDK filesystem adapter and serves upload collection files at `/:collection/files/:key`.
  */
 export interface StorageLocalConfig extends StorageBaseConfig {
 	/**
@@ -319,31 +327,49 @@ export interface StorageLocalConfig extends StorageBaseConfig {
 	 * @default "./uploads"
 	 */
 	location?: string;
-	driver?: never;
+	adapter?: never;
 }
 
 /**
- * Custom driver storage configuration (S3, R2, GCS, etc.).
- * Cloud providers serve files directly - no local file serving.
+ * Files SDK adapter-first storage configuration.
  */
-export interface StorageDriverConfig extends StorageBaseConfig {
+export interface StorageAdapterConfig<
+	TAdapter extends Adapter = Adapter,
+> extends StorageBaseConfig {
 	/**
-	 * Custom FlyDrive driver instance.
+	 * Files SDK adapter used to construct QUESTPIE's direct `Files` instance.
 	 *
 	 * @example
 	 * ```ts
-	 * import { S3Driver } from "flydrive/drivers/s3";
-	 * storage: { driver: new S3Driver({ ... }) }
+	 * import { s3 } from "files-sdk/s3";
+	 *
+	 * storage: { adapter: s3({ bucket: "uploads" }) }
 	 * ```
 	 */
-	driver: DriverContract;
+	adapter: TAdapter;
 	location?: never;
 }
 
 /**
- * Storage configuration - either local filesystem or custom driver.
+ * Storage configuration - local filesystem or Files SDK adapter.
  */
-export type StorageConfig = StorageLocalConfig | StorageDriverConfig;
+export type StorageConfig<TAdapter extends Adapter = Adapter> =
+	| StorageLocalConfig
+	| StorageAdapterConfig<TAdapter>;
+
+export type StorageAdapterFromConfig<TStorage> =
+	NonNullable<TStorage> extends { adapter: infer TAdapter extends Adapter }
+		? TAdapter
+		: Adapter;
+
+export type StorageFromQuestpieConfig<TConfig> =
+	IsAny<TConfig> extends true
+		? any
+		: Files<
+				StorageAdapterFromConfig<
+					TConfig extends { storage?: infer TStorage } ? TStorage : undefined
+				>
+			>;
 
 export type DbCloseFn = () => void | Promise<void>;
 

--- a/packages/questpie/src/server/modules/core/integrated/storage/create-driver.ts
+++ b/packages/questpie/src/server/modules/core/integrated/storage/create-driver.ts
@@ -1,8 +1,7 @@
-import type { DriverContract } from "flydrive/types";
+import { Files } from "files-sdk";
 
+import { assertValidStorageConfig } from "#questpie/server/config/cloud-env.js";
 import type { QuestpieConfig } from "#questpie/server/config/types.js";
-
-import { generateSignedUrlToken } from "./signed-url.js";
 
 const DEFAULT_BASE_PATH = "/";
 
@@ -27,143 +26,34 @@ const resolveLocalPath = (location: string): string => {
 
 /**
  * Get the resolved storage location path.
- * Returns null if using custom driver (cloud storage).
  */
-export function getStorageLocation(config: QuestpieConfig): string | null {
-	if (config.storage?.driver) {
-		return null; // Custom driver, no local path
-	}
+export function getStorageLocation(config: QuestpieConfig): string {
 	const location = config.storage?.location || DEFAULT_LOCATION;
 	return resolveLocalPath(location);
 }
 
-class LazyFSDriver implements DriverContract {
-	private driver: Promise<DriverContract> | null = null;
+export const createFilesStorage = async (
+	config: QuestpieConfig,
+): Promise<Files> => {
+	const storage = config.storage;
+	assertValidStorageConfig(storage);
 
-	constructor(private readonly config: QuestpieConfig) {}
-
-	private async use(): Promise<DriverContract> {
-		this.driver ??= this.create();
-		return this.driver;
+	if (storage?.adapter) {
+		return new Files({ adapter: storage.adapter });
 	}
 
-	private async create(): Promise<DriverContract> {
-		const { FSDriver } = await import("flydrive/drivers/fs");
-		const location = getStorageLocation(this.config)!;
-		const secret = this.config.secret || "questpie-default-secret";
-		const expiration = this.config.storage?.signedUrlExpiration || 3600;
-		const basePath = resolveBasePath(this.config);
-		const appUrl = this.config.app.url;
+	const { fs } = await import("files-sdk/fs");
+	const location = getStorageLocation(config);
+	const expiration = config.storage?.signedUrlExpiration || 3600;
+	const basePath = resolveBasePath(config);
+	const appUrl = config.app.url;
+	const prefix = `${appUrl}${basePath === "/" ? "" : basePath}/files`;
 
-		const prefix = `${appUrl}${basePath === "/" ? "" : basePath}/files`;
-
-		return new FSDriver({
-			location,
-			visibility: "public",
-			urlBuilder: {
-				async generateURL(key) {
-					return `${prefix}/${encodeURIComponent(key)}`;
-				},
-				async generateSignedURL(key, _filePath, options) {
-					const tokenExpiration = options?.expiresIn
-						? Math.floor(
-								(typeof options.expiresIn === "string"
-									? parseInt(options.expiresIn, 10)
-									: options.expiresIn) / 1000,
-							)
-						: expiration;
-
-					const token = await generateSignedUrlToken(
-						key,
-						secret,
-						tokenExpiration,
-					);
-					return `${prefix}/${encodeURIComponent(key)}?token=${token}`;
-				},
-			},
-		});
-	}
-
-	async exists(...args: Parameters<DriverContract["exists"]>) {
-		return (await this.use()).exists(...args);
-	}
-
-	async get(...args: Parameters<DriverContract["get"]>) {
-		return (await this.use()).get(...args);
-	}
-
-	async getStream(...args: Parameters<DriverContract["getStream"]>) {
-		return (await this.use()).getStream(...args);
-	}
-
-	async getBytes(...args: Parameters<DriverContract["getBytes"]>) {
-		return (await this.use()).getBytes(...args);
-	}
-
-	async getMetaData(...args: Parameters<DriverContract["getMetaData"]>) {
-		return (await this.use()).getMetaData(...args);
-	}
-
-	async getVisibility(...args: Parameters<DriverContract["getVisibility"]>) {
-		return (await this.use()).getVisibility(...args);
-	}
-
-	async getUrl(...args: Parameters<DriverContract["getUrl"]>) {
-		return (await this.use()).getUrl(...args);
-	}
-
-	async getSignedUrl(...args: Parameters<DriverContract["getSignedUrl"]>) {
-		return (await this.use()).getSignedUrl(...args);
-	}
-
-	async getSignedUploadUrl(
-		...args: Parameters<DriverContract["getSignedUploadUrl"]>
-	) {
-		return (await this.use()).getSignedUploadUrl(...args);
-	}
-
-	async setVisibility(...args: Parameters<DriverContract["setVisibility"]>) {
-		return (await this.use()).setVisibility(...args);
-	}
-
-	async put(...args: Parameters<DriverContract["put"]>) {
-		return (await this.use()).put(...args);
-	}
-
-	async putStream(...args: Parameters<DriverContract["putStream"]>) {
-		return (await this.use()).putStream(...args);
-	}
-
-	async copy(...args: Parameters<DriverContract["copy"]>) {
-		return (await this.use()).copy(...args);
-	}
-
-	async move(...args: Parameters<DriverContract["move"]>) {
-		return (await this.use()).move(...args);
-	}
-
-	async delete(...args: Parameters<DriverContract["delete"]>) {
-		return (await this.use()).delete(...args);
-	}
-
-	async deleteAll(...args: Parameters<DriverContract["deleteAll"]>) {
-		return (await this.use()).deleteAll(...args);
-	}
-
-	async listAll(...args: Parameters<DriverContract["listAll"]>) {
-		return (await this.use()).listAll(...args);
-	}
-}
-
-/**
- * Creates the storage driver.
- * - Custom `driver` → use it (cloud)
- * - Otherwise → FSDriver with `location` (local)
- */
-export const createDiskDriver = (config: QuestpieConfig): DriverContract => {
-	if (config.storage?.driver) {
-		return config.storage.driver;
-	}
-
-	return new LazyFSDriver(config);
+	return new Files({
+		adapter: fs({
+			root: location,
+			urlBaseUrl: prefix,
+			defaultUrlExpiresIn: expiration,
+		}),
+	});
 };

--- a/packages/questpie/src/server/modules/core/routes/[collection]/files/[...key].ts
+++ b/packages/questpie/src/server/modules/core/routes/[collection]/files/[...key].ts
@@ -4,17 +4,39 @@
  * GET /[collection]/files/:key
  */
 
-import { createStorageRoutes } from "#questpie/server/adapters/routes/storage.js";
+import { storageCollectionServe } from "#questpie/server/adapters/routes/storage.js";
+import type { AdapterContext } from "#questpie/server/adapters/types.js";
 import { route } from "#questpie/server/routes/define-route.js";
+
+type StorageRouteHandlerContext = AdapterContext["appContext"] &
+	Pick<
+		AdapterContext,
+		"locale" | "session" | "localeFallback" | "stage" | "requestId" | "traceId"
+	>;
 
 export default route()
 	.get()
 	.raw()
 	.access(true)
-	.handler(async ({ app, request, params }) => {
-		const routes = createStorageRoutes(app);
-		return routes.collectionServe(request, {
-			collection: params.collection,
-			key: params.key,
-		});
+	.handler(async (ctx) => {
+		const routeContext = ctx as unknown as StorageRouteHandlerContext;
+		const adapterContext: AdapterContext = {
+			appContext: routeContext,
+			locale: routeContext.locale,
+			session: routeContext.session,
+			localeFallback: routeContext.localeFallback,
+			stage: routeContext.stage,
+			requestId: routeContext.requestId,
+			traceId: routeContext.traceId,
+		};
+
+		return storageCollectionServe(
+			ctx.app,
+			ctx.request,
+			{
+				collection: ctx.params.collection,
+				key: ctx.params.key,
+			},
+			adapterContext,
+		);
 	});

--- a/packages/questpie/src/server/modules/core/routes/[collection]/upload.ts
+++ b/packages/questpie/src/server/modules/core/routes/[collection]/upload.ts
@@ -4,15 +4,37 @@
  * POST /[collection]/upload
  */
 
-import { createStorageRoutes } from "#questpie/server/adapters/routes/storage.js";
+import { storageCollectionUpload } from "#questpie/server/adapters/routes/storage.js";
+import type { AdapterContext } from "#questpie/server/adapters/types.js";
 import { route } from "#questpie/server/routes/define-route.js";
+
+type StorageRouteHandlerContext = AdapterContext["appContext"] &
+	Pick<
+		AdapterContext,
+		"locale" | "session" | "localeFallback" | "stage" | "requestId" | "traceId"
+	>;
 
 export default route()
 	.post()
 	.raw()
-	.handler(async ({ app, request, params }) => {
-		const routes = createStorageRoutes(app);
-		return routes.collectionUpload(request, {
-			collection: params.collection,
-		});
+	.handler(async (ctx) => {
+		const routeContext = ctx as unknown as StorageRouteHandlerContext;
+		const adapterContext: AdapterContext = {
+			appContext: routeContext,
+			locale: routeContext.locale,
+			session: routeContext.session,
+			localeFallback: routeContext.localeFallback,
+			stage: routeContext.stage,
+			requestId: routeContext.requestId,
+			traceId: routeContext.traceId,
+		};
+
+		return storageCollectionUpload(
+			ctx.app,
+			ctx.request,
+			{
+				collection: ctx.params.collection,
+			},
+			adapterContext,
+		);
 	});

--- a/packages/questpie/src/server/modules/core/services/storage.ts
+++ b/packages/questpie/src/server/modules/core/services/storage.ts
@@ -1,38 +1,13 @@
-import { DriveManager } from "flydrive";
-
-import { createDiskDriver } from "#questpie/server/modules/core/integrated/storage/create-driver.js";
+import { createFilesStorage } from "#questpie/server/modules/core/integrated/storage/create-driver.js";
 import { service } from "#questpie/server/services/define-service.js";
 
 /**
- * Storage service — creates the DriveManager (flydrive) instance.
+ * Storage service — creates the direct Files SDK-backed storage instance.
  *
  * Namespace: null (top-level in AppContext as `storage`).
  */
 export default service({
 	namespace: null,
 	lifecycle: "singleton",
-	create: ({ app }) => {
-		const storageDriverName = "appDefault";
-		const fakeStorageId =
-			globalThis.crypto?.randomUUID?.() ??
-			`${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
-
-		return new DriveManager({
-			default: storageDriverName,
-			fakes: {
-				location: `/tmp/questpie-fakes/${fakeStorageId}`,
-				urlBuilder: {
-					generateSignedURL(key, _filePath, _options) {
-						return Promise.resolve(`http://fake-storage.local/${key}`);
-					},
-					generateURL(key, _filePath) {
-						return Promise.resolve(`http://fake-storage.local/${key}`);
-					},
-				},
-			},
-			services: {
-				[storageDriverName]: () => createDiskDriver(app.config),
-			},
-		});
-	},
+	create: ({ app }) => createFilesStorage(app.config),
 });

--- a/packages/questpie/src/server/modules/starter/collections/assets.ts
+++ b/packages/questpie/src/server/modules/starter/collections/assets.ts
@@ -50,21 +50,4 @@ export default collection("assets")
 	.upload({
 		visibility: "public",
 	})
-	.hooks({
-		afterDelete: async (ctx) => {
-			const storage = (ctx as any).storage;
-			const logger = (ctx as any).logger;
-			const record = ctx.data as any;
-			if (!storage || !record?.key) return;
-
-			try {
-				await storage.use().delete(record.key);
-			} catch (error) {
-				logger?.warn?.("Failed to delete asset file from storage", {
-					key: record.key,
-					error: error instanceof Error ? error.message : String(error),
-				});
-			}
-		},
-	})
 	.title(({ f }) => f.filename);

--- a/packages/questpie/test/codegen/config-features.test.ts
+++ b/packages/questpie/test/codegen/config-features.test.ts
@@ -306,7 +306,7 @@ describe("generateTemplate — config bucket emission", () => {
 
 		// authConfig should be emitted inside config bucket
 		expect(code).toContain("config: {");
-		expect(code).toContain("auth: _authConfig as any,");
+		expect(code).toContain("auth: _authConfig,");
 		// Should NOT emit "authConfig:" as a flat createApp key
 		expect(code).not.toMatch(/\bauthConfig:\s*_authConfig\s+as\s+any/);
 	});
@@ -328,7 +328,7 @@ describe("generateTemplate — config bucket emission", () => {
 
 		// appConfig should be emitted as whole object in config bucket
 		expect(code).toContain("config: {");
-		expect(code).toContain("app: _appConfig as any,");
+		expect(code).toContain("app: _appConfig,");
 	});
 
 	it("multiple config singles are grouped in a single config bucket", () => {
@@ -349,8 +349,8 @@ describe("generateTemplate — config bucket emission", () => {
 
 		// Both should be inside config bucket
 		expect(code).toContain("config: {");
-		expect(code).toContain("auth: _authConfig as any,");
-		expect(code).toContain("app: _appConfig as any,");
+		expect(code).toContain("auth: _authConfig,");
+		expect(code).toContain("app: _appConfig,");
 	});
 
 	it("non-config singles are emitted as flat keys alongside config bucket", () => {
@@ -371,9 +371,8 @@ describe("generateTemplate — config bucket emission", () => {
 
 		// config bucket for configKey singles
 		expect(code).toContain("config: {");
-		expect(code).toContain("app: _appConfig as any,");
+		expect(code).toContain("app: _appConfig,");
 		// fields as flat key
-		expect(code).toContain("fields: _fields as any,");
+		expect(code).toContain("fields: _fields,");
 	});
 });
-

--- a/packages/questpie/test/codegen/module-template.test.ts
+++ b/packages/questpie/test/codegen/module-template.test.ts
@@ -296,13 +296,13 @@ describe("generateModuleTemplate — routes with slash-separated keys", () => {
 	it("emits flat type interface with camelCase slash keys", () => {
 		expect(output).toContain("export interface TestRoutes {");
 		expect(output).toContain(
-			'"admin/stats": RouteWithParams<typeof _route_admin_stats, RouteParamsFromKey<"admin/stats">>;',
+			'"admin/stats": RouteDefinition<unknown, unknown, RouteParamsFromKey<"admin/stats">>;',
 		);
 		expect(output).toContain(
-			'"admin/users/export": RouteWithParams<typeof _route_admin_users_export, RouteParamsFromKey<"admin/users/export">>;',
+			'"admin/users/export": RouteDefinition<unknown, unknown, RouteParamsFromKey<"admin/users/export">>;',
 		);
 		expect(output).toContain(
-			'getConfig: RouteWithParams<typeof _route_getConfig, RouteParamsFromKey<"getConfig">>;',
+			'getConfig: RouteDefinition<unknown, unknown, RouteParamsFromKey<"getConfig">>;',
 		);
 	});
 });
@@ -337,7 +337,7 @@ describe("generateModuleTemplate — bundle routes", () => {
 		// When bundles are present, type is emitted as intersection, not interface
 		expect(output).toContain("export type TestRoutes =");
 		expect(output).toContain(
-			'getConfig: RouteWithParams<typeof _route_getConfig, RouteParamsFromKey<"getConfig">>',
+			'getConfig: RouteDefinition<unknown, unknown, RouteParamsFromKey<"getConfig">>',
 		);
 		expect(output).toContain("typeof _route_setup");
 	});

--- a/packages/questpie/test/codegen/template.test.ts
+++ b/packages/questpie/test/codegen/template.test.ts
@@ -158,9 +158,9 @@ describe("generateTemplate — minimal (modules.ts only)", () => {
 		expect(code).toContain("DO NOT EDIT");
 	});
 
-	it("imports createApp from questpie", () => {
+	it("imports createApp from questpie/app", () => {
 		expect(code).toContain("import { createApp");
-		expect(code).toContain('from "questpie"');
+		expect(code).toContain('from "questpie/app"');
 	});
 
 	it("imports runtime config", () => {
@@ -197,9 +197,12 @@ describe("generateTemplate — minimal (modules.ts only)", () => {
 	it("emits AppConfig type", () => {
 		expect(code).toContain("export type AppConfig = {");
 		expect(code).toContain(
-			"collections: AppCollections & Record<string, any>;",
+			"collections: AppCollections & Record<string, AnyCollectionOrBuilder>;",
 		);
-		expect(code).toContain("globals: AppGlobals & Record<string, any>;");
+		expect(code).toContain(
+			"globals: AppGlobals & Record<string, AnyGlobalOrBuilder>;",
+		);
+		expect(code).toContain('storage: (typeof _runtime)["storage"];');
 	});
 
 	it("emits createApp call with modules", () => {
@@ -235,6 +238,9 @@ describe("generateTemplate — minimal (modules.ts only)", () => {
 			'type _AppQuestpie = Omit<_AppQuestpieBase, "collections" | "globals">',
 		);
 		expect(code).toContain("type _AppQuestpieConfig = Omit<QuestpieConfig");
+		expect(
+			code.match(/storage: \(typeof _runtime\)\["storage"\];/g)?.length,
+		).toBe(2);
 		expect(code).toContain(
 			"type _AppDb = DrizzleClientFromQuestpieConfig<_AppQuestpieConfig>;",
 		);
@@ -247,6 +253,7 @@ describe("generateTemplate — minimal (modules.ts only)", () => {
 		expect(code).toContain("db: _AppDb;");
 		expect(code).toContain('email: _AppQuestpie["email"];');
 		expect(code).toContain("storage: _AppStorage;");
+		expect(code).not.toContain("storage: unknown;");
 		expect(code).toContain('kv: _AppQuestpie["kv"];');
 		expect(code).toContain('logger: _AppQuestpie["logger"];');
 		expect(code).toContain('search: _AppQuestpie["search"];');
@@ -663,7 +670,7 @@ describe("generateTemplate — services", () => {
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe("generateTemplate — emails", () => {
-	it("emits MailerService type only once when emails exist", () => {
+	it("emits MailerService import and typed email contexts", () => {
 		const result = minimalResult();
 		cat(result, "emails").set(
 			"welcome",
@@ -677,8 +684,8 @@ describe("generateTemplate — emails", () => {
 			singletonFactories: coreSingletonFactories(),
 		});
 
-		expect(code).toContain("type MailerService");
-		expect(code.match(/MailerService/g)?.length).toBe(2);
+		expect(code).toContain("MailerService, Questpie");
+		expect(code.match(/\bMailerService\b/g)?.length).toBe(4);
 	});
 
 	it("emits email: MailerService<AppEmailTemplates> in AppContext", () => {
@@ -741,7 +748,7 @@ describe("generateTemplate — routes (flat record)", () => {
 
 		expect(code).toContain("type AppRoutes = _ModuleRoutes & {");
 		expect(code).toContain(
-			'"apps/[appId]/install": RouteWithParams<typeof _route_apps_appId_install, RouteParamsFromKey<"apps/[appId]/install">>;',
+			'"apps/[appId]/install": RouteWithParams<_RouteDefinitionWithoutHandler<typeof _route_apps_appId_install>, RouteParamsFromKey<"apps/[appId]/install">>;',
 		);
 	});
 
@@ -865,7 +872,7 @@ describe("generateTemplate — auth", () => {
 		});
 
 		expect(code).toContain('import _auth from "../auth"');
-		expect(code).toContain("auth: _auth as any,");
+		expect(code).toContain("auth: _auth,");
 		expect(code).toContain("auth: typeof _auth;");
 	});
 });
@@ -902,8 +909,8 @@ describe("generateTemplate — plugin singles", () => {
 		});
 
 		expect(code).toContain('import _sidebar from "../sidebar"');
-		expect(code).toContain("sidebar: _sidebar as any,");
-		expect(code).toContain("branding: _branding as any,");
+		expect(code).toContain("sidebar: _sidebar,");
+		expect(code).toContain("branding: _branding,");
 	});
 });
 
@@ -930,7 +937,7 @@ describe("generateTemplate — core singles", () => {
 			singletonFactories: coreSingletonFactories(),
 		});
 
-		expect(code).toContain("locale: _locale as any,");
+		expect(code).toContain("locale: _locale,");
 	});
 });
 
@@ -986,7 +993,7 @@ describe("generateTemplate — spreads", () => {
 		});
 
 		expect(code).toContain(
-			"sidebar: [...(_sidebar_root as any ?? []), ...(_sidebar_admin as any ?? [])],",
+			"sidebar: [...(_sidebar_root ?? []), ...(_sidebar_admin ?? [])],",
 		);
 	});
 
@@ -1002,7 +1009,7 @@ describe("generateTemplate — spreads", () => {
 			singletonFactories: coreSingletonFactories(),
 		});
 
-		expect(code).toContain("sidebar: [...(_sidebar_root as any ?? [])],");
+		expect(code).toContain("sidebar: [...(_sidebar_root ?? [])],");
 	});
 
 	it("emits _Module<Key> type for module contributions", () => {
@@ -1032,8 +1039,8 @@ describe("generateTemplate — spreads", () => {
 			singletonFactories: coreSingletonFactories(),
 		});
 
-		// Spread singles should not appear as plain singles (no "sidebar: _sidebar_root as any,")
-		expect(code).not.toContain("sidebar: _sidebar_root as any,");
+		// Spread singles should not appear as plain singles.
+		expect(code).not.toContain("sidebar: _sidebar_root,");
 	});
 
 	it("emits spread section label in imports", () => {
@@ -1074,9 +1081,9 @@ describe("generateTemplate — spreads", () => {
 			singletonFactories: coreSingletonFactories(),
 		});
 
-		expect(code).toContain("sidebar: [...(_sidebar_root as any ?? [])],");
+		expect(code).toContain("sidebar: [...(_sidebar_root ?? [])],");
 		expect(code).toContain(
-			"dashboard: [...(_dashboard_root as any ?? []), ...(_dashboard_admin as any ?? [])],",
+			"dashboard: [...(_dashboard_root ?? []), ...(_dashboard_admin ?? [])],",
 		);
 	});
 });

--- a/packages/questpie/test/collection/collection-upload.test.ts
+++ b/packages/questpie/test/collection/collection-upload.test.ts
@@ -1,15 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { Readable } from "node:stream";
 
-import type {
-	DriverContract,
-	ObjectMetaData,
-	ObjectVisibility,
-	WriteOptions,
-} from "flydrive/types";
+import { Files, type Adapter, type Body, type UploadOptions } from "files-sdk";
+import { memory } from "files-sdk/memory";
 
-import { Questpie, collection } from "../../src/exports/index.js";
-import { createFetchHandler } from "../../src/server/adapters/http.js";
+import { collection } from "../../src/exports/index.js";
+import {
+	createAdapterRoutes,
+	createFetchHandler,
+} from "../../src/server/adapters/http.js";
+import { storageCollectionServe } from "../../src/server/adapters/routes/storage.js";
+import { generateSignedUrlToken } from "../../src/server/modules/core/integrated/storage/signed-url.js";
 import { buildMockApp } from "../utils/mocks/mock-app-builder";
 import { createTestContext } from "../utils/test-context";
 import { runTestDbMigrations } from "../utils/test-db";
@@ -35,6 +35,42 @@ const services = collection("services").fields(({ f }) => ({
 	image: f.relation("assets").relationName("image"),
 }));
 
+const restrictedAssets = collection("restricted_assets")
+	.access({ read: false })
+	.fields(({ f }) => ({
+		alt: f.text(500),
+	}))
+	.upload({
+		visibility: "public",
+	});
+
+const throwingAfterChangeAssets = collection("throwing_after_change_assets")
+	.fields(({ f }) => ({
+		alt: f.text(500),
+	}))
+	.hooks({
+		afterChange: async ({ operation }) => {
+			if (operation === "update") {
+				throw new Error("afterChange failed");
+			}
+		},
+	})
+	.upload({
+		visibility: "public",
+	});
+
+const throwingAfterDeleteAssets = collection("throwing_after_delete_assets")
+	.fields(({ f }) => ({
+		alt: f.text(500),
+	}))
+	.hooks({
+		afterDelete: async () => {
+			throw new Error("afterDelete failed");
+		},
+	})
+	.upload({
+		visibility: "public",
+	});
 const textEncoder = new TextEncoder();
 const textDecoder = new TextDecoder();
 
@@ -58,105 +94,83 @@ const normalizeChunk = (chunk: unknown) => {
 	return textEncoder.encode(String(chunk));
 };
 
-const createInstrumentedStorageDriver = (
+const readStream = async (stream: ReadableStream<Uint8Array>) => {
+	const reader = stream.getReader();
+	const chunks: Uint8Array[] = [];
+	while (true) {
+		const next = await reader.read();
+		if (next.done) break;
+		chunks.push(normalizeChunk(next.value));
+	}
+	return mergeChunks(chunks);
+};
+
+const bodyToBytes = async (body: Body) => {
+	if (typeof body === "string") return textEncoder.encode(body);
+	if (body instanceof Uint8Array) return body;
+	if (body instanceof ArrayBuffer) return new Uint8Array(body);
+	if (ArrayBuffer.isView(body)) {
+		return new Uint8Array(body.buffer, body.byteOffset, body.byteLength);
+	}
+	if (body instanceof Blob) {
+		return new Uint8Array(await body.arrayBuffer());
+	}
+	return readStream(body);
+};
+
+const createInstrumentedStorageAdapter = (
 	initialFiles: Record<string, Uint8Array> = {},
 ) => {
-	const files = new Map(Object.entries(initialFiles));
+	const adapter = memory({
+		initial: Object.fromEntries(
+			Object.entries(initialFiles).map(([key, body]) => [
+				key,
+				{
+					body,
+					contentType: key.endsWith(".pdf") ? "application/pdf" : "text/plain",
+				},
+			]),
+		),
+	});
 	const calls = {
-		put: 0,
-		putStream: 0,
-		getBytes: 0,
-		getStream: 0,
+		upload: 0,
+		download: 0,
+		head: 0,
+		exists: 0,
 		lastKey: "",
-		lastWriteOptions: undefined as WriteOptions | undefined,
-		lastWriteBody: new Uint8Array(),
+		lastUploadOptions: undefined as UploadOptions | undefined,
+		lastUploadBody: new Uint8Array(),
 		deletedKeys: [] as string[],
 	};
 
-	const getFile = (key: string) => {
-		const file = files.get(key);
-		if (!file) throw new Error(`Missing file: ${key}`);
-		return file;
-	};
-
-	const driver: DriverContract = {
-		async exists(key) {
-			return files.has(key);
-		},
-		async get(key) {
-			return textDecoder.decode(getFile(key));
-		},
-		async getStream(key) {
-			calls.getStream++;
-			return Readable.from([getFile(key)]);
-		},
-		async getBytes() {
-			calls.getBytes++;
-			throw new Error("getBytes should not be used by storage routes");
-		},
-		async getMetaData(key): Promise<ObjectMetaData> {
-			const file = getFile(key);
-			return {
-				contentLength: file.byteLength,
-				contentType: key.endsWith(".pdf") ? "application/pdf" : "text/plain",
-				etag: `"${key}"`,
-				lastModified: new Date("2026-01-01T00:00:00.000Z"),
-			};
-		},
-		async getVisibility(): Promise<ObjectVisibility> {
-			return "public";
-		},
-		async getUrl(key) {
-			return `http://localhost:3000/assets/files/${encodeURIComponent(key)}`;
-		},
-		async getSignedUrl(key) {
-			return `http://localhost:3000/assets/files/${encodeURIComponent(key)}?token=test`;
-		},
-		async getSignedUploadUrl(key) {
-			return `http://localhost:3000/assets/files/${encodeURIComponent(key)}?upload=test`;
-		},
-		async setVisibility() {},
-		async put(key, contents, options) {
-			calls.put++;
+	const instrumented: Adapter = {
+		...adapter,
+		async upload(key, body, options) {
+			calls.upload++;
 			calls.lastKey = key;
-			calls.lastWriteOptions = options;
-			calls.lastWriteBody =
-				typeof contents === "string" ? textEncoder.encode(contents) : contents;
-			files.set(key, calls.lastWriteBody);
+			calls.lastUploadOptions = options;
+			calls.lastUploadBody = await bodyToBytes(body);
+			return adapter.upload(key, calls.lastUploadBody, options);
 		},
-		async putStream(key, contents, options) {
-			calls.putStream++;
-			calls.lastKey = key;
-			calls.lastWriteOptions = options;
-			const chunks: Uint8Array[] = [];
-			for await (const chunk of contents) {
-				chunks.push(normalizeChunk(chunk));
-			}
-			calls.lastWriteBody = mergeChunks(chunks);
-			files.set(key, calls.lastWriteBody);
+		async download(key, options) {
+			calls.download++;
+			return adapter.download(key, options);
 		},
-		async copy(source, destination) {
-			files.set(destination, getFile(source));
+		async head(key, options) {
+			calls.head++;
+			return adapter.head(key, options);
 		},
-		async move(source, destination) {
-			files.set(destination, getFile(source));
-			files.delete(source);
+		async exists(key, options) {
+			calls.exists++;
+			return adapter.exists(key, options);
 		},
 		async delete(key) {
 			calls.deletedKeys.push(key);
-			files.delete(key);
-		},
-		async deleteAll(prefix) {
-			for (const key of files.keys()) {
-				if (key.startsWith(prefix)) files.delete(key);
-			}
-		},
-		async listAll() {
-			return [] as any;
+			return adapter.delete(key);
 		},
 	};
 
-	return { calls, driver, files };
+	return { adapter: instrumented, calls, files: adapter.raw };
 };
 
 // ==============================================================================
@@ -343,6 +357,62 @@ describe("collection upload URL generation", () => {
 	});
 });
 
+describe("collection upload storage access", () => {
+	let setup: Awaited<ReturnType<typeof buildMockApp>>;
+
+	beforeEach(async () => {
+		setup = await buildMockApp({
+			collections: { restricted_assets: restrictedAssets },
+		});
+		await runTestDbMigrations(setup.app);
+	});
+
+	afterEach(async () => {
+		await setup.cleanup();
+	});
+
+	it("does not serve a storage object when the upload row is not readable", async () => {
+		const key = "uploads/restricted.png";
+		const storage = createInstrumentedStorageAdapter({
+			[key]: new Uint8Array([1, 2, 3]),
+		});
+		await setup.cleanup();
+		setup = await buildMockApp(
+			{
+				collections: { restricted_assets: restrictedAssets },
+			},
+			{ storage: { adapter: storage.adapter } },
+		);
+		await runTestDbMigrations(setup.app);
+
+		await setup.app.collections.restricted_assets.create(
+			{
+				id: crypto.randomUUID(),
+				key,
+				filename: "restricted.png",
+				mimeType: "image/png",
+				size: 3,
+				visibility: "public",
+				alt: "Restricted",
+			},
+			createTestContext(),
+		);
+
+		const response = await storageCollectionServe(
+			setup.app,
+			new Request(`http://localhost:3000/restricted_assets/files/${key}`),
+			{ collection: "restricted_assets", key },
+			undefined,
+			{ getSession: async () => null },
+		);
+
+		expect(response.status).toBe(403);
+		expect(storage.calls.exists).toBe(0);
+		expect(storage.calls.head).toBe(0);
+		expect(storage.calls.download).toBe(0);
+	});
+});
+
 describe("collection storage route streaming", () => {
 	let setup: Awaited<ReturnType<typeof buildMockApp>>;
 	let app: (typeof setup)["app"];
@@ -351,14 +421,13 @@ describe("collection storage route streaming", () => {
 		await setup?.cleanup();
 	});
 
-	it("uploads form files through putStream with explicit content length", async () => {
-		const storage = createInstrumentedStorageDriver();
+	it("uploads form files through the Files adapter", async () => {
+		const storage = createInstrumentedStorageAdapter();
 		setup = await buildMockApp(
 			{ collections: { assets } },
-			{ storage: { driver: storage.driver } },
+			{ storage: { adapter: storage.adapter } },
 		);
 		app = setup.app;
-		app.storage.restore(Questpie.__internal.storageDriverServiceName);
 		await runTestDbMigrations(app);
 
 		const handler = createFetchHandler(app, {
@@ -385,26 +454,287 @@ describe("collection storage route streaming", () => {
 		const json = (await response!.json()) as any;
 		expect(json.filename).toBe("menu.pdf");
 		expect(json.size).toBe(body.byteLength);
-		expect(storage.calls.putStream).toBe(1);
-		expect(storage.calls.put).toBe(0);
-		expect(storage.calls.lastWriteOptions?.contentLength).toBe(body.byteLength);
-		expect(storage.calls.lastWriteOptions?.contentType).toBe("application/pdf");
-		expect(textDecoder.decode(storage.calls.lastWriteBody)).toBe(
+		expect(storage.calls.upload).toBe(1);
+		expect(storage.calls.lastUploadOptions?.contentType).toBe(
+			"application/pdf",
+		);
+		expect(textDecoder.decode(storage.calls.lastUploadBody)).toBe(
 			"%PDF-1.4\nmenu",
 		);
 	});
 
+	it("removes the stored object when upload row creation fails", async () => {
+		const storage = createInstrumentedStorageAdapter();
+		setup = await buildMockApp(
+			{ collections: { assets } },
+			{ storage: { adapter: storage.adapter } },
+		);
+		app = setup.app;
+		await runTestDbMigrations(app);
+
+		const body = textEncoder.encode("private");
+		const file = new File([body], "private.txt", { type: "text/plain" });
+
+		await expect(
+			(app.collections.assets as any).upload(
+				file,
+				createTestContext({ accessMode: "user", session: null }),
+			),
+		).rejects.toThrow();
+
+		expect(storage.calls.upload).toBe(1);
+		expect(storage.calls.deletedKeys).toEqual([storage.calls.lastKey]);
+		expect(await app.storage.exists(storage.calls.lastKey)).toBe(false);
+		const rows = await app.collections.assets.find({}, createTestContext());
+		expect(rows.docs).toHaveLength(0);
+	});
+
+	it("removes the previous stored object after an upload row key update", async () => {
+		const oldBody = textEncoder.encode("old");
+		const newBody = textEncoder.encode("new");
+		const storage = createInstrumentedStorageAdapter({
+			"old.txt": oldBody,
+			"new.txt": newBody,
+		});
+		setup = await buildMockApp(
+			{ collections: { assets } },
+			{ storage: { adapter: storage.adapter } },
+		);
+		app = setup.app;
+		await runTestDbMigrations(app);
+
+		const asset = await app.collections.assets.create(
+			{
+				id: crypto.randomUUID(),
+				key: "old.txt",
+				filename: "old.txt",
+				mimeType: "text/plain",
+				size: oldBody.byteLength,
+				visibility: "public",
+			},
+			createTestContext(),
+		);
+
+		const updated = await app.collections.assets.updateById(
+			{
+				id: asset.id,
+				data: {
+					key: "new.txt",
+					filename: "new.txt",
+					size: newBody.byteLength,
+				},
+			},
+			createTestContext(),
+		);
+
+		expect(updated.key).toBe("new.txt");
+		expect(storage.calls.deletedKeys).toEqual(["old.txt"]);
+		expect(await app.storage.exists("old.txt")).toBe(false);
+		expect(await app.storage.exists("new.txt")).toBe(true);
+	});
+
+	it("removes the previous stored object when a user afterChange hook throws", async () => {
+		const oldBody = textEncoder.encode("old");
+		const newBody = textEncoder.encode("new");
+		const storage = createInstrumentedStorageAdapter({
+			"old-throwing-after-change.txt": oldBody,
+			"new-throwing-after-change.txt": newBody,
+		});
+		setup = await buildMockApp(
+			{ collections: { assets: throwingAfterChangeAssets } },
+			{ storage: { adapter: storage.adapter } },
+		);
+		app = setup.app;
+		await runTestDbMigrations(app);
+
+		const asset = await app.collections.assets.create(
+			{
+				id: crypto.randomUUID(),
+				key: "old-throwing-after-change.txt",
+				filename: "old-throwing-after-change.txt",
+				mimeType: "text/plain",
+				size: oldBody.byteLength,
+				visibility: "public",
+			},
+			createTestContext(),
+		);
+
+		const updated = await app.collections.assets.updateById(
+			{
+				id: asset.id,
+				data: {
+					key: "new-throwing-after-change.txt",
+					filename: "new-throwing-after-change.txt",
+					size: newBody.byteLength,
+				},
+			},
+			createTestContext(),
+		);
+
+		expect(updated.key).toBe("new-throwing-after-change.txt");
+		expect(storage.calls.deletedKeys).toEqual([
+			"old-throwing-after-change.txt",
+		]);
+		expect(await app.storage.exists("old-throwing-after-change.txt")).toBe(
+			false,
+		);
+		expect(await app.storage.exists("new-throwing-after-change.txt")).toBe(
+			true,
+		);
+	});
+
+	it("removes the stored object after an upload row delete", async () => {
+		const body = textEncoder.encode("delete me");
+		const storage = createInstrumentedStorageAdapter({
+			"delete.txt": body,
+		});
+		setup = await buildMockApp(
+			{ collections: { assets } },
+			{ storage: { adapter: storage.adapter } },
+		);
+		app = setup.app;
+		await runTestDbMigrations(app);
+
+		const asset = await app.collections.assets.create(
+			{
+				id: crypto.randomUUID(),
+				key: "delete.txt",
+				filename: "delete.txt",
+				mimeType: "text/plain",
+				size: body.byteLength,
+				visibility: "public",
+			},
+			createTestContext(),
+		);
+
+		const result = await app.collections.assets.deleteById(
+			{ id: asset.id },
+			createTestContext(),
+		);
+
+		expect(result.success).toBe(true);
+		expect(storage.calls.deletedKeys).toEqual(["delete.txt"]);
+		expect(await app.storage.exists("delete.txt")).toBe(false);
+		const deleted = await app.collections.assets.findOne(
+			{ where: { id: asset.id } },
+			createTestContext(),
+		);
+		expect(deleted).toBeNull();
+	});
+
+	it("removes the stored object when a user afterDelete hook throws", async () => {
+		const body = textEncoder.encode("delete me");
+		const storage = createInstrumentedStorageAdapter({
+			"delete-throwing-after-delete.txt": body,
+		});
+		setup = await buildMockApp(
+			{ collections: { assets: throwingAfterDeleteAssets } },
+			{ storage: { adapter: storage.adapter } },
+		);
+		app = setup.app;
+		await runTestDbMigrations(app);
+
+		const asset = await app.collections.assets.create(
+			{
+				id: crypto.randomUUID(),
+				key: "delete-throwing-after-delete.txt",
+				filename: "delete-throwing-after-delete.txt",
+				mimeType: "text/plain",
+				size: body.byteLength,
+				visibility: "public",
+			},
+			createTestContext(),
+		);
+
+		const result = await app.collections.assets.deleteById(
+			{ id: asset.id },
+			createTestContext(),
+		);
+
+		expect(result.success).toBe(true);
+		expect(storage.calls.deletedKeys).toEqual([
+			"delete-throwing-after-delete.txt",
+		]);
+		expect(await app.storage.exists("delete-throwing-after-delete.txt")).toBe(
+			false,
+		);
+		const deleted = await app.collections.assets.findOne(
+			{ where: { id: asset.id } },
+			createTestContext(),
+		);
+		expect(deleted).toBeNull();
+	});
+
+	it("removes stored objects for later bulk delete rows when a user afterDelete hook throws", async () => {
+		const bodyA = textEncoder.encode("delete me a");
+		const bodyB = textEncoder.encode("delete me b");
+		const storage = createInstrumentedStorageAdapter({
+			"bulk-delete-throwing-after-delete-a.txt": bodyA,
+			"bulk-delete-throwing-after-delete-b.txt": bodyB,
+		});
+		setup = await buildMockApp(
+			{ collections: { assets: throwingAfterDeleteAssets } },
+			{ storage: { adapter: storage.adapter } },
+		);
+		app = setup.app;
+		await runTestDbMigrations(app);
+
+		const first = await app.collections.assets.create(
+			{
+				id: crypto.randomUUID(),
+				key: "bulk-delete-throwing-after-delete-a.txt",
+				filename: "bulk-delete-throwing-after-delete-a.txt",
+				mimeType: "text/plain",
+				size: bodyA.byteLength,
+				visibility: "public",
+			},
+			createTestContext(),
+		);
+		const second = await app.collections.assets.create(
+			{
+				id: crypto.randomUUID(),
+				key: "bulk-delete-throwing-after-delete-b.txt",
+				filename: "bulk-delete-throwing-after-delete-b.txt",
+				mimeType: "text/plain",
+				size: bodyB.byteLength,
+				visibility: "public",
+			},
+			createTestContext(),
+		);
+
+		const result = await app.collections.assets.delete(
+			{ where: { id: { in: [first.id, second.id] } } },
+			createTestContext(),
+		);
+
+		expect(result).toEqual({ success: true, count: 2 });
+		expect([...storage.calls.deletedKeys].sort()).toEqual([
+			"bulk-delete-throwing-after-delete-a.txt",
+			"bulk-delete-throwing-after-delete-b.txt",
+		]);
+		expect(
+			await app.storage.exists("bulk-delete-throwing-after-delete-a.txt"),
+		).toBe(false);
+		expect(
+			await app.storage.exists("bulk-delete-throwing-after-delete-b.txt"),
+		).toBe(false);
+		const remaining = await app.collections.assets.find(
+			{ where: { id: { in: [first.id, second.id] } } },
+			createTestContext(),
+		);
+		expect(remaining.docs).toHaveLength(0);
+	});
+
 	it("serves full files and ranges from storage streams", async () => {
 		const fileBody = textEncoder.encode("abcdef");
-		const storage = createInstrumentedStorageDriver({
+		const storage = createInstrumentedStorageAdapter({
 			"file.txt": fileBody,
 		});
 		setup = await buildMockApp(
 			{ collections: { assets } },
-			{ storage: { driver: storage.driver } },
+			{ storage: { adapter: storage.adapter } },
 		);
 		app = setup.app;
-		app.storage.restore(Questpie.__internal.storageDriverServiceName);
 		await runTestDbMigrations(app);
 
 		await app.collections.assets.create(
@@ -429,10 +759,15 @@ describe("collection storage route streaming", () => {
 		);
 		expect(full).not.toBeNull();
 		expect(full?.status).toBe(200);
+		expect(full?.headers.get("content-type")).toBe("text/plain");
+		expect(full?.headers.get("content-disposition")).toBe(
+			'inline; filename="file.txt"',
+		);
 		expect(full?.headers.get("content-length")).toBe("6");
 		expect(await full!.text()).toBe("abcdef");
-		expect(storage.calls.getStream).toBe(1);
-		expect(storage.calls.getBytes).toBe(0);
+		expect(storage.calls.exists).toBe(1);
+		expect(storage.calls.download).toBe(1);
+		expect(storage.calls.head).toBe(1);
 
 		const range = await handler(
 			new Request("http://localhost/api/assets/files/file.txt", {
@@ -444,7 +779,162 @@ describe("collection storage route streaming", () => {
 		expect(range?.headers.get("content-range")).toBe("bytes 2-4/6");
 		expect(range?.headers.get("content-length")).toBe("3");
 		expect(await range!.text()).toBe("cde");
-		expect(storage.calls.getStream).toBe(2);
-		expect(storage.calls.getBytes).toBe(0);
+		expect(storage.calls.exists).toBe(2);
+		expect(storage.calls.download).toBe(2);
+		expect(storage.calls.head).toBe(2);
+	});
+
+	it("serves files through storage from the resolved handler context", async () => {
+		const fileBody = textEncoder.encode("context file");
+		const appStorage = createInstrumentedStorageAdapter();
+		const contextStorage = createInstrumentedStorageAdapter({
+			"context-file.txt": fileBody,
+		});
+		setup = await buildMockApp(
+			{ collections: { assets } },
+			{ storage: { adapter: appStorage.adapter } },
+		);
+		app = setup.app;
+		await runTestDbMigrations(app);
+
+		await app.collections.assets.create(
+			{
+				id: crypto.randomUUID(),
+				key: "context-file.txt",
+				filename: "context-file.txt",
+				mimeType: "text/plain",
+				size: fileBody.byteLength,
+				visibility: "public",
+			},
+			createTestContext(),
+		);
+
+		const appContext = await app.createContext({
+			accessMode: "system",
+			locale: "en",
+		});
+		const contextStorageClient = new Files({
+			adapter: contextStorage.adapter,
+		});
+
+		const response = await storageCollectionServe(
+			app,
+			new Request("http://localhost/assets/files/context-file.txt"),
+			{ collection: "assets", key: "context-file.txt" },
+			{
+				appContext: {
+					...appContext,
+					storage: contextStorageClient,
+				},
+				locale: appContext.locale,
+				session: appContext.session,
+			},
+		);
+
+		expect(response.status).toBe(200);
+		expect(await response.text()).toBe("context file");
+		expect(appStorage.calls.exists).toBe(0);
+		expect(contextStorage.calls.exists).toBe(1);
+		expect(contextStorage.calls.head).toBe(1);
+		expect(contextStorage.calls.download).toBe(1);
+	});
+
+	it("serves files through createAdapterRoutes compatibility when context is omitted", async () => {
+		const fileBody = textEncoder.encode("standalone route");
+		const storage = createInstrumentedStorageAdapter({
+			"standalone-file.txt": fileBody,
+		});
+		setup = await buildMockApp(
+			{ collections: { assets } },
+			{ storage: { adapter: storage.adapter } },
+		);
+		app = setup.app;
+		await runTestDbMigrations(app);
+
+		await app.collections.assets.create(
+			{
+				id: crypto.randomUUID(),
+				key: "standalone-file.txt",
+				filename: "standalone-file.txt",
+				mimeType: "text/plain",
+				size: fileBody.byteLength,
+				visibility: "public",
+			},
+			createTestContext(),
+		);
+
+		const routes = createAdapterRoutes(app, {
+			getSession: async () => null,
+		});
+		const response = await routes.collectionServe(
+			new Request("http://localhost/assets/files/standalone-file.txt"),
+			{ collection: "assets", key: "standalone-file.txt" },
+		);
+
+		expect(response.status).toBe(200);
+		expect(await response.text()).toBe("standalone route");
+		expect(storage.calls.exists).toBe(1);
+		expect(storage.calls.head).toBe(1);
+		expect(storage.calls.download).toBe(1);
+	});
+
+	it("checks private file tokens before accessing storage", async () => {
+		const fileBody = textEncoder.encode("secret file");
+		const storage = createInstrumentedStorageAdapter({
+			"private-file.txt": fileBody,
+		});
+		setup = await buildMockApp(
+			{ collections: { assets } },
+			{
+				secret: "test-secret",
+				storage: { adapter: storage.adapter },
+			},
+		);
+		app = setup.app;
+		await runTestDbMigrations(app);
+
+		await app.collections.assets.create(
+			{
+				id: crypto.randomUUID(),
+				key: "private-file.txt",
+				filename: "private-file.txt",
+				mimeType: "text/plain",
+				size: fileBody.byteLength,
+				visibility: "private",
+			},
+			createTestContext(),
+		);
+
+		const handler = createFetchHandler(app, {
+			basePath: "/api",
+			requestLogging: false,
+		});
+
+		const missingToken = await handler(
+			new Request("http://localhost/api/assets/files/private-file.txt"),
+		);
+		expect(missingToken).not.toBeNull();
+		expect(missingToken?.status).toBe(401);
+		expect(storage.calls.exists).toBe(0);
+		expect(storage.calls.head).toBe(0);
+		expect(storage.calls.download).toBe(0);
+
+		const token = await generateSignedUrlToken(
+			"private-file.txt",
+			"test-secret",
+			60,
+		);
+		const served = await handler(
+			new Request(
+				`http://localhost/api/assets/files/private-file.txt?token=${token}`,
+			),
+		);
+
+		expect(served).not.toBeNull();
+		expect(served?.status).toBe(200);
+		expect(await served!.text()).toBe("secret file");
+		expect(storage.calls.exists).toBe(1);
+		expect(storage.calls.head).toBe(1);
+		expect(storage.calls.download).toBe(1);
 	});
 });

--- a/packages/questpie/test/types/storage-public-api.test-d.ts
+++ b/packages/questpie/test/types/storage-public-api.test-d.ts
@@ -1,0 +1,164 @@
+import type { Adapter, Files } from "files-sdk";
+import { memory } from "files-sdk/memory";
+
+import { runtimeConfig } from "#questpie/server/config/create-app.js";
+import type {
+	ResolvedRuntimeConfig,
+	RuntimeConfig,
+	RuntimeConfigInput,
+} from "#questpie/server/config/module-types.js";
+import type { Questpie } from "#questpie/server/config/questpie.js";
+import type {
+	DbConfig,
+	QuestpieConfig,
+	StorageAdapterConfig,
+} from "#questpie/server/config/types.js";
+import type { JsonRouteHandlerArgs } from "#questpie/server/routes/types.js";
+
+import type { Equal, Expect, HasKey } from "./type-test-utils.js";
+
+const adapter = memory();
+
+const runtime = runtimeConfig({
+	app: { url: "http://localhost:3000" },
+	db: { url: "postgres://localhost/test" },
+	storage: { adapter },
+});
+
+const legacyDriverRuntimeConfig = {
+	app: { url: "http://localhost:3000" },
+	db: { url: "postgres://localhost/test" },
+	storage: { driver: {} },
+};
+// @ts-expect-error Removed storage registration shape must not compile.
+runtimeConfig(legacyDriverRuntimeConfig);
+
+const legacyFilesRuntimeConfig = {
+	app: { url: "http://localhost:3000" },
+	db: { url: "postgres://localhost/test" },
+	storage: { files: {} },
+};
+// @ts-expect-error Removed storage registration shape must not compile.
+runtimeConfig(legacyFilesRuntimeConfig);
+
+type RuntimeStorage = typeof runtime.storage;
+type _runtimeStorageKeepsAdapter = Expect<
+	Equal<RuntimeStorage["adapter"], typeof adapter>
+>;
+
+type KnownRuntimeConfig = RuntimeConfig<
+	DbConfig,
+	StorageAdapterConfig<typeof adapter>
+>;
+type _runtimeConfigKeepsStaticAdapter = Expect<
+	Equal<NonNullable<KnownRuntimeConfig["storage"]>["adapter"], typeof adapter>
+>;
+
+const knownRuntimeInput = {
+	app: { url: "http://localhost:3000" },
+	db: { url: "postgres://localhost/test" },
+	storage: { adapter },
+} satisfies RuntimeConfigInput<DbConfig, StorageAdapterConfig<typeof adapter>>;
+
+type _runtimeConfigInputKeepsStaticAdapter = Expect<
+	Equal<typeof knownRuntimeInput.storage.adapter, typeof adapter>
+>;
+
+declare const envAdapter: Adapter;
+const envRuntime = runtimeConfig({
+	app: { url: "http://localhost:3000" },
+	db: { url: "postgres://localhost/test" },
+	storage: { adapter: envAdapter },
+});
+
+type EnvAppConfig = Omit<
+	QuestpieConfig,
+	"app" | "db" | "collections" | "storage"
+> & {
+	app: (typeof envRuntime)["app"];
+	db: (typeof envRuntime)["db"];
+	collections: {};
+	storage: (typeof envRuntime)["storage"];
+};
+
+type _runtimeEnvAdapterStorage = Expect<
+	Equal<Questpie<EnvAppConfig>["storage"], Files<Adapter>>
+>;
+type _resolvedRuntimeConfigKeepsStorage = Expect<
+	Equal<
+		ResolvedRuntimeConfig<typeof knownRuntimeInput>["storage"],
+		(typeof knownRuntimeInput)["storage"]
+	>
+>;
+
+type AppConfig = Omit<
+	QuestpieConfig,
+	"app" | "db" | "collections" | "storage"
+> & {
+	app: (typeof runtime)["app"];
+	db: (typeof runtime)["db"];
+	collections: {};
+	storage: (typeof runtime)["storage"];
+};
+
+type AppStorage = Questpie<AppConfig>["storage"];
+type _appStorageIsFiles = Expect<Equal<AppStorage, Files<typeof adapter>>>;
+type _appStorageHasUpload = Expect<Equal<HasKey<AppStorage, "upload">, true>>;
+type _appStorageHasDownload = Expect<
+	Equal<HasKey<AppStorage, "download">, true>
+>;
+type _appStorageHasUse = Expect<Equal<HasKey<AppStorage, "use">, false>>;
+type _generatedAppConfigHasStorage = Expect<
+	Equal<AppConfig["storage"], (typeof runtime)["storage"]>
+>;
+
+declare const appStorage: AppStorage;
+appStorage.upload("contract.txt", "contract");
+appStorage.download("contract.txt");
+appStorage.head("contract.txt");
+appStorage.exists("contract.txt");
+appStorage.delete("contract.txt");
+appStorage.copy("from.txt", "to.txt");
+appStorage.move("from.txt", "to.txt");
+appStorage.list({ prefix: "uploads/" });
+appStorage.listAll({ prefix: "uploads/" });
+appStorage.url("contract.txt");
+appStorage.signedUploadUrl("contract.txt", { expiresIn: 60 });
+// @ts-expect-error Direct Files storage has no legacy disk selector.
+appStorage.use();
+
+type GeneratedAppContext = {
+	storage: AppStorage;
+};
+
+type GeneratedRouteContext = GeneratedAppContext & JsonRouteHandlerArgs;
+type _routeContextStorageIsFiles = Expect<
+	Equal<GeneratedRouteContext["storage"], AppStorage>
+>;
+
+declare const routeContext: GeneratedRouteContext;
+routeContext.storage.upload("route.txt", "route");
+routeContext.storage.exists("route.txt");
+// @ts-expect-error Generated route context storage must not expose `.use()`.
+routeContext.storage.use();
+
+type GeneratedServiceContext = GeneratedAppContext &
+	Questpie.ServiceCreateContext;
+type _serviceContextStorageIsFiles = Expect<
+	Equal<GeneratedServiceContext["storage"], AppStorage>
+>;
+
+declare const serviceContext: GeneratedServiceContext;
+serviceContext.storage.download("service.txt");
+// @ts-expect-error Generated service context storage must not expose `.use()`.
+serviceContext.storage.use();
+
+type GeneratedJobContext = GeneratedAppContext & Questpie.JobHandlerContext;
+type _jobContextStorageIsFiles = Expect<
+	Equal<GeneratedJobContext["storage"], AppStorage>
+>;
+
+declare const jobContext: GeneratedJobContext;
+jobContext.storage.head("job.txt");
+// @ts-expect-error Generated job context storage must not expose `.use()`.
+jobContext.storage.use();

--- a/packages/questpie/test/units/cloudflare-adapter.test.ts
+++ b/packages/questpie/test/units/cloudflare-adapter.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
+import { memory } from "files-sdk/memory";
 import { z } from "zod";
 
 import {
@@ -54,7 +55,7 @@ function createApp(queueOverrides: Record<string, unknown> = {}) {
 			app: { url: "https://example.com" },
 			db: { create: () => ({ marker: "drizzle" }) },
 			collections: {},
-			storage: { driver: {} },
+			storage: { adapter: memory() },
 			queue: {
 				jobs: {
 					dailyDigest: {

--- a/packages/questpie/test/units/runtime-compatibility.test.ts
+++ b/packages/questpie/test/units/runtime-compatibility.test.ts
@@ -1,11 +1,17 @@
 import { describe, expect, test } from "bun:test";
 
+import { memory } from "files-sdk/memory";
+
 import {
 	cloudflareKVAdapter,
 	type CloudflareKVNamespace,
 } from "../../src/exports/adapters/cloudflare-kv.js";
 import { cloudflareQueuesAdapter } from "../../src/exports/adapters/cloudflare-queues.js";
 import { cloudflareRealtimeAdapter } from "../../src/exports/adapters/cloudflare-realtime.js";
+import {
+	CLOUD_ENV,
+	resolveStorageConfig,
+} from "../../src/server/config/cloud-env.js";
 import {
 	assertCloudflareCompatible,
 	CloudflareCompatibilityError,
@@ -39,7 +45,7 @@ function createCompatibleConfig() {
 		},
 		collections: {},
 		storage: {
-			driver: {} as any,
+			adapter: memory(),
 		},
 		queue: {
 			jobs: {},
@@ -56,6 +62,29 @@ function createCompatibleConfig() {
 			}),
 		},
 	} as any;
+}
+
+function withCloudStorageEnv<T>(run: () => T): T {
+	const keys = Object.values(CLOUD_ENV);
+	const previous = new Map(keys.map((key) => [key, process.env[key]]));
+
+	process.env[CLOUD_ENV.STORAGE_ENDPOINT] = "https://r2.example.com";
+	process.env[CLOUD_ENV.STORAGE_BUCKET] = "uploads";
+	process.env[CLOUD_ENV.STORAGE_ACCESS_KEY] = "access-key";
+	process.env[CLOUD_ENV.STORAGE_SECRET_KEY] = "secret-key";
+	delete process.env[CLOUD_ENV.STORAGE_REGION];
+
+	try {
+		return run();
+	} finally {
+		for (const [key, value] of previous) {
+			if (value === undefined) {
+				delete process.env[key];
+			} else {
+				process.env[key] = value;
+			}
+		}
+	}
 }
 
 describe("Cloudflare compatibility", () => {
@@ -108,5 +137,18 @@ describe("Cloudflare compatibility", () => {
 				collections: {},
 			} as any),
 		).toThrow(CloudflareCompatibilityError);
+	});
+
+	test("lazy cloud S3 storage adapter preserves Files SDK optional methods", () => {
+		const config = withCloudStorageEnv(() => resolveStorageConfig());
+		const adapter = config?.adapter as any;
+
+		expect(adapter.name).toBe("s3");
+		expect(adapter.raw).toBeUndefined();
+		expect(adapter.reportsUploadProgress).toBe(true);
+		expect(adapter.supportsRange).toBe(true);
+		expect(typeof adapter.deleteMany).toBe("function");
+		expect(adapter.move).toBeUndefined();
+		expect("move" in adapter).toBe(false);
 	});
 });

--- a/packages/questpie/test/units/storage-driver.test.ts
+++ b/packages/questpie/test/units/storage-driver.test.ts
@@ -1,141 +1,165 @@
-/**
- * Tests for storage driver creation and configuration
- */
-
 import { describe, expect, test } from "bun:test";
-import { resolve } from "node:path";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
-import type { QuestpieConfig } from "../../src/server/config/types.js";
-import {
-	createDiskDriver,
-	getStorageLocation,
-} from "../../src/server/modules/core/integrated/storage/create-driver.js";
+import { Files } from "files-sdk";
+import { memory } from "files-sdk/memory";
 
-// Minimal mock config
-const createMockConfig = (
-	overrides: Partial<QuestpieConfig> = {},
-): QuestpieConfig =>
-	({
-		app: { url: "http://localhost:3000", name: "test" },
-		db: { url: "postgres://localhost/test" },
-		secret: "test-secret",
-		...overrides,
-	}) as QuestpieConfig;
+import { runtimeConfig } from "../../src/server/config/create-app.js";
+import { createFilesStorage } from "../../src/server/modules/core/integrated/storage/create-driver.js";
+import { buildMockApp } from "../utils/mocks/mock-app-builder.js";
 
-describe("storage-driver", () => {
-	describe("getStorageLocation", () => {
-		test("returns null when custom driver is provided", () => {
-			const mockDriver = { put: () => {} } as any;
-			const config = createMockConfig({
-				storage: { driver: mockDriver },
-			});
+describe("storage public API contract", () => {
+	test("runtimeConfig accepts the adapter-first Files SDK storage shape", () => {
+		const adapter = memory();
 
-			const location = getStorageLocation(config);
-
-			expect(location).toBeNull();
+		const config = runtimeConfig({
+			app: { url: "http://localhost:3000" },
+			db: { url: "postgres://localhost/test" },
+			storage: {
+				adapter,
+				defaultVisibility: "private",
+				signedUrlExpiration: 120,
+			},
 		});
 
-		test("returns default ./uploads when no storage config", () => {
-			const config = createMockConfig();
-
-			const location = getStorageLocation(config);
-
-			expect(location).toBe(resolve(process.cwd(), "./uploads"));
-		});
-
-		test("returns custom location when specified", () => {
-			const config = createMockConfig({
-				storage: { location: "./my-uploads" },
-			});
-
-			const location = getStorageLocation(config);
-
-			expect(location).toBe(resolve(process.cwd(), "./my-uploads"));
-		});
-
-		test("resolves absolute path correctly", () => {
-			const config = createMockConfig({
-				storage: { location: "/var/data/uploads" },
-			});
-
-			const location = getStorageLocation(config);
-
-			expect(location).toBe("/var/data/uploads");
+		expect(config.storage).toEqual({
+			adapter,
+			defaultVisibility: "private",
+			signedUrlExpiration: 120,
 		});
 	});
 
-	describe("createDiskDriver", () => {
-		test("returns custom driver when provided", () => {
-			const mockDriver = { put: () => {}, get: () => {} } as any;
-			const config = createMockConfig({
-				storage: { driver: mockDriver },
-			});
+	test("runtimeConfig rejects removed storage registration shapes", () => {
+		expect(() =>
+			runtimeConfig({
+				app: { url: "http://localhost:3000" },
+				db: { url: "postgres://localhost/test" },
+				storage: { driver: {} } as any,
+			}),
+		).toThrow(/Unsupported storage config key/);
 
-			const driver = createDiskDriver(config);
+		expect(() =>
+			runtimeConfig({
+				app: { url: "http://localhost:3000" },
+				db: { url: "postgres://localhost/test" },
+				storage: { files: {} } as any,
+			}),
+		).toThrow(/Unsupported storage config key/);
+	});
 
-			expect(driver).toBe(mockDriver);
+	test("createFilesStorage rejects explicit unknown storage objects", async () => {
+		const config = runtimeConfig({
+			app: { url: "http://localhost:3000" },
+			db: { url: "postgres://localhost/test" },
+			storage: { location: "./uploads" },
 		});
 
-		test("creates FSDriver when no custom driver", () => {
-			const config = createMockConfig({
-				storage: { location: "./test-uploads" },
-			});
+		await expect(
+			createFilesStorage({
+				...config,
+				storage: { unexpected: true },
+			} as any),
+		).rejects.toThrow(/Unknown storage config key/);
+	});
 
-			const driver = createDiskDriver(config);
+	test("the storage target is a direct Files instance, not a disk manager", async () => {
+		const adapter = memory();
+		const storage = new Files({ adapter });
 
-			// FSDriver should have these methods
-			expect(typeof driver.put).toBe("function");
-			expect(typeof driver.get).toBe("function");
-			expect(typeof driver.delete).toBe("function");
-			expect(typeof driver.exists).toBe("function");
-			expect(typeof driver.getUrl).toBe("function");
-			expect(typeof driver.getSignedUrl).toBe("function");
+		await storage.upload("hello.txt", "hello", {
+			contentType: "text/plain",
 		});
 
-		test("FSDriver generates correct URLs", async () => {
-			const config = createMockConfig({
-				storage: { location: "./test-uploads" },
-			});
+		const file = await storage.download("hello.txt");
 
-			const driver = createDiskDriver(config);
+		expect(await file.text()).toBe("hello");
+		expect(await storage.exists("hello.txt")).toBe(true);
+		expect(typeof storage.upload).toBe("function");
+		expect(typeof storage.download).toBe("function");
+		expect(typeof storage.head).toBe("function");
+		expect(typeof storage.delete).toBe("function");
+		expect(typeof storage.copy).toBe("function");
+		expect(typeof storage.move).toBe("function");
+		expect(typeof storage.list).toBe("function");
+		expect(typeof storage.listAll).toBe("function");
+		expect(typeof storage.url).toBe("function");
+		expect(typeof storage.signedUploadUrl).toBe("function");
+		expect("use" in storage).toBe(false);
+	});
 
-			const url = await driver.getUrl("test-file.jpg");
-
-			expect(url).toBe("http://localhost:3000/files/test-file.jpg");
+	test("runtime storage adapter is sufficient to construct the app.storage target", async () => {
+		const adapter = memory();
+		const config = runtimeConfig({
+			app: { url: "http://localhost:3000" },
+			db: { url: "postgres://localhost/test" },
+			storage: { adapter },
 		});
 
-		test("FSDriver generates signed URLs with token", async () => {
-			const config = createMockConfig({
-				storage: { location: "./test-uploads" },
+		const appStorage = await createFilesStorage(config as any);
+
+		expect(appStorage).toBeInstanceOf(Files);
+		expect(appStorage.adapter).toBe(adapter);
+		expect("use" in appStorage).toBe(false);
+	});
+
+	test("app.storage performs direct Files SDK operations", async () => {
+		const setup = await buildMockApp({});
+
+		try {
+			await setup.app.storage.upload("direct.txt", "direct body", {
+				contentType: "text/plain",
 			});
 
-			const driver = createDiskDriver(config);
+			const file = await setup.app.storage.download("direct.txt");
+			const metadata = await setup.app.storage.head("direct.txt");
 
-			const signedUrl = await driver.getSignedUrl("secret.pdf");
+			expect(setup.app.storage).toBeInstanceOf(Files);
+			expect(await file.text()).toBe("direct body");
+			expect(metadata.key).toBe("direct.txt");
+			expect(metadata.type).toBe("text/plain");
+			expect(await setup.app.storage.exists("direct.txt")).toBe(true);
 
-			expect(signedUrl).toContain(
-				"http://localhost:3000/files/secret.pdf",
-			);
-			expect(signedUrl).toContain("?token=");
+			await setup.app.storage.delete("direct.txt");
+
+			expect(await setup.app.storage.exists("direct.txt")).toBe(false);
+			expect("use" in setup.app.storage).toBe(false);
+		} finally {
+			await setup.cleanup();
+		}
+	});
+
+	test("local storage config creates a direct Files SDK instance", async () => {
+		const location = await mkdtemp(join(tmpdir(), "questpie-storage-"));
+		const config = runtimeConfig({
+			app: { url: "http://localhost:3000" },
+			db: { url: "postgres://localhost/test" },
+			storage: { location },
 		});
 
-		test("uses custom expiration for signed URLs", async () => {
-			const config = createMockConfig({
-				storage: {
-					location: "./test-uploads",
-					signedUrlExpiration: 60, // 1 minute
-				},
+		try {
+			const appStorage = await createFilesStorage(config as any);
+
+			await appStorage.upload("local.txt", "local body", {
+				contentType: "text/plain",
 			});
 
-			const driver = createDiskDriver(config);
+			const file = await appStorage.download("local.txt");
+			const metadata = await appStorage.head("local.txt");
 
-			// Generate two URLs with default and custom expiration
-			const url1 = await driver.getSignedUrl("file.pdf");
-			const url2 = await driver.getSignedUrl("file.pdf");
+			expect(appStorage).toBeInstanceOf(Files);
+			expect(await file.text()).toBe("local body");
+			expect(metadata.key).toBe("local.txt");
+			expect(metadata.type).toBe("text/plain");
+			expect(await appStorage.exists("local.txt")).toBe(true);
 
-			// Both should have tokens (implementation detail: tokens include expiration)
-			expect(url1).toContain("?token=");
-			expect(url2).toContain("?token=");
-		});
+			await appStorage.delete("local.txt");
+
+			expect(await appStorage.exists("local.txt")).toBe(false);
+			expect("use" in appStorage).toBe(false);
+		} finally {
+			await rm(location, { force: true, recursive: true });
+		}
 	});
 });

--- a/packages/questpie/test/utils/mocks/mock-app-builder.ts
+++ b/packages/questpie/test/utils/mocks/mock-app-builder.ts
@@ -1,6 +1,7 @@
-import type { DriveManager } from "flydrive";
+import type { Adapter } from "files-sdk";
+import { memory } from "files-sdk/memory";
 
-import { Questpie, createApp, module } from "../../../src/exports/index.js";
+import { createApp, module } from "../../../src/exports/index.js";
 import type {
 	ModuleDefinition,
 	RuntimeConfig,
@@ -20,7 +21,7 @@ export type MockApp<TApp = any> = TApp & {
 		queue: MockQueueAdapter;
 		mailer: MockMailAdapter;
 		logger: MockLogger;
-		fakes: ReturnType<DriveManager<any>["fake"]>;
+		storage: Adapter;
 	};
 };
 
@@ -61,6 +62,10 @@ export async function buildMockApp(
 	const queueAdapter = new MockQueueAdapter();
 	const kvAdapter = new MockKVAdapter();
 	const logger = new MockLogger();
+	const storageAdapter =
+		runtimeOverrides.storage && "adapter" in runtimeOverrides.storage
+			? runtimeOverrides.storage.adapter
+			: memory();
 
 	const usesCustomDb = Boolean(runtimeOverrides.db);
 	const testDb = usesCustomDb ? null : await createTestDb();
@@ -102,7 +107,7 @@ export async function buildMockApp(
 	const app = await createApp({ modules: [normalizedDef] }, {
 		app: runtimeOverrides.app ?? { url: "http://localhost:3000" },
 		db: dbConfig,
-		storage: runtimeOverrides.storage,
+		storage: runtimeOverrides.storage ?? { adapter: storageAdapter },
 		email: {
 			...(runtimeOverrides.email ?? {}),
 			adapter: mailerAdapter,
@@ -131,7 +136,7 @@ export async function buildMockApp(
 		queue: queueAdapter,
 		mailer: mailerAdapter,
 		logger: logger,
-		fakes: app.storage.fake(Questpie.__internal.storageDriverServiceName),
+		storage: storageAdapter,
 	};
 
 	let cleanedUp = false;
@@ -143,7 +148,6 @@ export async function buildMockApp(
 			await mockApp.search?.flushPending?.();
 			await mockApp.destroy();
 		} finally {
-			mockApp.storage.restore(Questpie.__internal.storageDriverServiceName);
 			if (testDb) {
 				await testDb.close();
 			}

--- a/skills/questpie/AGENTS.md
+++ b/skills/questpie/AGENTS.md
@@ -57,7 +57,7 @@ QuestPie is a **headless CMS framework** for TypeScript. You define your content
 | Runtime  | **Bun**                                           |
 | Database | **PostgreSQL** via **Drizzle ORM**                |
 | Auth     | **Better Auth**                                   |
-| Storage  | **FlyDrive** (local FS, S3, R2, GCS)              |
+| Storage  | **Files SDK** (local FS, S3, R2, GCS)             |
 | Admin UI | **React** + **TanStack Router** + **Tailwind**    |
 | HTTP     | Custom trie-based router (no Express/Hono needed) |
 | Build    | **tsdown** (Rolldown-based) + **Turbo** monorepo  |
@@ -913,8 +913,9 @@ export default route()
 | `search`                      | POST   | Full-text search    |
 | `search/reindex/[collection]` | POST   | Reindex collection  |
 | `realtime`                    | POST   | SSE subscriptions   |
-| `storage/files/[...key]`      | GET    | Legacy file serving |
 | `health`                      | GET    | Health check        |
+
+File serving stays collection-scoped through QUESTPIE routes such as `/api/:collection/files/:key` or `/api/assets/files/:key`, so file reads remain behind collection access rules instead of a global storage namespace.
 
 ---
 
@@ -1173,14 +1174,27 @@ f.upload({
 ### Storage Adapters
 
 ```ts
+import { fs } from "files-sdk/fs";
+import { s3 } from "files-sdk/s3";
+
 // Local filesystem (default)
 runtimeConfig({
-	storage: { location: "./uploads", basePath: "/api" },
+	storage: { adapter: fs({ root: "./uploads" }), basePath: "/api" },
 });
 
 // S3-compatible (R2, Minio, etc.)
 runtimeConfig({
-	storage: { driver: myS3Driver },
+	storage: {
+		adapter: s3({
+			bucket: process.env.S3_BUCKET!,
+			region: process.env.S3_REGION!,
+			credentials: {
+				accessKeyId: process.env.S3_ACCESS_KEY!,
+				secretAccessKey: process.env.S3_SECRET_KEY!,
+			},
+		}),
+		basePath: "/api",
+	},
 });
 
 // Auto-detected from env vars:
@@ -1430,7 +1444,7 @@ interface AppContext {
 	globals: { [name]: GlobalAPI }; // typed CRUD for all globals
 	queue: QueueClient; // dispatch background jobs
 	email: MailerService; // send emails
-	storage: DriveManager; // file storage operations
+	storage: Files; // direct typed Files SDK storage operations
 	kv: KVService; // key-value store
 	logger: LoggerService; // structured logging
 	search: SearchService; // full-text search
@@ -2357,11 +2371,11 @@ Configure it through plugin-discovered `config/mcp.ts`, not `mcpModule(options)`
 
 ### Storage Adapters
 
-| Config                        | Driver                         |
-| ----------------------------- | ------------------------------ |
-| Default                       | `FSDriver` (local `./uploads`) |
-| `QUESTPIE_STORAGE_*` env vars | S3-compatible (auto-detected)  |
-| `{ driver: customDriver }`    | Any FlyDrive `DriverContract`  |
+| Config                              | Storage backend                  |
+| ----------------------------------- | -------------------------------- |
+| Default                             | Filesystem adapter (`./uploads`) |
+| `QUESTPIE_STORAGE_*` env vars       | S3-compatible (auto-detected)    |
+| `{ adapter: customAdapter }`        | Files SDK adapter instance       |
 
 ### Queue Adapters
 

--- a/skills/questpie/references/infrastructure-adapters.md
+++ b/skills/questpie/references/infrastructure-adapters.md
@@ -57,7 +57,7 @@ collection("posts")
 
 ## Storage
 
-File storage via [Flydrive](https://flydrive.dev/).
+File storage via [Files SDK](https://files-sdk.dev/).
 
 ### Local (Development)
 
@@ -76,16 +76,18 @@ export default runtimeConfig({
 Works with AWS S3, MinIO, DigitalOcean Spaces, Cloudflare R2:
 
 ```ts
-import { S3Driver } from "flydrive/drivers/s3";
+import { s3 } from "files-sdk/s3";
 
 export default runtimeConfig({
 	storage: {
 		basePath: "/api",
-		driver: new S3Driver({
+		adapter: s3({
 			bucket: process.env.S3_BUCKET,
 			region: process.env.S3_REGION,
-			accessKeyId: process.env.S3_ACCESS_KEY,
-			secretAccessKey: process.env.S3_SECRET_KEY,
+			credentials: {
+				accessKeyId: process.env.S3_ACCESS_KEY!,
+				secretAccessKey: process.env.S3_SECRET_KEY!,
+			},
 		}),
 	},
 });
@@ -524,7 +526,7 @@ import { runtimeConfig } from "questpie/app";
 import { pgBossAdapter } from "questpie/adapters/pg-boss";
 import { pgNotifyAdapter } from "questpie/adapters/pg-notify";
 import { SmtpAdapter } from "questpie/adapters/smtp";
-import { S3Driver } from "flydrive/drivers/s3";
+import { s3 } from "files-sdk/s3";
 
 export default runtimeConfig({
 	db: {
@@ -532,11 +534,13 @@ export default runtimeConfig({
 	},
 	storage: {
 		basePath: "/api",
-		driver: new S3Driver({
+		adapter: s3({
 			bucket: process.env.S3_BUCKET!,
 			region: process.env.S3_REGION!,
-			accessKeyId: process.env.S3_ACCESS_KEY!,
-			secretAccessKey: process.env.S3_SECRET_KEY!,
+			credentials: {
+				accessKeyId: process.env.S3_ACCESS_KEY!,
+				secretAccessKey: process.env.S3_SECRET_KEY!,
+			},
 		}),
 	},
 	queue: {

--- a/skills/questpie/references/production.md
+++ b/skills/questpie/references/production.md
@@ -1,7 +1,7 @@
 ---
 name: questpie-core/production
 description:
-  QUESTPIE production deployment authentication better-auth OAuth database PostgreSQL Drizzle storage S3 Flydrive queue pg-boss jobs realtime SSE pgNotify Redis migrations email SMTP KV key-value logger Pino OpenAPI Docker environment variables adapters infrastructure
+  QUESTPIE production deployment authentication better-auth OAuth database PostgreSQL Drizzle storage S3 Files SDK queue pg-boss jobs realtime SSE pgNotify Redis migrations email SMTP KV key-value logger Pino OpenAPI Docker environment variables adapters infrastructure
   - questpie-core
 ---
 
@@ -121,7 +121,7 @@ Configure migration and seed directories in `questpie.config.ts` under `cli.migr
 
 ## Storage
 
-QUESTPIE uses [Flydrive](https://flydrive.dev/) for file storage.
+QUESTPIE uses [Files SDK](https://files-sdk.dev/) for file storage.
 
 ### Local (Development Default)
 
@@ -136,16 +136,18 @@ export default runtimeConfig({
 ### S3 (Production)
 
 ```ts
-import { S3Driver } from "flydrive/drivers/s3";
+import { s3 } from "files-sdk/s3";
 
 export default runtimeConfig({
 	storage: {
 		basePath: "/api",
-		driver: new S3Driver({
+		adapter: s3({
 			bucket: process.env.S3_BUCKET,
 			region: process.env.S3_REGION,
-			accessKeyId: process.env.S3_ACCESS_KEY,
-			secretAccessKey: process.env.S3_SECRET_KEY,
+			credentials: {
+				accessKeyId: process.env.S3_ACCESS_KEY!,
+				secretAccessKey: process.env.S3_SECRET_KEY!,
+			},
 		}),
 	},
 });
@@ -466,15 +468,17 @@ The local storage adapter writes to the filesystem. In containerized deployments
 storage: { basePath: "/api" }
 
 // CORRECT -- persistent S3 storage
-import { S3Driver } from "flydrive/drivers/s3";
+import { s3 } from "files-sdk/s3";
 
 storage: {
   basePath: "/api",
-  driver: new S3Driver({
+  adapter: s3({
     bucket: process.env.S3_BUCKET,
     region: process.env.S3_REGION,
-    accessKeyId: process.env.S3_ACCESS_KEY,
-    secretAccessKey: process.env.S3_SECRET_KEY,
+    credentials: {
+      accessKeyId: process.env.S3_ACCESS_KEY!,
+      secretAccessKey: process.env.S3_SECRET_KEY!,
+    },
   }),
 }
 ```


### PR DESCRIPTION
## Summary

- Migrate QUESTPIE storage from Flydrive-style disk manager APIs to the direct Files SDK adapter shape.
- Update storage routes, upload cleanup, runtime config typing, docs, examples, and skills to use `runtimeConfig({ storage: { adapter } })` and direct `app.storage` operations.
- Add storage public API type contracts and route coverage, including a read-access regression where explicit `.access({ read: false })` must not be bypassed by public upload visibility.
- Keep the branch based directly on `main`, separate from the local refocus/autopilot branch history.

## Validation

- `bun test packages/questpie/test/collection/collection-upload.test.ts packages/questpie/test/units/storage-driver.test.ts packages/questpie/test/units/runtime-compatibility.test.ts packages/questpie/test/units/cloudflare-adapter.test.ts packages/questpie/test/codegen/template.test.ts`
- `cd packages/questpie && bun run check-types`