### PR TITLE
Fix field-level not where operator typing

### DIFF
--- a/.changeset/fix-where-not-operator.md
+++ b/.changeset/fix-where-not-operator.md
@@ -1,0 +1,5 @@
+---
+"questpie": patch
+---
+
+Allow field-level `not` where operators in typed CRUD filters, matching existing runtime support.

--- a/packages/questpie/src/server/collection/crud/types.ts
+++ b/packages/questpie/src/server/collection/crud/types.ts
@@ -68,6 +68,7 @@ export type CRUDContext = RequestContext;
 export interface WhereOperatorsLegacy<T> {
 	eq?: T;
 	ne?: T;
+	not?: T | null;
 	gt?: T extends Date ? Date | string : T extends number | string ? T : never;
 	gte?: T extends Date ? Date | string : T extends number | string ? T : never;
 	lt?: T extends Date ? Date | string : T extends number | string ? T : never;

--- a/packages/questpie/src/server/fields/operators/builtin.ts
+++ b/packages/questpie/src/server/fields/operators/builtin.ts
@@ -25,6 +25,7 @@ import {
 	notLike,
 	sql,
 } from "drizzle-orm";
+import type { AnyPgColumn } from "drizzle-orm/pg-core";
 
 import type { DateInput } from "#questpie/shared/type-utils.js";
 
@@ -32,6 +33,10 @@ import { operator } from "../types.js";
 import type { CollectionWherePlaceholder } from "../types.js";
 import { jsonbPathRef, textArray } from "./jsonb-sql.js";
 import { extendOperatorSet, operatorSet } from "./operator-set.js";
+
+function notEqualOrNotNull<T>(col: AnyPgColumn, value: T | null) {
+	return value === null ? isNotNull(col) : ne(col, value);
+}
 
 // ============================================================================
 // String Operators
@@ -46,6 +51,9 @@ export const stringOps = operatorSet({
 	column: {
 		eq: operator<string, unknown>((col, value) => eq(col, value)),
 		ne: operator<string, unknown>((col, value) => ne(col, value)),
+		not: operator<string | null, unknown>((col, value) =>
+			notEqualOrNotNull(col, value),
+		),
 		in: operator<string[], unknown>((col, values) => inArray(col, values)),
 		notIn: operator<string[], unknown>((col, values) =>
 			notInArray(col, values),
@@ -84,6 +92,9 @@ export const numberOps = operatorSet({
 	column: {
 		eq: operator<number, unknown>((col, value) => eq(col, value)),
 		ne: operator<number, unknown>((col, value) => ne(col, value)),
+		not: operator<number | null, unknown>((col, value) =>
+			notEqualOrNotNull(col, value),
+		),
 		gt: operator<number, unknown>((col, value) => gt(col, value)),
 		gte: operator<number, unknown>((col, value) => gte(col, value)),
 		lt: operator<number, unknown>((col, value) => lt(col, value)),
@@ -113,6 +124,9 @@ export const booleanOps = operatorSet({
 	column: {
 		eq: operator<boolean, unknown>((col, value) => eq(col, value)),
 		ne: operator<boolean, unknown>((col, value) => ne(col, value)),
+		not: operator<boolean | null, unknown>((col, value) =>
+			notEqualOrNotNull(col, value),
+		),
 		isNull: operator<boolean, unknown>((col, value) =>
 			value ? isNull(col) : isNotNull(col),
 		),
@@ -135,6 +149,9 @@ export const dateOps = operatorSet({
 	column: {
 		eq: operator<DateInput, unknown>((col, value) => eq(col, value)),
 		ne: operator<DateInput, unknown>((col, value) => ne(col, value)),
+		not: operator<DateInput | null, unknown>((col, value) =>
+			notEqualOrNotNull(col, value),
+		),
 		gt: operator<DateInput, unknown>((col, value) => gt(col, value)),
 		gte: operator<DateInput, unknown>((col, value) => gte(col, value)),
 		lt: operator<DateInput, unknown>((col, value) => lt(col, value)),
@@ -250,6 +267,9 @@ export const selectSingleOps = operatorSet({
 	column: {
 		eq: operator<string, unknown>((col, value) => eq(col, value)),
 		ne: operator<string, unknown>((col, value) => ne(col, value)),
+		not: operator<string | null, unknown>((col, value) =>
+			notEqualOrNotNull(col, value),
+		),
 		in: operator<string[], unknown>((col, values) => inArray(col, values)),
 		notIn: operator<string[], unknown>((col, values) =>
 			notInArray(col, values),
@@ -436,6 +456,9 @@ export const belongsToOps = operatorSet({
 	column: {
 		eq: operator<string, unknown>((col, value) => eq(col, value)),
 		ne: operator<string, unknown>((col, value) => ne(col, value)),
+		not: operator<string | null, unknown>((col, value) =>
+			notEqualOrNotNull(col, value),
+		),
 		in: operator<string[], unknown>((col, values) => inArray(col, values)),
 		notIn: operator<string[], unknown>((col, values) =>
 			notInArray(col, values),
@@ -547,6 +570,9 @@ export const basicOps = operatorSet({
 	column: {
 		eq: operator<unknown, unknown>((col, value) => eq(col, value)),
 		ne: operator<unknown, unknown>((col, value) => ne(col, value)),
+		not: operator<unknown, unknown>((col, value) =>
+			notEqualOrNotNull(col, value),
+		),
 		in: operator<unknown[], unknown>((col, values) => inArray(col, values)),
 		notIn: operator<unknown[], unknown>((col, values) =>
 			notInArray(col, values),

--- a/packages/questpie/test/collection/collection-queries.test.ts
+++ b/packages/questpie/test/collection/collection-queries.test.ts
@@ -728,6 +728,32 @@ describe("collection query operations", () => {
 			expect(posts.length).toBe(5);
 			expect(posts.every((p: any) => p.status !== "draft")).toBe(true);
 		});
+
+		it("filters with not alias", async () => {
+			const ctx = createTestContext();
+
+			const result = await setup.app.collections.posts.find(
+				{ where: { id: { not: testPosts[0].id } } },
+				ctx,
+			);
+			const posts = result.docs;
+
+			expect(posts.length).toBe(5);
+			expect(posts.some((p: any) => p.id === testPosts[0].id)).toBe(false);
+		});
+
+		it("filters null values with not alias", async () => {
+			const ctx = createTestContext();
+
+			const result = await setup.app.collections.posts.find(
+				{ where: { publishedAt: { not: null } } },
+				ctx,
+			);
+			const posts = result.docs;
+
+			expect(posts.length).toBe(5);
+			expect(posts.every((p: any) => p.publishedAt !== null)).toBe(true);
+		});
 	});
 
 	describe("batch operations", () => {

--- a/packages/questpie/test/fields/v2/builtin.test.ts
+++ b/packages/questpie/test/fields/v2/builtin.test.ts
@@ -121,6 +121,7 @@ describe("email()", () => {
 
 	it("has email-specific operators (domain)", () => {
 		const ops = email().getOperators();
+		expect(ops.column.not).toBeDefined();
 		expect(ops.column.domain).toBeDefined();
 		expect(ops.column.domainIn).toBeDefined();
 	});
@@ -145,6 +146,7 @@ describe("url()", () => {
 
 	it("has url-specific operators (host, protocol)", () => {
 		const ops = url().getOperators();
+		expect(ops.column.not).toBeDefined();
 		expect(ops.column.host).toBeDefined();
 		expect(ops.column.hostIn).toBeDefined();
 		expect(ops.column.protocol).toBeDefined();
@@ -563,15 +565,15 @@ describe("Cross-cutting field behavior", () => {
 	});
 
 	it("all fields produce operators", () => {
-		expect(text().getOperators().column).toBeDefined();
-		expect(number().getOperators().column).toBeDefined();
-		expect(boolean().getOperators().column).toBeDefined();
-		expect(date().getOperators().column).toBeDefined();
-		expect(datetime().getOperators().column).toBeDefined();
-		expect(email().getOperators().column).toBeDefined();
-		expect(url().getOperators().column).toBeDefined();
+		expect(text().getOperators().column.not).toBeDefined();
+		expect(number().getOperators().column.not).toBeDefined();
+		expect(boolean().getOperators().column.not).toBeDefined();
+		expect(date().getOperators().column.not).toBeDefined();
+		expect(datetime().getOperators().column.not).toBeDefined();
+		expect(email().getOperators().column.not).toBeDefined();
+		expect(url().getOperators().column.not).toBeDefined();
 		expect(
-			select([{ value: "a", label: { en: "A" } }]).getOperators().column,
+			select([{ value: "a", label: { en: "A" } }]).getOperators().column.not,
 		).toBeDefined();
 	});
 

--- a/packages/questpie/test/fields/v2/relation.test.ts
+++ b/packages/questpie/test/fields/v2/relation.test.ts
@@ -66,10 +66,11 @@ describe("relation() — belongsTo", () => {
 		expect(f._state.relationName).toBe("author");
 	});
 
-	it("has belongsTo operators (eq, ne, in, notIn, is, isNot)", () => {
+	it("has belongsTo operators (eq, ne, not, in, notIn, is, isNot)", () => {
 		const ops = relation("users").getOperators();
 		expect(ops.column.eq).toBeDefined();
 		expect(ops.column.ne).toBeDefined();
+		expect(ops.column.not).toBeDefined();
 		expect(ops.column.in).toBeDefined();
 		expect(ops.column.is).toBeDefined();
 		expect(ops.column.isNot).toBeDefined();

--- a/packages/questpie/test/types/crud-types.test-d.ts
+++ b/packages/questpie/test/types/crud-types.test-d.ts
@@ -53,8 +53,14 @@ type DateOps = WhereOperators<Date>;
 
 type _stringEq = Expect<Equal<HasKey<StringOps, "eq">, true>>;
 type _stringNe = Expect<Equal<HasKey<StringOps, "ne">, true>>;
+type _stringNot = Expect<Equal<HasKey<StringOps, "not">, true>>;
+type _stringNotValue = Expect<
+	Equal<StringOps["not"], string | null | undefined>
+>;
 type _numberEq = Expect<Equal<HasKey<NumberOps, "eq">, true>>;
+type _numberNot = Expect<Equal<HasKey<NumberOps, "not">, true>>;
 type _dateEq = Expect<Equal<HasKey<DateOps, "eq">, true>>;
+type _dateNot = Expect<Equal<HasKey<DateOps, "not">, true>>;
 
 // Numbers support gt, gte, lt, lte
 type _numberGt = Expect<Extends<NumberOps["gt"], number | undefined>>;
@@ -98,6 +104,10 @@ const _where2: PostWhere = { views: 100 };
 const _where3: PostWhere = { title: { like: "%hello%" } };
 const _where4: PostWhere = { views: { gt: 100 } };
 const _where5: PostWhere = { publishedAt: { gte: new Date() } };
+const _whereNotAliasText: PostWhere = { title: { not: "Archived" } };
+const _whereNotAliasNumber: PostWhere = { views: { not: 0 } };
+const _whereNotAliasDate: PostWhere = { publishedAt: { not: null } };
+const _whereNotAliasRelation: PostWhere = { author: { not: "user-1" } };
 
 // Logical operators
 const _whereAnd: PostWhere = {

--- a/skills/questpie/references/query-operators.md
+++ b/skills/questpie/references/query-operators.md
@@ -9,10 +9,16 @@ Applies to: `text`, `textarea`, `richText`, `email`, `url`, `slug`
 | Operator     | Example                           | Description             |
 | ------------ | --------------------------------- | ----------------------- |
 | equality     | `{ title: "Hello" }`              | Exact match (shorthand) |
+| `eq`         | `{ title: { eq: "Hello" } }`      | Exact match             |
+| `ne`         | `{ title: { ne: "Draft" } }`      | Not equal               |
+| `not`        | `{ title: { not: "Draft" } }`     | Not equal alias         |
 | `contains`   | `{ title: { contains: "ell" } }`  | Substring match         |
 | `startsWith` | `{ title: { startsWith: "He" } }` | Prefix match            |
 | `endsWith`   | `{ title: { endsWith: "lo" } }`   | Suffix match            |
 | `in`         | `{ title: { in: ["A", "B"] } }`   | One of values           |
+| `notIn`      | `{ title: { notIn: ["A"] } }`     | Not one of values       |
+| `isNull`     | `{ title: { isNull: true } }`     | Is null                 |
+| `isNotNull`  | `{ title: { isNotNull: true } }`  | Is not null             |
 
 ## Number Fields
 
@@ -21,32 +27,44 @@ Applies to: `number`
 | Operator | Example                           | Description           |
 | -------- | --------------------------------- | --------------------- |
 | equality | `{ price: 1000 }`                 | Exact match           |
+| `eq`     | `{ price: { eq: 1000 } }`         | Exact match           |
+| `ne`     | `{ price: { ne: 1000 } }`         | Not equal             |
+| `not`    | `{ price: { not: 1000 } }`        | Not equal alias       |
 | `gt`     | `{ price: { gt: 1000 } }`         | Greater than          |
 | `gte`    | `{ price: { gte: 1000 } }`        | Greater than or equal |
 | `lt`     | `{ price: { lt: 5000 } }`         | Less than             |
 | `lte`    | `{ price: { lte: 5000 } }`        | Less than or equal    |
 | `in`     | `{ price: { in: [1000, 2000] } }` | One of values         |
+| `notIn`  | `{ price: { notIn: [1000] } }`    | Not one of values     |
+| `isNull` | `{ price: { isNull: true } }`     | Is null               |
 
 ## Boolean Fields
 
 Applies to: `boolean`
 
-| Operator | Example              | Description |
-| -------- | -------------------- | ----------- |
-| equality | `{ isActive: true }` | Exact match |
+| Operator | Example                          | Description     |
+| -------- | -------------------------------- | --------------- |
+| equality | `{ isActive: true }`             | Exact match     |
+| `eq`     | `{ isActive: { eq: true } }`     | Exact match     |
+| `ne`     | `{ isActive: { ne: true } }`     | Not equal       |
+| `not`    | `{ isActive: { not: true } }`    | Not equal alias |
+| `isNull` | `{ isActive: { isNull: true } }` | Is null         |
 
 ## Date / DateTime Fields
 
 Applies to: `date`, `dateTime`
 
-| Operator | Example                           | Description  |
-| -------- | --------------------------------- | ------------ |
-| equality | `{ date: "2025-03-01" }`          | Exact match  |
-| `eq`     | `{ date: { eq: someDate } }`      | Exact match  |
-| `gt`     | `{ date: { gt: "2025-01-01" } }`  | After        |
-| `gte`    | `{ date: { gte: "2025-01-01" } }` | On or after  |
-| `lt`     | `{ date: { lt: "2025-12-31" } }`  | Before       |
-| `lte`    | `{ date: { lte: "2025-12-31" } }` | On or before |
+| Operator | Example                           | Description     |
+| -------- | --------------------------------- | --------------- |
+| equality | `{ date: "2025-03-01" }`          | Exact match     |
+| `eq`     | `{ date: { eq: someDate } }`      | Exact match     |
+| `ne`     | `{ date: { ne: someDate } }`      | Not equal       |
+| `not`    | `{ date: { not: someDate } }`     | Not equal alias |
+| `gt`     | `{ date: { gt: "2025-01-01" } }`  | After           |
+| `gte`    | `{ date: { gte: "2025-01-01" } }` | On or after     |
+| `lt`     | `{ date: { lt: "2025-12-31" } }`  | Before          |
+| `lte`    | `{ date: { lte: "2025-12-31" } }` | On or before    |
+| `isNull` | `{ date: { isNull: true } }`      | Is null         |
 
 For `Date` instance values, always use the explicit `{ eq: someDate }`
 operator — the bare equality shorthand only works for string/primitive
@@ -61,18 +79,28 @@ compares exactly against the stored value — safe for keyset cursors
 
 Applies to: `select`, `multiSelect`
 
-| Operator | Example                                      | Description   |
-| -------- | -------------------------------------------- | ------------- |
-| equality | `{ status: "published" }`                    | Exact match   |
-| `in`     | `{ status: { in: ["draft", "published"] } }` | One of values |
+| Operator | Example                                      | Description       |
+| -------- | -------------------------------------------- | ----------------- |
+| equality | `{ status: "published" }`                    | Exact match       |
+| `eq`     | `{ status: { eq: "published" } }`            | Exact match       |
+| `ne`     | `{ status: { ne: "draft" } }`                | Not equal         |
+| `not`    | `{ status: { not: "draft" } }`               | Not equal alias   |
+| `in`     | `{ status: { in: ["draft", "published"] } }` | One of values     |
+| `notIn`  | `{ status: { notIn: ["draft"] } }`           | Not one of values |
 
 ## Relation Fields
 
 Applies to: `relation`
 
-| Operator | Example                 | Description         |
-| -------- | ----------------------- | ------------------- |
-| equality | `{ author: "user-id" }` | Match by related ID |
+| Operator | Example                          | Description              |
+| -------- | -------------------------------- | ------------------------ |
+| equality | `{ author: "user-id" }`          | Match by related ID      |
+| `eq`     | `{ author: { eq: "user-id" } }`  | Match by related ID      |
+| `ne`     | `{ author: { ne: "user-id" } }`  | Exclude related ID       |
+| `not`    | `{ author: { not: "user-id" } }` | Exclude related ID alias |
+| `in`     | `{ author: { in: ["a", "b"] } }` | One of related IDs       |
+| `notIn`  | `{ author: { notIn: ["a"] } }`   | Not one of related IDs   |
+| `isNull` | `{ author: { isNull: true } }`   | No related ID            |
 
 ## Combining Operators
 
@@ -95,9 +123,27 @@ Multiple operators on one field are ANDed together:
 
 ```ts
 where: {
-  price: { gte: 1000, lt: 5000 },
+	price: { gte: 1000, lt: 5000 },
 }
 // 1000 <= price < 5000
+```
+
+### Inequality Alias
+
+`not` is a field-level alias for `ne`. Use either form for scalar fields:
+
+```ts
+where: {
+	id: { not: excludedId },
+}
+```
+
+When the compared value is `null`, `not` maps to an `IS NOT NULL` check:
+
+```ts
+where: {
+	publishedAt: { not: null },
+}
 ```
 
 ### Equality Shorthand


### PR DESCRIPTION
## Summary
- expose field-level `not` as a typed alias for `ne` in legacy and field-driven where operators
- keep `not: null` aligned with runtime `IS NOT NULL` behavior
- add type/runtime regression tests and update query operator docs
- add a patch changeset for `questpie`

## Verification
- `bun run --cwd packages/questpie check-types`
- `bun test packages/questpie/test/fields/v2/builtin.test.ts packages/questpie/test/fields/v2/relation.test.ts`
- `bun test packages/questpie/test/collection/collection-queries.test.ts`
- `agent-board verify fix-where-operator-type-runtime-mismatch-for-field-level-not`
