### PR TITLE
fix(cli): questpie/cli import is side-effect-free + atomic codegen writes

### DIFF
--- a/.changeset/cli-import-side-effect.md
+++ b/.changeset/cli-import-side-effect.md
@@ -1,0 +1,5 @@
+---
+"questpie": patch
+---
+
+fix(cli): importing `questpie/cli` no longer executes the CLI. `program.parse()` is now guarded by `import.meta.main`, so it only runs when the CLI file is the process entry (the `questpie` bin or a direct `bun run .../exports/cli.ts`). Previously, a `questpie.config.ts` importing `packageConfig` from `"questpie/cli"` during `bun x questpie generate` loaded a second module instance (src vs dist) whose top-level parse started the same generate again concurrently, corrupting `.generated/module.ts` files (truncated output with NUL bytes). Codegen also writes generated files atomically now (temp file + rename), so concurrent or killed runs can never leave truncated output behind.

--- a/apps/autopilot/package.json
+++ b/apps/autopilot/package.json
@@ -16,7 +16,7 @@
 		"dev:ai-worker": "bun --bun run --watch ./src/ai-worker.ts",
 		"ai-worker": "bun --bun run ./src/ai-worker.ts",
 		"dev:sandbox": "SANDBOX_BROKER_URL=http://127.0.0.1:3000/api/sandbox/rpc PORT=8787 deno run --allow-net --allow-env --allow-run --allow-read ../../packages/sandbox/src/sandbox-server.ts",
-		"questpie": "bun --conditions=development ../../packages/questpie/src/cli/index.ts",
+		"questpie": "bun --conditions=development ../../packages/questpie/src/exports/cli.ts",
 		"generate": "bun run questpie generate -c src/questpie/server/questpie.config.ts",
 		"db:setup": "bun run generate && bun run migrate:status && bun run migrate && bun run db:dev-admin && bun run db:seed",
 		"db:dev-admin": "bun --conditions=development scripts/ensure-dev-admin.ts",

--- a/packages/questpie/src/cli/codegen/index.ts
+++ b/packages/questpie/src/cli/codegen/index.ts
@@ -10,7 +10,7 @@
  * @see RFC-MODULE-ARCHITECTURE §9 (Generated Code)
  */
 
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, rename, writeFile } from "node:fs/promises";
 import { join, relative, resolve } from "node:path";
 
 import { discoverFiles } from "./discover.js";
@@ -636,7 +636,7 @@ export async function runCodegen(
 	if (!dryRun) {
 		await mkdir(outDir, { recursive: true });
 		for (const file of filesToWrite) {
-			await writeFile(file.path, file.code, "utf-8");
+			await atomicWriteFile(file.path, file.code);
 		}
 	}
 
@@ -646,6 +646,17 @@ export async function runCodegen(
 		outputPath,
 		discovered,
 	};
+}
+
+/**
+ * Write via temp file + rename so a concurrent or killed run can never leave
+ * a truncated/interleaved .generated file behind (rename is atomic within
+ * the same directory).
+ */
+async function atomicWriteFile(path: string, code: string): Promise<void> {
+	const tmpPath = `${path}.${process.pid}.tmp`;
+	await writeFile(tmpPath, code, "utf-8");
+	await rename(tmpPath, path);
 }
 
 // ============================================================================
@@ -787,14 +798,14 @@ export async function runAllTargets(
 
 				if (!dryRun) {
 					await mkdir(targetOutDir, { recursive: true });
-					await writeFile(outputPath, output.code, "utf-8");
+					await atomicWriteFile(outputPath, output.code);
 
 					if (output.additionalFiles) {
 						for (const [relPath, content] of Object.entries(
 							output.additionalFiles,
 						)) {
 							const absPath = join(targetOutDir, relPath);
-							await writeFile(absPath, content, "utf-8");
+							await atomicWriteFile(absPath, content);
 						}
 					}
 				}

--- a/packages/questpie/src/cli/index.ts
+++ b/packages/questpie/src/cli/index.ts
@@ -613,8 +613,16 @@ cloud
 				),
 			});
 		} catch (error) {
-			handleCloudCommandError("Failed to roll back through Questpie Cloud", error);
+			handleCloudCommandError(
+				"Failed to roll back through Questpie Cloud",
+				error,
+			);
 		}
 	});
 
-program.parse();
+// Parsing happens in src/exports/cli.ts (the bin entry), guarded by
+// import.meta.main. Importing this module must never execute a command:
+// questpie.config.ts files import "questpie/cli" for packageConfig, and in
+// the workspace that resolves to a second module instance (src vs dist) —
+// a top-level parse here would run the in-flight command twice and corrupt
+// generated output.

--- a/packages/questpie/src/exports/cli.ts
+++ b/packages/questpie/src/exports/cli.ts
@@ -4,6 +4,8 @@
  *
  * These types and helpers are used for questpie.config.ts configuration files
  */
+import { program } from "#questpie/cli/index.js";
+
 export type {
 	PackageConfig,
 	QuestpieCliConfig,
@@ -11,4 +13,13 @@ export type {
 } from "#questpie/cli/config.js";
 export { config, packageConfig } from "#questpie/cli/config.js";
 
-export { program } from "#questpie/cli/index.js";
+export { program };
+
+// Only run the CLI when this file is the process entry (bin or `bun run`).
+// Config files import "questpie/cli" for packageConfig — that import must be
+// side-effect-free: in the workspace it resolves to a second module instance
+// (src vs dist), and a top-level parse would start the in-flight command a
+// second time in the same process, corrupting .generated output.
+if (import.meta.main) {
+	program.parse();
+}

--- a/packages/questpie/test/cli/cli-import-side-effect.test.ts
+++ b/packages/questpie/test/cli/cli-import-side-effect.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "bun:test";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const SRC_CLI_ENTRY = resolve(import.meta.dirname, "../../src/exports/cli.ts");
+
+/**
+ * Regression tests for the double-parse incident: questpie.config.ts files
+ * import "questpie/cli" for packageConfig. In the workspace that import
+ * resolves to src/exports/cli.ts — a second module instance next to the
+ * dist/cli.mjs the bin already loaded — and a top-level program.parse()
+ * side effect started the in-flight generate a second time. Two concurrent
+ * generates wrote the same .generated/module.ts files and corrupted them
+ * (truncated output ending in NUL bytes).
+ */
+describe("questpie/cli import side effects", () => {
+	it("importing questpie/cli never executes a command, even with a command-shaped argv", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "questpie-cli-import-"));
+		const script = join(dir, "import-cli.ts");
+		await writeFile(
+			script,
+			[
+				// Simulate the incident: a generate is in flight, so argv carries
+				// the command while the config file imports "questpie/cli".
+				`process.argv = [process.argv[0], "questpie", "generate", "--verbose"];`,
+				`await import(${JSON.stringify(SRC_CLI_ENTRY)});`,
+				`console.log("IMPORT_OK");`,
+			].join("\n"),
+			"utf-8",
+		);
+
+		const proc = Bun.spawn(["bun", script], {
+			cwd: dir,
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		const code = await proc.exited;
+		const stdout = await new Response(proc.stdout).text();
+
+		expect(code).toBe(0);
+		expect(stdout.trim()).toBe("IMPORT_OK");
+	}, 30000);
+
+	it("running src/exports/cli.ts as the process entry still parses", async () => {
+		const proc = Bun.spawn(["bun", SRC_CLI_ENTRY, "--help"], {
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		const code = await proc.exited;
+		const stdout = await new Response(proc.stdout).text();
+
+		expect(code).toBe(0);
+		expect(stdout).toContain("Usage: questpie");
+	}, 30000);
+});


### PR DESCRIPTION
## Problem

`packages/questpie/src/cli/index.ts` ended with a top-level `program.parse()` that ran as an import side effect.

When the CLI is invoked through the bin (`bun x questpie generate` — used by `packages/admin` `questpie:generate` and turbo tasks), the process loads `dist/cli.mjs` (parse #1, generate starts). The generate then imports the package's `questpie.config.ts`, which does `import { packageConfig } from "questpie/cli"` — in the workspace that resolves through devExports to `src/exports/cli.ts`, a **different module instance**, so its top-level parse fired a **second generate in the same process**. Two concurrent generates wrote the same `.generated/module.ts` files and corrupted them (truncated output ending in NUL bytes).

Repro (before): `cd packages/admin && bun x questpie generate --verbose` → "Package mode: generating 3 module(s)" printed **twice**, `src/server/modules/admin/.generated/module.ts` ended corrupted.

## Fix

- `program.parse()` moved out of `cli/index.ts` into `src/exports/cli.ts` behind `import.meta.main` — the bin (`dist/cli.mjs`) and direct `bun run .../exports/cli.ts` invocations still parse; plain imports of `questpie/cli` are inert.
- `apps/autopilot` `questpie` script pointed at `exports/cli.ts` (it invoked `cli/index.ts` directly, which no longer parses).
- **Hardening:** codegen writes generated files via temp file + rename (atomic within the directory), so concurrent or killed runs can never leave truncated output behind.

## Verification

- New regression test `test/cli/cli-import-side-effect.test.ts`: importing `questpie/cli` with a command-shaped argv executes nothing; running `exports/cli.ts` as the process entry still parses.
- Repro after fix: "Package mode" prints **once**, all 5 `.generated/*.ts` files NUL-free, regen is a no-op vs committed state.
- `bun test test/cli/` 19/19, `tsc --noEmit` clean, oxlint/oxfmt clean, dist rebuilt — shebang preserved, exactly one `import.meta.main` guard in the bundle (no double-parse inside dist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)