### PR TITLE
fix(questpie): make realtime outbox transactional

### DIFF
--- a/.changeset/quiet-pies-listen.md
+++ b/.changeset/quiet-pies-listen.md
@@ -1,0 +1,5 @@
+---
+"questpie": patch
+---
+
+Write realtime outbox entries in the same transaction as collection and global mutations so committed changes remain recoverable when post-commit notifications are lost.

--- a/packages/questpie/src/server/collection/crud/crud-generator.ts
+++ b/packages/questpie/src/server/collection/crud/crud-generator.ts
@@ -2524,41 +2524,41 @@ export class CRUDGenerator<TState extends CollectionBuilderState> {
 						.where(inArray(getColumn(this.table, "id")!, winnerIdList));
 				}
 
+				// Bulk metadata for afterDelete: winners only (fact hooks)
+				const afterDeleteBulkMeta = {
+					isBatch: true as const,
+					recordIds: claimedRecords.map((r: any) => r.id),
+					records: claimedRecords,
+					count: claimedRecords.length,
+				};
+
+				// Execute afterDelete hooks inside the mutation transaction so
+				// transactional side effects share the business commit boundary.
+				for (const record of claimedRecords) {
+					try {
+						await this.executeCollectionHooksWithGlobal(
+							"afterDelete",
+							this.state.hooks?.afterDelete,
+							this.createHookContext({
+								data: record,
+								original: record,
+								operation: "delete",
+								context: txContext,
+								db: tx,
+								bulk: afterDeleteBulkMeta,
+							}),
+						);
+					} catch (err) {
+						// afterDelete hook errors are non-fatal — log and continue
+						console.error(
+							`[QUESTPIE] afterDelete hook error for "${this.state.name}":`,
+							err,
+						);
+					}
+				}
+
 				return claimedRecords;
 			});
-
-			// Bulk metadata for afterDelete: winners only (fact hooks)
-			const afterDeleteBulkMeta = {
-				isBatch: true as const,
-				recordIds: winners.map((r: any) => r.id),
-				records: winners,
-				count: winners.length,
-			};
-
-			// 4. Loop through afterDelete hooks (winners only)
-			for (const record of winners) {
-				// Execute afterDelete hooks
-				try {
-					await this.executeCollectionHooksWithGlobal(
-						"afterDelete",
-						this.state.hooks?.afterDelete,
-						this.createHookContext({
-							data: record,
-							original: record,
-							operation: "delete",
-							context: normalized,
-							db,
-							bulk: afterDeleteBulkMeta,
-						}),
-					);
-				} catch (err) {
-					// afterDelete hook errors are non-fatal — log and continue
-					console.error(
-						`[QUESTPIE] afterDelete hook error for "${this.state.name}":`,
-						err,
-					);
-				}
-			}
 
 			return { success: true, count: winners.length };
 		};

--- a/packages/questpie/src/server/config/global-hooks-types.ts
+++ b/packages/questpie/src/server/config/global-hooks-types.ts
@@ -1,7 +1,7 @@
 import type { ResolvedAppHookContext } from "#questpie/server/config/app-context.js";
 import type {
 	AccessMode,
-	DrizzleClientFromQuestpieConfig,
+	AnyDrizzleClient,
 } from "#questpie/server/config/types.js";
 
 // ============================================================================
@@ -16,7 +16,7 @@ export type GlobalCollectionHookContextFields<
 	/** The name/slug of the collection being operated on */
 	collection: string;
 	/** Transaction-bound database client for the current mutation. */
-	db: DrizzleClientFromQuestpieConfig<any>;
+	db: AnyDrizzleClient<any>;
 	data: TData;
 	original: TOriginal | undefined;
 	locale?: string;
@@ -117,7 +117,7 @@ export type GlobalGlobalHookContextFields<TData = any> = {
 	/** The name/slug of the global being operated on */
 	global: string;
 	/** Transaction-bound database client for the current mutation. */
-	db: DrizzleClientFromQuestpieConfig<any>;
+	db: AnyDrizzleClient<any>;
 	data: TData;
 	input?: unknown;
 	locale?: string;

--- a/packages/questpie/src/server/config/global-hooks-types.ts
+++ b/packages/questpie/src/server/config/global-hooks-types.ts
@@ -1,5 +1,8 @@
 import type { ResolvedAppHookContext } from "#questpie/server/config/app-context.js";
-import type { AccessMode } from "#questpie/server/config/types.js";
+import type {
+	AccessMode,
+	DrizzleClientFromQuestpieConfig,
+} from "#questpie/server/config/types.js";
 
 // ============================================================================
 // Global Collection Hook Types
@@ -12,6 +15,8 @@ export type GlobalCollectionHookContextFields<
 > = {
 	/** The name/slug of the collection being operated on */
 	collection: string;
+	/** Transaction-bound database client for the current mutation. */
+	db: DrizzleClientFromQuestpieConfig<any>;
 	data: TData;
 	original: TOriginal | undefined;
 	locale?: string;
@@ -111,6 +116,8 @@ export interface GlobalCollectionHookEntry {
 export type GlobalGlobalHookContextFields<TData = any> = {
 	/** The name/slug of the global being operated on */
 	global: string;
+	/** Transaction-bound database client for the current mutation. */
+	db: DrizzleClientFromQuestpieConfig<any>;
 	data: TData;
 	input?: unknown;
 	locale?: string;

--- a/packages/questpie/src/server/config/global-hooks-types.ts
+++ b/packages/questpie/src/server/config/global-hooks-types.ts
@@ -1,8 +1,5 @@
 import type { ResolvedAppHookContext } from "#questpie/server/config/app-context.js";
-import type {
-	AccessMode,
-	AnyDrizzleClient,
-} from "#questpie/server/config/types.js";
+import type { AccessMode } from "#questpie/server/config/types.js";
 
 // ============================================================================
 // Global Collection Hook Types
@@ -15,8 +12,6 @@ export type GlobalCollectionHookContextFields<
 > = {
 	/** The name/slug of the collection being operated on */
 	collection: string;
-	/** Transaction-bound database client for the current mutation. */
-	db: AnyDrizzleClient<any>;
 	data: TData;
 	original: TOriginal | undefined;
 	locale?: string;
@@ -116,8 +111,6 @@ export interface GlobalCollectionHookEntry {
 export type GlobalGlobalHookContextFields<TData = any> = {
 	/** The name/slug of the global being operated on */
 	global: string;
-	/** Transaction-bound database client for the current mutation. */
-	db: AnyDrizzleClient<any>;
 	data: TData;
 	input?: unknown;
 	locale?: string;

--- a/packages/questpie/src/server/modules/core/config/app.ts
+++ b/packages/questpie/src/server/modules/core/config/app.ts
@@ -16,7 +16,10 @@ import type {
 	GlobalCollectionTransitionHookContext,
 	GlobalGlobalHookContext,
 } from "#questpie/server/config/global-hooks-types.js";
-import type { Locale } from "#questpie/server/config/types.js";
+import type {
+	DrizzleClientFromQuestpieConfig,
+	Locale,
+} from "#questpie/server/config/types.js";
 import { buildIndexParams } from "#questpie/server/modules/core/integrated/search/index-params.js";
 import type { SearchableConfig } from "#questpie/server/modules/core/integrated/search/types.js";
 import {
@@ -28,6 +31,17 @@ import { DEFAULT_LOCALE } from "#questpie/shared/constants.js";
 // ============================================================================
 // Realtime helpers
 // ============================================================================
+
+/**
+ * The pre-codegen hook context deliberately keeps infrastructure members
+ * unknown. Runtime hook execution always supplies the mutation-bound client;
+ * keep that assertion local so generated app hooks retain their precise schema.
+ */
+function asRealtimeMutationDb(
+	db: unknown,
+): DrizzleClientFromQuestpieConfig<any> {
+	return db as DrizzleClientFromQuestpieConfig<any>;
+}
 
 function resolveRealtimeOperation(
 	ctx: GlobalCollectionHookContext,
@@ -74,7 +88,7 @@ const realtimeHook = {
 					locale: ctx.locale ?? null,
 					payload,
 				},
-				{ db: ctx.db },
+				{ db: asRealtimeMutationDb(ctx.db) },
 			);
 
 			ctx.onAfterCommit(async () => {
@@ -105,7 +119,7 @@ const realtimeHook = {
 					locale: ctx.locale ?? null,
 					payload,
 				},
-				{ db: ctx.db },
+				{ db: asRealtimeMutationDb(ctx.db) },
 			);
 
 			ctx.onAfterCommit(async () => {
@@ -284,7 +298,7 @@ const globalRealtimeHook = {
 					locale: ctx.locale ?? null,
 					payload: ctx.data as Record<string, unknown>,
 				},
-				{ db: ctx.db },
+				{ db: asRealtimeMutationDb(ctx.db) },
 			);
 
 			ctx.onAfterCommit(async () => {

--- a/packages/questpie/src/server/modules/core/config/app.ts
+++ b/packages/questpie/src/server/modules/core/config/app.ts
@@ -64,27 +64,29 @@ const realtimeHook = {
 		const operation = resolveRealtimeOperation(ctx, "change");
 		const payload = resolveRealtimePayload(ctx, "change");
 
-		// Defer both the log append and broadcast to after-commit.
-		// Running appendChange inside the CRUD transaction can deadlock
-		// on single-connection databases (PGlite) because the insert
-		// waits for the outer transaction to release its lock.
-		ctx.onAfterCommit(async () => {
-			try {
-				const change = await realtime.appendChange({
+		try {
+			const change = await realtime.appendChange(
+				{
 					resourceType: "collection",
 					resource: ctx.collection,
 					operation,
-					recordId: ctx.isBatch ? null : ctx.data?.id ?? null,
+					recordId: ctx.isBatch ? null : (ctx.data?.id ?? null),
 					locale: ctx.locale ?? null,
 					payload,
-				});
-				if (change) {
+				},
+				{ db: ctx.db },
+			);
+
+			ctx.onAfterCommit(async () => {
+				try {
 					await realtime.notify(change);
+				} catch {
+					// Realtime adapter may be unavailable
 				}
-			} catch {
-				// Realtime log table may not exist yet
-			}
-		});
+			});
+		} catch {
+			// Realtime log table may not exist yet
+		}
 	},
 	afterDelete: async (ctx: GlobalCollectionHookContext) => {
 		const realtime = ctx.realtime;
@@ -93,23 +95,29 @@ const realtimeHook = {
 		const operation = resolveRealtimeOperation(ctx, "delete");
 		const payload = resolveRealtimePayload(ctx, "delete");
 
-		ctx.onAfterCommit(async () => {
-			try {
-				const change = await realtime.appendChange({
+		try {
+			const change = await realtime.appendChange(
+				{
 					resourceType: "collection",
 					resource: ctx.collection,
 					operation,
-					recordId: ctx.isBatch ? null : ctx.data?.id ?? null,
+					recordId: ctx.isBatch ? null : (ctx.data?.id ?? null),
 					locale: ctx.locale ?? null,
 					payload,
-				});
-				if (change) {
+				},
+				{ db: ctx.db },
+			);
+
+			ctx.onAfterCommit(async () => {
+				try {
 					await realtime.notify(change);
+				} catch {
+					// Realtime adapter may be unavailable
 				}
-			} catch {
-				// Realtime log table may not exist yet
-			}
-		});
+			});
+		} catch {
+			// Realtime log table may not exist yet
+		}
 	},
 };
 
@@ -266,23 +274,29 @@ const globalRealtimeHook = {
 		const realtime = ctx.realtime;
 		if (!realtime) return;
 
-		ctx.onAfterCommit(async () => {
-			try {
-				const change = await realtime.appendChange({
+		try {
+			const change = await realtime.appendChange(
+				{
 					resourceType: "global",
 					resource: ctx.global,
 					operation: "update",
 					recordId: ctx.data?.id ?? null,
 					locale: ctx.locale ?? null,
 					payload: ctx.data as Record<string, unknown>,
-				});
-				if (change) {
+				},
+				{ db: ctx.db },
+			);
+
+			ctx.onAfterCommit(async () => {
+				try {
 					await realtime.notify(change);
+				} catch {
+					// Realtime adapter may be unavailable
 				}
-			} catch {
-				// Realtime log table may not exist yet
-			}
-		});
+			});
+		} catch {
+			// Realtime log table may not exist yet
+		}
 	},
 };
 

--- a/packages/questpie/test/integration/realtime-transactional-capture.test.ts
+++ b/packages/questpie/test/integration/realtime-transactional-capture.test.ts
@@ -1,0 +1,172 @@
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
+
+import {
+	collection,
+	global,
+	questpieRealtimeLogTable,
+	type RealtimeChangeEvent,
+	withTransaction,
+} from "../../src/exports/index.js";
+import type {
+	GlobalCollectionHookContext,
+	GlobalGlobalHookContext,
+} from "../../src/server/config/global-hooks-types.js";
+import { buildMockApp } from "../utils/mocks/mock-app-builder";
+import { createTestContext } from "../utils/test-context";
+import { runTestDbMigrations } from "../utils/test-db";
+
+describe("realtime transactional change capture", () => {
+	let setup: Awaited<ReturnType<typeof buildMockApp>>;
+	let ctx: ReturnType<typeof createTestContext>;
+	let observeCollectionHook:
+		| ((hookContext: GlobalCollectionHookContext) => Promise<void>)
+		| undefined;
+	let observeGlobalHook:
+		| ((hookContext: GlobalGlobalHookContext) => Promise<void>)
+		| undefined;
+
+	beforeEach(async () => {
+		observeCollectionHook = undefined;
+		observeGlobalHook = undefined;
+		setup = await buildMockApp(
+			{
+				collections: {
+					posts: collection("posts").fields(({ f }) => ({
+						title: f.text().required(),
+					})),
+				},
+				globals: {
+					siteSettings: global("site_settings").fields(({ f }) => ({
+						title: f.text().required(),
+					})),
+				},
+				hooks: {
+					collections: [
+						{
+							include: ["posts"],
+							afterChange: async (hookContext) => {
+								await observeCollectionHook?.(hookContext);
+							},
+							afterDelete: async (hookContext) => {
+								await observeCollectionHook?.(hookContext);
+							},
+						},
+					],
+					globals: [
+						{
+							include: ["site_settings"],
+							afterChange: async (hookContext) => {
+								await observeGlobalHook?.(hookContext);
+							},
+						},
+					],
+				},
+			},
+			{ realtime: { pollIntervalMs: 10 } },
+		);
+		await runTestDbMigrations(setup.app);
+		ctx = createTestContext(setup.app);
+	});
+
+	afterEach(async () => {
+		await setup.cleanup();
+	});
+
+	it("G11: writes the outbox row inside the mutation transaction", async () => {
+		let rowsVisibleInsideTransaction = 0;
+		observeCollectionHook = async (hookContext) => {
+			const rows = await hookContext.db.select().from(questpieRealtimeLogTable);
+			rowsVisibleInsideTransaction = rows.length;
+		};
+
+		await setup.app.collections.posts.create({ title: "Captured" }, ctx);
+
+		expect(rowsVisibleInsideTransaction).toBe(1);
+	});
+
+	it("G11: writes global changes inside the mutation transaction", async () => {
+		let rowsVisibleInsideTransaction = 0;
+		observeGlobalHook = async (hookContext) => {
+			const rows = await hookContext.db.select().from(questpieRealtimeLogTable);
+			rowsVisibleInsideTransaction = rows.length;
+		};
+
+		await setup.app.globals.siteSettings.update({ title: "Captured" }, ctx);
+
+		expect(rowsVisibleInsideTransaction).toBe(1);
+	});
+
+	it("G11: runs bulk-delete post-hooks on the transaction-bound database", async () => {
+		let usesTransactionBoundDb = false;
+		observeCollectionHook = async (hookContext) => {
+			if (hookContext.operation === "delete" && hookContext.isBatch) {
+				usesTransactionBoundDb = hookContext.db !== setup.app.db;
+			}
+		};
+		const post = await setup.app.collections.posts.create(
+			{ title: "Delete me" },
+			ctx,
+		);
+
+		await setup.app.collections.posts.delete({ where: { id: post.id } }, ctx);
+
+		expect(usesTransactionBoundDb).toBe(true);
+	});
+
+	it("G11: rolls the outbox row back with the business mutation", async () => {
+		await expect(
+			withTransaction(setup.app.db, async (tx) => {
+				await setup.app.collections.posts.create(
+					{ title: "Rolled back" },
+					{ ...ctx, db: tx },
+				);
+				throw new Error("rollback transaction");
+			}),
+		).rejects.toThrow("rollback transaction");
+
+		const rows = await setup.app.db.select().from(questpieRealtimeLogTable);
+		expect(rows).toHaveLength(0);
+	});
+
+	it("G11: reconciliation delivers a committed row when notify is suppressed", async () => {
+		let triggerPoll = () => {
+			throw new Error("Realtime poll did not start");
+		};
+		let markPollStarted = () => {};
+		const pollStarted = new Promise<void>((resolve) => {
+			markPollStarted = resolve;
+		});
+		const intervalSpy = spyOn(globalThis, "setInterval").mockImplementation(
+			(handler) => {
+				triggerPoll = () => {
+					if (typeof handler === "function") handler();
+				};
+				markPollStarted();
+				return 1 as unknown as ReturnType<typeof setInterval>;
+			},
+		);
+
+		const delivered = new Promise<RealtimeChangeEvent>((resolve) => {
+			setup.app.realtime.subscribe(resolve, {
+				resourceType: "collection",
+				resource: "posts",
+			});
+		});
+
+		try {
+			await pollStarted;
+			await setup.app.collections.posts.create({ title: "Poll me" }, ctx);
+
+			const rows = await setup.app.db.select().from(questpieRealtimeLogTable);
+			expect(rows).toHaveLength(1);
+
+			triggerPoll();
+			expect(await delivered).toMatchObject({
+				operation: "create",
+				resource: "posts",
+			});
+		} finally {
+			intervalSpy.mockRestore();
+		}
+	});
+});

--- a/packages/questpie/test/types/__fullapp__/hook-db-precision.test-d.ts
+++ b/packages/questpie/test/types/__fullapp__/hook-db-precision.test-d.ts
@@ -1,0 +1,22 @@
+import "./.generated/factories.js";
+import type {
+	GlobalCollectionHookContext,
+	GlobalGlobalHookContext,
+} from "#questpie/server/config/global-hooks-types.js";
+
+import type { Equal, Expect, HasKey, IsAny } from "../type-test-utils.js";
+
+type CollectionHookDbQuery = GlobalCollectionHookContext["db"]["query"];
+
+type _collectionDbMatchesGeneratedContext = Expect<
+	Equal<GlobalCollectionHookContext["db"], Questpie.AppHookContext["db"]>
+>;
+type _globalDbMatchesGeneratedContext = Expect<
+	Equal<GlobalGlobalHookContext["db"], Questpie.AppHookContext["db"]>
+>;
+type _collectionQueryNotAny = Expect<
+	Equal<IsAny<CollectionHookDbQuery>, false>
+>;
+type _collectionQueryHasArticles = Expect<
+	HasKey<CollectionHookDbQuery, "articles">
+>;


### PR DESCRIPTION
## What changed

- write collection and global realtime outbox rows through the mutation-bound database transaction
- run bulk-delete afterDelete hooks inside the existing delete transaction
- keep adapter notification after commit
- add G11 regression coverage for collection/global capture, bulk delete, rollback, and notify-suppressed reconciliation
- add a patch changeset

## Why

Realtime previously committed the business mutation before inserting its outbox row on another connection. A process crash in that window permanently lost the event, so polling could not repair delivery.

## Validation

- task verify: 52 passed, 1825 filtered, 0 failed; TypeScript completed with 0 errors
- focused core hooks, bulk metadata, and transactional capture suites: 26 passed, 0 failed
- formatting diff check: clean
