### PR TITLE
fix(questpie): bound realtime outbox retention

### DIFF
--- a/.changeset/clean-realtime-outbox.md
+++ b/.changeset/clean-realtime-outbox.md
@@ -1,0 +1,5 @@
+---
+"questpie": patch
+---
+
+Bound the realtime outbox with a three-day default retention window, remove unsafe process-local watermark deletion, store scalar pre/post routing projections instead of hydrated records, and remove redundant indexes. Existing applications should run `bun questpie migrate:generate` to generate the two index drops.

--- a/apps/docs/content/docs/adapters/realtime.mdx
+++ b/apps/docs/content/docs/adapters/realtime.mdx
@@ -67,7 +67,7 @@ interface RealtimeConfig {
   adapter?: RealtimeAdapter;       // transport (pg_notify, redis, …). Omit → poll / auto pg_notify
   pollIntervalMs?: number;         // default 2000, drain interval when running pollless (no adapter)
   batchSize?: number;              // default 500, max outbox rows read per drain
-  retentionDays?: number;          // optional time-based outbox safety window
+  retentionDays?: number;          // default 3; set 0 to disable time-based cleanup
   keepAliveIntervalMs?: number;    // default 8000, SSE keep-alive ping interval
 }
 ```
@@ -79,7 +79,7 @@ interface RealtimeConfig {
 | `adapter` | *(none)* | The transport that broadcasts change notices. Omit it for the poll / auto-`pg_notify` default (below). |
 | `pollIntervalMs` | `2000` | How often the service drains the outbox **when there is no adapter** (defaults to `0` if you omit it while an adapter is set). With an adapter, drains are notice-driven, so this is ignored, the poll timer only runs on the no-adapter path. |
 | `batchSize` | `500` | Max outbox rows pulled per drain. Raise it for very high write volume. |
-| `retentionDays` | *(none)* | Adds a time-based cleanup window. The service **always** does watermark cleanup (it deletes rows below the min consumed `seq` across active subscribers); `retentionDays` is an extra safety net for rows no subscriber will ever read. |
+| `retentionDays` | `3` | Time horizon for outbox cleanup, including apps with zero subscribers. Set `0` to disable. Cleanup never uses a process-local subscriber watermark, because that could delete rows another instance has not drained yet. |
 | `keepAliveIntervalMs` | `8000` | Interval between `ping` keep-alive events on each `POST /realtime` SSE stream. |
 
 <Callout type="warn" title="Keep `keepAliveIntervalMs` under your idle timeout">
@@ -250,7 +250,7 @@ The change log lives in one Drizzle table, `questpie_realtime_log`, created by c
 | `resource` | The collection/global name. |
 | `operation` | `create` / `update` / `delete` / `bulk_update` / `bulk_delete`. |
 | `record_id`, `locale` | Nullable; the specific record + locale when applicable. |
-| `payload` | `jsonb` (default `{}`), the change detail, kept server-side (never broadcast). |
+| `payload` | `jsonb` (default `{}`), kept server-side (never broadcast). Single-record changes store shallow scalar `{ before, after }` equality projections; bulk changes store `{ count, recordIds }`. Nested objects, arrays, and hydrated relations are excluded. |
 | `created_at` | Insert timestamp; powers `retentionDays` cleanup. |
 
 
@@ -264,6 +264,8 @@ import type {
   RealtimeAdapter,        // the transport contract you implement for a custom adapter
   RealtimeConfig,         // the `realtime` config shape
   RealtimeChangeEvent,    // a full outbox event
+  RealtimeChangePayload,  // { before, after } or { count, recordIds }
+  RealtimeEqualityProjection, // shallow scalar fields used for equality routing
   RealtimeNotice,         // the minimal broadcast notice
   RealtimeOperation,      // "create" | "update" | "delete" | "bulk_update" | "bulk_delete"
   RealtimeResourceType,   // "collection" | "global"

--- a/packages/questpie/src/server/modules/core/config/app.ts
+++ b/packages/questpie/src/server/modules/core/config/app.ts
@@ -20,7 +20,11 @@ import type {
 	DrizzleClientFromQuestpieConfig,
 	Locale,
 } from "#questpie/server/config/types.js";
-import type { RealtimeChangeEvent } from "#questpie/server/modules/core/integrated/realtime/types.js";
+import type {
+	RealtimeChangeEvent,
+	RealtimeChangePayload,
+	RealtimeEqualityProjection,
+} from "#questpie/server/modules/core/integrated/realtime/types.js";
 import { buildIndexParams } from "#questpie/server/modules/core/integrated/search/index-params.js";
 import type { SearchableConfig } from "#questpie/server/modules/core/integrated/search/types.js";
 import {
@@ -58,15 +62,39 @@ function resolveRealtimeOperation(
 function resolveRealtimePayload(
 	ctx: GlobalCollectionHookContext,
 	hookType: "change" | "delete",
-): Record<string, unknown> {
+): RealtimeChangePayload {
 	if (ctx.isBatch) {
 		return {
 			count: ctx.count ?? 0,
 			recordIds: ctx.recordIds ? [...ctx.recordIds] : [],
 		};
 	}
-	if (hookType === "delete") return {};
-	return ctx.data as Record<string, unknown>;
+
+	const before = hookType === "delete" ? ctx.data : ctx.original;
+	const after = hookType === "delete" ? undefined : ctx.data;
+	return {
+		before: before ? projectRealtimeEqualityFields(before) : null,
+		after: after ? projectRealtimeEqualityFields(after) : null,
+	};
+}
+
+function projectRealtimeEqualityFields(
+	data: unknown,
+): RealtimeEqualityProjection {
+	if (!data || typeof data !== "object" || Array.isArray(data)) return {};
+
+	const projection: RealtimeEqualityProjection = {};
+	for (const [key, value] of Object.entries(data)) {
+		if (
+			value === null ||
+			typeof value === "string" ||
+			typeof value === "number" ||
+			typeof value === "boolean"
+		) {
+			projection[key] = value;
+		}
+	}
+	return projection;
 }
 
 const capturedRealtimeBatches = new WeakSet<object>();
@@ -317,7 +345,10 @@ const globalRealtimeHook = {
 					operation: "update",
 					recordId: ctx.data?.id ?? null,
 					locale: ctx.locale ?? null,
-					payload: ctx.data as Record<string, unknown>,
+					payload: {
+						before: null,
+						after: projectRealtimeEqualityFields(ctx.data),
+					},
 				},
 				{ db: asRealtimeMutationDb(ctx.db) },
 			);

--- a/packages/questpie/src/server/modules/core/integrated/realtime/collection.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/collection.ts
@@ -18,9 +18,5 @@ export const questpieRealtimeLogTable = pgTable(
 		payload: jsonb("payload").default({}),
 		createdAt: systemTimestamp("created_at").defaultNow().notNull(),
 	},
-	(t) => [
-		index("idx_realtime_log_seq").on(t.seq),
-		index("idx_realtime_log_resource").on(t.resourceType, t.resource),
-		index("idx_realtime_log_created_at").on(t.createdAt),
-	],
+	(t) => [index("idx_realtime_log_created_at").on(t.createdAt)],
 );

--- a/packages/questpie/src/server/modules/core/integrated/realtime/service.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/service.ts
@@ -6,6 +6,7 @@ import type { RealtimeAdapter } from "./adapter.js";
 import { questpieRealtimeLogTable } from "./collection.js";
 import type {
 	RealtimeChangeEvent,
+	RealtimeChangePayload,
 	RealtimeConfig,
 	RealtimeNotice,
 	RealtimeOperation,
@@ -21,12 +22,13 @@ type AppendChangeOptions = {
 	db?: DrizzleClientFromQuestpieConfig<any>;
 };
 
+const DEFAULT_RETENTION_DAYS = 3;
+
 type ListenerEntry = {
 	listener: RealtimeListener;
 	topics: import("./types").RealtimeTopics;
 	whereFilters: Record<string, unknown>;
 	hasComplexWhere: boolean;
-	lastDeliveredSeq: number;
 	// Track which resources this listener cares about (main + dependencies)
 	watchedResources: {
 		collections: Set<string>;
@@ -158,9 +160,11 @@ export class RealtimeService {
 		this.batchSize = config.batchSize ?? 500;
 		this.pollIntervalMs = config.pollIntervalMs ?? (this.adapter ? 0 : 2000);
 		this.retentionDays =
-			typeof config.retentionDays === "number" && config.retentionDays > 0
-				? config.retentionDays
-				: undefined;
+			config.retentionDays === undefined
+				? DEFAULT_RETENTION_DAYS
+				: config.retentionDays > 0
+					? config.retentionDays
+					: undefined;
 		this.retentionCleanupIntervalMs = 60 * 60 * 1000;
 	}
 
@@ -238,7 +242,7 @@ export class RealtimeService {
 			operation: row.operation as RealtimeOperation,
 			recordId: row.recordId ?? null,
 			locale: row.locale ?? null,
-			payload: (row.payload ?? {}) as Record<string, unknown>,
+			payload: (row.payload ?? {}) as RealtimeChangePayload,
 			createdAt: row.createdAt,
 		};
 
@@ -310,7 +314,6 @@ export class RealtimeService {
 			topics: resolvedTopics,
 			whereFilters: whereAnalysis.filters,
 			hasComplexWhere: whereAnalysis.hasComplex,
-			lastDeliveredSeq: this.lastSeq,
 			watchedResources,
 		};
 
@@ -378,7 +381,16 @@ export class RealtimeService {
 
 	private async readSince(seq: number): Promise<RealtimeChangeEvent[]> {
 		const rows = await this.db
-			.select()
+			.select({
+				seq: questpieRealtimeLogTable.seq,
+				resourceType: questpieRealtimeLogTable.resourceType,
+				resource: questpieRealtimeLogTable.resource,
+				operation: questpieRealtimeLogTable.operation,
+				recordId: questpieRealtimeLogTable.recordId,
+				locale: questpieRealtimeLogTable.locale,
+				payload: questpieRealtimeLogTable.payload,
+				createdAt: questpieRealtimeLogTable.createdAt,
+			})
 			.from(questpieRealtimeLogTable)
 			.where(gt(questpieRealtimeLogTable.seq, seq))
 			.orderBy(asc(questpieRealtimeLogTable.seq))
@@ -391,7 +403,7 @@ export class RealtimeService {
 			operation: row.operation as RealtimeOperation,
 			recordId: row.recordId ?? null,
 			locale: row.locale ?? null,
-			payload: (row.payload ?? {}) as Record<string, unknown>,
+			payload: (row.payload ?? {}) as RealtimeChangePayload,
 			createdAt: row.createdAt,
 		}));
 	}
@@ -517,8 +529,13 @@ export class RealtimeService {
 
 	private emit(event: RealtimeChangeEvent): void {
 		// Extract simple equality filters from event payload for matching
+		const afterProjection = event.payload?.after;
 		const eventFilters = event.payload
-			? extractSimpleEquality(event.payload)
+			? extractSimpleEquality(
+					afterProjection && typeof afterProjection === "object"
+						? afterProjection
+						: event.payload,
+				)
 			: {};
 
 		const candidates = new Set<ListenerEntry>();
@@ -592,31 +609,15 @@ export class RealtimeService {
 
 		// Notify all collected listeners
 		for (const entry of notifiedListeners) {
-			entry.lastDeliveredSeq = Math.max(entry.lastDeliveredSeq, event.seq);
 			entry.listener(event);
 		}
 
 		void this.scheduleRetentionCleanup();
 	}
 
-	private getMinConsumedSeq(): number | null {
-		if (this.listeners.size === 0) return null;
-
-		let min = Number.POSITIVE_INFINITY;
-		for (const entry of this.listeners) {
-			min = Math.min(min, entry.lastDeliveredSeq);
-		}
-
-		if (!Number.isFinite(min) || min <= 0) return null;
-		return min;
-	}
-
 	private async scheduleRetentionCleanup(force = false): Promise<void> {
 		const hasTimeRetention = !!this.retentionDays && this.retentionDays > 0;
-		const minConsumedSeq = this.getMinConsumedSeq();
-		const hasWatermarkCleanup = !!minConsumedSeq;
-
-		if (!hasTimeRetention && !hasWatermarkCleanup) return;
+		if (!hasTimeRetention) return;
 
 		const now = Date.now();
 		if (!force && now < this.nextRetentionCleanupAt) return;
@@ -626,20 +627,12 @@ export class RealtimeService {
 		this.nextRetentionCleanupAt = now + this.retentionCleanupIntervalMs;
 
 		try {
-			if (hasTimeRetention) {
-				const cutoff = new Date(
-					now - (this.retentionDays as number) * 24 * 60 * 60 * 1000,
-				);
-				await this.db
-					.delete(questpieRealtimeLogTable)
-					.where(lt(questpieRealtimeLogTable.createdAt, cutoff));
-			}
-
-			if (hasWatermarkCleanup) {
-				await this.db
-					.delete(questpieRealtimeLogTable)
-					.where(lt(questpieRealtimeLogTable.seq, minConsumedSeq as number));
-			}
+			const cutoff = new Date(
+				now - (this.retentionDays as number) * 24 * 60 * 60 * 1000,
+			);
+			await this.db
+				.delete(questpieRealtimeLogTable)
+				.where(lt(questpieRealtimeLogTable.createdAt, cutoff));
 		} catch {
 			// Best-effort cleanup; keep realtime delivery resilient to cleanup failures.
 		} finally {

--- a/packages/questpie/src/server/modules/core/integrated/realtime/types.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/types.ts
@@ -9,6 +9,26 @@ export type RealtimeOperation =
 	| "bulk_update"
 	| "bulk_delete";
 
+export type RealtimeEqualityValue = string | number | boolean | null;
+
+/**
+ * Shallow scalar fields that can participate in cheap equality routing.
+ * Nested objects, arrays, relations, and hydrated payloads are deliberately
+ * excluded from the durable outbox.
+ */
+export type RealtimeEqualityProjection = Record<string, RealtimeEqualityValue>;
+
+/**
+ * Durable routing payload. Single-record changes carry pre/post projections;
+ * bulk changes carry only their affected ids and count.
+ */
+export type RealtimeChangePayload = {
+	before?: RealtimeEqualityProjection | null;
+	after?: RealtimeEqualityProjection | null;
+	count?: number;
+	recordIds?: (string | number)[];
+};
+
 export type RealtimeChangeEvent = {
 	seq: number;
 	resourceType: RealtimeResourceType;
@@ -16,7 +36,7 @@ export type RealtimeChangeEvent = {
 	operation: RealtimeOperation;
 	recordId?: string | null;
 	locale?: string | null;
-	payload?: Record<string, unknown>;
+	payload?: RealtimeChangePayload;
 	createdAt: Date;
 };
 
@@ -84,9 +104,10 @@ export interface RealtimeConfig {
 	/**
 	 * Retention window in days for time-based outbox cleanup.
 	 *
-	 * Note: realtime service always performs watermark cleanup based on
-	 * min consumed seq for active subscribers. `retentionDays` adds an
-	 * additional time-based safety window.
+	 * Cleanup is time-based only so one process can never delete rows that a
+	 * different process has not drained yet. Set to `0` to disable cleanup.
+	 *
+	 * @default 3
 	 */
 	retentionDays?: number;
 

--- a/packages/questpie/test/integration/realtime-transactional-capture.test.ts
+++ b/packages/questpie/test/integration/realtime-transactional-capture.test.ts
@@ -354,4 +354,34 @@ describe("realtime transactional change capture", () => {
 			setup.app.mocks.logger.getLogsContaining("Realtime publish failed"),
 		).toHaveLength(1);
 	});
+
+	it("G8: stores pre/post scalar projections for update and delete", async () => {
+		const post = await setup.app.collections.posts.create(
+			{ title: "Original" },
+			ctx,
+		);
+
+		await setup.app.collections.posts.updateById(
+			{ id: post.id, data: { title: "Updated" } },
+			ctx,
+		);
+		await setup.app.collections.posts.deleteById({ id: post.id }, ctx);
+
+		const rows = await setup.app.db.select().from(questpieRealtimeLogTable);
+		const update = rows.find(
+			(row: { operation: string }) => row.operation === "update",
+		);
+		const deletion = rows.find(
+			(row: { operation: string }) => row.operation === "delete",
+		);
+
+		expect(update?.payload).toMatchObject({
+			before: { id: post.id, title: "Original" },
+			after: { id: post.id, title: "Updated" },
+		});
+		expect(deletion?.payload).toMatchObject({
+			before: { id: post.id, title: "Updated" },
+			after: null,
+		});
+	});
 });

--- a/packages/questpie/test/integration/realtime.test.ts
+++ b/packages/questpie/test/integration/realtime.test.ts
@@ -297,6 +297,7 @@ describe("realtime", () => {
 			const posts = collection("posts").fields(({ f }) => ({
 				title: f.textarea().required(),
 				status: f.textarea().required(),
+				metadata: f.json(),
 			}));
 
 			const testModule = {
@@ -316,7 +317,11 @@ describe("realtime", () => {
 			);
 
 			await setup.app.collections.posts.create(
-				{ title: "Hello", status: "published" },
+				{
+					title: "Hello",
+					status: "published",
+					metadata: { nested: { value: "not-routing-data" } },
+				},
 				ctx,
 			);
 
@@ -324,8 +329,12 @@ describe("realtime", () => {
 
 			expect(events.length).toBe(1);
 			expect(events[0].payload).toBeDefined();
-			expect(events[0].payload?.title).toBe("Hello");
-			expect(events[0].payload?.status).toBe("published");
+			expect(events[0].payload?.before).toBeNull();
+			expect(events[0].payload?.after).toMatchObject({
+				title: "Hello",
+				status: "published",
+			});
+			expect(events[0].payload?.after).not.toHaveProperty("metadata");
 
 			unsub?.();
 		});
@@ -461,8 +470,9 @@ describe("realtime", () => {
 			);
 			await new Promise((resolve) => setTimeout(resolve, 100));
 			expect(events.length).toBe(1);
-			expect(events[0].payload?.status).toBe("published");
-			expect(events[0].payload?.authorId).toBe("author1");
+			const after = events[0].payload?.after as Record<string, unknown>;
+			expect(after.status).toBe("published");
+			expect(after.authorId).toBe("author1");
 
 			unsub?.();
 		});
@@ -1372,10 +1382,38 @@ describe("realtime", () => {
 
 			const hasOldRow = logs.some((row: any) => row.recordId === "old-record");
 			expect(hasOldRow).toBe(false);
-			expect(logs.some((row: any) => row.payload?.name === "new")).toBe(true);
+			expect(logs.some((row: any) => row.payload?.after?.name === "new")).toBe(
+				true,
+			);
 		});
 
-		it("cleans up consumed realtime rows using min consumed seq", async () => {
+		it("cleans up old rows by default with no subscribers", async () => {
+			const adapter = new MockRealtimeAdapter();
+			const items = collection("items").fields(({ f }) => ({
+				name: f.textarea().required(),
+			}));
+
+			setup = await buildMockApp(
+				{ collections: { items } },
+				{ realtime: { adapter } },
+			);
+			await runTestDbMigrations(setup.app);
+
+			await setup.app.db.insert(questpieRealtimeLogTable).values({
+				resourceType: "collection",
+				resource: "items",
+				operation: "create",
+				recordId: "expired-headless-row",
+				createdAt: new Date(Date.now() - 4 * 24 * 60 * 60 * 1000),
+			});
+
+			await setup.app.realtime.cleanupOutbox(true);
+
+			const logs = await setup.app.db.select().from(questpieRealtimeLogTable);
+			expect(logs).toHaveLength(0);
+		});
+
+		it("does not delete rows from a local subscriber watermark", async () => {
 			const adapter = new MockRealtimeAdapter();
 			const items = collection("items").fields(({ f }) => ({
 				name: f.textarea().required(),
@@ -1419,10 +1457,10 @@ describe("realtime", () => {
 				.orderBy(questpieRealtimeLogTable.seq);
 
 			expect(logs.some((row: any) => row.recordId === "pre-existing")).toBe(
-				false,
+				true,
 			);
 			expect(
-				logs.some((row: any) => row.payload?.name === "after-subscribe"),
+				logs.some((row: any) => row.payload?.after?.name === "after-subscribe"),
 			).toBe(true);
 
 			unsub?.();
@@ -1591,12 +1629,12 @@ describe("realtime", () => {
 			await new Promise((resolve) => setTimeout(resolve, 100));
 
 			expect(events.length).toBe(1);
-			// Payload should include all fields from the create operation
-			expect(events[0].payload?.title).toBe("Public Title");
-			expect(events[0].payload?.content).toBe("Public content");
-			// internalNotes is filtered at read time via CRUD, but event payload
-			// contains the raw data - this is the current behavior
-			expect(events[0].payload?.internalNotes).toBeDefined();
+			const after = events[0].payload?.after as Record<string, unknown>;
+			// The routing projection retains raw scalar fields. ACL filtering is
+			// still applied to the refreshed snapshot, not to the internal outbox row.
+			expect(after.title).toBe("Public Title");
+			expect(after.content).toBe("Public content");
+			expect(after.internalNotes).toBeDefined();
 
 			unsub?.();
 		});

--- a/packages/questpie/test/migration/migrations.test.ts
+++ b/packages/questpie/test/migration/migrations.test.ts
@@ -12,14 +12,17 @@ import { pathToFileURL } from "node:url";
 
 import type { PGlite } from "@electric-sql/pglite";
 import { sql } from "drizzle-orm";
+import { bigserial, index, jsonb, pgTable, text } from "drizzle-orm/pg-core";
 
 import { createApp, module } from "../../src/exports/index.js";
 import { collection } from "../../src/exports/index.js";
+import { systemTimestamp } from "../../src/server/db/system-columns.js";
 import { MigrationRunner } from "../../src/server/migration/runner.js";
 import type {
 	Migration,
 	OperationSnapshot,
 } from "../../src/server/migration/types.js";
+import { questpieRealtimeLogTable } from "../../src/server/modules/core/integrated/realtime/collection.js";
 import { createPostgresSearchAdapter } from "../../src/server/modules/core/integrated/search/adapters/postgres.js";
 import { MockKVAdapter } from "../utils/mocks/kv.adapter";
 import { MockLogger } from "../utils/mocks/logger.adapter";
@@ -428,6 +431,57 @@ describe("Migration System - DrizzleMigrationGenerator", () => {
 			migrationDir: testMigrationDir,
 		});
 		expect(result2.skipped).toBe(true);
+	});
+
+	test("generates drops for obsolete realtime outbox indexes", async () => {
+		const { DrizzleMigrationGenerator } =
+			await import("../../src/server/migration/generator.js");
+		const generator = new DrizzleMigrationGenerator();
+		const oldRealtimeLogTable = pgTable(
+			"questpie_realtime_log",
+			{
+				seq: bigserial("seq", { mode: "number" }).primaryKey(),
+				resourceType: text("resource_type").notNull(),
+				resource: text("resource").notNull(),
+				operation: text("operation").notNull(),
+				recordId: text("record_id"),
+				locale: text("locale"),
+				payload: jsonb("payload").default({}),
+				createdAt: systemTimestamp("created_at").defaultNow().notNull(),
+			},
+			(table) => [
+				index("idx_realtime_log_seq").on(table.seq),
+				index("idx_realtime_log_resource").on(
+					table.resourceType,
+					table.resource,
+				),
+				index("idx_realtime_log_created_at").on(table.createdAt),
+			],
+		);
+
+		await generator.generateMigration({
+			migrationName: "realtimeIndexesBefore",
+			fileBaseName: "20250108_realtime_indexes_before",
+			schema: { questpieRealtimeLogTable: oldRealtimeLogTable },
+			migrationDir: testMigrationDir,
+		});
+		const result = await generator.generateMigration({
+			migrationName: "dropDeadRealtimeIndexes",
+			fileBaseName: "20250109_drop_dead_realtime_indexes",
+			schema: { questpieRealtimeLogTable },
+			migrationDir: testMigrationDir,
+		});
+
+		expect(result.skipped).toBe(false);
+		const migrationSource = readFileSync(
+			join(testMigrationDir, "20250109_drop_dead_realtime_indexes.ts"),
+			"utf8",
+		);
+		expect(migrationSource).toContain('DROP INDEX "idx_realtime_log_seq"');
+		expect(migrationSource).toContain('DROP INDEX "idx_realtime_log_resource"');
+		expect(migrationSource).not.toContain(
+			'DROP INDEX "idx_realtime_log_created_at"',
+		);
 	});
 
 	test("does not re-emit a column whose migration is on disk but missing from the in-memory list", async () => {


### PR DESCRIPTION
## Summary
- default realtime outbox retention to three days and remove unsafe process-local watermark deletes
- persist shallow scalar before/after projections for single changes while retaining bounded bulk metadata
- drop the duplicate/unused outbox indexes through the official migration generator contract
- document the retention and payload contract and add a patch changeset

## Stack
Stacked on #134, which is stacked on #128. Keep this draft until the parent PRs land and the branch can be retargeted to main.

## Verification
- `cd packages/questpie && bun test test/ --test-name-pattern "realtime|migration"` — 70 pass, 0 fail
- `cd packages/questpie && bunx tsc --noEmit -p tsconfig.json`
- migration generator regression emits exactly two DROP INDEX operations
- targeted oxlint: 0 errors; one pre-existing `_title` warning
- `git diff --check`