### PR TITLE
fix(questpie): start realtime publishers at boot

### DIFF
--- a/.changeset/eager-realtime-publisher.md
+++ b/.changeset/eager-realtime-publisher.md
@@ -1,0 +1,5 @@
+---
+"questpie": patch
+---
+
+Start realtime publishers with the app lifecycle so write-only instances broadcast changes before any local subscription and keep adapters alive until app teardown.

--- a/packages/questpie/src/server/modules/core/integrated/realtime/adapter.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/adapter.ts
@@ -6,6 +6,8 @@ export type RealtimeAdapterState = "connected" | "disconnected";
  * Transport adapter for realtime change notifications.
  */
 export interface RealtimeAdapter {
+	/** Prepare the publish side without requiring a local subscription. */
+	startPublisher?(): Promise<void>;
 	start(): Promise<void>;
 	stop(): Promise<void>;
 	notify(event: RealtimeChangeEvent): Promise<void>;

--- a/packages/questpie/src/server/modules/core/integrated/realtime/adapters/cloudflare.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/adapters/cloudflare.ts
@@ -75,6 +75,7 @@ export class CloudflareRealtimeAdapter implements RealtimeAdapter {
 	}
 
 	async start(): Promise<void> {}
+	async startPublisher(): Promise<void> {}
 
 	async stop(): Promise<void> {
 		this.handlers.clear();

--- a/packages/questpie/src/server/modules/core/integrated/realtime/adapters/pg-notify.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/adapters/pg-notify.ts
@@ -47,8 +47,8 @@ export class PgNotifyAdapter implements RealtimeAdapter {
 
 	async start(): Promise<void> {
 		if (this.started) return;
-		const client = await this.ensureClient();
-		await this.ensureConnected(client);
+		await this.startPublisher();
+		const client = this.client!;
 		await client.query(`LISTEN ${this.channel}`);
 		this.notificationHandler = (msg) => {
 			if (!msg.payload) return;
@@ -66,8 +66,13 @@ export class PgNotifyAdapter implements RealtimeAdapter {
 		this.started = true;
 	}
 
+	async startPublisher(): Promise<void> {
+		const client = await this.ensureClient();
+		await this.ensureConnected(client);
+	}
+
 	async stop(): Promise<void> {
-		if (!this.started) return;
+		const wasStarted = this.started;
 		this.started = false;
 		const client = this.client;
 		if (!client) return;
@@ -77,10 +82,12 @@ export class PgNotifyAdapter implements RealtimeAdapter {
 			this.notificationHandler = undefined;
 		}
 
-		try {
-			await client.query(`UNLISTEN ${this.channel}`);
-		} catch {
-			// Ignore UNLISTEN failures during shutdown.
+		if (wasStarted) {
+			try {
+				await client.query(`UNLISTEN ${this.channel}`);
+			} catch {
+				// Ignore UNLISTEN failures during shutdown.
+			}
 		}
 
 		if (this.ownsClient) {

--- a/packages/questpie/src/server/modules/core/integrated/realtime/adapters/redis-streams.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/adapters/redis-streams.ts
@@ -64,6 +64,8 @@ export class RedisStreamsAdapter implements RealtimeAdapter {
 		});
 	}
 
+	async startPublisher(): Promise<void> {}
+
 	async stop(): Promise<void> {
 		this.running = false;
 	}

--- a/packages/questpie/src/server/modules/core/integrated/realtime/service.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/service.ts
@@ -3,6 +3,7 @@ import { asc, desc, gt, lt } from "drizzle-orm";
 import type { DrizzleClientFromQuestpieConfig } from "#questpie/server/config/types.js";
 
 import type { RealtimeAdapter } from "./adapter.js";
+import { PgNotifyAdapter } from "./adapters/pg-notify.js";
 import { questpieRealtimeLogTable } from "./collection.js";
 import type {
 	RealtimeChangeEvent,
@@ -136,6 +137,8 @@ export class RealtimeService {
 	private drainPending = false;
 	private started = false;
 	private startPromise: Promise<void> | null = null;
+	private publisherStartPromise: Promise<void> | null = null;
+	private publisherStarted = false;
 	private lastSeq = 0;
 	private pollTimer: ReturnType<typeof setInterval> | null = null;
 	private unsubscribeAdapter: (() => void) | null = null;
@@ -156,8 +159,14 @@ export class RealtimeService {
 		if (config.adapter) {
 			// User provided custom adapter
 			this.adapter = config.adapter;
+		} else if (this.pgConnectionString) {
+			// Create the default publisher at service construction so write-only
+			// instances can broadcast before they ever receive a local subscription.
+			this.adapter = new PgNotifyAdapter({
+				connectionString: this.pgConnectionString,
+				channel: "questpie_realtime",
+			});
 		}
-		// PgNotifyAdapter will be lazily created on first subscribe (if needed)
 
 		this.batchSize = config.batchSize ?? 500;
 		this.pollIntervalMs =
@@ -256,7 +265,24 @@ export class RealtimeService {
 
 	async notify(event: RealtimeChangeEvent): Promise<void> {
 		if (!this.adapter) return;
+		await this.initialize();
 		await this.adapter.notify(event);
+	}
+
+	async initialize(): Promise<void> {
+		if (this.publisherStarted) return;
+		if (this.publisherStartPromise) {
+			await this.publisherStartPromise;
+			return;
+		}
+
+		this.publisherStartPromise = (async () => {
+			await this.adapter?.startPublisher?.();
+			this.publisherStarted = true;
+		})().finally(() => {
+			this.publisherStartPromise = null;
+		});
+		await this.publisherStartPromise;
 	}
 
 	/**
@@ -368,10 +394,6 @@ export class RealtimeService {
 					entry,
 				);
 			}
-
-			if (this.listeners.size === 0) {
-				void this.stop();
-			}
 		};
 	}
 
@@ -412,16 +434,8 @@ export class RealtimeService {
 		}
 
 		this.startPromise = (async () => {
+			await this.initialize();
 			const latestSeq = await this.getLatestSeq();
-
-			// Lazy-load pg-notify adapter if Postgres connection string is available
-			if (!this.adapter && this.pgConnectionString) {
-				const { PgNotifyAdapter } = await import("./adapters/pg-notify");
-				this.adapter = new PgNotifyAdapter({
-					connectionString: this.pgConnectionString,
-					channel: "questpie_realtime",
-				});
-			}
 
 			if (this.adapter) {
 				await this.adapter.start();
@@ -487,7 +501,22 @@ export class RealtimeService {
 	}
 
 	private async stop(): Promise<void> {
-		if (!this.started && !this.startPromise) return;
+		if (
+			!this.started &&
+			!this.startPromise &&
+			!this.publisherStarted &&
+			!this.publisherStartPromise
+		) {
+			return;
+		}
+
+		if (this.publisherStartPromise) {
+			try {
+				await this.publisherStartPromise;
+			} catch {
+				// startup already failed, continue cleanup
+			}
+		}
 
 		if (this.startPromise) {
 			try {
@@ -497,7 +526,6 @@ export class RealtimeService {
 			}
 		}
 
-		if (!this.started) return;
 		this.started = false;
 
 		if (this.pollTimer) {
@@ -518,6 +546,7 @@ export class RealtimeService {
 		if (this.adapter) {
 			await this.adapter.stop();
 		}
+		this.publisherStarted = false;
 	}
 
 	private async drain(): Promise<void> {

--- a/packages/questpie/src/server/modules/core/services/realtime.ts
+++ b/packages/questpie/src/server/modules/core/services/realtime.ts
@@ -1,5 +1,5 @@
-import { service } from "#questpie/server/services/define-service.js";
 import { RealtimeService } from "#questpie/server/modules/core/integrated/realtime/service.js";
+import { service } from "#questpie/server/services/define-service.js";
 
 /**
  * Realtime service — creates the RealtimeService from app config.
@@ -10,7 +10,7 @@ import { RealtimeService } from "#questpie/server/modules/core/integrated/realti
 export default service({
 	namespace: null,
 	lifecycle: "singleton",
-	create: ({ app }) => {
+	create: async ({ app }) => {
 		const realtime = new RealtimeService(
 			// Widen — RealtimeService takes the general client type; the generated
 			// `app.db` is narrowed to the app's concrete drizzle schema.
@@ -28,6 +28,7 @@ export default service({
 				return app._resolveGlobalDependencies(globalName, withConfig);
 			},
 		});
+		await realtime.initialize();
 
 		return realtime;
 	},

--- a/packages/questpie/test/integration/realtime-reconciliation.test.ts
+++ b/packages/questpie/test/integration/realtime-reconciliation.test.ts
@@ -6,12 +6,15 @@ import {
 	type RealtimeChangeEvent,
 	type RealtimeNotice,
 } from "../../src/exports/index.js";
+import { PgNotifyAdapter } from "../../src/server/modules/core/integrated/realtime/adapters/pg-notify.js";
 import { RealtimeService } from "../../src/server/modules/core/integrated/realtime/service.js";
 import { buildMockApp } from "../utils/mocks/mock-app-builder";
 import { runTestDbMigrations } from "../utils/test-db";
 
 class DroppingRealtimeAdapter implements RealtimeAdapter {
 	readonly started: Promise<void>;
+	publisherStarts = 0;
+	stops = 0;
 	private markStarted: () => void = () => {};
 	private noticeHandler: ((notice: RealtimeNotice) => void) | undefined;
 	private stateHandler:
@@ -28,7 +31,13 @@ class DroppingRealtimeAdapter implements RealtimeAdapter {
 		this.markStarted();
 	}
 
-	async stop(): Promise<void> {}
+	async startPublisher(): Promise<void> {
+		this.publisherStarts += 1;
+	}
+
+	async stop(): Promise<void> {
+		this.stops += 1;
+	}
 
 	subscribe(handler: (notice: RealtimeNotice) => void): () => void {
 		this.noticeHandler = handler;
@@ -56,6 +65,65 @@ class DroppingRealtimeAdapter implements RealtimeAdapter {
 
 	emitState(state: "connected" | "disconnected"): void {
 		this.stateHandler?.(state);
+	}
+}
+
+class SharedWakeBroker {
+	private handlers = new Set<(notice: RealtimeNotice) => void>();
+
+	subscribe(handler: (notice: RealtimeNotice) => void): () => void {
+		this.handlers.add(handler);
+		return () => this.handlers.delete(handler);
+	}
+
+	publish(notice: RealtimeNotice): void {
+		for (const handler of this.handlers) handler(notice);
+	}
+}
+
+class BrokerRealtimeAdapter implements RealtimeAdapter {
+	readonly listening: Promise<void>;
+	publisherStarts = 0;
+	localSubscriptions = 0;
+	private markListening: () => void = () => {};
+	private publisherStarted = false;
+	private brokerUnsubscribe: (() => void) | undefined;
+	private handlers = new Set<(notice: RealtimeNotice) => void>();
+
+	constructor(private broker: SharedWakeBroker) {
+		this.listening = new Promise((resolve) => {
+			this.markListening = resolve;
+		});
+	}
+
+	async startPublisher(): Promise<void> {
+		this.publisherStarts += 1;
+		this.publisherStarted = true;
+	}
+
+	async start(): Promise<void> {
+		this.brokerUnsubscribe ??= this.broker.subscribe((notice) => {
+			for (const handler of this.handlers) handler(notice);
+		});
+	}
+
+	async stop(): Promise<void> {
+		this.brokerUnsubscribe?.();
+		this.brokerUnsubscribe = undefined;
+	}
+
+	async notify(event: RealtimeChangeEvent): Promise<void> {
+		if (!this.publisherStarted) {
+			throw new Error("publisher not started");
+		}
+		this.broker.publish(RealtimeService.noticeFromEvent(event));
+	}
+
+	subscribe(handler: (notice: RealtimeNotice) => void): () => void {
+		this.localSubscriptions += 1;
+		this.handlers.add(handler);
+		this.markListening();
+		return () => this.handlers.delete(handler);
 	}
 }
 
@@ -127,6 +195,111 @@ describe("realtime reconciliation", () => {
 
 	afterEach(async () => {
 		await cleanup?.();
+	});
+
+	it("G1: implicit pg publisher notifies with zero local subscribers", async () => {
+		const startPublisherSpy = spyOn(
+			PgNotifyAdapter.prototype,
+			"startPublisher",
+		).mockResolvedValue();
+		const notifySpy = spyOn(
+			PgNotifyAdapter.prototype,
+			"notify",
+		).mockResolvedValue();
+		const realtime = new RealtimeService(
+			new ControlledRealtimeReadDb() as never,
+			{ pollIntervalMs: 0 },
+			"postgres://questpie.test/app",
+		);
+		cleanup = () => realtime.destroy();
+		const change: RealtimeChangeEvent = {
+			seq: 1,
+			resourceType: "collection",
+			resource: "posts",
+			operation: "create",
+			recordId: "post-1",
+			locale: null,
+			payload: { id: "post-1" },
+			createdAt: new Date("2026-07-13T20:00:00.000Z"),
+		};
+
+		try {
+			await realtime.notify(change);
+			expect(notifySpy).toHaveBeenCalledTimes(1);
+			expect(notifySpy).toHaveBeenCalledWith(change);
+		} finally {
+			notifySpy.mockRestore();
+			startPublisherSpy.mockRestore();
+		}
+	});
+
+	it("G1: app boot starts the adapter publisher without a subscription", async () => {
+		const adapter = new DroppingRealtimeAdapter();
+		const setup = await buildMockApp({}, { realtime: { adapter } });
+		cleanup = setup.cleanup;
+
+		expect(adapter.publisherStarts).toBe(1);
+	});
+
+	it("G1: zero listeners keep the app-lifecycle publisher running", async () => {
+		const adapter = new DroppingRealtimeAdapter();
+		const setup = await buildMockApp({}, { realtime: { adapter } });
+		cleanup = setup.cleanup;
+		await runTestDbMigrations(setup.app);
+		const unsubscribe = setup.app.realtime.subscribe(() => {}, {
+			resourceType: "collection",
+			resource: "posts",
+		});
+		await adapter.started;
+
+		unsubscribe();
+		await flushMicrotasks();
+
+		expect(adapter.stops).toBe(0);
+		expect(adapter.publisherStarts).toBe(1);
+	});
+
+	it("G1: a zero-subscriber instance wakes a second service instance", async () => {
+		const broker = new SharedWakeBroker();
+		const publisherAdapter = new BrokerRealtimeAdapter(broker);
+		const receiverAdapter = new BrokerRealtimeAdapter(broker);
+		const publisher = new RealtimeService(
+			new ControlledRealtimeReadDb() as never,
+			{ adapter: publisherAdapter, pollIntervalMs: 0 },
+		);
+		const receiverDb = new ControlledRealtimeReadDb();
+		const receiver = new RealtimeService(receiverDb as never, {
+			adapter: receiverAdapter,
+			pollIntervalMs: 0,
+		});
+		cleanup = async () => {
+			await Promise.all([publisher.destroy(), receiver.destroy()]);
+		};
+		const delivered: RealtimeChangeEvent[] = [];
+		receiver.subscribe((event) => delivered.push(event), {
+			resourceType: "collection",
+			resource: "posts",
+		});
+		await receiverAdapter.listening;
+		await flushMicrotasks();
+
+		const change: RealtimeChangeEvent = {
+			seq: 1,
+			resourceType: "collection",
+			resource: "posts",
+			operation: "create",
+			recordId: "post-1",
+			locale: null,
+			payload: { id: "post-1" },
+			createdAt: new Date("2026-07-13T20:00:00.000Z"),
+		};
+		receiverDb.rows = [change];
+		await publisher.notify(change);
+		await flushMicrotasks();
+
+		expect(delivered).toEqual([change]);
+		expect(publisherAdapter.localSubscriptions).toBe(0);
+		expect(publisherAdapter.publisherStarts).toBe(1);
 	});
 
 	it("G2: adapter mode defaults to a slow reconciliation poll", async () => {

--- a/packages/questpie/test/integration/realtime.test.ts
+++ b/packages/questpie/test/integration/realtime.test.ts
@@ -46,11 +46,21 @@ class MockRealtimeAdapter implements RealtimeAdapter {
 }
 
 class LifecycleTrackingRealtimeAdapter extends MockRealtimeAdapter {
+	public readonly started: Promise<void>;
 	public startCalls = 0;
 	public stopCalls = 0;
+	private markStarted: () => void = () => {};
+
+	constructor() {
+		super();
+		this.started = new Promise((resolve) => {
+			this.markStarted = resolve;
+		});
+	}
 
 	async start(): Promise<void> {
 		this.startCalls += 1;
+		this.markStarted();
 	}
 
 	async stop(): Promise<void> {
@@ -223,10 +233,7 @@ describe("realtime", () => {
 				{ id: created.id, data: { title: "Ahoj" } },
 				ctxSk,
 			);
-			await setup.app.collections.posts.deleteById(
-				{ id: created.id },
-				ctxEn,
-			);
+			await setup.app.collections.posts.deleteById({ id: created.id }, ctxEn);
 
 			const logs = await setup.app.db
 				.select()
@@ -1108,7 +1115,7 @@ describe("realtime", () => {
 	// ==========================================================================
 
 	describe("edge cases", () => {
-		it("restarts adapter after all subscribers disconnect", async () => {
+		it("keeps adapter running until app teardown", async () => {
 			const adapter = new LifecycleTrackingRealtimeAdapter();
 			const items = collection("items").fields(({ f }) => ({
 				name: f.textarea().required(),
@@ -1123,21 +1130,24 @@ describe("realtime", () => {
 				resourceType: "collection",
 				resource: "items",
 			});
-			await new Promise((resolve) => setTimeout(resolve, 50));
+			await adapter.started;
 			expect(adapter.startCalls).toBe(1);
 
 			firstUnsub?.();
-			await new Promise((resolve) => setTimeout(resolve, 50));
-			expect(adapter.stopCalls).toBe(1);
+			await Promise.resolve();
+			expect(adapter.stopCalls).toBe(0);
 
 			const secondUnsub = setup.app.realtime?.subscribe(() => {}, {
 				resourceType: "collection",
 				resource: "items",
 			});
-			await new Promise((resolve) => setTimeout(resolve, 50));
-			expect(adapter.startCalls).toBe(2);
+			await Promise.resolve();
+			expect(adapter.startCalls).toBe(1);
 
 			secondUnsub?.();
+			await setup.app.realtime.getLatestSeq();
+			await setup.cleanup();
+			expect(adapter.stopCalls).toBe(1);
 		});
 
 		it("handles multiple subscribers with different filters", async () => {
@@ -1757,18 +1767,9 @@ describe("realtime", () => {
 			const ctx = createTestContext();
 
 			// Create multiple records rapidly
-			await setup.app.collections.counters.create(
-				{ name: "A", value: 1 },
-				ctx,
-			);
-			await setup.app.collections.counters.create(
-				{ name: "B", value: 2 },
-				ctx,
-			);
-			await setup.app.collections.counters.create(
-				{ name: "C", value: 3 },
-				ctx,
-			);
+			await setup.app.collections.counters.create({ name: "A", value: 1 }, ctx);
+			await setup.app.collections.counters.create({ name: "B", value: 2 }, ctx);
+			await setup.app.collections.counters.create({ name: "C", value: 3 }, ctx);
 
 			// Should receive snapshots reflecting the changes
 			let snapshotCount = 0;


### PR DESCRIPTION
## Summary
- create the implicit pg adapter before any local subscription
- add an optional publish-side lifecycle hook and initialize built-in publishers with the app singleton
- keep adapter/listener lifecycle alive across zero-subscriber periods and stop only on app teardown
- close publisher-only pg clients correctly

## Tests
- zero-subscriber implicit-pg publish
- publisher start at app boot
- no stop/restart churn at zero listeners
- zero-subscriber publisher wakes a second service instance

## Verification
- `cd packages/questpie && bun test test/ --test-name-pattern realtime` (45 pass)
- `cd packages/questpie && bun run check-types`
- targeted oxfmt and diff checks

## Stack
Temporarily based on #130 because both tasks touch the realtime lifecycle. Retarget to `main` after #130 merges.

Agent-board: `rt0-2-eager-adapter-start-publish-capable-at-boot-on-every-instance`