### PR TITLE
fix(questpie): coalesce bulk realtime changes

### DIFF
--- a/packages/questpie/src/server/modules/core/config/app.ts
+++ b/packages/questpie/src/server/modules/core/config/app.ts
@@ -20,6 +20,7 @@ import type {
 	DrizzleClientFromQuestpieConfig,
 	Locale,
 } from "#questpie/server/config/types.js";
+import type { RealtimeChangeEvent } from "#questpie/server/modules/core/integrated/realtime/types.js";
 import { buildIndexParams } from "#questpie/server/modules/core/integrated/search/index-params.js";
 import type { SearchableConfig } from "#questpie/server/modules/core/integrated/search/types.js";
 import {
@@ -58,9 +59,39 @@ function resolveRealtimePayload(
 	ctx: GlobalCollectionHookContext,
 	hookType: "change" | "delete",
 ): Record<string, unknown> {
-	if (ctx.isBatch) return { count: ctx.count ?? 0 };
+	if (ctx.isBatch) {
+		return {
+			count: ctx.count ?? 0,
+			recordIds: ctx.recordIds ? [...ctx.recordIds] : [],
+		};
+	}
 	if (hookType === "delete") return {};
 	return ctx.data as Record<string, unknown>;
+}
+
+const capturedRealtimeBatches = new WeakSet<object>();
+
+function shouldCaptureRealtimeChange(
+	ctx: GlobalCollectionHookContext,
+): boolean {
+	if (!ctx.isBatch) return true;
+	const batchMarker = ctx.records ?? ctx.recordIds;
+	if (!batchMarker) return true;
+	if (capturedRealtimeBatches.has(batchMarker)) return false;
+	capturedRealtimeBatches.add(batchMarker);
+	return true;
+}
+
+function publishRealtimeAfterCommit(
+	ctx: Pick<GlobalCollectionHookContext, "logger" | "onAfterCommit">,
+	realtime: NonNullable<GlobalCollectionHookContext["realtime"]>,
+	change: RealtimeChangeEvent,
+): void {
+	ctx.onAfterCommit(async () => {
+		void realtime.notify(change).catch((error) => {
+			ctx.logger?.error("[Core] Realtime publish failed:", error);
+		});
+	});
 }
 
 // ============================================================================
@@ -74,6 +105,7 @@ const realtimeHook = {
 	afterChange: async (ctx: GlobalCollectionHookContext) => {
 		const realtime = ctx.realtime;
 		if (!realtime) return;
+		if (!shouldCaptureRealtimeChange(ctx)) return;
 
 		const operation = resolveRealtimeOperation(ctx, "change");
 		const payload = resolveRealtimePayload(ctx, "change");
@@ -91,13 +123,7 @@ const realtimeHook = {
 				{ db: asRealtimeMutationDb(ctx.db) },
 			);
 
-			ctx.onAfterCommit(async () => {
-				try {
-					await realtime.notify(change);
-				} catch {
-					// Realtime adapter may be unavailable
-				}
-			});
+			publishRealtimeAfterCommit(ctx, realtime, change);
 		} catch {
 			// Realtime log table may not exist yet
 		}
@@ -105,6 +131,7 @@ const realtimeHook = {
 	afterDelete: async (ctx: GlobalCollectionHookContext) => {
 		const realtime = ctx.realtime;
 		if (!realtime) return;
+		if (!shouldCaptureRealtimeChange(ctx)) return;
 
 		const operation = resolveRealtimeOperation(ctx, "delete");
 		const payload = resolveRealtimePayload(ctx, "delete");
@@ -122,13 +149,7 @@ const realtimeHook = {
 				{ db: asRealtimeMutationDb(ctx.db) },
 			);
 
-			ctx.onAfterCommit(async () => {
-				try {
-					await realtime.notify(change);
-				} catch {
-					// Realtime adapter may be unavailable
-				}
-			});
+			publishRealtimeAfterCommit(ctx, realtime, change);
 		} catch {
 			// Realtime log table may not exist yet
 		}
@@ -301,13 +322,7 @@ const globalRealtimeHook = {
 				{ db: asRealtimeMutationDb(ctx.db) },
 			);
 
-			ctx.onAfterCommit(async () => {
-				try {
-					await realtime.notify(change);
-				} catch {
-					// Realtime adapter may be unavailable
-				}
-			});
+			publishRealtimeAfterCommit(ctx, realtime, change);
 		} catch {
 			// Realtime log table may not exist yet
 		}

--- a/packages/questpie/test/integration/realtime-transactional-capture.test.ts
+++ b/packages/questpie/test/integration/realtime-transactional-capture.test.ts
@@ -15,6 +15,27 @@ import { buildMockApp } from "../utils/mocks/mock-app-builder";
 import { createTestContext } from "../utils/test-context";
 import { runTestDbMigrations } from "../utils/test-db";
 
+async function settleWithinEventLoopTurns(
+	promise: Promise<unknown>,
+	turns = 50,
+): Promise<boolean> {
+	let settled = false;
+	void promise.finally(() => {
+		settled = true;
+	});
+	for (let turn = 0; turn < turns; turn += 1) {
+		if (settled) return true;
+		await new Promise<void>((resolve) => setImmediate(resolve));
+	}
+	return settled;
+}
+
+async function flushEventLoopTurns(turns = 10): Promise<void> {
+	for (let turn = 0; turn < turns; turn += 1) {
+		await new Promise<void>((resolve) => setImmediate(resolve));
+	}
+}
+
 describe("realtime transactional change capture", () => {
 	let setup: Awaited<ReturnType<typeof buildMockApp>>;
 	let ctx: ReturnType<typeof createTestContext>;
@@ -168,5 +189,169 @@ describe("realtime transactional change capture", () => {
 		} finally {
 			intervalSpy.mockRestore();
 		}
+	});
+
+	it("G9: emits exactly one outbox row and notify for a bulk update", async () => {
+		const notifications: RealtimeChangeEvent[] = [];
+		const notifySpy = spyOn(setup.app.realtime, "notify").mockImplementation(
+			async (event: RealtimeChangeEvent) => {
+				notifications.push(event);
+			},
+		);
+		const first = await setup.app.collections.posts.create(
+			{ title: "First" },
+			ctx,
+		);
+		const second = await setup.app.collections.posts.create(
+			{ title: "Second" },
+			ctx,
+		);
+		notifications.length = 0;
+
+		try {
+			await setup.app.collections.posts.update(
+				{
+					where: { id: { in: [first.id, second.id] } },
+					data: { title: "Updated" },
+				},
+				ctx,
+			);
+		} finally {
+			notifySpy.mockRestore();
+		}
+
+		const rows = await setup.app.db.select().from(questpieRealtimeLogTable);
+		const bulkRows = rows.filter(
+			(row: { operation: string }) => row.operation === "bulk_update",
+		);
+		const bulkNotices = notifications.filter(
+			(event) => event.operation === "bulk_update",
+		);
+
+		expect(bulkRows).toHaveLength(1);
+		expect(bulkNotices).toHaveLength(1);
+		expect(bulkRows[0]?.payload).toEqual({
+			count: 2,
+			recordIds: [first.id, second.id],
+		});
+	});
+
+	it("G9: emits exactly one outbox row and notify for a bulk delete", async () => {
+		const notifications: RealtimeChangeEvent[] = [];
+		const notifySpy = spyOn(setup.app.realtime, "notify").mockImplementation(
+			async (event: RealtimeChangeEvent) => {
+				notifications.push(event);
+			},
+		);
+		const first = await setup.app.collections.posts.create(
+			{ title: "First" },
+			ctx,
+		);
+		const second = await setup.app.collections.posts.create(
+			{ title: "Second" },
+			ctx,
+		);
+		notifications.length = 0;
+
+		try {
+			await setup.app.collections.posts.delete(
+				{ where: { id: { in: [first.id, second.id] } } },
+				ctx,
+			);
+		} finally {
+			notifySpy.mockRestore();
+		}
+
+		const rows = await setup.app.db.select().from(questpieRealtimeLogTable);
+		const bulkRows = rows.filter(
+			(row: { operation: string }) => row.operation === "bulk_delete",
+		);
+		const bulkNotices = notifications.filter(
+			(event) => event.operation === "bulk_delete",
+		);
+
+		expect(bulkRows).toHaveLength(1);
+		expect(bulkNotices).toHaveLength(1);
+		expect(bulkRows[0]?.payload).toEqual({
+			count: 2,
+			recordIds: [first.id, second.id],
+		});
+	});
+
+	it("G9: does not hold the bulk response open for adapter publish", async () => {
+		const first = await setup.app.collections.posts.create(
+			{ title: "First" },
+			ctx,
+		);
+		const second = await setup.app.collections.posts.create(
+			{ title: "Second" },
+			ctx,
+		);
+		let signalPublishStarted = () => {};
+		const publishStarted = new Promise<void>((resolve) => {
+			signalPublishStarted = resolve;
+		});
+		let releasePublish = () => {};
+		const blockedPublish = new Promise<void>((resolve) => {
+			releasePublish = resolve;
+		});
+		const notifySpy = spyOn(setup.app.realtime, "notify").mockImplementation(
+			async (event: RealtimeChangeEvent) => {
+				if (event.operation !== "bulk_update") return;
+				signalPublishStarted();
+				await blockedPublish;
+			},
+		);
+		const mutation = setup.app.collections.posts.update(
+			{
+				where: { id: { in: [first.id, second.id] } },
+				data: { title: "Updated" },
+			},
+			ctx,
+		);
+
+		try {
+			await publishStarted;
+			expect(await settleWithinEventLoopTurns(mutation)).toBe(true);
+		} finally {
+			releasePublish();
+			await mutation;
+			notifySpy.mockRestore();
+		}
+	});
+
+	it("G9: logs fire-and-forget adapter publish failures", async () => {
+		const first = await setup.app.collections.posts.create(
+			{ title: "First" },
+			ctx,
+		);
+		const second = await setup.app.collections.posts.create(
+			{ title: "Second" },
+			ctx,
+		);
+		const notifySpy = spyOn(setup.app.realtime, "notify").mockImplementation(
+			async (event: RealtimeChangeEvent) => {
+				if (event.operation === "bulk_update") {
+					throw new Error("publish failed for bulk_update");
+				}
+			},
+		);
+
+		try {
+			await setup.app.collections.posts.update(
+				{
+					where: { id: { in: [first.id, second.id] } },
+					data: { title: "Updated" },
+				},
+				ctx,
+			);
+			await flushEventLoopTurns();
+		} finally {
+			notifySpy.mockRestore();
+		}
+
+		expect(
+			setup.app.mocks.logger.getLogsContaining("Realtime publish failed"),
+		).toHaveLength(1);
 	});
 });


### PR DESCRIPTION
## Summary
- emit exactly one transactional outbox row for each bulk update or bulk delete while preserving per-record user hook behavior
- include count and recordIds in the bulk event payload
- start adapter publish after commit without holding the mutation response open, and log publish failures through the app logger
- add exact-count integration tests for outbox rows, notices, blocked publish latency, and failure logging

## Verification
- bun test test/ --test-name-pattern "realtime|bulk" (57 pass, 0 fail)
- bunx tsc --noEmit -p tsconfig.json
- targeted oxlint
- git diff --check

## Compatibility audit
No runtime consumer relies on per-record bulk events. RealtimeService treats all non-create events as conservative snapshot refreshes. The breaking behavior note remains assigned to the RT4.0 program changeset.

## Stack
Depends on #128 for same-transaction outbox capture. Retarget this PR to main after #128 merges.

Agent-board: rt0-4-bulk-batch-guard-one-realtime-event-per-operation-publish-off-response-path