### PR TITLE
Harden admin and service security follow-ups

### DIFF
--- a/.changeset/refocus-security-hardening.md
+++ b/.changeset/refocus-security-hardening.md
@@ -6,3 +6,5 @@
 Add declarative admin list view filters, quick filters, filter-panel controls, system-field default sorting, and nested sidebar access filtering.
 
 Harden CRUD response field access, audit log route access, storage upload and private file serving, auth credential collection redaction, admin RPC authorization, admin action form validation, JSONB filtering, search access SQL generation, and upload file serving authorization.
+
+Harden global update auto-create races, nested field write access validation, Redis KV clearing, Postgres search query sanitization, admin widget/action caller context propagation, and frontend reactive hidden/read-only/disabled field state handling.

--- a/apps/docs/content/docs/reference/admin-api.mdx
+++ b/apps/docs/content/docs/reference/admin-api.mdx
@@ -320,6 +320,7 @@ Override field behavior per-form:
 {
   field: f.slug,
   hidden: ({ data }) => !data.title,
+  disabled: ({ data }) => data.status === "archived",
   readOnly: ({ data }) => data.status === "published",
   compute: {
     handler: ({ data }) => slugify(data.title),

--- a/apps/docs/content/docs/workspace/actions/custom.mdx
+++ b/apps/docs/content/docs/workspace/actions/custom.mdx
@@ -68,6 +68,12 @@ Custom actions can be added to collections with forms and handlers:
 | `handler` | `function`       | Server-side handler                   |
 | `bulk`    | `boolean`        | Available as bulk action in list view |
 
+## Security Model
+
+Custom action handlers run on the server in user mode for the authenticated admin request. Built-in actions call the collection CRUD API with the same caller context, and custom action form fields are validated on the server before the handler runs.
+
+Action results are returned to the client as data. If an action returns effects such as invalidation, redirect, or toast metadata, the client applies those effects; the server does not implicitly execute another action from an action result. To chain privileged work, call the required service or collection method explicitly inside the handler and rely on the normal access checks.
+
 ## Related Pages
 
 - [Built-in Actions](/docs/workspace/actions/builtin) — Default CRUD actions

--- a/apps/docs/content/docs/workspace/blocks/prefetch.mdx
+++ b/apps/docs/content/docs/workspace/blocks/prefetch.mdx
@@ -39,6 +39,34 @@ Prefetch nested relations:
 })
 ```
 
+## Custom Loader
+
+Use a loader when the block needs computed data after declared relations are expanded:
+
+```ts
+.prefetch({
+  with: {
+    featuredPost: {
+      with: { author: true },
+    },
+  },
+  loader: async ({ values, expanded, ctx }) => {
+    const related = await ctx.collections.posts.find({
+      where: { status: "published" },
+      limit: 3,
+    });
+
+    return {
+      featuredPost: expanded.featuredPost,
+      related: related.docs,
+      heading: values.title,
+    };
+  },
+})
+```
+
+Custom prefetch functions and loaders run on the server in the current request context. Use `ctx.collections` and `ctx.globals` instead of importing the generated app, and return only data that is safe for the caller to read.
+
 ## Using Prefetched Data
 
 In the renderer, prefetched data appears in the `data` prop:

--- a/apps/docs/content/docs/workspace/views/dashboard.mdx
+++ b/apps/docs/content/docs/workspace/views/dashboard.mdx
@@ -109,6 +109,8 @@ Custom-loaded value with trend indicator:
 }
 ```
 
+Widget loaders run on the server from the authenticated admin request. Nested CRUD calls made by the loader inherit the caller context, so collection and field access rules still apply. Return only serializable data that is safe for the admin client; do not return secrets or server-only configuration.
+
 ### Progress
 
 Progress bar toward a goal:

--- a/apps/docs/content/docs/workspace/visibility.mdx
+++ b/apps/docs/content/docs/workspace/visibility.mdx
@@ -1,9 +1,9 @@
 ---
 title: Visibility Rules
-description: Reactive field visibility — show or hide fields based on other field values.
+description: Reactive field visibility and state — show, hide, disable, or lock fields based on other field values.
 ---
 
-Make form fields conditionally visible based on the current record data. Fields can be hidden or shown based on other field values.
+Make form fields conditionally visible or non-editable based on the current record data. Fields can be hidden, disabled, or made read-only from other field values.
 
 ## Basic Visibility
 
@@ -30,7 +30,7 @@ The `cancellationReason` field only appears when `status` is `"cancelled"`.
 
 ## Reactive
 
-Visibility rules are **reactive** — they re-evaluate as the user changes field values in the form. No page refresh needed.
+Visibility and state rules are **reactive** — they re-evaluate as the user changes field values in the form. No page refresh needed.
 
 ## Multiple Conditions
 
@@ -53,6 +53,19 @@ Make a field visible but non-editable based on conditions:
   readOnly: ({ data }) => !!data.customer,
 }
 ```
+
+## Disabled Fields
+
+Disable a field while keeping it visible in the form:
+
+```ts
+{
+  field: f.discountCode,
+  disabled: ({ data }) => data.status === "paid",
+}
+```
+
+`readOnly` is best for values the user may inspect but not edit. `disabled` is best for controls that should be temporarily unavailable because another value makes them irrelevant.
 
 ## Section Visibility
 

--- a/packages/admin/src/client/hooks/use-reactive-fields.ts
+++ b/packages/admin/src/client/hooks/use-reactive-fields.ts
@@ -77,6 +77,12 @@ export interface UseReactiveFieldsResult {
 
 type ReactiveType = "hidden" | "readOnly" | "disabled" | "compute";
 
+const EMPTY_REACTIVE_FIELD_STATE: ReactiveFieldState = {};
+
+const ReactiveFieldStatesContext = React.createContext<
+	Record<string, ReactiveFieldState>
+>({});
+
 type ReactiveRequestDescriptor = {
 	field: string;
 	type: ReactiveType;
@@ -190,6 +196,36 @@ function getChangedDeps(
 	}
 
 	return changed;
+}
+
+export function mergeReactiveFieldState(
+	base: ReactiveFieldState,
+	reactive: ReactiveFieldState | undefined,
+): ReactiveFieldState {
+	return {
+		hidden: base.hidden === true || reactive?.hidden === true,
+		readOnly: base.readOnly === true || reactive?.readOnly === true,
+		disabled: base.disabled === true || reactive?.disabled === true,
+	};
+}
+
+export function ReactiveFieldStatesProvider({
+	fieldStates,
+	children,
+}: {
+	fieldStates: Record<string, ReactiveFieldState>;
+	children: React.ReactNode;
+}) {
+	return React.createElement(
+		ReactiveFieldStatesContext.Provider,
+		{ value: fieldStates },
+		children,
+	);
+}
+
+export function useReactiveFieldState(fieldPath: string): ReactiveFieldState {
+	const fieldStates = React.useContext(ReactiveFieldStatesContext);
+	return fieldStates[fieldPath] ?? EMPTY_REACTIVE_FIELD_STATE;
 }
 
 // ============================================================================

--- a/packages/admin/src/client/views/collection/field-renderer.tsx
+++ b/packages/admin/src/client/views/collection/field-renderer.tsx
@@ -13,6 +13,10 @@ import type { FieldInstance } from "../../builder/field/field";
 import { Skeleton } from "../../components/ui/skeleton";
 import { useAdminConfig } from "../../hooks/use-admin-config";
 import { useFieldHooks } from "../../hooks/use-field-hooks";
+import {
+	mergeReactiveFieldState,
+	useReactiveFieldState,
+} from "../../hooks/use-reactive-fields";
 import { useReactiveProps } from "../../hooks/use-reactive-prop";
 import { useResolveText } from "../../i18n/hooks";
 import { useScopedLocale } from "../../runtime";
@@ -349,6 +353,15 @@ export function FieldRenderer({
 		entityMeta: entityMetaProp,
 		formValues, // Pass pre-watched values to avoid calling form.watch() internally
 	});
+	const reactiveFieldState = useReactiveFieldState(fullFieldName);
+	const effectiveFieldState = mergeReactiveFieldState(
+		{
+			hidden: context.isHidden,
+			readOnly: context.isReadOnly,
+			disabled: context.isDisabled,
+		},
+		reactiveFieldState,
+	);
 
 	// Resolve lazy component (supports () => import(...) loaders)
 	const { Component: resolvedComponent, loading: componentLoading } =
@@ -405,11 +418,11 @@ export function FieldRenderer({
 		entityType: mode,
 		field: fullFieldName,
 		props: mergedFieldProps,
-		enabled: !context.isHidden && !!fieldDef,
+		enabled: !effectiveFieldState.hidden && !!fieldDef,
 	});
 
 	// Hidden fields are not rendered
-	if (context.isHidden) return null;
+	if (effectiveFieldState.hidden) return null;
 
 	// Field not found in config
 	if (!fieldDef) {
@@ -441,7 +454,8 @@ export function FieldRenderer({
 		// Pass loading state for async options
 		optionsLoading,
 		// Computed fields are always readonly
-		readOnly: rawComponentProps.readOnly || isComputed,
+		readOnly: effectiveFieldState.readOnly || isComputed,
+		disabled: effectiveFieldState.disabled === true,
 		label: resolveText(rawComponentProps.label, "", formValues),
 		description: resolveText(rawComponentProps.description, "", formValues),
 		placeholder: resolveText(rawComponentProps.placeholder, "", formValues),

--- a/packages/admin/src/client/views/collection/form-view.tsx
+++ b/packages/admin/src/client/views/collection/form-view.tsx
@@ -68,8 +68,8 @@ import {
 	useSearchParamToggle,
 	useSidebarSearchParam,
 } from "../../hooks";
-import { useAdminConfig } from "../../hooks/use-admin-config";
 import { adminCollectionKey } from "../../hooks/query-access";
+import { useAdminConfig } from "../../hooks/use-admin-config";
 import {
 	useCollectionCreate,
 	useCollectionDelete,
@@ -81,7 +81,10 @@ import {
 } from "../../hooks/use-collection";
 import { useCollectionFields } from "../../hooks/use-collection-fields";
 import { getLockUser, useLock } from "../../hooks/use-locks";
-import { useReactiveFields } from "../../hooks/use-reactive-fields";
+import {
+	ReactiveFieldStatesProvider,
+	useReactiveFields,
+} from "../../hooks/use-reactive-fields";
 import { useServerActions } from "../../hooks/use-server-actions";
 import { useTransitionStage } from "../../hooks/use-transition-stage";
 import { useResolveText, useTranslation } from "../../i18n/hooks";
@@ -275,17 +278,19 @@ function ReactiveFieldsManager({
 	mode = "collection",
 	reactiveConfigs,
 	enabled,
+	children,
 }: {
 	collection: string;
 	mode?: "collection" | "global";
 	reactiveConfigs: Record<string, FieldReactiveSchema>;
 	enabled: boolean;
+	children: React.ReactNode;
 }) {
 	// This hook handles:
 	// 1. Watching form values for changes to reactive dependencies
 	// 2. Calling server /reactive endpoint to execute handlers
 	// 3. Setting computed values via form.setValue
-	useReactiveFields({
+	const { fieldStates } = useReactiveFields({
 		collection,
 		mode,
 		reactiveConfigs,
@@ -293,7 +298,11 @@ function ReactiveFieldsManager({
 		debounce: 300,
 	});
 
-	return null;
+	return (
+		<ReactiveFieldStatesProvider fieldStates={fieldStates}>
+			{children}
+		</ReactiveFieldStatesProvider>
+	);
 }
 
 type FormFieldsContentProps = {
@@ -2150,278 +2159,285 @@ export default function FormView({
 					collection={collection}
 					reactiveConfigs={reactiveConfigs}
 					enabled={!isBlocked && !isMutationPending}
-				/>
-				<RenderProfiler id={`form.shell.${collection}`} minDurationMs={12}>
-					<form
-						ref={formElementRef}
-						onSubmit={(e) => {
-							e.stopPropagation();
-							if (isBlocked) {
-								e.preventDefault();
-								toast.error(t("lock.cannotSave"));
-								return;
-							}
-							form.handleSubmit(onSubmit, (errors) => {
-								console.warn("[FormView] Validation errors:", errors);
-								toast.error(t("toast.validationFailed"), {
-									description: t("toast.validationDescription"),
-								});
-							})(e);
-						}}
-						className="qa-form-view__form space-y-4"
-					>
-						<AdminViewHeader
-							className="qa-form-view__header"
-							title={title}
-							titleAccessory={
-								<>
-									{localeOptions.length > 0 && (
-										<LocaleSwitcher
-											locales={localeOptions}
-											value={contentLocale}
-											onChange={setContentLocale}
-										/>
-									)}
-
-									{/* Autosave status indicator */}
-									<AutosaveIndicator
-										control={form.control}
-										enabled={autoSaveConfig.enabled}
-										indicator={autoSaveConfig.indicator}
-										isEditMode={isEditMode}
-										isSaving={isSaving}
-										lastSaved={lastSaved}
-										formatTimeAgo={formatTimeAgo}
-										t={t}
-									/>
-
-									{/* Workflow stage badge */}
-									{workflowEnabled && currentStage && (
-										<Badge variant="outline" className="gap-1.5">
-											<Icon icon="ph:git-branch" className="size-3" />
-											{currentStageLabel}
-										</Badge>
-									)}
-								</>
-							}
-							meta={
-								showMeta && item ? (
+				>
+					<RenderProfiler id={`form.shell.${collection}`} minDurationMs={12}>
+						<form
+							ref={formElementRef}
+							onSubmit={(e) => {
+								e.stopPropagation();
+								if (isBlocked) {
+									e.preventDefault();
+									toast.error(t("lock.cannotSave"));
+									return;
+								}
+								form.handleSubmit(onSubmit, (errors) => {
+									console.warn("[FormView] Validation errors:", errors);
+									toast.error(t("toast.validationFailed"), {
+										description: t("toast.validationDescription"),
+									});
+								})(e);
+							}}
+							className="qa-form-view__form space-y-4"
+						>
+							<AdminViewHeader
+								className="qa-form-view__header"
+								title={title}
+								titleAccessory={
 									<>
-										<span className="opacity-60">{t("form.id")}:</span>
-										<button
-											type="button"
-											className="hover:text-foreground cursor-pointer transition-colors"
-											onClick={() => {
-												navigator.clipboard.writeText(String(item.id)).then(
-													() => toast.success(t("toast.idCopied")),
-													() => toast.error(t("toast.copyFailed")),
-												);
-											}}
-											title={t("common.copy")}
-										>
-											{item.id}
-										</button>
-										{item.createdAt && (
-											<>
-												<span className="opacity-40">·</span>
-												<span>
-													<span className="opacity-60">
-														{t("form.created")}{" "}
-													</span>
-													{formatDate(item.createdAt)}
-												</span>
-											</>
+										{localeOptions.length > 0 && (
+											<LocaleSwitcher
+												locales={localeOptions}
+												value={contentLocale}
+												onChange={setContentLocale}
+											/>
 										)}
-										{item.updatedAt && (
-											<>
-												<span className="opacity-40">·</span>
-												<span>
-													<span className="opacity-60">
-														{t("form.updated")}{" "}
-													</span>
-													{formatDate(item.updatedAt)}
-												</span>
-											</>
+
+										{/* Autosave status indicator */}
+										<AutosaveIndicator
+											control={form.control}
+											enabled={autoSaveConfig.enabled}
+											indicator={autoSaveConfig.indicator}
+											isEditMode={isEditMode}
+											isSaving={isSaving}
+											lastSaved={lastSaved}
+											formatTimeAgo={formatTimeAgo}
+											t={t}
+										/>
+
+										{/* Workflow stage badge */}
+										{workflowEnabled && currentStage && (
+											<Badge variant="outline" className="gap-1.5">
+												<Icon icon="ph:git-branch" className="size-3" />
+												{currentStageLabel}
+											</Badge>
 										)}
 									</>
-								) : undefined
-							}
-							actions={
-								<>
-									{headerActions}
+								}
+								meta={
+									showMeta && item ? (
+										<>
+											<span className="opacity-60">{t("form.id")}:</span>
+											<button
+												type="button"
+												className="hover:text-foreground cursor-pointer transition-colors"
+												onClick={() => {
+													navigator.clipboard.writeText(String(item.id)).then(
+														() => toast.success(t("toast.idCopied")),
+														() => toast.error(t("toast.copyFailed")),
+													);
+												}}
+												title={t("common.copy")}
+											>
+												{item.id}
+											</button>
+											{item.createdAt && (
+												<>
+													<span className="opacity-40">·</span>
+													<span>
+														<span className="opacity-60">
+															{t("form.created")}{" "}
+														</span>
+														{formatDate(item.createdAt)}
+													</span>
+												</>
+											)}
+											{item.updatedAt && (
+												<>
+													<span className="opacity-40">·</span>
+													<span>
+														<span className="opacity-60">
+															{t("form.updated")}{" "}
+														</span>
+														{formatDate(item.updatedAt)}
+													</span>
+												</>
+											)}
+										</>
+									) : undefined
+								}
+								actions={
+									<>
+										{headerActions}
 
-									{/* Live Preview button */}
-									{canUseLivePreview && (
-										<Button
-											type="button"
-											variant="outline"
-											size="icon-sm"
-											onClick={() => setIsLivePreviewOpen(true)}
-											title={t("preview.livePreview")}
-										>
-											<Icon icon="ph:eye" className="size-4" />
-											<span className="sr-only">
-												{t("preview.livePreview")}
-											</span>
-										</Button>
-									)}
+										{/* Live Preview button */}
+										{canUseLivePreview && (
+											<Button
+												type="button"
+												variant="outline"
+												size="icon-sm"
+												onClick={() => setIsLivePreviewOpen(true)}
+												title={t("preview.livePreview")}
+											>
+												<Icon icon="ph:eye" className="size-4" />
+												<span className="sr-only">
+													{t("preview.livePreview")}
+												</span>
+											</Button>
+										)}
 
-									{/* History button — only show when versioning is enabled */}
-									{isEditMode && id && schema?.options?.versioning && (
-										<Button
-											type="button"
-											variant="outline"
-											size="icon-sm"
-											onClick={() => setIsHistoryOpen(true)}
-											title={t("history.title")}
-										>
-											<Icon
-												icon="ph:clock-counter-clockwise"
-												className="size-4"
+										{/* History button — only show when versioning is enabled */}
+										{isEditMode && id && schema?.options?.versioning && (
+											<Button
+												type="button"
+												variant="outline"
+												size="icon-sm"
+												onClick={() => setIsHistoryOpen(true)}
+												title={t("history.title")}
+											>
+												<Icon
+													icon="ph:clock-counter-clockwise"
+													className="size-4"
+												/>
+												<span className="sr-only">{t("history.title")}</span>
+											</Button>
+										)}
+
+										{/* Workflow transition dropdown */}
+										{workflowEnabled &&
+											isEditMode &&
+											id &&
+											allowedTransitions.length > 0 && (
+												<DropdownMenu>
+													<DropdownMenuTrigger
+														render={workflowTransitionTriggerRender}
+													>
+														<Icon
+															icon="ph:arrows-left-right"
+															className="size-4"
+														/>
+														{t("workflow.transition")}
+													</DropdownMenuTrigger>
+													<DropdownMenuContent align="end">
+														{allowedTransitions.map((stage) => (
+															<DropdownMenuItem
+																key={stage.name}
+																onClick={() =>
+																	setTransitionTarget({
+																		name: stage.name,
+																		label: stage.label,
+																	})
+																}
+															>
+																<Icon
+																	icon="ph:arrow-right"
+																	className="mr-2 size-4"
+																/>
+																{stage.label || stage.name}
+															</DropdownMenuItem>
+														))}
+													</DropdownMenuContent>
+												</DropdownMenu>
+											)}
+
+										{/* Primary form actions as buttons */}
+										{visiblePrimaryActions.map((action) => (
+											<ActionButton
+												key={action.id}
+												action={action}
+												collection={collection}
+												helpers={actionHelpers}
+												size="sm"
+												onOpenDialog={(a) => setDialogAction(a)}
 											/>
-											<span className="sr-only">{t("history.title")}</span>
-										</Button>
-									)}
+										))}
 
-									{/* Workflow transition dropdown */}
-									{workflowEnabled &&
-										isEditMode &&
-										id &&
-										allowedTransitions.length > 0 && (
+										{/* Save button */}
+										<SaveSubmitButton
+											control={form.control}
+											isMutationPending={isMutationPending}
+											t={t}
+										/>
+
+										{/* Secondary form actions in dropdown */}
+										{visibleSecondaryActions.length > 0 && (
 											<DropdownMenu>
 												<DropdownMenuTrigger
-													render={workflowTransitionTriggerRender}
+													render={secondaryActionsTriggerRender}
 												>
 													<Icon
-														icon="ph:arrows-left-right"
+														icon="ph:dots-three-vertical"
 														className="size-4"
 													/>
-													{t("workflow.transition")}
+													<span className="sr-only">
+														{t("common.moreActions")}
+													</span>
 												</DropdownMenuTrigger>
 												<DropdownMenuContent align="end">
-													{allowedTransitions.map((stage) => (
-														<DropdownMenuItem
-															key={stage.name}
-															onClick={() =>
-																setTransitionTarget({
-																	name: stage.name,
-																	label: stage.label,
-																})
-															}
-														>
-															<Icon
-																icon="ph:arrow-right"
-																className="mr-2 size-4"
-															/>
-															{stage.label || stage.name}
-														</DropdownMenuItem>
-													))}
+													{regularSecondary.map((action) => {
+														const iconElement = resolveIconElement(
+															action.icon,
+															{
+																className: "mr-2 size-4",
+															},
+														);
+														return (
+															<DropdownMenuItem
+																key={action.id}
+																onClick={() => handleActionClick(action)}
+																disabled={actionLoading}
+															>
+																{iconElement}
+																{resolveText(action.label)}
+															</DropdownMenuItem>
+														);
+													})}
+
+													{regularSecondary.length > 0 &&
+														destructiveSecondary.length > 0 && (
+															<DropdownMenuSeparator />
+														)}
+
+													{destructiveSecondary.map((action) => {
+														const iconElement = resolveIconElement(
+															action.icon,
+															{
+																className: "mr-2 size-4",
+															},
+														);
+														return (
+															<DropdownMenuItem
+																key={action.id}
+																variant="destructive"
+																onClick={() => handleActionClick(action)}
+																disabled={actionLoading}
+															>
+																{iconElement}
+																{resolveText(action.label)}
+															</DropdownMenuItem>
+														);
+													})}
 												</DropdownMenuContent>
 											</DropdownMenu>
 										)}
+									</>
+								}
+							/>
 
-									{/* Primary form actions as buttons */}
-									{visiblePrimaryActions.map((action) => (
-										<ActionButton
-											key={action.id}
-											action={action}
-											collection={collection}
-											helpers={actionHelpers}
-											size="sm"
-											onOpenDialog={(a) => setDialogAction(a)}
-										/>
-									))}
+							{/* Soft-deleted banner */}
+							{item?.deletedAt && (
+								<div className="qa-form-view__deleted-banner border-destructive/30 bg-destructive/5 text-destructive flex items-center gap-2 border px-4 py-3 text-sm">
+									<Icon icon="ph:trash" className="size-4 shrink-0" />
+									<span>
+										{t("form.deletedBanner", {
+											date: formatDate(item.deletedAt),
+											defaultValue: `This record was deleted on ${formatDate(item.deletedAt)}. Use the Restore action to make it active again.`,
+										})}
+									</span>
+								</div>
+							)}
 
-									{/* Save button */}
-									<SaveSubmitButton
-										control={form.control}
-										isMutationPending={isMutationPending}
-										t={t}
-									/>
-
-									{/* Secondary form actions in dropdown */}
-									{visibleSecondaryActions.length > 0 && (
-										<DropdownMenu>
-											<DropdownMenuTrigger
-												render={secondaryActionsTriggerRender}
-											>
-												<Icon
-													icon="ph:dots-three-vertical"
-													className="size-4"
-												/>
-												<span className="sr-only">
-													{t("common.moreActions")}
-												</span>
-											</DropdownMenuTrigger>
-											<DropdownMenuContent align="end">
-												{regularSecondary.map((action) => {
-													const iconElement = resolveIconElement(action.icon, {
-														className: "mr-2 size-4",
-													});
-													return (
-														<DropdownMenuItem
-															key={action.id}
-															onClick={() => handleActionClick(action)}
-															disabled={actionLoading}
-														>
-															{iconElement}
-															{resolveText(action.label)}
-														</DropdownMenuItem>
-													);
-												})}
-
-												{regularSecondary.length > 0 &&
-													destructiveSecondary.length > 0 && (
-														<DropdownMenuSeparator />
-													)}
-
-												{destructiveSecondary.map((action) => {
-													const iconElement = resolveIconElement(action.icon, {
-														className: "mr-2 size-4",
-													});
-													return (
-														<DropdownMenuItem
-															key={action.id}
-															variant="destructive"
-															onClick={() => handleActionClick(action)}
-															disabled={actionLoading}
-														>
-															{iconElement}
-															{resolveText(action.label)}
-														</DropdownMenuItem>
-													);
-												})}
-											</DropdownMenuContent>
-										</DropdownMenu>
-									)}
-								</>
-							}
-						/>
-
-						{/* Soft-deleted banner */}
-						{item?.deletedAt && (
-							<div className="qa-form-view__deleted-banner border-destructive/30 bg-destructive/5 text-destructive flex items-center gap-2 border px-4 py-3 text-sm">
-								<Icon icon="ph:trash" className="size-4 shrink-0" />
-								<span>
-									{t("form.deletedBanner", {
-										date: formatDate(item.deletedAt),
-										defaultValue: `This record was deleted on ${formatDate(item.deletedAt)}. Use the Restore action to make it active again.`,
-									})}
-								</span>
-							</div>
-						)}
-
-						{/* Main Content - Form Fields */}
-						<FormFieldsContent
-							collection={collection}
-							config={formConfigBridge}
-							registry={registry}
-							allCollectionsConfig={allCollectionsConfig}
-							resolvedFields={resolvedFields as any}
-							schema={schema}
-						/>
-					</form>
-				</RenderProfiler>
+							{/* Main Content - Form Fields */}
+							<FormFieldsContent
+								collection={collection}
+								config={formConfigBridge}
+								registry={registry}
+								allCollectionsConfig={allCollectionsConfig}
+								resolvedFields={resolvedFields as any}
+								schema={schema}
+							/>
+						</form>
+					</RenderProfiler>
+				</ReactiveFieldsManager>
 			</FormProvider>
 
 			{/* Locale Change Confirmation Dialog */}

--- a/packages/admin/src/client/views/globals/global-form-view.tsx
+++ b/packages/admin/src/client/views/globals/global-form-view.tsx
@@ -49,7 +49,10 @@ import {
 	useSidebarSearchParam,
 } from "../../hooks";
 import { useGlobalFields } from "../../hooks/use-global-fields";
-import { useReactiveFields } from "../../hooks/use-reactive-fields";
+import {
+	ReactiveFieldStatesProvider,
+	useReactiveFields,
+} from "../../hooks/use-reactive-fields";
 import { useGlobalServerValidation } from "../../hooks/use-server-validation";
 import { useTransitionStage } from "../../hooks/use-transition-stage";
 import { useResolveText, useTranslation } from "../../i18n/hooks";
@@ -555,7 +558,7 @@ export default function GlobalFormView({
 	);
 
 	// Use reactive fields hook for server-side compute/hidden/readOnly/disabled
-	useReactiveFields({
+	const { fieldStates: reactiveFieldStates } = useReactiveFields({
 		collection: globalName,
 		mode: "global",
 		reactiveConfigs,
@@ -797,14 +800,16 @@ export default function GlobalFormView({
 				/>
 
 				{/* Main Content - Form Fields */}
-				<AutoFormFields
-					collection={globalName}
-					mode="global"
-					config={resolvedConfig}
-					registry={registry}
-					resolvedFields={schemaFields as any}
-					schema={globalSchema}
-				/>
+				<ReactiveFieldStatesProvider fieldStates={reactiveFieldStates}>
+					<AutoFormFields
+						collection={globalName}
+						mode="global"
+						config={resolvedConfig}
+						registry={registry}
+						resolvedFields={schemaFields as any}
+						schema={globalSchema}
+					/>
+				</ReactiveFieldStatesProvider>
 			</form>
 
 			{isHistoryOpen && (

--- a/packages/admin/src/server/modules/admin/routes/execute-action.ts
+++ b/packages/admin/src/server/modules/admin/routes/execute-action.ts
@@ -16,7 +16,7 @@
  * ```
  */
 
-import { route } from "questpie";
+import { route, runWithContext } from "questpie";
 import { z } from "zod";
 
 import type {
@@ -280,7 +280,16 @@ export async function executeAction(
 			t,
 		};
 
-		const result = await customAction.handler(context);
+		const result = await runWithContext(
+			{
+				app,
+				db: appRec.db,
+				session,
+				locale,
+				accessMode: "user",
+			},
+			() => customAction.handler(context),
+		);
 
 		return {
 			success: result.type === "success" || result.type === "redirect",
@@ -327,6 +336,7 @@ async function executeBuiltinAction(
 		db: appRec.db,
 		session: params.session,
 		locale: params.locale,
+		accessMode: "user" as const,
 	};
 
 	try {

--- a/packages/admin/src/server/modules/admin/routes/widget-data.ts
+++ b/packages/admin/src/server/modules/admin/routes/widget-data.ts
@@ -5,7 +5,7 @@
  * Called by the client when a widget has `hasLoader: true`.
  */
 
-import { ApiError, route, tryGetContext } from "questpie";
+import { ApiError, route, runWithContext, tryGetContext } from "questpie";
 import { z } from "zod";
 
 import type { ServerDashboardItem } from "../../../augmentation.js";
@@ -75,8 +75,11 @@ export const fetchWidgetData = route()
 	.handler(async (ctx) => {
 		// Access dashboard config from the app's internal state
 		const stored = tryGetContext();
-		const appState = ((stored?.app as Record<string, any>)?.state ||
-			{}) as Record<string, any>;
+		const routeApp = (ctx as { app?: unknown }).app ?? stored?.app;
+		const appState = ((routeApp as Record<string, any>)?.state || {}) as Record<
+			string,
+			any
+		>;
 		const dashboard = appState.config?.admin?.dashboard ?? appState.dashboard;
 
 		if (!dashboard?.items) {
@@ -111,8 +114,19 @@ export const fetchWidgetData = route()
 			}
 		}
 
-		// Execute loader with server context
-		return widget.loader(widgetCtx);
+		// Execute loader inside an explicit user-mode context so nested CRUD calls
+		// inherit the admin caller session even when the route handler is invoked
+		// directly in tests or non-HTTP environments.
+		return runWithContext(
+			{
+				app: routeApp,
+				db: (ctx as { db?: unknown }).db,
+				session: (ctx as { session?: unknown }).session,
+				locale: (ctx as { locale?: string }).locale,
+				accessMode: "user",
+			},
+			() => widget.loader(widgetCtx),
+		);
 	});
 
 // ============================================================================

--- a/packages/admin/test/client/reactive-field-state.test.ts
+++ b/packages/admin/test/client/reactive-field-state.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "bun:test";
+
+import { mergeReactiveFieldState } from "#questpie/admin/client/hooks/use-reactive-fields";
+
+describe("reactive field state", () => {
+	it("applies server reactive hidden/readOnly/disabled state over visible editable fields", () => {
+		expect(
+			mergeReactiveFieldState(
+				{ hidden: false, readOnly: false, disabled: false },
+				{ hidden: true, readOnly: true, disabled: true },
+			),
+		).toEqual({
+			hidden: true,
+			readOnly: true,
+			disabled: true,
+		});
+	});
+
+	it("does not let reactive false override static hidden/readOnly/disabled field state", () => {
+		expect(
+			mergeReactiveFieldState(
+				{ hidden: true, readOnly: true, disabled: true },
+				{ hidden: false, readOnly: false, disabled: false },
+			),
+		).toEqual({
+			hidden: true,
+			readOnly: true,
+			disabled: true,
+		});
+	});
+});

--- a/packages/admin/test/server/execute-action-runtime-shape.test.ts
+++ b/packages/admin/test/server/execute-action-runtime-shape.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 
+import { tryGetContext } from "questpie";
 import { z } from "zod";
 
 import {
@@ -12,6 +13,7 @@ describe("admin execute action runtime shape", () => {
 		const collectionCruds = { user: { marker: "collections" } };
 		const globalCruds = { settings: { marker: "globals" } };
 		const calls: Array<Record<string, unknown>> = [];
+		const runtimeContexts: unknown[] = [];
 		const app = {
 			state: {},
 			collections: collectionCruds,
@@ -28,6 +30,7 @@ describe("admin execute action runtime shape", () => {
 										label: "Create user",
 										handler: (ctx: Record<string, unknown>) => {
 											calls.push(ctx);
+											runtimeContexts.push(tryGetContext());
 											return { type: "success" };
 										},
 									},
@@ -54,6 +57,7 @@ describe("admin execute action runtime shape", () => {
 		expect(calls).toHaveLength(1);
 		expect(calls[0]?.collections).toBe(collectionCruds);
 		expect(calls[0]?.globals).toBe(globalCruds);
+		expect((runtimeContexts[0] as any)?.accessMode).toBe("user");
 	});
 
 	it("runs built-in create through the collection CRUD API", async () => {
@@ -89,6 +93,7 @@ describe("admin execute action runtime shape", () => {
 		expect(result.success).toBe(true);
 		expect(createCall?.data).toEqual({ title: "Hello" });
 		expect(createCall?.context.db).toBe(app.db);
+		expect(createCall?.context.accessMode).toBe("user");
 		expect(result.result?.effects?.redirect).toBe(
 			"/admin/collections/posts/post-1",
 		);

--- a/packages/admin/test/server/widget-data.test.ts
+++ b/packages/admin/test/server/widget-data.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "bun:test";
+
+import { tryGetContext } from "questpie";
+
+import { widgetDataFunctions } from "#questpie/admin/server/modules/admin/routes/widget-data";
+
+describe("admin widget data route", () => {
+	it("runs widget loaders inside a user-mode request context", async () => {
+		const session = { user: { id: "user-1" } };
+		const contexts: unknown[] = [];
+		const app = {
+			state: {
+				config: {
+					admin: {
+						dashboard: {
+							items: [
+								{
+									id: "secure-widget",
+									type: "value",
+									loader: async () => {
+										contexts.push(tryGetContext());
+										return { value: 42 };
+									},
+								},
+							],
+						},
+					},
+				},
+			},
+		};
+
+		const result = await widgetDataFunctions.fetchWidgetData.handler({
+			app,
+			db: { marker: "db" },
+			session,
+			locale: "en",
+			input: { widgetId: "secure-widget" },
+		} as any);
+
+		expect(result).toEqual({ value: 42 });
+		expect(contexts).toHaveLength(1);
+		expect((contexts[0] as any)?.accessMode).toBe("user");
+		expect((contexts[0] as any)?.session).toBe(session);
+	});
+});

--- a/packages/questpie/src/server/collection/crud/shared/access-control.ts
+++ b/packages/questpie/src/server/collection/crud/shared/access-control.ts
@@ -284,6 +284,92 @@ export async function checkFieldWriteAccess(
 	);
 }
 
+const META_FIELD_NAMES = new Set(["id", "createdAt", "updatedAt", "deletedAt"]);
+
+function isRecord(value: unknown): value is Record<string, any> {
+	return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function getPathValue(source: unknown, path: Array<string | number>): unknown {
+	let current = source;
+	for (const segment of path) {
+		if (!isRecord(current) && !Array.isArray(current)) return undefined;
+		current = (current as Record<string, unknown>)[segment];
+	}
+	return current;
+}
+
+async function validateFieldPathWriteAccess(params: {
+	data: unknown;
+	fieldAccess: Record<string, FieldAccess>;
+	context: CRUDContext;
+	options: { app?: Questpie<any>; db: any };
+	collectionName: string;
+	operation: "create" | "update";
+	existingRow?: any;
+	accessPath?: string[];
+	valuePath?: Array<string | number>;
+}): Promise<void> {
+	if (!isRecord(params.data) && !Array.isArray(params.data)) return;
+
+	if (Array.isArray(params.data)) {
+		for (const [index, item] of params.data.entries()) {
+			await validateFieldPathWriteAccess({
+				...params,
+				data: item,
+				valuePath: [...(params.valuePath ?? []), index],
+			});
+		}
+		return;
+	}
+
+	for (const [fieldName, value] of Object.entries(params.data)) {
+		if (!params.accessPath?.length && META_FIELD_NAMES.has(fieldName)) {
+			continue;
+		}
+
+		const accessPath = [...(params.accessPath ?? []), fieldName];
+		const valuePath = [...(params.valuePath ?? []), fieldName];
+		const fieldPath = accessPath.join(".");
+
+		if (
+			params.operation === "update" &&
+			params.existingRow &&
+			Object.is(value, getPathValue(params.existingRow, valuePath))
+		) {
+			continue;
+		}
+
+		const canWrite = await checkFieldWriteAccess(
+			fieldPath,
+			params.fieldAccess,
+			params.context,
+			params.options,
+			params.operation,
+			params.existingRow,
+		);
+
+		if (!canWrite) {
+			const { ApiError } = await import("#questpie/server/errors/index.js");
+			throw ApiError.forbidden({
+				operation: params.operation,
+				resource: params.collectionName,
+				reason: `Cannot write field '${fieldPath}': access denied`,
+				fieldPath,
+			});
+		}
+
+		if (isRecord(value) || Array.isArray(value)) {
+			await validateFieldPathWriteAccess({
+				...params,
+				data: value,
+				accessPath,
+				valuePath,
+			});
+		}
+	}
+}
+
 /**
  * Validate write access for all fields in input data
  * Throws ApiError if any field cannot be written
@@ -304,9 +390,6 @@ export async function validateFieldsWriteAccess(
 	operation: "create" | "update",
 	existingRow?: any,
 ): Promise<void> {
-	// Lazy import to avoid circular dependency
-	const { ApiError } = await import("#questpie/server/errors/index.js");
-
 	const normalized = normalizeContext(context);
 
 	// System mode bypasses field access control
@@ -314,46 +397,15 @@ export async function validateFieldsWriteAccess(
 
 	if (!fieldAccess) return;
 
-	for (const fieldName of Object.keys(data)) {
-		// Skip meta fields
-		if (
-			fieldName === "id" ||
-			fieldName === "createdAt" ||
-			fieldName === "updatedAt" ||
-			fieldName === "deletedAt"
-		) {
-			continue;
-		}
-
-		// Skip no-op writes on update: forms (especially admin) re-submit
-		// readOnly fields with their original value. Denying these breaks
-		// every form save even though nothing actually changed.
-		if (
-			operation === "update" &&
-			existingRow &&
-			Object.is(data[fieldName], (existingRow as any)[fieldName])
-		) {
-			continue;
-		}
-
-		const canWrite = await checkFieldWriteAccess(
-			fieldName,
-			fieldAccess,
-			context,
-			options,
-			operation,
-			existingRow,
-		);
-
-		if (!canWrite) {
-			throw ApiError.forbidden({
-				operation: "update",
-				resource: collectionName,
-				reason: `Cannot write field '${fieldName}': access denied`,
-				fieldPath: fieldName,
-			});
-		}
-	}
+	await validateFieldPathWriteAccess({
+		data,
+		fieldAccess,
+		context,
+		options,
+		collectionName,
+		operation,
+		existingRow,
+	});
 }
 
 /**

--- a/packages/questpie/src/server/global/crud/global-crud-generator.ts
+++ b/packages/questpie/src/server/global/crud/global-crud-generator.ts
@@ -637,33 +637,10 @@ export class GlobalCRUDGenerator<TState extends GlobalBuilderState> {
 				: normalized;
 			const isScoped = this.state.options.scoped !== undefined;
 			const scopeId = isScoped ? this.resolveScopeId(normalized) : undefined;
-			const existing = await this.getCurrentRow(db, normalized);
-
-			const canUpdate = await this.enforceAccessControl(
-				"update",
-				normalized,
-				existing,
-				data,
-			);
-			if (!canUpdate)
-				throw ApiError.forbidden({
-					operation: "update",
-					resource: this.state.name,
-					reason: "User does not have permission to update global settings",
-				});
-
-			await this.executeHooks(
-				this.state.hooks?.beforeUpdate,
-				this.createHookContext({
-					data: existing,
-					input: data,
-					context: normalized,
-					db,
-				}),
-			);
+			let existing = await this.getCurrentRow(db, normalized);
 
 			// Separate nested relation operations from regular fields
-			let { regularFields, nestedRelations } =
+			let { regularFields: baseRegularFields, nestedRelations } =
 				this.separateNestedRelationsInternal(data);
 
 			// Decode any pre-stringified jsonb values before any hook or write
@@ -671,45 +648,84 @@ export class GlobalCRUDGenerator<TState extends GlobalBuilderState> {
 			// caller (legacy seed, RPC, etc.) passes an already-encoded JSON
 			// string for a jsonb column, double-encoding stores a jsonb string
 			// instead of the intended array/object.
-			regularFields = normalizeJsonbInput(
-				regularFields,
+			baseRegularFields = normalizeJsonbInput(
+				baseRegularFields,
 				this.state.fieldDefinitions,
 			);
 
-			// Validate field-level write access
-			await this.validateFieldWriteAccess(
-				regularFields,
-				normalized,
-				existing ? "update" : "create",
-				existing,
-			);
+			const prepareWrite = async (
+				currentExisting: any,
+				writeDb: any,
+			): Promise<Record<string, unknown>> => {
+				const canUpdate = await this.enforceAccessControl(
+					"update",
+					normalized,
+					currentExisting,
+					data,
+				);
+				if (!canUpdate) {
+					throw ApiError.forbidden({
+						operation: "update",
+						resource: this.state.name,
+						reason: "User does not have permission to update global settings",
+					});
+				}
 
-			regularFields = await this.runFieldInputHooks(
-				regularFields,
-				existing ? "update" : "create",
-				normalized,
-				db,
-				existing,
-			);
+				await this.executeHooks(
+					this.state.hooks?.beforeUpdate,
+					this.createHookContext({
+						data: currentExisting,
+						input: data,
+						context: normalized,
+						db: writeDb,
+					}),
+				);
 
-			await this.executeHooksWithGlobal(
-				"beforeChange",
-				this.state.hooks?.beforeChange,
-				this.createHookContext({
-					data: existing,
-					input: regularFields,
-					context: normalized,
-					db,
-				}),
-			);
+				const operation = currentExisting ? "update" : "create";
 
-			const updatedRecord = await withTransaction(db, async (tx: any) => {
+				// Validate field-level write access after any missing-row lock
+				// re-check, so a racing updater cannot pass create rules and then
+				// update a row that another request inserted first.
+				await this.validateFieldWriteAccess(
+					baseRegularFields,
+					normalized,
+					operation,
+					currentExisting,
+				);
+
+				const preparedFields = await this.runFieldInputHooks(
+					baseRegularFields,
+					operation,
+					normalized,
+					writeDb,
+					currentExisting,
+				);
+
+				await this.executeHooksWithGlobal(
+					"beforeChange",
+					this.state.hooks?.beforeChange,
+					this.createHookContext({
+						data: currentExisting,
+						input: preparedFields,
+						context: normalized,
+						db: writeDb,
+					}),
+				);
+
+				return preparedFields;
+			};
+
+			const writeRecord = async (
+				tx: any,
+				currentExisting: any,
+				preparedFields: Record<string, unknown>,
+			) => {
 				const { localized, nonLocalized } =
-					this.splitLocalizedFields(regularFields);
+					this.splitLocalizedFields(preparedFields);
 
-				let updatedId = existing?.id;
+				let updatedId = currentExisting?.id;
 
-				if (existing) {
+				if (currentExisting) {
 					if (Object.keys(nonLocalized).length > 0) {
 						await tx
 							.update(this.table)
@@ -719,7 +735,7 @@ export class GlobalCRUDGenerator<TState extends GlobalBuilderState> {
 									? { updatedAt: new Date() }
 									: {}),
 							})
-							.where(eq((this.table as any).id, existing.id));
+							.where(eq((this.table as any).id, currentExisting.id));
 					}
 				} else {
 					// Include scope_id when creating new record for scoped globals
@@ -806,7 +822,7 @@ export class GlobalCRUDGenerator<TState extends GlobalBuilderState> {
 				await this.createVersion(
 					tx,
 					baseRecord,
-					existing ? "update" : "create",
+					currentExisting ? "update" : "create",
 					workflowContext,
 				);
 
@@ -831,6 +847,19 @@ export class GlobalCRUDGenerator<TState extends GlobalBuilderState> {
 				);
 
 				return updatedRecord;
+			};
+
+			const updatedRecord = await withTransaction(db, async (tx: any) => {
+				if (!existing) {
+					// Serialize concurrent update auto-creates the same way get()
+					// does: take the lock first, then re-check inside the locked
+					// transaction before deciding between INSERT and UPDATE.
+					await this.acquireAutoCreateLock(tx);
+					existing = await this.getCurrentRow(tx, normalized);
+				}
+
+				const preparedFields = await prepareWrite(existing, tx);
+				return writeRecord(tx, existing, preparedFields);
 			});
 
 			// Resolve relations if requested

--- a/packages/questpie/src/server/modules/core/integrated/kv/adapters/redis.ts
+++ b/packages/questpie/src/server/modules/core/integrated/kv/adapters/redis.ts
@@ -43,6 +43,13 @@ export interface RedisKVAdapterOptions {
 	 * @default 100
 	 */
 	scanCount?: number;
+	/**
+	 * Allow clear() to call Redis FLUSHDB when no keyPrefix is configured.
+	 * Disabled by default so a shared Redis database is not wiped by accident.
+	 *
+	 * @default false
+	 */
+	allowFlushDb?: boolean;
 }
 
 /**
@@ -54,12 +61,14 @@ export class RedisKVAdapter implements KVAdapter {
 	private readonly keyPrefix: string;
 	private readonly tagIndexPrefix: string;
 	private readonly scanCount: number;
+	private readonly allowFlushDb: boolean;
 
 	constructor(options: RedisKVAdapterOptions) {
 		this.clientInput = options.client;
 		this.keyPrefix = options.keyPrefix ?? "";
 		this.tagIndexPrefix = options.tagIndexPrefix ?? "__questpie_tag:";
 		this.scanCount = options.scanCount ?? 100;
+		this.allowFlushDb = options.allowFlushDb === true;
 	}
 
 	async get<T = unknown>(key: string): Promise<T | null> {
@@ -121,7 +130,7 @@ export class RedisKVAdapter implements KVAdapter {
 
 	async clear(): Promise<void> {
 		const client = await this.getClient();
-		if (!this.keyPrefix && client.flushDb) {
+		if (!this.keyPrefix && this.allowFlushDb && client.flushDb) {
 			await client.flushDb();
 			return;
 		}

--- a/packages/questpie/src/server/modules/core/integrated/search/adapters/postgres.ts
+++ b/packages/questpie/src/server/modules/core/integrated/search/adapters/postgres.ts
@@ -51,6 +51,18 @@ export interface PostgresSearchAdapterOptions {
 	ftsWeight?: number;
 }
 
+function buildPrefixTsQuery(query: string): string | null {
+	const words = query
+		.replace(/[^\p{L}\p{N}_]+/gu, " ")
+		.trim()
+		.split(/\s+/)
+		.filter(Boolean);
+
+	if (words.length === 0) return null;
+
+	return words.map((word) => `${word}:*`).join(" & ");
+}
+
 // ============================================================================
 // Adapter Implementation
 // ============================================================================
@@ -230,15 +242,8 @@ export class PostgresSearchAdapter implements SearchAdapter {
 		}
 
 		// Build query condition (for non-empty queries)
-		const hasQuery = query.trim().length > 0;
-		const prefixQuery = hasQuery
-			? query
-					.trim()
-					.split(/\s+/)
-					.filter(Boolean)
-					.map((word) => `${word}:*`)
-					.join(" & ")
-			: null;
+		const prefixQuery = buildPrefixTsQuery(query);
+		const hasQuery = prefixQuery !== null;
 		const tsQuery = prefixQuery
 			? sql`to_tsquery('simple', ${prefixQuery})`
 			: null;

--- a/packages/questpie/test/collection/field-access.test.ts
+++ b/packages/questpie/test/collection/field-access.test.ts
@@ -66,6 +66,37 @@ const writeResponseDocs = collection("write_response_docs")
 		},
 	});
 
+const profileDocs = collection("profile_docs")
+	.fields(({ f }) => ({
+		title: f.text(255).required(),
+		settings: f.object({
+			publicNote: f.text(255),
+			secret: f.text(255),
+		}),
+		auditEntries: f
+			.object({
+				label: f.text(255),
+				secret: f.text(255),
+			})
+			.array(),
+	}))
+	.access({
+		read: true,
+		create: true,
+		update: true,
+		delete: true,
+		fields: {
+			"settings.secret": {
+				create: false,
+				update: false,
+			},
+			"auditEntries.secret": {
+				create: false,
+				update: false,
+			},
+		},
+	});
+
 describe("field-level access control", () => {
 	let setup: Awaited<ReturnType<typeof buildMockApp>>;
 
@@ -75,6 +106,7 @@ describe("field-level access control", () => {
 				users,
 				public_posts: publicPosts,
 				write_response_docs: writeResponseDocs,
+				profile_docs: profileDocs,
 			},
 		});
 		await runTestDbMigrations(setup.app);
@@ -379,6 +411,120 @@ describe("field-level access control", () => {
 
 			expect(created.ssn).toBe("999-88-7777");
 			expect(created.salary).toBe("250000");
+		});
+
+		it("nested write access validation on create: throws if restricted nested field present", async () => {
+			const userCtx = createTestContext({
+				accessMode: "user",
+				role: "user",
+			});
+
+			await expect(
+				setup.app.collections.profile_docs.create(
+					{
+						id: crypto.randomUUID(),
+						title: "Profile",
+						settings: {
+							publicNote: "Visible",
+							secret: "Hidden",
+						},
+					},
+					userCtx,
+				),
+			).rejects.toThrow("Cannot write field 'settings.secret': access denied");
+		});
+
+		it("nested write access validation on update: throws if restricted nested field changes", async () => {
+			const userCtx = createTestContext({
+				accessMode: "user",
+				role: "user",
+			});
+			const systemCtx = createTestContext({ accessMode: "system" });
+
+			const created = await setup.app.collections.profile_docs.create(
+				{
+					id: crypto.randomUUID(),
+					title: "Profile",
+					settings: {
+						publicNote: "Visible",
+						secret: "Original",
+					},
+				},
+				systemCtx,
+			);
+
+			await expect(
+				setup.app.collections.profile_docs.updateById(
+					{
+						id: created.id,
+						data: {
+							settings: {
+								publicNote: "Still visible",
+								secret: "Changed",
+							},
+						},
+					},
+					userCtx,
+				),
+			).rejects.toThrow("Cannot write field 'settings.secret': access denied");
+		});
+
+		it("nested array write access validation: allows unchanged restricted fields but denies changes", async () => {
+			const userCtx = createTestContext({
+				accessMode: "user",
+				role: "user",
+			});
+			const systemCtx = createTestContext({ accessMode: "system" });
+
+			const created = await setup.app.collections.profile_docs.create(
+				{
+					id: crypto.randomUUID(),
+					title: "Profile",
+					auditEntries: [
+						{
+							label: "Visible",
+							secret: "Original",
+						},
+					],
+				},
+				systemCtx,
+			);
+
+			const unchanged = await setup.app.collections.profile_docs.updateById(
+				{
+					id: created.id,
+					data: {
+						auditEntries: [
+							{
+								label: "Still visible",
+								secret: "Original",
+							},
+						],
+					},
+				},
+				userCtx,
+			);
+
+			expect(unchanged.auditEntries?.[0]?.label).toBe("Still visible");
+
+			await expect(
+				setup.app.collections.profile_docs.updateById(
+					{
+						id: created.id,
+						data: {
+							auditEntries: [
+								{
+									label: "Still visible",
+									secret: "Changed",
+								},
+							],
+						},
+					},
+					userCtx,
+				),
+			).rejects.toThrow(
+				"Cannot write field 'auditEntries.secret': access denied",
+			);
 		});
 
 		it("partial updates: can update allowed fields while restricted fields exist on record", async () => {

--- a/packages/questpie/test/global/global-auto-create-race.test.ts
+++ b/packages/questpie/test/global/global-auto-create-race.test.ts
@@ -10,8 +10,9 @@
  * `packages/questpie/src/server/global/crud/global-crud-generator.ts`.
  */
 
-import { sql } from "drizzle-orm";
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+
+import { sql } from "drizzle-orm";
 
 import { global } from "../../src/exports/index.js";
 import { buildMockApp } from "../utils/mocks/mock-app-builder";
@@ -48,10 +49,30 @@ describe("globals auto-create race condition", () => {
 		const ctx = createTestContext({ accessMode: "system" });
 
 		const results = await Promise.all(
-			Array.from({ length: 20 }, () => app.globals.header_settings.get({}, ctx)),
+			Array.from({ length: 20 }, () =>
+				app.globals.header_settings.get({}, ctx),
+			),
 		);
 
 		// All callers see the auto-created row
+		expect(results.every((r) => r != null)).toBe(true);
+
+		const countResult = await app.db.execute(
+			sql`SELECT COUNT(*)::int AS c FROM header_settings`,
+		);
+		const row = (countResult.rows ?? countResult)[0];
+		expect(row.c).toBe(1);
+	});
+
+	it("produces exactly one row under N concurrent update() calls (plain branch)", async () => {
+		const ctx = createTestContext({ accessMode: "system" });
+
+		const results = await Promise.all(
+			Array.from({ length: 20 }, (_, index) =>
+				app.globals.header_settings.update({ title: `Header ${index}` }, ctx),
+			),
+		);
+
 		expect(results.every((r) => r != null)).toBe(true);
 
 		const countResult = await app.db.execute(

--- a/packages/questpie/test/search/search-adapter.test.ts
+++ b/packages/questpie/test/search/search-adapter.test.ts
@@ -219,6 +219,25 @@ describe("PostgresSearchAdapter", () => {
 			expect(response.results[0].recordId).toBe("post-1");
 		});
 
+		it("should ignore tsquery operator characters in user search input", async () => {
+			await setup.app.search.index({
+				collection: "posts",
+				recordId: "post-1",
+				locale: "en",
+				title: "Hello World",
+				content: "This is my first blog post about programming",
+				metadata: { status: "published" },
+			});
+
+			const response = await setup.app.search.search({
+				query: "Hello:* '",
+				locale: "en",
+			});
+
+			expect(response.results.length).toBe(1);
+			expect(response.results[0].recordId).toBe("post-1");
+		});
+
 		it("should search with FTS", async () => {
 			// Index multiple records
 			await setup.app.search.index({

--- a/packages/questpie/test/units/kv-adapter.test.ts
+++ b/packages/questpie/test/units/kv-adapter.test.ts
@@ -405,6 +405,20 @@ describe("RedisKVAdapter", () => {
 
 			expect(await adapter.get<string>("key1")).toBeNull();
 			expect(await adapter.get<string>("key2")).toBeNull();
+			expect(mockRedis.flushDbCalls).toBe(0);
+		});
+
+		test("should only call flushDb when explicitly allowed", async () => {
+			adapter = new RedisKVAdapter({
+				client: mockRedis,
+				allowFlushDb: true,
+			});
+
+			await adapter.set("key1", "value1");
+			await adapter.clear();
+
+			expect(await adapter.get<string>("key1")).toBeNull();
+			expect(mockRedis.flushDbCalls).toBe(1);
 		});
 
 		test("should handle objects as values", async () => {
@@ -630,6 +644,7 @@ class MockRedis {
 	store = new Map<string, string>();
 	sets = new Map<string, Set<string>>();
 	expirations = new Map<string, number>();
+	flushDbCalls = 0;
 
 	async get(key: string): Promise<string | null> {
 		return this.store.get(key) ?? null;
@@ -661,6 +676,7 @@ class MockRedis {
 	}
 
 	async flushDb(): Promise<"OK"> {
+		this.flushDbCalls += 1;
 		this.store.clear();
 		this.sets.clear();
 		this.expirations.clear();


### PR DESCRIPTION
## Summary

- Harden global update auto-create with transaction/advisory-lock recheck and recursive nested field write access validation.
- Propagate user-mode request context through admin custom actions and dashboard widget loaders.
- Apply server reactive field state on the admin frontend for hidden, read-only, and disabled fields in collection/global forms.
- Harden Redis KV clearing and Postgres search query sanitization.
- Document widget loaders, block custom loaders/prefetch, admin actions, and reactive field behavior.

## Verification

- `QUESTPIE_MIGRATIONS_SILENT=1 bun test packages/questpie/test/collection/field-access.test.ts packages/questpie/test/global/global-auto-create-race.test.ts packages/questpie/test/units/kv-adapter.test.ts packages/questpie/test/search/search-adapter.test.ts packages/admin/test/client/reactive-field-state.test.ts packages/admin/test/server/execute-action-runtime-shape.test.ts packages/admin/test/server/widget-data.test.ts packages/admin/test/server/admin-rpc-auth.test.ts`
- `bun run check-types`

## Notes

- Updated the existing security changeset only; no new changeset was added.
- Agent-board still has two open follow-up tasks: block loader runtime hardening, and remaining realtime/OpenAPI/TanStack exposure work. Search+KV subitems are captured as partial completion on that task.
