### PR TITLE
fix(questpie): reconcile realtime adapter delivery

### DIFF
--- a/.changeset/slow-realtime-reconciliation.md
+++ b/.changeset/slow-realtime-reconciliation.md
@@ -1,0 +1,5 @@
+---
+"questpie": patch
+---
+
+Keep realtime delivery bounded after dropped adapter notices by polling alongside adapters, draining again after concurrent wake-ups, and reconciling immediately when adapters reconnect.

--- a/packages/questpie/src/server/modules/core/integrated/realtime/adapter.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/adapter.ts
@@ -1,5 +1,7 @@
 import type { RealtimeChangeEvent, RealtimeNotice } from "./types.js";
 
+export type RealtimeAdapterState = "connected" | "disconnected";
+
 /**
  * Transport adapter for realtime change notifications.
  */
@@ -8,4 +10,5 @@ export interface RealtimeAdapter {
 	stop(): Promise<void>;
 	notify(event: RealtimeChangeEvent): Promise<void>;
 	subscribe(handler: (notice: RealtimeNotice) => void): () => void;
+	onStateChange?(handler: (state: RealtimeAdapterState) => void): () => void;
 }

--- a/packages/questpie/src/server/modules/core/integrated/realtime/service.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/service.ts
@@ -21,6 +21,8 @@ type AppendChangeOptions = {
 	db?: DrizzleClientFromQuestpieConfig<any>;
 };
 
+const DEFAULT_ADAPTER_RECONCILIATION_INTERVAL_MS = 15_000;
+
 type ListenerEntry = {
 	listener: RealtimeListener;
 	topics: import("./types").RealtimeTopics;
@@ -131,11 +133,13 @@ export class RealtimeService {
 	private pollIntervalMs: number;
 	private batchSize: number;
 	private draining = false;
+	private drainPending = false;
 	private started = false;
 	private startPromise: Promise<void> | null = null;
 	private lastSeq = 0;
 	private pollTimer: ReturnType<typeof setInterval> | null = null;
 	private unsubscribeAdapter: (() => void) | null = null;
+	private unsubscribeAdapterState: (() => void) | null = null;
 	private subscriptionContext?: RealtimeSubscriptionContext;
 	private retentionDays?: number;
 	private retentionCleanupIntervalMs: number;
@@ -156,7 +160,11 @@ export class RealtimeService {
 		// PgNotifyAdapter will be lazily created on first subscribe (if needed)
 
 		this.batchSize = config.batchSize ?? 500;
-		this.pollIntervalMs = config.pollIntervalMs ?? (this.adapter ? 0 : 2000);
+		this.pollIntervalMs =
+			config.pollIntervalMs ??
+			(this.adapter || this.pgConnectionString
+				? DEFAULT_ADAPTER_RECONCILIATION_INTERVAL_MS
+				: 2000);
 		this.retentionDays =
 			typeof config.retentionDays === "number" && config.retentionDays > 0
 				? config.retentionDays
@@ -420,7 +428,15 @@ export class RealtimeService {
 				this.unsubscribeAdapter = this.adapter.subscribe(() => {
 					void this.drain();
 				});
-			} else if (this.pollIntervalMs > 0) {
+				this.unsubscribeAdapterState =
+					this.adapter.onStateChange?.((state) => {
+						if (state === "connected") {
+							void this.drain();
+						}
+					}) ?? null;
+			}
+
+			if (this.pollIntervalMs > 0) {
 				this.pollTimer = setInterval(() => {
 					void this.drain();
 				}, this.pollIntervalMs);
@@ -442,6 +458,11 @@ export class RealtimeService {
 				if (this.unsubscribeAdapter) {
 					this.unsubscribeAdapter();
 					this.unsubscribeAdapter = null;
+				}
+
+				if (this.unsubscribeAdapterState) {
+					this.unsubscribeAdapterState();
+					this.unsubscribeAdapterState = null;
 				}
 
 				if (this.adapter) {
@@ -489,13 +510,21 @@ export class RealtimeService {
 			this.unsubscribeAdapter = null;
 		}
 
+		if (this.unsubscribeAdapterState) {
+			this.unsubscribeAdapterState();
+			this.unsubscribeAdapterState = null;
+		}
+
 		if (this.adapter) {
 			await this.adapter.stop();
 		}
 	}
 
 	private async drain(): Promise<void> {
-		if (this.draining) return;
+		if (this.draining) {
+			this.drainPending = true;
+			return;
+		}
 		this.draining = true;
 
 		try {
@@ -511,7 +540,13 @@ export class RealtimeService {
 				if (events.length < this.batchSize) break;
 			}
 		} finally {
+			const shouldDrainAgain = this.drainPending;
+			this.drainPending = false;
 			this.draining = false;
+
+			if (shouldDrainAgain) {
+				void this.drain();
+			}
 		}
 	}
 

--- a/packages/questpie/src/server/modules/core/integrated/realtime/types.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/types.ts
@@ -70,8 +70,10 @@ export interface RealtimeConfig {
 	adapter?: RealtimeAdapter;
 
 	/**
-	 * Poll interval in ms if no adapter is configured.
-	 * @default 2000
+	 * Reconciliation poll interval in ms. Polling runs alongside adapters so a
+	 * dropped wake-up notice cannot stall delivery indefinitely.
+	 *
+	 * @default 15000 with an adapter; 2000 without one
 	 */
 	pollIntervalMs?: number;
 

--- a/packages/questpie/test/integration/realtime-reconciliation.test.ts
+++ b/packages/questpie/test/integration/realtime-reconciliation.test.ts
@@ -1,0 +1,290 @@
+import { afterEach, describe, expect, it, spyOn } from "bun:test";
+
+import {
+	collection,
+	type RealtimeAdapter,
+	type RealtimeChangeEvent,
+	type RealtimeNotice,
+} from "../../src/exports/index.js";
+import { RealtimeService } from "../../src/server/modules/core/integrated/realtime/service.js";
+import { buildMockApp } from "../utils/mocks/mock-app-builder";
+import { runTestDbMigrations } from "../utils/test-db";
+
+class DroppingRealtimeAdapter implements RealtimeAdapter {
+	readonly started: Promise<void>;
+	private markStarted: () => void = () => {};
+	private noticeHandler: ((notice: RealtimeNotice) => void) | undefined;
+	private stateHandler:
+		| ((state: "connected" | "disconnected") => void)
+		| undefined;
+
+	constructor() {
+		this.started = new Promise((resolve) => {
+			this.markStarted = resolve;
+		});
+	}
+
+	async start(): Promise<void> {
+		this.markStarted();
+	}
+
+	async stop(): Promise<void> {}
+
+	subscribe(handler: (notice: RealtimeNotice) => void): () => void {
+		this.noticeHandler = handler;
+		return () => {
+			this.noticeHandler = undefined;
+		};
+	}
+
+	async notify(_event: RealtimeChangeEvent): Promise<void> {
+		// Simulate a broker that accepted but dropped the wake-up notice.
+	}
+
+	emit(notice: RealtimeNotice): void {
+		this.noticeHandler?.(notice);
+	}
+
+	onStateChange(
+		handler: (state: "connected" | "disconnected") => void,
+	): () => void {
+		this.stateHandler = handler;
+		return () => {
+			this.stateHandler = undefined;
+		};
+	}
+
+	emitState(state: "connected" | "disconnected"): void {
+		this.stateHandler?.(state);
+	}
+}
+
+type ReadGate = {
+	reached: Promise<void>;
+	release: () => void;
+};
+
+type SelectQuery = {
+	from: () => SelectQuery;
+	where: () => SelectQuery;
+	orderBy: () => SelectQuery;
+	limit: () => Promise<Array<Record<string, unknown>>>;
+};
+
+class ControlledRealtimeReadDb {
+	rows: RealtimeChangeEvent[] = [];
+	private nextReadGate:
+		| (ReadGate & { markReached: () => void; released: Promise<void> })
+		| undefined;
+
+	pauseNextRead(): ReadGate {
+		let markReached = () => {};
+		let release = () => {};
+		const reached = new Promise<void>((resolve) => {
+			markReached = resolve;
+		});
+		const released = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		this.nextReadGate = { reached, released, markReached, release };
+		return { reached, release };
+	}
+
+	select(selection?: unknown): SelectQuery {
+		const isLatestSeqRead = selection !== undefined;
+		const query: SelectQuery = {
+			from: () => query,
+			where: () => query,
+			orderBy: () => query,
+			limit: async () => {
+				if (isLatestSeqRead) {
+					const latest = this.rows.at(-1);
+					return latest ? [{ seq: latest.seq }] : [];
+				}
+
+				const snapshot = this.rows.map((row) => ({ ...row }));
+				const gate = this.nextReadGate;
+				this.nextReadGate = undefined;
+				if (gate) {
+					gate.markReached();
+					await gate.released;
+				}
+				return snapshot;
+			},
+		};
+		return query;
+	}
+}
+
+async function flushMicrotasks(): Promise<void> {
+	for (let index = 0; index < 10; index++) {
+		await Promise.resolve();
+	}
+}
+
+describe("realtime reconciliation", () => {
+	let cleanup: (() => Promise<void>) | undefined;
+
+	afterEach(async () => {
+		await cleanup?.();
+	});
+
+	it("G2: adapter mode defaults to a slow reconciliation poll", async () => {
+		const adapter = new DroppingRealtimeAdapter();
+		const db = new ControlledRealtimeReadDb();
+		let scheduledDelay: number | undefined;
+		const intervalSpy = spyOn(globalThis, "setInterval").mockImplementation(
+			(_handler, delay) => {
+				scheduledDelay = Number(delay);
+				return 1 as unknown as ReturnType<typeof setInterval>;
+			},
+		);
+
+		try {
+			const realtime = new RealtimeService(db as never, { adapter });
+			cleanup = () => realtime.destroy();
+			realtime.subscribe(() => {}, {
+				resourceType: "collection",
+				resource: "posts",
+			});
+			await adapter.started;
+			await flushMicrotasks();
+
+			expect(scheduledDelay).toBe(15_000);
+		} finally {
+			intervalSpy.mockRestore();
+		}
+	});
+
+	it("G2: adapter mode heals a dropped notice on the reconciliation poll", async () => {
+		const adapter = new DroppingRealtimeAdapter();
+		const setup = await buildMockApp(
+			{
+				collections: {
+					posts: collection("posts").fields(({ f }) => ({
+						title: f.text().required(),
+					})),
+				},
+			},
+			{ realtime: { adapter, pollIntervalMs: 25_000 } },
+		);
+		cleanup = setup.cleanup;
+		await runTestDbMigrations(setup.app);
+
+		let triggerPoll: (() => void) | undefined;
+		const intervalSpy = spyOn(globalThis, "setInterval").mockImplementation(
+			(handler, delay) => {
+				if (delay === 25_000) {
+					triggerPoll = () => {
+						if (typeof handler === "function") handler();
+					};
+				}
+				return 1 as unknown as ReturnType<typeof setInterval>;
+			},
+		);
+
+		try {
+			const delivered = new Promise<RealtimeChangeEvent>((resolve) => {
+				setup.app.realtime.subscribe(resolve, {
+					resourceType: "collection",
+					resource: "posts",
+				});
+			});
+			await adapter.started;
+			await Promise.resolve();
+
+			expect(triggerPoll).toBeDefined();
+
+			const change = await setup.app.realtime.appendChange({
+				resourceType: "collection",
+				resource: "posts",
+				operation: "create",
+				recordId: "post-1",
+				locale: null,
+				payload: { id: "post-1", title: "Dropped wake" },
+			});
+			await setup.app.realtime.notify(change);
+
+			triggerPoll?.();
+			expect(await delivered).toEqual(change);
+		} finally {
+			intervalSpy.mockRestore();
+		}
+	});
+
+	it("G2: a notice during the final drain read triggers another drain", async () => {
+		const adapter = new DroppingRealtimeAdapter();
+		const db = new ControlledRealtimeReadDb();
+		const realtime = new RealtimeService(db as never, {
+			adapter,
+			pollIntervalMs: 0,
+		});
+		cleanup = () => realtime.destroy();
+		const delivered: RealtimeChangeEvent[] = [];
+		realtime.subscribe((event) => delivered.push(event), {
+			resourceType: "collection",
+			resource: "posts",
+		});
+		await adapter.started;
+		await flushMicrotasks();
+
+		const finalRead = db.pauseNextRead();
+		adapter.emit({
+			seq: 1,
+			resourceType: "collection",
+			resource: "posts",
+			operation: "create",
+		});
+		await finalRead.reached;
+
+		const change: RealtimeChangeEvent = {
+			seq: 1,
+			resourceType: "collection",
+			resource: "posts",
+			operation: "create",
+			recordId: "post-1",
+			locale: null,
+			payload: { id: "post-1" },
+			createdAt: new Date("2026-07-13T20:00:00.000Z"),
+		};
+		db.rows = [change];
+		adapter.emit(RealtimeService.noticeFromEvent(change));
+		finalRead.release();
+		await flushMicrotasks();
+
+		expect(delivered).toEqual([change]);
+	});
+
+	it("G2: reconnect triggers an immediate reconciliation drain", async () => {
+		const adapter = new DroppingRealtimeAdapter();
+		const db = new ControlledRealtimeReadDb();
+		const realtime = new RealtimeService(db as never, {
+			adapter,
+			pollIntervalMs: 0,
+		});
+		cleanup = () => realtime.destroy();
+		const delivered: RealtimeChangeEvent[] = [];
+		realtime.subscribe((event) => delivered.push(event), {
+			resourceType: "collection",
+			resource: "posts",
+		});
+		await adapter.started;
+		await flushMicrotasks();
+
+		const change: RealtimeChangeEvent = {
+			seq: 1,
+			resourceType: "collection",
+			resource: "posts",
+			operation: "create",
+			recordId: "post-1",
+			locale: null,
+			payload: { id: "post-1" },
+			createdAt: new Date("2026-07-13T20:00:00.000Z"),
+		};
+		db.rows = [change];
+		adapter.emitState("connected");
+		await flushMicrotasks();
+
+		expect(delivered).toEqual([change]);
+	});
+});


### PR DESCRIPTION
## Summary
- run a 15s reconciliation poll alongside realtime adapters while honoring explicit poll intervals
- redrain after notices that arrive during an active drain
- add an optional adapter connection-state signal and reconcile immediately on reconnect

## Tests
- adapter default and explicit reconciliation polling
- dropped notice healed by poll
- notice during final drain read
- immediate drain on reconnect

## Verification
- `cd packages/questpie && bun test test/ --test-name-pattern realtime` (41 pass)
- `cd packages/questpie && bun run check-types`
- targeted oxlint and oxfmt checks

Agent-board: `rt0-1-unconditional-reconciliation-poll-drain-race-fix`