### PR TITLE
fix(questpie): make pg-notify reconnect safely

### DIFF
--- a/.changeset/resilient-pg-notify.md
+++ b/.changeset/resilient-pg-notify.md
@@ -1,0 +1,5 @@
+---
+"questpie": patch
+---
+
+Make pg-notify resilient to dropped connections with dedicated publish and listen clients, bounded reconnect backoff, re-LISTEN signals, payload guards, and rate-limited failure reporting.

--- a/packages/questpie/src/server/modules/core/integrated/realtime/adapters/pg-notify.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/adapters/pg-notify.ts
@@ -1,37 +1,78 @@
 import type { Client, ClientConfig } from "pg";
 
-import type { RealtimeAdapter } from "../adapter.js";
+import type { RealtimeAdapter, RealtimeAdapterState } from "../adapter.js";
 import type { RealtimeChangeEvent, RealtimeNotice } from "../types.js";
 
 export type PgNotifyAdapterOptions = {
 	channel?: string;
+	/** Dedicated LISTEN connection. */
 	client?: Client;
+	/** Separate connection used for pg_notify calls. */
+	publisherClient?: Client;
 	connection?: ClientConfig;
 	connectionString?: string;
+	onError?: (error: unknown) => void;
+	errorLogIntervalMs?: number;
+	reconnectInitialDelayMs?: number;
+	reconnectMaxDelayMs?: number;
 };
 
+const PG_NOTIFY_MAX_PAYLOAD_BYTES = 8_000;
+
 export class PgNotifyAdapter implements RealtimeAdapter {
-	private client: Client | null = null;
+	private listenerClient: Client | null = null;
+	private publisherClient: Client | null = null;
 	private clientConfig?: ClientConfig;
 	private connectionString?: string;
 	private channel: string;
 	private listeners = new Set<(notice: RealtimeNotice) => void>();
 	private started = false;
-	private connected = false;
-	private ownsClient = true;
+	private listenerConnected = false;
+	private publisherConnected = false;
+	private ownsListenerClient = true;
+	private ownsPublisherClient = true;
 	private notificationHandler?: (msg: { payload?: string | null }) => void;
+	private readonly onError: (error: unknown) => void;
+	private readonly errorLogIntervalMs: number;
+	private readonly lastErrorLogAt = new Map<string, number>();
+	private readonly stateHandlers = new Set<
+		(state: RealtimeAdapterState) => void
+	>();
+	private readonly reconnectInitialDelayMs: number;
+	private readonly reconnectMaxDelayMs: number;
+	private reconnectAttempt = 0;
+	private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+	private stopping = false;
+	private listenerErrorHandler?: (error: Error) => void;
+	private listenerEndHandler?: () => void;
+	private publisherErrorHandler?: (error: Error) => void;
+	private publisherEndHandler?: () => void;
 
 	constructor(options: PgNotifyAdapterOptions = {}) {
 		this.channel = options.channel ?? "questpie_realtime";
+		this.onError =
+			options.onError ??
+			((error) => console.error("[questpie] pg-notify error:", error));
+		this.errorLogIntervalMs = options.errorLogIntervalMs ?? 30_000;
+		this.reconnectInitialDelayMs = options.reconnectInitialDelayMs ?? 100;
+		this.reconnectMaxDelayMs = options.reconnectMaxDelayMs ?? 30_000;
 
 		if (!/^[a-zA-Z0-9_]+$/.test(this.channel)) {
 			throw new Error(`Invalid pg notify channel name: "${this.channel}"`);
 		}
 
 		if (options.client) {
-			this.client = options.client;
-			this.ownsClient = false;
-			return;
+			this.listenerClient = options.client;
+			this.ownsListenerClient = false;
+		}
+
+		if (options.publisherClient) {
+			this.publisherClient = options.publisherClient;
+			this.ownsPublisherClient = false;
+		} else if (options.client) {
+			// Backward compatibility for callers that only provide one client.
+			this.publisherClient = options.client;
+			this.ownsPublisherClient = false;
 		}
 
 		if (options.connection) {
@@ -47,8 +88,14 @@ export class PgNotifyAdapter implements RealtimeAdapter {
 
 	async start(): Promise<void> {
 		if (this.started) return;
-		await this.startPublisher();
-		const client = this.client!;
+		this.stopping = false;
+		await this.connectListener();
+	}
+
+	private async connectListener(): Promise<void> {
+		const client = await this.ensureListenerClient();
+		this.attachListenerLifecycle(client);
+		await this.ensureListenerConnected(client);
 		await client.query(`LISTEN ${this.channel}`);
 		this.notificationHandler = (msg) => {
 			if (!msg.payload) return;
@@ -64,40 +111,62 @@ export class PgNotifyAdapter implements RealtimeAdapter {
 		};
 		client.on("notification", this.notificationHandler as any);
 		this.started = true;
+		this.reconnectAttempt = 0;
+		this.emitState("connected");
 	}
 
 	async startPublisher(): Promise<void> {
-		const client = await this.ensureClient();
-		await this.ensureConnected(client);
+		const client = await this.ensurePublisherClient();
+		await this.ensurePublisherConnected(client);
 	}
 
 	async stop(): Promise<void> {
+		this.stopping = true;
+		if (this.reconnectTimer) {
+			clearTimeout(this.reconnectTimer);
+			this.reconnectTimer = null;
+		}
 		const wasStarted = this.started;
 		this.started = false;
-		const client = this.client;
-		if (!client) return;
+		const listenerClient = this.listenerClient;
+		const publisherClient = this.publisherClient;
 
-		if (this.notificationHandler) {
-			client.off("notification", this.notificationHandler as any);
+		if (listenerClient && this.notificationHandler) {
+			listenerClient.off("notification", this.notificationHandler as any);
 			this.notificationHandler = undefined;
 		}
+		if (listenerClient) this.detachListenerLifecycle(listenerClient);
 
-		if (wasStarted) {
+		if (listenerClient && wasStarted) {
 			try {
-				await client.query(`UNLISTEN ${this.channel}`);
+				await listenerClient.query(`UNLISTEN ${this.channel}`);
 			} catch {
 				// Ignore UNLISTEN failures during shutdown.
 			}
 		}
 
-		if (this.ownsClient) {
+		if (listenerClient && this.ownsListenerClient) {
 			try {
-				await client.end();
+				await listenerClient.end();
 			} finally {
-				this.connected = false;
-				this.client = null;
+				this.listenerConnected = false;
+				this.listenerClient = null;
 			}
 		}
+
+		if (
+			publisherClient &&
+			publisherClient !== listenerClient &&
+			this.ownsPublisherClient
+		) {
+			try {
+				await publisherClient.end();
+			} finally {
+				this.publisherConnected = false;
+				this.publisherClient = null;
+			}
+		}
+		if (publisherClient) this.detachPublisherLifecycle(publisherClient);
 	}
 
 	subscribe(handler: (notice: RealtimeNotice) => void): () => void {
@@ -107,6 +176,11 @@ export class PgNotifyAdapter implements RealtimeAdapter {
 		};
 	}
 
+	onStateChange(handler: (state: RealtimeAdapterState) => void): () => void {
+		this.stateHandlers.add(handler);
+		return () => this.stateHandlers.delete(handler);
+	}
+
 	async notify(event: RealtimeChangeEvent): Promise<void> {
 		const payload = JSON.stringify({
 			seq: event.seq,
@@ -114,23 +188,159 @@ export class PgNotifyAdapter implements RealtimeAdapter {
 			resource: event.resource,
 			operation: event.operation,
 		});
-		const client = await this.ensureClient();
-		await this.ensureConnected(client);
-		await client.query("select pg_notify($1, $2)", [this.channel, payload]);
+		const payloadBytes = new TextEncoder().encode(payload).byteLength;
+		if (payloadBytes >= PG_NOTIFY_MAX_PAYLOAD_BYTES) {
+			const error = new Error(
+				`PgNotifyAdapter payload must be smaller than ${PG_NOTIFY_MAX_PAYLOAD_BYTES} bytes (received ${payloadBytes}).`,
+			);
+			this.reportError("payload", error);
+			throw error;
+		}
+		const client = await this.ensurePublisherClient();
+		await this.ensurePublisherConnected(client);
+		try {
+			await client.query("select pg_notify($1, $2)", [this.channel, payload]);
+		} catch (error) {
+			this.reportError("notify", error);
+			throw error;
+		}
 	}
 
-	private async ensureClient(): Promise<Client> {
-		if (this.client) return this.client;
+	private reportError(kind: string, error: unknown): void {
+		const now = Date.now();
+		const lastLoggedAt = this.lastErrorLogAt.get(kind);
+		if (
+			lastLoggedAt !== undefined &&
+			now - lastLoggedAt < this.errorLogIntervalMs
+		) {
+			return;
+		}
+		this.lastErrorLogAt.set(kind, now);
+		this.onError(error);
+	}
+
+	private emitState(state: RealtimeAdapterState): void {
+		for (const handler of this.stateHandlers) handler(state);
+	}
+
+	private attachListenerLifecycle(client: Client): void {
+		this.detachListenerLifecycle(client);
+		this.listenerErrorHandler = (error) => {
+			this.handleListenerDisconnect(client, error);
+		};
+		this.listenerEndHandler = () => {
+			this.handleListenerDisconnect(client);
+		};
+		client.on("error", this.listenerErrorHandler);
+		client.on("end", this.listenerEndHandler);
+	}
+
+	private attachPublisherLifecycle(client: Client): void {
+		this.detachPublisherLifecycle(client);
+		this.publisherErrorHandler = (error) => {
+			this.handlePublisherDisconnect(client, error);
+		};
+		this.publisherEndHandler = () => {
+			this.handlePublisherDisconnect(
+				client,
+				new Error("pg-notify publisher connection ended"),
+			);
+		};
+		client.on("error", this.publisherErrorHandler);
+		client.on("end", this.publisherEndHandler);
+	}
+
+	private detachListenerLifecycle(client: Client): void {
+		if (this.listenerErrorHandler) {
+			client.off("error", this.listenerErrorHandler);
+			this.listenerErrorHandler = undefined;
+		}
+		if (this.listenerEndHandler) {
+			client.off("end", this.listenerEndHandler);
+			this.listenerEndHandler = undefined;
+		}
+	}
+
+	private detachPublisherLifecycle(client: Client): void {
+		if (this.publisherErrorHandler) {
+			client.off("error", this.publisherErrorHandler);
+			this.publisherErrorHandler = undefined;
+		}
+		if (this.publisherEndHandler) {
+			client.off("end", this.publisherEndHandler);
+			this.publisherEndHandler = undefined;
+		}
+	}
+
+	private handleListenerDisconnect(client: Client, error?: unknown): void {
+		if (
+			this.stopping ||
+			client !== this.listenerClient ||
+			(!this.started && !this.listenerConnected)
+		) {
+			return;
+		}
+
+		this.started = false;
+		this.listenerConnected = false;
+		if (this.notificationHandler) {
+			client.off("notification", this.notificationHandler as any);
+			this.notificationHandler = undefined;
+		}
+		this.detachListenerLifecycle(client);
+		if (this.ownsListenerClient) this.listenerClient = null;
+		if (error) this.reportError("listener", error);
+		this.emitState("disconnected");
+		this.scheduleReconnect();
+	}
+
+	private handlePublisherDisconnect(client: Client, error: unknown): void {
+		if (
+			this.stopping ||
+			client !== this.publisherClient ||
+			!this.publisherConnected
+		) {
+			return;
+		}
+
+		this.publisherConnected = false;
+		this.detachPublisherLifecycle(client);
+		if (this.ownsPublisherClient) this.publisherClient = null;
+		this.reportError("publisher", error);
+	}
+
+	private scheduleReconnect(): void {
+		if (this.stopping || this.reconnectTimer) return;
+		const delay = Math.min(
+			this.reconnectInitialDelayMs * 2 ** this.reconnectAttempt,
+			this.reconnectMaxDelayMs,
+		);
+		this.reconnectAttempt += 1;
+		this.reconnectTimer = setTimeout(() => {
+			this.reconnectTimer = null;
+			void this.reconnect();
+		}, delay);
+	}
+
+	private async reconnect(): Promise<void> {
+		if (this.stopping) return;
+		try {
+			await this.connectListener();
+		} catch (error) {
+			this.reportError("reconnect", error);
+			this.scheduleReconnect();
+		}
+	}
+
+	private async createClient(): Promise<Client> {
 		const { Client: PgClient } = await import("pg");
 
 		if (this.clientConfig) {
-			this.client = new PgClient(this.clientConfig);
-			return this.client;
+			return new PgClient(this.clientConfig);
 		}
 
 		if (this.connectionString) {
-			this.client = new PgClient({ connectionString: this.connectionString });
-			return this.client;
+			return new PgClient({ connectionString: this.connectionString });
 		}
 
 		throw new Error(
@@ -138,17 +348,43 @@ export class PgNotifyAdapter implements RealtimeAdapter {
 		);
 	}
 
-	private async ensureConnected(client: Client): Promise<void> {
-		if (this.connected) return;
+	private async ensureListenerClient(): Promise<Client> {
+		this.listenerClient ??= await this.createClient();
+		return this.listenerClient;
+	}
 
+	private async ensurePublisherClient(): Promise<Client> {
+		this.publisherClient ??= await this.createClient();
+		return this.publisherClient;
+	}
+
+	private async ensureListenerConnected(client: Client): Promise<void> {
+		if (this.listenerConnected) return;
+		await this.connect(client, () => {
+			this.listenerConnected = true;
+		});
+	}
+
+	private async ensurePublisherConnected(client: Client): Promise<void> {
+		if (this.publisherConnected) return;
+		this.attachPublisherLifecycle(client);
+		await this.connect(client, () => {
+			this.publisherConnected = true;
+		});
+	}
+
+	private async connect(
+		client: Client,
+		markConnected: () => void,
+	): Promise<void> {
 		try {
 			await client.connect();
-			this.connected = true;
+			markConnected();
 			return;
 		} catch (error) {
 			const message = String((error as { message?: string })?.message || "");
 			if (message.includes("already been connected")) {
-				this.connected = true;
+				markConnected();
 				return;
 			}
 			throw error;

--- a/packages/questpie/test/units/pg-notify-adapter.test.ts
+++ b/packages/questpie/test/units/pg-notify-adapter.test.ts
@@ -1,0 +1,282 @@
+import { describe, expect, spyOn, test } from "bun:test";
+
+import { PgNotifyAdapter } from "../../src/server/modules/core/integrated/realtime/adapters/pg-notify.js";
+
+class FakePgClient {
+	connectCalls = 0;
+	connectOutcomes: Array<"ok" | Error> = [];
+	endCalls = 0;
+	queryOutcomes: Array<"ok" | Error> = [];
+	queries: Array<{ text: string; params?: unknown[] }> = [];
+	private handlers = new Map<string, Set<(...args: any[]) => void>>();
+
+	async connect(): Promise<void> {
+		this.connectCalls += 1;
+		const outcome = this.connectOutcomes.shift();
+		if (outcome instanceof Error) throw outcome;
+	}
+
+	async query(text: string, params?: unknown[]): Promise<void> {
+		this.queries.push({ text, params });
+		const outcome = this.queryOutcomes.shift();
+		if (outcome instanceof Error) throw outcome;
+	}
+
+	on(event: string, handler: (...args: any[]) => void): this {
+		const handlers = this.handlers.get(event) ?? new Set();
+		handlers.add(handler);
+		this.handlers.set(event, handlers);
+		return this;
+	}
+
+	off(event: string, handler: (...args: any[]) => void): this {
+		this.handlers.get(event)?.delete(handler);
+		return this;
+	}
+
+	async end(): Promise<void> {
+		this.endCalls += 1;
+	}
+
+	emit(event: string, ...args: any[]): void {
+		for (const handler of this.handlers.get(event) ?? []) handler(...args);
+	}
+
+	listenerCount(event: string): number {
+		return this.handlers.get(event)?.size ?? 0;
+	}
+}
+
+describe("pg-notify adapter", () => {
+	test("uses a dedicated listener connection and separate publisher", async () => {
+		const listener = new FakePgClient();
+		const publisher = new FakePgClient();
+		const adapter = new PgNotifyAdapter({
+			client: listener as any,
+			publisherClient: publisher as any,
+		} as any);
+
+		await adapter.startPublisher();
+		await adapter.start();
+		await adapter.notify({
+			seq: 1,
+			resourceType: "collection",
+			resource: "posts",
+			operation: "update",
+			createdAt: new Date("2026-07-13T20:00:00.000Z"),
+		});
+
+		expect(listener.queries).toEqual([{ text: "LISTEN questpie_realtime" }]);
+		expect(publisher.queries).toEqual([
+			{
+				text: "select pg_notify($1, $2)",
+				params: [
+					"questpie_realtime",
+					JSON.stringify({
+						seq: 1,
+						resourceType: "collection",
+						resource: "posts",
+						operation: "update",
+					}),
+				],
+			},
+		]);
+	});
+
+	test("rejects and reports notices at the PostgreSQL 8KB limit", async () => {
+		const publisher = new FakePgClient();
+		const errors: unknown[] = [];
+		const adapter = new PgNotifyAdapter({
+			publisherClient: publisher as any,
+			onError: (error: unknown) => errors.push(error),
+		});
+
+		const result = adapter.notify({
+			seq: 1,
+			resourceType: "collection",
+			resource: "x".repeat(8_000),
+			operation: "update",
+			createdAt: new Date("2026-07-13T20:00:00.000Z"),
+		});
+
+		await expect(result).rejects.toThrow("must be smaller than 8000 bytes");
+		expect(publisher.queries).toEqual([]);
+		expect(errors).toHaveLength(1);
+	});
+
+	test("reconnects, re-LISTENs, and signals connected after error/end", async () => {
+		const listener = new FakePgClient();
+		const publisher = new FakePgClient();
+		const errors: unknown[] = [];
+		let triggerReconnect: (() => void) | undefined;
+		let markReconnected = () => {};
+		const reconnected = new Promise<void>((resolve) => {
+			markReconnected = resolve;
+		});
+		const timeoutSpy = spyOn(globalThis, "setTimeout").mockImplementation(
+			(handler, delay) => {
+				expect(delay).toBe(100);
+				triggerReconnect = () => {
+					if (typeof handler === "function") handler();
+				};
+				return 1 as unknown as ReturnType<typeof setTimeout>;
+			},
+		);
+		const adapter = new PgNotifyAdapter({
+			client: listener as any,
+			publisherClient: publisher as any,
+			reconnectInitialDelayMs: 100,
+			reconnectMaxDelayMs: 1_000,
+			onError: (error) => errors.push(error),
+		});
+		const states: string[] = [];
+
+		try {
+			const unsubscribeState = adapter.onStateChange((state) => {
+				states.push(state);
+				if (state === "connected" && states.includes("disconnected")) {
+					markReconnected();
+				}
+			});
+			await adapter.start();
+			expect(listener.listenerCount("error")).toBe(1);
+			expect(listener.listenerCount("end")).toBe(1);
+
+			listener.emit("error", new Error("connection lost"));
+			listener.emit("end");
+			expect(triggerReconnect).toBeDefined();
+			triggerReconnect?.();
+			await reconnected;
+
+			expect(
+				listener.queries.filter((query) => query.text.startsWith("LISTEN")),
+			).toHaveLength(2);
+			expect(states).toEqual(["connected", "disconnected", "connected"]);
+			expect(errors).toHaveLength(1);
+			unsubscribeState();
+		} finally {
+			timeoutSpy.mockRestore();
+			await adapter.stop();
+		}
+	});
+
+	test("backs off failed reconnects and caps the delay", async () => {
+		const listener = new FakePgClient();
+		const publisher = new FakePgClient();
+		const delays: number[] = [];
+		const reconnects: Array<() => void> = [];
+		let markSecondScheduled = () => {};
+		let markThirdScheduled = () => {};
+		const secondScheduled = new Promise<void>((resolve) => {
+			markSecondScheduled = resolve;
+		});
+		const thirdScheduled = new Promise<void>((resolve) => {
+			markThirdScheduled = resolve;
+		});
+		const timeoutSpy = spyOn(globalThis, "setTimeout").mockImplementation(
+			(handler, delay) => {
+				delays.push(Number(delay));
+				reconnects.push(() => {
+					if (typeof handler === "function") handler();
+				});
+				if (delays.length === 2) markSecondScheduled();
+				if (delays.length === 3) markThirdScheduled();
+				return delays.length as unknown as ReturnType<typeof setTimeout>;
+			},
+		);
+		const adapter = new PgNotifyAdapter({
+			client: listener as any,
+			publisherClient: publisher as any,
+			reconnectInitialDelayMs: 100,
+			reconnectMaxDelayMs: 250,
+			onError: () => {},
+		});
+		let disconnected = false;
+		let markReconnected = () => {};
+		const reconnected = new Promise<void>((resolve) => {
+			markReconnected = resolve;
+		});
+		adapter.onStateChange((state) => {
+			if (state === "disconnected") disconnected = true;
+			if (state === "connected" && disconnected) markReconnected();
+		});
+
+		try {
+			await adapter.start();
+			listener.connectOutcomes.push(
+				new Error("retry one"),
+				new Error("retry two"),
+				"ok",
+			);
+			listener.emit("end");
+
+			reconnects[0]!();
+			await secondScheduled;
+			reconnects[1]!();
+			await thirdScheduled;
+			reconnects[2]!();
+			await reconnected;
+
+			expect(delays).toEqual([100, 200, 250]);
+			expect(listener.connectCalls).toBe(4);
+		} finally {
+			timeoutSpy.mockRestore();
+			await adapter.stop();
+		}
+	});
+
+	test("rate-limits publisher failure reports while preserving rejection", async () => {
+		const publisher = new FakePgClient();
+		publisher.queryOutcomes.push(
+			new Error("publisher unavailable"),
+			new Error("publisher unavailable"),
+		);
+		const errors: unknown[] = [];
+		const adapter = new PgNotifyAdapter({
+			publisherClient: publisher as any,
+			onError: (error) => errors.push(error),
+			errorLogIntervalMs: 30_000,
+		});
+		const change = {
+			seq: 1,
+			resourceType: "collection" as const,
+			resource: "posts",
+			operation: "update" as const,
+			createdAt: new Date("2026-07-13T20:00:00.000Z"),
+		};
+
+		await expect(adapter.notify(change)).rejects.toThrow(
+			"publisher unavailable",
+		);
+		await expect(adapter.notify(change)).rejects.toThrow(
+			"publisher unavailable",
+		);
+		expect(errors).toHaveLength(1);
+	});
+
+	test("handles idle publisher disconnects and reconnects on the next notify", async () => {
+		const publisher = new FakePgClient();
+		const adapter = new PgNotifyAdapter({
+			publisherClient: publisher as any,
+			onError: () => {},
+		});
+		await adapter.startPublisher();
+
+		expect(publisher.listenerCount("error")).toBe(1);
+		expect(publisher.listenerCount("end")).toBe(1);
+		publisher.emit("error", new Error("publisher connection lost"));
+		publisher.emit("end");
+		await adapter.notify({
+			seq: 2,
+			resourceType: "collection",
+			resource: "posts",
+			operation: "create",
+			createdAt: new Date("2026-07-13T20:00:00.000Z"),
+		});
+
+		expect(publisher.connectCalls).toBe(2);
+		expect(
+			publisher.queries.filter((query) => query.text.includes("pg_notify")),
+		).toHaveLength(1);
+	});
+});


### PR DESCRIPTION
## Summary
- split PostgreSQL LISTEN and pg_notify onto dedicated connections by default
- recover listener error/end with bounded exponential backoff, re-LISTEN, and connected state signaling for immediate outbox reconciliation
- guard PostgreSQL NOTIFY payload size and rate-limit surfaced transport failures
- handle idle publisher disconnects and reconnect on the next publish

## Verification
- bun test test/ --test-name-pattern "pg-notify|realtime" (51 pass, 0 fail)
- bunx tsc --noEmit -p tsconfig.json
- targeted oxfmt and oxlint
- git diff --check

## Stack
Depends on #132, which depends on #130. Retarget this PR to main after its parents merge.

Agent-board: rt0-3-pg-notify-resilience-error-end-handlers-reconnect-re-listen-drain-on-reconnect