### PR TITLE
chore(sandbox): make @questpie/sandbox publishable

### DIFF
--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@questpie/sandbox",
 	"version": "3.1.0",
-	"private": true,
+	"private": false,
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/questpie/questpie.git",


### PR DESCRIPTION
Flips \`@questpie/sandbox\` from \`private: true\` → \`private: false\` so it can be released alongside \`@questpie/ai\` and \`@questpie/mcp\`.

Verified locally:
- \`turbo build\` — clean (tsdown, 6 dist files)
- \`tsc --noEmit\` — passes
- \`bun test\` — 161 pass, 4 skip, 0 fail
- \`npm publish --dry-run\` — valid tarball (dist + guest src), no "skipping private"

**First publish** still needs a create-capable npm token (bootstrap once with \`npm publish\`, same as ai/mcp — npm OIDC/granular tokens can't create a brand-new package). After it exists on npm, configure a trusted publisher so future releases go via CI OIDC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)