### PR TITLE
fix(questpie): harden Cloudflare realtime topology

### DIFF
--- a/.changeset/cloudflare-realtime-topology.md
+++ b/.changeset/cloudflare-realtime-topology.md
@@ -1,0 +1,5 @@
+---
+"questpie": patch
+---
+
+Harden Cloudflare realtime by sharding Durable Objects per resource, broadcasting notice-only payloads off the mutation path, and keeping snapshot queries in the requesting Worker.

--- a/packages/questpie/src/server/adapters/cloudflare.ts
+++ b/packages/questpie/src/server/adapters/cloudflare.ts
@@ -4,7 +4,10 @@ import { assertCloudflareCompatible } from "#questpie/server/config/runtime-comp
 import type { Questpie } from "../config/questpie.js";
 import type { QueuePushBatch } from "../modules/core/integrated/queue/adapter.js";
 import type { JobDefinition } from "../modules/core/integrated/queue/types.js";
-import type { RealtimeChangeEvent } from "../modules/core/integrated/realtime/types.js";
+import type {
+	RealtimeChangeEvent,
+	RealtimeNotice,
+} from "../modules/core/integrated/realtime/types.js";
 import { createFetchHandler } from "./http.js";
 import type { AdapterConfig, AdapterContext } from "./types.js";
 
@@ -37,8 +40,12 @@ type CloudflareRealtimeAdapterLike = {
 	runtime: "cloudflare";
 	subscribePath: string;
 	notifyPath: string;
-	fetch(request: Request): Promise<Response>;
-	deliver(event: RealtimeChangeEvent): Promise<void>;
+	deliver(event: RealtimeChangeEvent | RealtimeNotice): Promise<void>;
+	subscribe(handler: (notice: RealtimeNotice) => void): () => void;
+	connect(
+		topics: Array<Pick<RealtimeNotice, "resourceType" | "resource">>,
+		signal?: AbortSignal,
+	): { ready: Promise<void>; done: Promise<void>; close(): void };
 };
 
 export type CloudflareFetchFallback = (
@@ -78,6 +85,105 @@ function matchesRealtimePath(request: Request, basePath: string | undefined) {
 	const pathname = new URL(request.url).pathname;
 	const prefix = normalizeBasePath(basePath);
 	return pathname === `${prefix}/realtime`;
+}
+
+function createCloudflareNoticeStream(
+	adapter: CloudflareRealtimeAdapterLike,
+): Response {
+	const encoder = new TextEncoder();
+	let unsubscribe: (() => void) | undefined;
+	const stream = new ReadableStream<Uint8Array>({
+		start(controller) {
+			unsubscribe = adapter.subscribe((notice) => {
+				controller.enqueue(encoder.encode(`${JSON.stringify(notice)}\n`));
+			});
+		},
+		cancel() {
+			unsubscribe?.();
+		},
+	});
+
+	return new Response(stream, {
+		headers: {
+			"Cache-Control": "no-cache, no-transform",
+			"Content-Type": "application/x-ndjson",
+		},
+	});
+}
+
+async function readCloudflareRealtimeShards(
+	request: Request,
+): Promise<Array<Pick<RealtimeNotice, "resourceType" | "resource">>> {
+	try {
+		const body = (await request.json()) as {
+			topics?: Array<{ resourceType?: unknown; resource?: unknown }>;
+		};
+		if (!Array.isArray(body.topics)) return [];
+
+		return body.topics.flatMap((topic) => {
+			if (
+				(topic.resourceType !== "collection" &&
+					topic.resourceType !== "global") ||
+				typeof topic.resource !== "string" ||
+				!topic.resource
+			) {
+				return [];
+			}
+
+			return [
+				{
+					resourceType: topic.resourceType,
+					resource: topic.resource,
+				},
+			];
+		});
+	} catch {
+		return [];
+	}
+}
+
+function withCloudflareRealtimeCleanup(
+	response: Response,
+	cleanup: () => void,
+): Response {
+	if (!response.body) {
+		cleanup();
+		return response;
+	}
+
+	const reader = response.body.getReader();
+	let cleanedUp = false;
+	const close = () => {
+		if (cleanedUp) return;
+		cleanedUp = true;
+		cleanup();
+	};
+	const stream = new ReadableStream<Uint8Array>({
+		async pull(controller) {
+			try {
+				const { done, value } = await reader.read();
+				if (done) {
+					close();
+					controller.close();
+					return;
+				}
+				controller.enqueue(value);
+			} catch (error) {
+				close();
+				controller.error(error);
+			}
+		},
+		async cancel(reason) {
+			close();
+			await reader.cancel(reason);
+		},
+	});
+
+	return new Response(stream, {
+		headers: response.headers,
+		status: response.status,
+		statusText: response.statusText,
+	});
 }
 
 export function toCloudflareQueuePushBatch(
@@ -176,7 +282,23 @@ export function createCloudflareFetchHandler(
 		context?: AdapterContext,
 	): Promise<Response> => {
 		if (matchesRealtimePath(request, config.basePath)) {
-			return getCloudflareRealtimeAdapter(app).fetch(request);
+			const adapter = getCloudflareRealtimeAdapter(app);
+			const shardsRequest = request.clone();
+			const response = await realtimeSubscribe(
+				app,
+				request,
+				{},
+				context,
+				config,
+			);
+			if (!response.ok || !response.body) return response;
+
+			const shards = await readCloudflareRealtimeShards(shardsRequest);
+			if (shards.length === 0) return response;
+
+			const connection = adapter.connect(shards, request.signal);
+			await connection.ready;
+			return withCloudflareRealtimeCleanup(response, connection.close);
 		}
 
 		const response = await fetchHandler(request, context);
@@ -194,19 +316,20 @@ export function createCloudflareRealtimeDurableObjectHandler(
 	config: AdapterConfig = {},
 ) {
 	assertCloudflareCompatible(app.config);
+	void config;
 	const adapter = getCloudflareRealtimeAdapter(app);
 
 	return async (request: Request): Promise<Response> => {
 		const url = new URL(request.url);
 
 		if (request.method === "POST" && url.pathname === adapter.notifyPath) {
-			const event = (await request.json()) as RealtimeChangeEvent;
-			await adapter.deliver(event);
+			const notice = (await request.json()) as RealtimeNotice;
+			await adapter.deliver(notice);
 			return new Response(null, { status: 204 });
 		}
 
 		if (request.method === "POST" && url.pathname === adapter.subscribePath) {
-			return realtimeSubscribe(app, request, {}, undefined, config);
+			return createCloudflareNoticeStream(adapter);
 		}
 
 		return new Response("Not Found", { status: 404 });

--- a/packages/questpie/src/server/modules/core/integrated/realtime/adapters/cloudflare.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/adapters/cloudflare.ts
@@ -24,6 +24,10 @@ export interface CloudflareRealtimeAdapterOptions {
 	namespace: CloudflareDurableObjectNamespaceInput;
 	objectName?: string;
 	hubPath?: string;
+	/** Keep non-blocking notify requests alive for the current Worker event. */
+	waitUntil?: (promise: Promise<unknown>) => void;
+	/** Receives background publish and relay failures. Defaults to console.error. */
+	onError?: (error: unknown) => void;
 }
 
 function isCloudflareDurableObjectNamespaceProvider(
@@ -49,12 +53,25 @@ function noticeFromEvent(
 	};
 }
 
+type CloudflareRealtimeShard = Pick<
+	RealtimeNotice,
+	"resourceType" | "resource"
+>;
+
+export interface CloudflareRealtimeConnection {
+	ready: Promise<void>;
+	done: Promise<void>;
+	close(): void;
+}
+
 export class CloudflareRealtimeAdapter implements RealtimeAdapter {
 	public readonly runtime = "cloudflare" as const;
 
 	private readonly getNamespace: CloudflareDurableObjectNamespaceProvider;
 	private readonly objectName: string;
 	private readonly hubPath: string;
+	private readonly waitUntil?: (promise: Promise<unknown>) => void;
+	private readonly onError?: (error: unknown) => void;
 	private readonly handlers = new Set<(notice: RealtimeNotice) => void>();
 
 	constructor(options: CloudflareRealtimeAdapterOptions) {
@@ -64,6 +81,8 @@ export class CloudflareRealtimeAdapter implements RealtimeAdapter {
 			: () => namespace;
 		this.objectName = options.objectName ?? "questpie-realtime";
 		this.hubPath = normalizeHubPath(options.hubPath);
+		this.waitUntil = options.waitUntil;
+		this.onError = options.onError;
 	}
 
 	get subscribePath(): string {
@@ -81,13 +100,21 @@ export class CloudflareRealtimeAdapter implements RealtimeAdapter {
 	}
 
 	async notify(event: RealtimeChangeEvent): Promise<void> {
-		const stub = await this.getStub();
+		const notice = noticeFromEvent(event);
+		const publish = this.publishNotice(notice).catch((error) => {
+			this.reportError(error);
+		});
+		this.waitUntil?.(publish);
+	}
+
+	private async publishNotice(notice: RealtimeNotice): Promise<void> {
+		const stub = await this.getStub(notice);
 		const response = await stub.fetch(
 			`https://questpie.internal${this.notifyPath}`,
 			{
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
-				body: JSON.stringify(event),
+				body: JSON.stringify(notice),
 			},
 		);
 
@@ -98,6 +125,15 @@ export class CloudflareRealtimeAdapter implements RealtimeAdapter {
 		}
 	}
 
+	private reportError(error: unknown): void {
+		if (this.onError) {
+			this.onError(error);
+			return;
+		}
+
+		console.error("[questpie] Cloudflare realtime publish failed.", error);
+	}
+
 	subscribe(handler: (notice: RealtimeNotice) => void): () => void {
 		this.handlers.add(handler);
 		return () => {
@@ -105,10 +141,77 @@ export class CloudflareRealtimeAdapter implements RealtimeAdapter {
 		};
 	}
 
+	connect(
+		topics: CloudflareRealtimeShard[],
+		signal?: AbortSignal,
+	): CloudflareRealtimeConnection {
+		const abortController = new AbortController();
+		const abort = () => abortController.abort();
+		signal?.addEventListener("abort", abort, { once: true });
+
+		const uniqueTopics = new Map<string, CloudflareRealtimeShard>();
+		for (const topic of topics) {
+			uniqueTopics.set(`${topic.resourceType}:${topic.resource}`, topic);
+		}
+
+		const streams = [...uniqueTopics.values()].map((topic) =>
+			this.openShard(topic, abortController.signal),
+		);
+		const ready = Promise.all(streams).then(
+			() => {},
+			() => {},
+		);
+		const done = Promise.all(
+			streams.map(async (stream) => this.consumeShard(await stream)),
+		)
+			.then(() => {})
+			.catch((error) => {
+				if (!abortController.signal.aborted) {
+					this.reportError(error);
+				}
+			});
+
+		return {
+			ready,
+			done,
+			close: () => {
+				signal?.removeEventListener("abort", abort);
+				abortController.abort();
+			},
+		};
+	}
+
 	async fetch(request: Request): Promise<Response> {
+		let body: {
+			topics?: Array<{ resourceType?: unknown; resource?: unknown }>;
+		};
+		try {
+			body = await request.clone().json();
+		} catch {
+			return new Response("A single realtime topic is required.", {
+				status: 400,
+			});
+		}
+
+		const topic = body.topics?.[0];
+		if (
+			body.topics?.length !== 1 ||
+			(topic?.resourceType !== "collection" &&
+				topic?.resourceType !== "global") ||
+			typeof topic.resource !== "string" ||
+			!topic.resource
+		) {
+			return new Response("A single realtime topic is required.", {
+				status: 400,
+			});
+		}
+
 		const url = new URL(request.url);
 		url.pathname = this.subscribePath;
-		const stub = await this.getStub();
+		const stub = await this.getStub({
+			resourceType: topic.resourceType,
+			resource: topic.resource,
+		});
 		return stub.fetch(new Request(url, request));
 	}
 
@@ -119,9 +222,63 @@ export class CloudflareRealtimeAdapter implements RealtimeAdapter {
 		}
 	}
 
-	private async getStub(): Promise<CloudflareDurableObjectStub> {
+	private async openShard(
+		shard: CloudflareRealtimeShard,
+		signal: AbortSignal,
+	): Promise<ReadableStream<Uint8Array>> {
+		const stub = await this.getStub(shard);
+		const response = await stub.fetch(
+			`https://questpie.internal${this.subscribePath}`,
+			{ method: "POST", signal },
+		);
+
+		if (!response.ok || !response.body) {
+			throw new Error(
+				`CloudflareRealtimeAdapter subscribe failed with ${response.status}.`,
+			);
+		}
+		return response.body;
+	}
+
+	private async consumeShard(
+		stream: ReadableStream<Uint8Array>,
+	): Promise<void> {
+		const reader = stream.getReader();
+		const decoder = new TextDecoder();
+		let buffered = "";
+
+		try {
+			while (true) {
+				const { done, value } = await reader.read();
+				if (done) break;
+
+				buffered += decoder.decode(value, { stream: true });
+				let newlineIndex = buffered.indexOf("\n");
+				while (newlineIndex >= 0) {
+					const line = buffered.slice(0, newlineIndex).trim();
+					buffered = buffered.slice(newlineIndex + 1);
+					if (line) {
+						await this.deliver(JSON.parse(line) as RealtimeNotice);
+					}
+					newlineIndex = buffered.indexOf("\n");
+				}
+			}
+
+			const finalLine = buffered.trim();
+			if (finalLine) {
+				await this.deliver(JSON.parse(finalLine) as RealtimeNotice);
+			}
+		} finally {
+			reader.releaseLock();
+		}
+	}
+
+	private async getStub(
+		shard: CloudflareRealtimeShard,
+	): Promise<CloudflareDurableObjectStub> {
 		const namespace = await this.getNamespace();
-		return namespace.get(namespace.idFromName(this.objectName));
+		const objectName = `${this.objectName}:${shard.resourceType}:${shard.resource}`;
+		return namespace.get(namespace.idFromName(objectName));
 	}
 }
 

--- a/packages/questpie/test/integration/cloudflare-realtime-topology.test.ts
+++ b/packages/questpie/test/integration/cloudflare-realtime-topology.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, test } from "bun:test";
+
+import { memory } from "files-sdk/memory";
+
+import {
+	cloudflareKVAdapter,
+	cloudflareQueuesAdapter,
+	cloudflareRealtimeAdapter,
+	createCloudflareFetchHandler,
+} from "../../src/exports/adapters/cloudflare.js";
+import { collection } from "../../src/exports/index.js";
+import { buildMockApp } from "../utils/mocks/mock-app-builder";
+import { runTestDbMigrations } from "../utils/test-db";
+
+function createRelayNamespace() {
+	const objectNames: string[] = [];
+	return {
+		objectNames,
+		idFromName: (name: string) => ({ name }),
+		get: (id: { name: string }) => ({
+			fetch: async () => {
+				objectNames.push(id.name);
+				return new Response("", {
+					headers: { "Content-Type": "application/x-ndjson" },
+				});
+			},
+		}),
+	};
+}
+
+describe("Cloudflare realtime topology", () => {
+	test("requesting Worker owns snapshot queries and connects resource shards", async () => {
+		const durableObjects = createRelayNamespace();
+		const scheduled: Promise<unknown>[] = [];
+		const realtimeAdapter = cloudflareRealtimeAdapter({
+			namespace: durableObjects,
+			waitUntil: (promise) => scheduled.push(promise),
+		});
+		let setup: Awaited<ReturnType<typeof buildMockApp>> | undefined;
+
+		try {
+			setup = await buildMockApp(
+				{
+					defaultAccess: true,
+					collections: {
+						posts: collection("posts")
+							.fields(({ f }) => ({
+								title: f.text().required(),
+							}))
+							.access({ read: true, create: true }),
+					},
+				},
+				{
+					storage: { adapter: memory() },
+					queue: {
+						adapter: cloudflareQueuesAdapter({
+							queue: { send: async () => undefined },
+						}),
+					},
+					kv: {
+						adapter: cloudflareKVAdapter({
+							namespace: {
+								get: async () => null,
+								put: async () => {},
+								delete: async () => {},
+								list: async () => ({ keys: [], list_complete: true }),
+							},
+						}),
+					},
+					realtime: { adapter: realtimeAdapter },
+				},
+			);
+			await runTestDbMigrations(setup.app);
+			await setup.app.collections.posts.create({ title: "From Worker DB" });
+			await Promise.all(scheduled.splice(0));
+			durableObjects.objectNames.length = 0;
+			// The test DB is PGlite, but the handler's compatibility check only needs
+			// the already-created Drizzle client to model a Worker-compatible binding.
+			setup.app.config.db = { drizzle: setup.app.db };
+			setup.app.config.queue!.adapter = cloudflareQueuesAdapter({
+				queue: { send: async () => undefined },
+			});
+			setup.app.config.kv!.adapter = cloudflareKVAdapter({
+				namespace: {
+					get: async () => null,
+					put: async () => {},
+					delete: async () => {},
+					list: async () => ({ keys: [], list_complete: true }),
+				},
+			});
+
+			const response = await createCloudflareFetchHandler(setup.app)(
+				new Request("https://example.com/realtime", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({
+						topics: [
+							{
+								id: "posts-list",
+								resourceType: "collection",
+								resource: "posts",
+							},
+						],
+					}),
+				}),
+			);
+			let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
+
+			try {
+				expect(response.headers.get("Content-Type")).toContain(
+					"text/event-stream",
+				);
+				expect(durableObjects.objectNames).toEqual([
+					"questpie-realtime:collection:posts",
+				]);
+
+				reader = response.body!.getReader();
+				const initial = await reader.read();
+				const text = new TextDecoder().decode(initial.value);
+				expect(text).toContain("event: snapshot");
+				expect(text).toContain('"title":"From Worker DB"');
+			} finally {
+				if (reader) await reader.cancel();
+				else await response.body?.cancel();
+			}
+		} finally {
+			await setup?.cleanup();
+		}
+	});
+});

--- a/packages/questpie/test/units/cloudflare-adapter.test.ts
+++ b/packages/questpie/test/units/cloudflare-adapter.test.ts
@@ -9,6 +9,7 @@ import {
 	cloudflareRealtimeAdapter,
 	createCloudflareFetchHandler,
 	createCloudflareQueueHandler,
+	createCloudflareRealtimeDurableObjectHandler,
 	createCloudflareScheduledHandler,
 	publishScheduledJobs,
 	toCloudflareQueuePushBatch,
@@ -29,11 +30,14 @@ const kvNamespace: CloudflareKVNamespace = {
 
 function createDurableObjectNamespace() {
 	const requests: Request[] = [];
+	const objectNames: string[] = [];
 	const namespace = {
 		requests,
+		objectNames,
 		idFromName: (name: string) => ({ name }),
-		get: () => ({
+		get: (id: { name: string }) => ({
 			fetch: async (input: RequestInfo | URL, init?: RequestInit) => {
+				objectNames.push(id.name);
 				const request =
 					input instanceof Request ? input : new Request(input, init);
 				requests.push(request);
@@ -172,6 +176,7 @@ describe("Cloudflare adapter helpers", () => {
 
 	test("Cloudflare adapters accept lazy runtime binding providers", async () => {
 		const sent: unknown[] = [];
+		const scheduled: Promise<unknown>[] = [];
 		const durableObjects = createDurableObjectNamespace();
 		const queue = cloudflareQueuesAdapter({
 			queue: async () => ({
@@ -183,6 +188,7 @@ describe("Cloudflare adapter helpers", () => {
 		const kv = cloudflareKVAdapter({ namespace: async () => kvNamespace });
 		const realtime = cloudflareRealtimeAdapter({
 			namespace: async () => durableObjects,
+			waitUntil: (promise) => scheduled.push(promise),
 		});
 
 		await queue.publish("daily-digest", {});
@@ -194,6 +200,7 @@ describe("Cloudflare adapter helpers", () => {
 			operation: "update",
 			createdAt: new Date(),
 		});
+		await Promise.all(scheduled);
 
 		expect(sent).toEqual([{ jobName: "daily-digest", payload: {} }]);
 		expect(
@@ -225,7 +232,11 @@ describe("Cloudflare adapter helpers", () => {
 
 	test("Cloudflare realtime adapter proxies notify and subscribe to Durable Object", async () => {
 		const durableObjects = createDurableObjectNamespace();
-		const adapter = cloudflareRealtimeAdapter({ namespace: durableObjects });
+		const scheduled: Promise<unknown>[] = [];
+		const adapter = cloudflareRealtimeAdapter({
+			namespace: durableObjects,
+			waitUntil: (promise) => scheduled.push(promise),
+		});
 
 		await adapter.notify({
 			seq: 1,
@@ -234,13 +245,199 @@ describe("Cloudflare adapter helpers", () => {
 			operation: "create",
 			createdAt: new Date(),
 		});
-		await adapter.fetch(new Request("https://example.com/api/realtime"));
+		await Promise.all(scheduled);
+		await adapter.fetch(
+			new Request("https://example.com/api/realtime", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({
+					topics: [
+						{
+							id: "posts-list",
+							resourceType: "collection",
+							resource: "posts",
+						},
+					],
+				}),
+			}),
+		);
 
+		expect(durableObjects.objectNames).toEqual([
+			"questpie-realtime:collection:posts",
+			"questpie-realtime:collection:posts",
+		]);
 		expect(
 			durableObjects.requests.map((request) => new URL(request.url).pathname),
 		).toEqual([
 			"/__questpie/realtime/notify",
 			"/__questpie/realtime/subscribe",
+		]);
+	});
+
+	test("Cloudflare realtime publishes notice-only payloads to resource shards", async () => {
+		const durableObjects = createDurableObjectNamespace();
+		const scheduled: Promise<unknown>[] = [];
+		const adapter = cloudflareRealtimeAdapter({
+			namespace: durableObjects,
+			waitUntil: (promise) => scheduled.push(promise),
+		});
+
+		await adapter.notify({
+			seq: 7,
+			resourceType: "collection",
+			resource: "posts",
+			operation: "update",
+			recordId: "post-1",
+			locale: "sk",
+			payload: { id: "post-1", title: "Never broadcast this row" },
+			createdAt: new Date("2026-07-13T20:00:00.000Z"),
+		});
+		await scheduled[0];
+
+		expect(durableObjects.objectNames).toEqual([
+			"questpie-realtime:collection:posts",
+		]);
+		expect(await durableObjects.requests[0]!.json()).toEqual({
+			seq: 7,
+			resourceType: "collection",
+			resource: "posts",
+			operation: "update",
+		});
+	});
+
+	test("Cloudflare realtime schedules notify with waitUntil and reports failures", async () => {
+		let resolveFetch = (_response: Response) => {};
+		const fetchResult = new Promise<Response>((resolve) => {
+			resolveFetch = resolve;
+		});
+		const scheduled: Promise<unknown>[] = [];
+		const errors: unknown[] = [];
+		const adapter = cloudflareRealtimeAdapter({
+			namespace: {
+				idFromName: (name: string) => ({ name }),
+				get: () => ({ fetch: () => fetchResult }),
+			},
+			waitUntil: (promise: Promise<unknown>) => scheduled.push(promise),
+			onError: (error: unknown) => errors.push(error),
+		});
+
+		let notifyResolved = false;
+		const notifyResult = adapter
+			.notify({
+				seq: 8,
+				resourceType: "collection",
+				resource: "posts",
+				operation: "create",
+				createdAt: new Date("2026-07-13T20:00:00.000Z"),
+			})
+			.then(() => {
+				notifyResolved = true;
+			});
+		await Promise.resolve();
+		await Promise.resolve();
+
+		try {
+			expect(notifyResolved).toBe(true);
+			expect(scheduled).toHaveLength(1);
+		} finally {
+			resolveFetch(new Response(null, { status: 503 }));
+			await notifyResult.catch(() => {});
+		}
+
+		await scheduled[0];
+		expect(errors).toHaveLength(1);
+		expect(String(errors[0])).toContain(
+			"CloudflareRealtimeAdapter notify failed with 503",
+		);
+	});
+
+	test("Cloudflare Durable Object is a notice-only fan-out hub", async () => {
+		const handler = createCloudflareRealtimeDurableObjectHandler(
+			createApp() as any,
+		);
+		const subscription = await handler(
+			new Request("https://questpie.internal/__questpie/realtime/subscribe", {
+				method: "POST",
+			}),
+		);
+
+		expect(subscription.status).toBe(200);
+		expect(subscription.headers.get("Content-Type")).toBe(
+			"application/x-ndjson",
+		);
+
+		const reader = subscription.body!.getReader();
+		const nextNotice = reader.read();
+		const notice = {
+			seq: 9,
+			resourceType: "collection",
+			resource: "posts",
+			operation: "delete",
+		} as const;
+		const notified = await handler(
+			new Request("https://questpie.internal/__questpie/realtime/notify", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify(notice),
+			}),
+		);
+
+		expect(notified.status).toBe(204);
+		const chunk = await nextNotice;
+		expect(new TextDecoder().decode(chunk.value)).toBe(
+			`${JSON.stringify(notice)}\n`,
+		);
+		await reader.cancel();
+	});
+
+	test("Cloudflare Worker relay connects resource shards and delivers notices", async () => {
+		const objectNames: string[] = [];
+		const namespace = {
+			idFromName: (name: string) => ({ name }),
+			get: (id: { name: string }) => ({
+				fetch: async () => {
+					objectNames.push(id.name);
+					const [, resourceType, resource] = id.name.split(":");
+					const notice = {
+						seq: objectNames.length,
+						resourceType,
+						resource,
+						operation: "update",
+					};
+					return new Response(`${JSON.stringify(notice)}\n`, {
+						headers: { "Content-Type": "application/x-ndjson" },
+					});
+				},
+			}),
+		};
+		const adapter = cloudflareRealtimeAdapter({ namespace });
+		const delivered: unknown[] = [];
+		adapter.subscribe((notice) => delivered.push(notice));
+
+		const connection = adapter.connect([
+			{ resourceType: "collection", resource: "posts" },
+			{ resourceType: "collection", resource: "posts" },
+			{ resourceType: "global", resource: "settings" },
+		]);
+		await connection.done;
+
+		expect(objectNames).toEqual([
+			"questpie-realtime:collection:posts",
+			"questpie-realtime:global:settings",
+		]);
+		expect(delivered).toEqual([
+			{
+				seq: 1,
+				resourceType: "collection",
+				resource: "posts",
+				operation: "update",
+			},
+			{
+				seq: 2,
+				resourceType: "global",
+				resource: "settings",
+				operation: "update",
+			},
 		]);
 	});
 });


### PR DESCRIPTION
## Summary
- shard Cloudflare Durable Objects by realtime resource and publish only 4-field notices
- remove DO-side snapshot queries; the requesting Worker owns the SSE stream and database reads
- relay DO notices back to the Worker and detach relay lifecycle with the response
- make mutation-path notify non-blocking through `waitUntil` with captured/logged failures

## Tests
- resource shard identity and notice-only payload
- non-blocking waitUntil publish and failure reporting
- pure DO fan-out stream
- unique Worker relay connections and notice delivery
- Worker-owned initial snapshot query

## Verification
- `cd packages/questpie && bun test test/ --test-name-pattern 'cloudflare|realtime'` (45 pass)
- `cd packages/questpie && bun run check-types`
- targeted oxlint and oxfmt checks

Agent-board: `rt0-10-cloudflare-realtime-topology-hardening-shard-do-notices-only-queries-out-of-do`