### PR TITLE
[codex] fix generated context initialization

### DIFF
--- a/packages/questpie/src/cli/codegen/factory-template.ts
+++ b/packages/questpie/src/cli/codegen/factory-template.ts
@@ -139,7 +139,7 @@ export function generateFactoryTemplate(
 	if (hasExtensions || hasFieldExtensions) {
 		const fieldImport = hasFieldExtensions ? ", Field" : "";
 		lines.push(
-			`import { CollectionBuilder, GlobalBuilder, wrapBuilderWithExtensions, builtinFields, type EmptyCollectionState, type EmptyGlobalState, type BuiltinFields${fieldImport} } from "questpie/builders";`,
+			`import { CollectionBuilder, GlobalBuilder, wrapBuilderWithExtensions, builtinFields, type EmptyCollectionState, type EmptyGlobalState, type BuiltinFields, type CollectionBuilderState, type GlobalBuilderState, type FieldState${fieldImport} } from "questpie/builders";`,
 		);
 	} else {
 		lines.push(
@@ -321,16 +321,19 @@ export function generateFactoryTemplate(
 
 		const placeholderMap = buildPlaceholderMap(registryCategories);
 
-		// Builder interface augmentations — keep declare module "questpie" for class merging
+		// Builder interface augmentations — generated factories import builders from
+		// questpie/builders, so augment that public subpath instead of the root barrel.
 		if (
 			collExtensions.size > 0 ||
 			globalExtensions.size > 0 ||
 			fieldExtensions.size > 0
 		) {
-			lines.push('declare module "questpie" {');
+			lines.push('declare module "questpie/builders" {');
 
 			if (collExtensions.size > 0) {
-				lines.push("\tinterface CollectionBuilder<TState> {");
+				lines.push(
+					"\tinterface CollectionBuilder<TState$1 extends CollectionBuilderState> {",
+				);
 				for (const [name, ext] of collExtensions) {
 					const paramName = ext.isCallback ? "configFn" : "config";
 					let paramType = ext.configType ?? "any";
@@ -339,15 +342,18 @@ export function generateFactoryTemplate(
 						hasModules,
 						placeholderMap,
 					);
+					paramType = paramType.replace(/\bTState\b/g, "TState$1");
 					lines.push(
-						`\t\t${name}(${paramName}: ${paramType}): CollectionBuilder<TState>;`,
+						`\t\t${name}(${paramName}: ${paramType}): CollectionBuilder<TState$1>;`,
 					);
 				}
 				lines.push("\t}");
 			}
 
 			if (globalExtensions.size > 0) {
-				lines.push("\tinterface GlobalBuilder<TState> {");
+				lines.push(
+					"\tinterface GlobalBuilder<TState extends GlobalBuilderState> {",
+				);
 				for (const [name, ext] of globalExtensions) {
 					const paramName = ext.isCallback ? "configFn" : "config";
 					let paramType = ext.configType ?? "any";
@@ -364,7 +370,9 @@ export function generateFactoryTemplate(
 			}
 
 			if (fieldExtensions.size > 0) {
-				lines.push("\tinterface Field<TState> {");
+				lines.push(
+					"\tinterface Field<TState extends FieldState = FieldState> {",
+				);
 				for (const [name, ext] of fieldExtensions) {
 					const paramName = ext.isCallback ? "configFn" : "config";
 					let paramType = ext.configType ?? "any";

--- a/packages/questpie/src/cli/codegen/template.ts
+++ b/packages/questpie/src/cli/codegen/template.ts
@@ -792,7 +792,19 @@ export function generateTemplate(options: TemplateOptions): string {
 	lines.push(" * const posts = await ctx.collections.posts.find({});");
 	lines.push(" * ```");
 	lines.push(" */");
-	lines.push("export const createContext = createContextFactory(app);");
+	lines.push("export async function createContext(");
+	lines.push(
+		"\toptions?: Parameters<ReturnType<typeof createContextFactory>>[0],",
+	);
+	lines.push(") {");
+	lines.push("\twhile (!_appPromise) {");
+	lines.push("\t\tawait new Promise((resolve) => setTimeout(resolve, 0));");
+	lines.push("\t}");
+	lines.push("");
+	lines.push(
+		"\treturn createContextFactory((await _appPromise) as _AppQuestpie)(options);",
+	);
+	lines.push("}");
 	lines.push("");
 
 	// Factories are available via #questpie/factories (separate entry to avoid circular deps)
@@ -835,7 +847,9 @@ function emitNewArchitectureRuntime(
 	}
 	const coreSingles = getCategorizedSingles(discovered.singles, allDecls);
 
-	lines.push("export const app = await createApp(");
+	lines.push("var _appPromise: Promise<unknown> | undefined;");
+	lines.push("");
+	lines.push("_appPromise = createApp(");
 	lines.push("\t({");
 
 	// Modules — preserve the concrete exported module types directly.
@@ -914,7 +928,11 @@ function emitNewArchitectureRuntime(
 
 	lines.push("\t}) satisfies AppDefinition,");
 	lines.push("\t_runtime,");
-	lines.push(") as unknown as _AppQuestpie;");
+	lines.push(");");
+	lines.push("");
+	lines.push(
+		"export const app = (await _appPromise) as unknown as _AppQuestpie;",
+	);
 	lines.push("");
 }
 

--- a/packages/questpie/test/codegen/template.test.ts
+++ b/packages/questpie/test/codegen/template.test.ts
@@ -18,6 +18,7 @@ import {
 	resolveTargetGraph,
 	runAllTargets,
 } from "../../src/cli/codegen/index.js";
+import { generateFactoryTemplate } from "../../src/cli/codegen/factory-template.js";
 import { generateTemplate } from "../../src/cli/codegen/template.js";
 import type {
 	CategoryDeclaration,
@@ -212,7 +213,10 @@ describe("generateTemplate — minimal (modules.ts only)", () => {
 	});
 
 	it("emits createApp call with modules", () => {
-		expect(code).toContain("export const app = await createApp(");
+		expect(code).toContain("_appPromise = createApp(");
+		expect(code).toContain(
+			"export const app = (await _appPromise) as unknown as _AppQuestpie;",
+		);
 		expect(code).toContain("modules: _modules,");
 		expect(code).not.toContain("ModuleDefinition[]");
 	});
@@ -284,8 +288,9 @@ describe("generateTemplate — minimal (modules.ts only)", () => {
 	});
 
 	it("emits createContext helper", () => {
+		expect(code).toContain("export async function createContext(");
 		expect(code).toContain(
-			"export const createContext = createContextFactory(app);",
+			"return createContextFactory((await _appPromise) as _AppQuestpie)(options);",
 		);
 	});
 
@@ -299,6 +304,83 @@ describe("generateTemplate — minimal (modules.ts only)", () => {
 
 	it("does not emit seeds section when no seeds", () => {
 		expect(code).not.toContain("seeds:");
+	});
+});
+
+describe("generateFactoryTemplate — builder module augmentation", () => {
+	it("augments questpie/builders with matching builder state constraints", () => {
+		const target = serverTarget([
+			{
+				name: "test-builder-extensions",
+				targets: {
+					server: {
+						root: ".",
+						outputFile: "index.ts",
+						registries: {
+							collectionExtensions: {
+								admin: {
+									stateKey: "admin",
+									configType: "AdminCollectionConfig<TState>",
+									imports: [
+										{
+											name: "AdminCollectionConfig",
+											from: "@questpie/admin/server",
+										},
+									],
+								},
+							},
+							globalExtensions: {
+								admin: {
+									stateKey: "admin",
+									configType: "AdminGlobalConfig<TState>",
+									imports: [
+										{
+											name: "AdminGlobalConfig",
+											from: "@questpie/admin/server",
+										},
+									],
+								},
+							},
+							fieldExtensions: {
+								admin: {
+									stateKey: "admin",
+									configType: "AdminFieldConfig<TState>",
+									imports: [
+										{
+											name: "AdminFieldConfig",
+											from: "@questpie/admin/server",
+										},
+									],
+								},
+							},
+						},
+					},
+				},
+			},
+		]);
+
+		const code = generateFactoryTemplate({
+			target,
+			hasModules: true,
+		});
+
+		expect(code).toContain('declare module "questpie/builders" {');
+		expect(code).not.toContain('declare module "questpie" {');
+		expect(code).toContain("type CollectionBuilderState");
+		expect(code).toContain("type GlobalBuilderState");
+		expect(code).toContain("type FieldState");
+		expect(code).toContain(
+			"interface CollectionBuilder<TState$1 extends CollectionBuilderState>",
+		);
+		expect(code).toContain(
+			"admin(config: AdminCollectionConfig<TState$1>): CollectionBuilder<TState$1>;",
+		);
+		expect(code).toContain(
+			"interface GlobalBuilder<TState extends GlobalBuilderState>",
+		);
+		expect(code).toContain(
+			"interface Field<TState extends FieldState = FieldState>",
+		);
 	});
 });
 


### PR DESCRIPTION
## Summary

Fixes generated QUESTPIE server code so consumers do not need to edit or post-process `.generated/*` output.

- Generate `createContext` as an async function backed by `_appPromise` instead of binding directly to `app` during module initialization.
- Generate builder extension module augmentation against `questpie/builders`, matching the public import path used by generated factories.
- Preserve builder state constraints for collection, global, and field extension interfaces.
- Add regression coverage for the generated runtime output and builder augmentation shape.

## Root Cause

Generated test/runtime imports could observe the generated module while `app` was still in top-level-await initialization, causing Bun/ESM TDZ failures around `createContextFactory(app)`. Generated factory augmentations also targeted the root `questpie` barrel and used unconstrained builder state parameters, which did not match the public `questpie/builders` declarations used by generated factories.

## Validation

- `bun test packages/questpie/test/codegen/template.test.ts` -> 72 pass
- `bun run check-types --filter=questpie` -> pass
- `git diff --check` -> pass