### PR TITLE
Fix runtimeConfig plugin tuple types

### DIFF
--- a/.changeset/fix-runtime-config-readonly-plugins.md
+++ b/.changeset/fix-runtime-config-readonly-plugins.md
@@ -1,0 +1,5 @@
+---
+"questpie": patch
+---
+
+Allow `runtimeConfig({ plugins: [...] })` results to be passed directly to `createApp` when TypeScript infers the plugins list as a readonly tuple.

--- a/packages/questpie/src/server/config/module-types.ts
+++ b/packages/questpie/src/server/config/module-types.ts
@@ -240,7 +240,7 @@ export interface RuntimeConfig<
 	TStorage extends StorageConfig | undefined = StorageConfig | undefined,
 > {
 	/** Codegen plugins — discover additional file patterns and extend generated output. */
-	plugins?: CodegenPlugin[];
+	plugins?: readonly CodegenPlugin[];
 
 	/** Application URL (required). */
 	app: { url: string };

--- a/packages/questpie/test/types/storage-public-api.test-d.ts
+++ b/packages/questpie/test/types/storage-public-api.test-d.ts
@@ -1,8 +1,9 @@
 import type { Adapter, Files } from "files-sdk";
 import { memory } from "files-sdk/memory";
 
-import { runtimeConfig } from "#questpie/server/config/create-app.js";
+import { createApp, runtimeConfig } from "#questpie/server/config/create-app.js";
 import type {
+	CodegenPlugin,
 	ResolvedRuntimeConfig,
 	RuntimeConfig,
 	RuntimeConfigInput,
@@ -24,6 +25,15 @@ const runtime = runtimeConfig({
 	db: { url: "postgres://localhost/test" },
 	storage: { adapter },
 });
+
+declare const plugin: CodegenPlugin;
+const runtimeWithPlugin = runtimeConfig({
+	app: { url: "http://localhost:3000" },
+	db: { url: "postgres://localhost/test" },
+	plugins: [plugin],
+});
+
+createApp({ modules: [] as const }, runtimeWithPlugin);
 
 const legacyDriverRuntimeConfig = {
 	app: { url: "http://localhost:3000" },


### PR DESCRIPTION
## Summary
- allow runtime config plugin lists inferred as readonly tuples to satisfy createApp runtime config overloads
- add a dts regression covering createApp({ modules }, runtimeConfig({ plugins: [plugin] }))
- add a patch changeset for questpie

## Verification
- bun run --cwd packages/questpie check-types
- bun run --cwd packages/questpie build
- bun run --cwd packages/questpie test (1676 pass, 0 fail)
- Nutrimeals apps/brain: questpie generate passed on 3.5.5; check-types failed on readonly plugins with published 3.5.5; after applying this one-line type fix to installed questpie, check-types passed

## Notes
- Nutrimeals verify:mock is blocked by local DB setup: Postgres on localhost:5432 does not have role questpie.