### PR TITLE
fix(framework): db.url connection-pool tuning + codegen output-dir cleanup

### DIFF
--- a/.changeset/codegen-clean-output-dir.md
+++ b/.changeset/codegen-clean-output-dir.md
@@ -1,0 +1,5 @@
+---
+"questpie": patch
+---
+
+Codegen now recreates each target's output directory on every non-dry run, so generated files from a convention that was removed (for example `env.client.*` modules after deleting `env.client.ts`) no longer linger after regeneration.

--- a/.changeset/db-pool-config.md
+++ b/.changeset/db-pool-config.md
@@ -1,0 +1,7 @@
+---
+"questpie": minor
+---
+
+Add optional connection-pool tuning to the `db: { url }` config via a new `pool` field (`DbPoolConfig`): `max`, `connectionTimeoutMs`, `idleTimeoutMs`, `maxLifetimeMs`, and `prepare` (Bun only, for PgBouncer transaction mode). Values are given in milliseconds and mapped to each driver's native unit — Bun `bun:sql` (seconds) and `node-postgres` (ms for acquire/idle, seconds for lifetime).
+
+Previously `db: { url }` created the pool with zero tuning (`new SQL({ url })` / `new pg.Pool({ connectionString })`), so it inherited driver defaults — notably node-postgres' `connectionTimeoutMillis: 0`, i.e. an unbounded wait to acquire a connection. On a shared Postgres running near its `max_connections` cap, that unbounded wait let a single request stall long enough to trip the SSR stream lifetime cap. Set a bounded `connectionTimeoutMs` so pool acquisition fails fast instead of hanging. Fully backward compatible: omit `pool` to keep the previous behavior.

--- a/packages/questpie/src/cli/codegen/index.ts
+++ b/packages/questpie/src/cli/codegen/index.ts
@@ -10,8 +10,8 @@
  * @see RFC-MODULE-ARCHITECTURE §9 (Generated Code)
  */
 
-import { mkdir, rename, writeFile } from "node:fs/promises";
-import { join, relative, resolve } from "node:path";
+import { mkdir, rename, rm, writeFile } from "node:fs/promises";
+import { dirname, join, relative, resolve } from "node:path";
 
 import { discoverFiles } from "./discover.js";
 import { generateClientEnvModules } from "./env-client-template.js";
@@ -645,10 +645,7 @@ export async function runCodegen(
 
 	// 8. Write output
 	if (!dryRun) {
-		await mkdir(outDir, { recursive: true });
-		for (const file of filesToWrite) {
-			await atomicWriteFile(file.path, file.code);
-		}
+		await writeGeneratedFiles(outDir, filesToWrite);
 	}
 
 	return {
@@ -665,9 +662,26 @@ export async function runCodegen(
  * the same directory).
  */
 async function atomicWriteFile(path: string, code: string): Promise<void> {
+	await mkdir(dirname(path), { recursive: true });
 	const tmpPath = `${path}.${process.pid}.tmp`;
 	await writeFile(tmpPath, code, "utf-8");
 	await rename(tmpPath, path);
+}
+
+/**
+ * A codegen target owns its output directory. Recreate it on every non-dry run
+ * so files from removed conventions (for example env.client.* modules) cannot
+ * remain visible after regeneration.
+ */
+async function writeGeneratedFiles(
+	outDir: string,
+	files: Array<{ path: string; code: string }>,
+): Promise<void> {
+	await rm(outDir, { recursive: true, force: true });
+	await mkdir(outDir, { recursive: true });
+	for (const file of files) {
+		await atomicWriteFile(file.path, file.code);
+	}
 }
 
 // ============================================================================
@@ -808,17 +822,18 @@ export async function runAllTargets(
 				}
 
 				if (!dryRun) {
-					await mkdir(targetOutDir, { recursive: true });
-					await atomicWriteFile(outputPath, output.code);
-
+					const filesToWrite = [{ path: outputPath, code: output.code }];
 					if (output.additionalFiles) {
 						for (const [relPath, content] of Object.entries(
 							output.additionalFiles,
 						)) {
-							const absPath = join(targetOutDir, relPath);
-							await atomicWriteFile(absPath, content);
+							filesToWrite.push({
+								path: join(targetOutDir, relPath),
+								code: content,
+							});
 						}
 					}
+					await writeGeneratedFiles(targetOutDir, filesToWrite);
 				}
 
 				results.set(targetId, {

--- a/packages/questpie/src/server/config/types.ts
+++ b/packages/questpie/src/server/config/types.ts
@@ -407,9 +407,54 @@ export type DbCreateResult<TDb extends AnyDrizzleClient = AnyDrizzleClient> =
 			close?: DbCloseFn;
 	  };
 
+/**
+ * Optional connection-pool tuning for the `db: { url }` variant. Applied to
+ * whichever Postgres driver the runtime selects — Bun's native `bun:sql` on
+ * Bun, `node-postgres` on Node. All timeouts are in MILLISECONDS; questpie
+ * converts to each driver's native unit.
+ *
+ * Omit entirely to keep driver defaults (pool `max` 10, and — critically for
+ * node-postgres — NO bounded acquire timeout, i.e. wait forever). On a shared
+ * Postgres running near its connection cap, that "wait forever" is exactly how
+ * a single request stalls long enough to trip an SSR stream lifetime cap. Set a
+ * bounded `connectionTimeoutMs` so pool acquisition fails fast instead.
+ */
+export interface DbPoolConfig {
+	/** Maximum connections in the pool. @default 10 (driver default) */
+	max?: number;
+	/**
+	 * Max time to wait when acquiring/establishing a pooled connection before
+	 * failing. Bounds the "server is at its connection cap" case so callers get
+	 * a fast error instead of hanging.
+	 * → Bun `connectionTimeout` (s), node-postgres `connectionTimeoutMillis` (ms).
+	 * @default driver default (Bun 30000; node-postgres 0 = wait forever)
+	 */
+	connectionTimeoutMs?: number;
+	/**
+	 * Close idle connections after this long.
+	 * → Bun `idleTimeout` (s), node-postgres `idleTimeoutMillis` (ms).
+	 */
+	idleTimeoutMs?: number;
+	/**
+	 * Recycle a connection after this long, even if healthy.
+	 * → Bun `maxLifetime` (s), node-postgres `maxLifetimeSeconds` (s).
+	 * @default 0 (no limit)
+	 */
+	maxLifetimeMs?: number;
+	/**
+	 * Disable server-side NAMED prepared statements. Required to route this pool
+	 * through PgBouncer in transaction mode. Bun only — node-postgres does not
+	 * create named prepared statements unless a query sets `name`.
+	 * @default true
+	 */
+	prepare?: boolean;
+}
+
 export type DbConfig =
 	| {
 			url: string;
+			/** Optional connection-pool tuning. Omit to use driver defaults. */
+			pool?: DbPoolConfig;
 	  }
 	| {
 			pglite: PGliteClient;

--- a/packages/questpie/src/server/modules/core/services/db.ts
+++ b/packages/questpie/src/server/modules/core/services/db.ts
@@ -52,6 +52,11 @@ export default service({
 		if ("url" in config.db) {
 			app._pgConnectionString = config.db.url;
 
+			// Optional pool tuning (see DbPoolConfig). questpie's config is in ms;
+			// each driver gets its native unit. Omitted keys keep driver defaults.
+			const pool = config.db.pool;
+			const msToSec = (ms: number) => Math.max(1, Math.ceil(ms / 1000));
+
 			// Pick the Postgres driver by runtime so a single `db.url` config runs
 			// on BOTH Bun and Node: Bun → the native zero-dep `bun:sql` client;
 			// Node (e.g. Next.js's server runtime) → `node-postgres` via the
@@ -62,7 +67,21 @@ export default service({
 					import("drizzle-orm/bun-sql"),
 				]);
 
-				const bunSqlClient = new SQL({ url: config.db.url });
+				// Bun's SQL takes all timeouts in SECONDS.
+				const bunSqlClient = new SQL({
+					url: config.db.url,
+					...(pool?.max !== undefined ? { max: pool.max } : {}),
+					...(pool?.connectionTimeoutMs !== undefined
+						? { connectionTimeout: msToSec(pool.connectionTimeoutMs) }
+						: {}),
+					...(pool?.idleTimeoutMs !== undefined
+						? { idleTimeout: msToSec(pool.idleTimeoutMs) }
+						: {}),
+					...(pool?.maxLifetimeMs !== undefined
+						? { maxLifetime: msToSec(pool.maxLifetimeMs) }
+						: {}),
+					...(pool?.prepare !== undefined ? { prepare: pool.prepare } : {}),
+				});
 				app._dbCleanup = () => bunSqlClient.close({ timeout: 5 });
 				return drizzleBun({ client: bunSqlClient, schema });
 			}
@@ -72,7 +91,23 @@ export default service({
 				import("drizzle-orm/node-postgres"),
 			]);
 
-			const pgPool = new pg.Pool({ connectionString: config.db.url });
+			// node-postgres takes acquire/idle timeouts in MILLISECONDS and
+			// connection lifetime in SECONDS. `prepare` has no pool-level knob (it
+			// only creates named statements when a query sets `name`), so it is
+			// intentionally not mapped here.
+			const pgPool = new pg.Pool({
+				connectionString: config.db.url,
+				...(pool?.max !== undefined ? { max: pool.max } : {}),
+				...(pool?.connectionTimeoutMs !== undefined
+					? { connectionTimeoutMillis: pool.connectionTimeoutMs }
+					: {}),
+				...(pool?.idleTimeoutMs !== undefined
+					? { idleTimeoutMillis: pool.idleTimeoutMs }
+					: {}),
+				...(pool?.maxLifetimeMs !== undefined
+					? { maxLifetimeSeconds: msToSec(pool.maxLifetimeMs) }
+					: {}),
+			});
 			app._dbCleanup = () => pgPool.end();
 			return drizzlePg({ client: pgPool, schema });
 		}

--- a/packages/questpie/test/codegen/env-codegen.test.ts
+++ b/packages/questpie/test/codegen/env-codegen.test.ts
@@ -10,7 +10,14 @@
  * 5. Regex fallback when env.client.ts cannot be imported
  */
 import { afterAll, describe, expect, it } from "bun:test";
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import {
+	mkdir,
+	mkdtemp,
+	readFile,
+	rm,
+	unlink,
+	writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -276,6 +283,25 @@ describe("runCodegen — client env emission", () => {
 		).toBeGreaterThan(0);
 		await expect(
 			readFile(join(dir, ".generated/env.client.expo.ts"), "utf-8"),
+		).rejects.toThrow();
+	});
+
+	it("removes stale client env modules when env.client.ts is deleted", async () => {
+		const dir = await writeFixtureProject({
+			clientEnvImport: `import { clientEnv } from "${CLIENT_ENV_FACTORY_PATH}";`,
+		});
+		await runFixtureCodegen(dir);
+		await readFile(join(dir, ".generated/env.client.expo.ts"), "utf-8");
+		await readFile(join(dir, ".generated/env.client.vite.ts"), "utf-8");
+
+		await unlink(join(dir, "env.client.ts"));
+		await runFixtureCodegen(dir);
+
+		await expect(
+			readFile(join(dir, ".generated/env.client.expo.ts"), "utf-8"),
+		).rejects.toThrow();
+		await expect(
+			readFile(join(dir, ".generated/env.client.vite.ts"), "utf-8"),
 		).rejects.toThrow();
 	});
 });


### PR DESCRIPTION
Two isolated framework fixes extracted from the `feat/ai-mcp-sandbox-production` umbrella so they can ship to `main` decoupled from the not-yet-ready AI/mcp/sandbox release (same pattern as the 3.12.0 extraction).

## 1. `db.url` connection-pool tuning — `DbPoolConfig` (questpie **minor**)
Adds an optional `pool` field to the `db: { url }` config: `max`, `connectionTimeoutMs`, `idleTimeoutMs`, `maxLifetimeMs`, and `prepare` (Bun-only, for PgBouncer transaction mode). Values are in **milliseconds** and mapped to each driver's native unit — Bun `bun:sql` (seconds), `node-postgres` (ms for acquire/idle, seconds for lifetime).

**Why:** previously `db: { url }` built the pool with zero tuning, inheriting driver defaults — notably node-postgres' `connectionTimeoutMillis: 0` (unbounded wait to acquire a connection). On a shared Postgres near its `max_connections` cap, that unbounded wait let a single request stall long enough to trip the SSR stream lifetime cap. Set a bounded `connectionTimeoutMs` so acquisition fails fast. Fully backward compatible — omit `pool` to keep the previous behavior.

## 2. Codegen recreates each target's output dir per run (questpie **patch**)
`writeGeneratedFiles` rm -rf's the output dir then recreates it before writing, so files from a removed convention (e.g. `env.client.*` modules after deleting `env.client.ts`) no longer linger after regeneration. Both write sites (`runCodegen` + `runAllTargets`) go through it; `atomicWriteFile` also mkdir's the file's dirname.

## Verification
- `bunx tsc --noEmit --project packages/questpie/tsconfig.json` → **0 errors**
- `bun test test/codegen/` → **250 pass, 0 fail**

🤖 Generated with [Claude Code](https://claude.com/claude-code)