### PR TITLE
Fix minimal QuestPie app scaffolding

### DIFF
--- a/.changeset/fix-minimal-app-scaffolding.md
+++ b/.changeset/fix-minimal-app-scaffolding.md
@@ -1,0 +1,6 @@
+---
+"questpie": patch
+"@questpie/hono": patch
+---
+
+Fix minimal app scaffolding type output by collapsing empty module intersections, guarding workflow service context access, importing generated zod types through QuestPie public types, and accepting generated app instances in the Hono adapter.

--- a/bun.lock
+++ b/bun.lock
@@ -607,6 +607,7 @@
     },
   },
   "overrides": {
+    "shell-quote": "^1.8.4",
     "vitest": "^3.2.6",
   },
   "packages": {
@@ -3220,7 +3221,7 @@
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
-    "shell-quote": ["shell-quote@1.8.3", "", {}, "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw=="],
+    "shell-quote": ["shell-quote@1.8.4", "", {}, "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ=="],
 
     "shiki": ["shiki@4.0.2", "", { "dependencies": { "@shikijs/core": "4.0.2", "@shikijs/engine-javascript": "4.0.2", "@shikijs/engine-oniguruma": "4.0.2", "@shikijs/langs": "4.0.2", "@shikijs/themes": "4.0.2", "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ=="],
 

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
 		"typescript": "5.9.2"
 	},
 	"overrides": {
+		"shell-quote": "^1.8.4",
 		"vitest": "^3.2.6"
 	},
 	"engines": {

--- a/packages/hono/README.md
+++ b/packages/hono/README.md
@@ -13,12 +13,15 @@ bun add @questpie/hono questpie hono
 ```ts
 import { Hono } from "hono";
 import { questpieHono } from "@questpie/hono/server";
-import { app } from "./questpie";
+import { app as questpieApp } from "./questpie";
 
-const app = new Hono().route("/", questpieHono(app, { basePath: "/api" }));
+const server = new Hono().route(
+	"/",
+	questpieHono(questpieApp, { basePath: "/api" }),
+);
 
-export default { port: 3000, fetch: app.fetch };
-export type AppType = typeof app;
+export default { port: 3000, fetch: server.fetch };
+export type AppType = typeof server;
 ```
 
 ## Client Setup

--- a/packages/hono/src/server.ts
+++ b/packages/hono/src/server.ts
@@ -12,12 +12,11 @@ import {
 /**
  * Variables stored in Hono context
  */
-export type QuestpieVariables<TQuestpie extends Questpie<any> = Questpie<any>> =
-	{
-		app: TQuestpie;
-		appContext: RequestContext;
-		user: any;
-	};
+export type QuestpieVariables<TQuestpie = Questpie<any>> = {
+	app: TQuestpie;
+	appContext: RequestContext;
+	user: any;
+};
 
 /**
  * Hono adapter configuration
@@ -31,16 +30,16 @@ export type HonoAdapterConfig = Pick<AdapterConfig, "requestLogging"> & {
 	basePath?: string;
 };
 
-export function questpieMiddleware<TQuestpie extends Questpie<any>>(
-	app: TQuestpie,
-) {
+export function questpieMiddleware<TQuestpie = Questpie<any>>(app: TQuestpie) {
 	return createMiddleware<{
 		Variables: QuestpieVariables<TQuestpie>;
 	}>(async (c, next) => {
 		c.set("app", app);
-		const adapterContext = await createAdapterContext(app, c.req.raw, {
-			accessMode: "user",
-		});
+		const adapterContext = await createAdapterContext(
+			app as Questpie<any>,
+			c.req.raw,
+			{ accessMode: "user" },
+		);
 
 		c.set("user", adapterContext.session?.user ?? null);
 		c.set("appContext", adapterContext.appContext);
@@ -55,11 +54,11 @@ export function questpieMiddleware<TQuestpie extends Questpie<any>>(
  * @example
  * ```ts
  * import { Hono } from 'hono'
- * import { questpieHono } from '@questpie/hono'
- * import { app } from './app'
+ * import { questpieHono } from '@questpie/hono/server'
+ * import { app as questpieApp } from './app'
  *
  * const server = new Hono()
- * server.route('/', questpieHono(app))
+ * server.route('/', questpieHono(questpieApp))
  *
  * export default server
  * ```
@@ -67,21 +66,17 @@ export function questpieMiddleware<TQuestpie extends Questpie<any>>(
  * @example
  * ```ts
  * // With custom config
- * server.route('/', questpieHono(app, {
- *   basePath: '/api',
- *   cors: {
- *     origin: 'https://example.com',
- *     credentials: true
- *   }
+ * server.route('/', questpieHono(questpieApp, {
+ *   basePath: '/api'
  * }))
  * ```
  */
-export function questpieHono<TQuestpie extends Questpie<any>>(
+export function questpieHono<TQuestpie = Questpie<any>>(
 	app: TQuestpie,
 	config: HonoAdapterConfig = {},
 ) {
 	const basePath = config.basePath || "/";
-	const handler = createFetchHandler(app, {
+	const handler = createFetchHandler(app as Questpie<any>, {
 		basePath,
 		accessMode: "user",
 		requestLogging: config.requestLogging,

--- a/packages/hono/test/server-types.test.ts
+++ b/packages/hono/test/server-types.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+	questpieHono,
+	questpieMiddleware,
+	type QuestpieVariables,
+} from "../src/server.js";
+
+const generatedApp = {
+	config: {
+		routes: {},
+		logger: {},
+	},
+	collections: {},
+	globals: {},
+} as const;
+
+describe("hono adapter public types", () => {
+	it("accepts generated app-like types at the adapter boundary", () => {
+		const variablesApp: QuestpieVariables<typeof generatedApp>["app"] =
+			generatedApp;
+
+		expect(questpieHono(generatedApp, { basePath: "/api" })).toBeDefined();
+		expect(questpieMiddleware(generatedApp)).toBeDefined();
+		expect(variablesApp).toBe(generatedApp);
+	});
+});

--- a/packages/questpie/src/cli/codegen/template.ts
+++ b/packages/questpie/src/cli/codegen/template.ts
@@ -96,9 +96,8 @@ export function generateTemplate(options: TemplateOptions): string {
 	// Import createApp + types
 	lines.push('import { createApp, createContextFactory } from "questpie/app";');
 	lines.push(
-		'import type { AnyCollectionOrBuilder, AnyGlobalOrBuilder, AppDefinition, CollectionAPI, CollectionSelect, DrizzleClientFromQuestpieConfig, InferContextExtensionsFromAppConfig, InferSessionFromAuthConfig, MailerService, Questpie, QuestpieConfig, QueueClient, QueueJobType, RouteParamsFromKey, RouteWithParams, TablesFromConfig } from "questpie/types";',
+		'import type { AnyCollectionOrBuilder, AnyGlobalOrBuilder, AppDefinition, CollectionAPI, CollectionSelect, DrizzleClientFromQuestpieConfig, InferContextExtensionsFromAppConfig, InferSessionFromAuthConfig, MailerService, Questpie, QuestpieConfig, QueueClient, QueueJobType, RouteParamsFromKey, RouteWithParams, TablesFromConfig, z } from "questpie/types";',
 	);
-	lines.push('import type { z } from "zod";');
 	lines.push("");
 
 	// Import runtime config
@@ -222,7 +221,7 @@ export function generateTemplate(options: TemplateOptions): string {
 		"type _MPRaw<K extends string> = UnionToIntersection<_Module extends infer M ? M extends Record<K, infer V> ? V : never : never>;",
 	);
 	lines.push(
-		"type _MP<K extends string> = [_MPRaw<K>] extends [never] ? {} : _MPRaw<K>;",
+		"type _MP<K extends string> = [_MPRaw<K>] extends [never] ? {} : unknown extends _MPRaw<K> ? {} : _MPRaw<K>;",
 	);
 	lines.push('type _ModuleConfig = _MP<"config">;');
 	const appConfigFile = discovered.singles.get("appConfig");
@@ -663,10 +662,13 @@ export function generateTemplate(options: TemplateOptions): string {
 				);
 			}
 			lines.push("");
-			if (hasServices && (name === "WorkflowContext" || name === "JobHandlerContext")) {
+			if (
+				hasServices &&
+				(name === "WorkflowContext" || name === "JobHandlerContext")
+			) {
 				lines.push("			// Top-level services (namespace: null)");
 				lines.push(
-					'			workflows?: "workflows" extends keyof _AppTopLevelServices ? _AppTopLevelServices["workflows"] : never;',
+					"			workflows?: _AppTopLevelServices extends { workflows: infer W } ? W : never;",
 				);
 				lines.push("");
 			}

--- a/packages/questpie/src/exports/types.ts
+++ b/packages/questpie/src/exports/types.ts
@@ -22,6 +22,7 @@ export type {
 	BaseRequestContext,
 	StoredContext,
 } from "#questpie/server/config/context.js";
+export type { z } from "zod";
 export {
 	getContext,
 	runWithContext,

--- a/packages/questpie/test/codegen/template.test.ts
+++ b/packages/questpie/test/codegen/template.test.ts
@@ -13,12 +13,12 @@
  */
 import { describe, expect, it } from "bun:test";
 
+import { generateFactoryTemplate } from "../../src/cli/codegen/factory-template.js";
 import {
 	coreCodegenPlugin,
 	resolveTargetGraph,
 	runAllTargets,
 } from "../../src/cli/codegen/index.js";
-import { generateFactoryTemplate } from "../../src/cli/codegen/factory-template.js";
 import { generateTemplate } from "../../src/cli/codegen/template.js";
 import type {
 	CategoryDeclaration,
@@ -170,6 +170,17 @@ describe("generateTemplate — minimal (modules.ts only)", () => {
 
 	it("imports modules file", () => {
 		expect(code).toContain('import _modules from "../modules"');
+	});
+
+	it("imports zod types through questpie public types", () => {
+		expect(code).toContain('TablesFromConfig, z } from "questpie/types";');
+		expect(code).not.toContain('from "zod"');
+	});
+
+	it("collapses empty module prop intersections to empty objects", () => {
+		expect(code).toContain(
+			"type _MP<K extends string> = [_MPRaw<K>] extends [never] ? {} : unknown extends _MPRaw<K> ? {} : _MPRaw<K>;",
+		);
 	});
 
 	it("emits AppCollections type alias (no user collections)", () => {
@@ -749,6 +760,32 @@ describe("generateTemplate — services", () => {
 		expect(code).toContain("services: _AppDefaultServices;");
 		expect(code).toContain(
 			"interface ServiceCreateContext extends _AppCoreContext {}",
+		);
+	});
+
+	it("guards workflows service access without indexed conditional access", () => {
+		const result = minimalResult();
+		cat(result, "services").set(
+			"stripe",
+			makeFile("stripe", {
+				varName: "_svc_stripe",
+				exportType: "named",
+				namedExportName: "stripe",
+			}),
+		);
+
+		const code = generateTemplate({
+			configImportPath: "../questpie.config",
+			discovered: result,
+			categories: coreCategories(),
+			singletonFactories: coreSingletonFactories(),
+		});
+
+		expect(code).toContain(
+			"workflows?: _AppTopLevelServices extends { workflows: infer W } ? W : never;",
+		);
+		expect(code).not.toContain(
+			'"workflows" extends keyof _AppTopLevelServices ? _AppTopLevelServices["workflows"] : never',
 		);
 	});
 });


### PR DESCRIPTION
## Summary
- fix generated type collapse for empty modules arrays so module props do not degrade to unknown
- guard generated workflows context typing without unsafe indexed conditional access
- import generated zod types through questpie/types instead of requiring a direct zod resolver for generated output
- loosen @questpie/hono adapter generics so generated app-like types can be mounted via questpieHono(app)
- add patch changeset for questpie and @questpie/hono
- add a root shell-quote 1.8.4 override to clear the new GHSA-w7jw-789q-3m8p audit gate failure without snoozing it

## Root Cause / Search
- Empty modules hit UnionToIntersection<never> => unknown, while the generated _MP guard only handled never.
- Generated workflows context indexed _AppTopLevelServices["workflows"] inside a conditional that still trips TS when the key is absent.
- @questpie/hono required TQuestpie extends Questpie<any>, but generated app types intentionally omit internal underscored Questpie members.
- Generated output imported type { z } from zod directly; manual apps without direct zod deps failed before user code.
- Searched existing questpie/questpie issues for these symptoms (empty modules unknown, workflows TS2538, questpieHono Questpie<any>, zod generated dependency); no matching existing issue found.

## Verification
- bun test packages/questpie/test/codegen/template.test.ts
- bun test packages/hono/test/server-types.test.ts
- bun run check-types --filter=questpie
- bun run check-types --filter=@questpie/hono
- bun install --frozen-lockfile
- bun run scripts/audit-gate.ts
- bunx oxfmt --check package.json bun.lock .changeset/fix-minimal-app-scaffolding.md packages/hono/README.md packages/hono/src/server.ts packages/hono/test/server-types.test.ts packages/questpie/src/cli/codegen/template.ts packages/questpie/src/exports/types.ts packages/questpie/test/codegen/template.test.ts
- bun run build --filter=questpie --filter=@questpie/hono

Note: repo-wide format:check and lint currently fail on unrelated pre-existing files, so verification above is scoped to this PR plus focused package build/typecheck/audit.