### PR TITLE
fix(questpie): make realtime async crash-safe

### DIFF
--- a/.changeset/safe-realtime-async.md
+++ b/.changeset/safe-realtime-async.md
@@ -1,0 +1,5 @@
+---
+"questpie": patch
+---
+
+Make realtime startup, drain, listener, and cleanup failures crash-safe. Transport failures now reach SSE clients as an error before the stream closes, and change capture only silently ignores a missing outbox table.

--- a/packages/questpie/src/server/adapters/routes/realtime.ts
+++ b/packages/questpie/src/server/adapters/routes/realtime.ts
@@ -223,6 +223,7 @@ export async function realtimeSubscribe(
 		start: (controller) => {
 			const unsubscribers: (() => void)[] = [];
 			let closed = false;
+			let transportFailed = false;
 
 			// Per-topic state
 			const topicState = new Map<string, TopicState>();
@@ -319,13 +320,29 @@ export async function realtimeSubscribe(
 
 				const unsub = app.realtime!.subscribe(
 					(event) => {
-						void refresh(topic.id, event.seq);
+						void refresh(topic.id, event.seq).catch((error) => {
+							sendTopicError(
+								topic.id,
+								error instanceof Error ? error.message : "Refresh failed",
+							);
+						});
 					},
 					{
 						resourceType: topic.resourceType,
 						resource: topic.resource,
 						where: topic.where,
 						with: topic.with,
+					},
+					(error) => {
+						transportFailed = true;
+						send("error", {
+							topicId: "*",
+							message:
+								error instanceof Error
+									? error.message
+									: "Realtime transport failed",
+						});
+						closeStream?.();
 					},
 				);
 				unsubscribers.push(unsub);
@@ -359,6 +376,7 @@ export async function realtimeSubscribe(
 				}
 			};
 			closeStream = close;
+			if (transportFailed) close();
 
 			// Handle abort signal
 			if (request.signal) {
@@ -367,29 +385,27 @@ export async function realtimeSubscribe(
 
 			// Send initial snapshots
 			void (async () => {
-				try {
-					const latestSeq = (await app.realtime?.getLatestSeq()) ?? 0;
+				const latestSeq = (await app.realtime?.getLatestSeq()) ?? 0;
 
-					// Initialize all topic states with latest seq
-					for (const topic of validatedTopics) {
-						const state = topicState.get(topic.id);
-						if (state) {
-							state.lastSeq = latestSeq;
-						}
+				// Initialize all topic states with latest seq
+				for (const topic of validatedTopics) {
+					const state = topicState.get(topic.id);
+					if (state) {
+						state.lastSeq = latestSeq;
 					}
-
-					// Fetch initial snapshots for all topics
-					await Promise.all(
-						validatedTopics.map((topic) => refresh(topic.id, latestSeq)),
-					);
-				} catch (error) {
-					send("error", {
-						topicId: "*",
-						message:
-							error instanceof Error ? error.message : "Failed to initialize",
-					});
 				}
-			})();
+
+				// Fetch initial snapshots for all topics
+				await Promise.all(
+					validatedTopics.map((topic) => refresh(topic.id, latestSeq)),
+				);
+			})().catch((error) => {
+				send("error", {
+					topicId: "*",
+					message:
+						error instanceof Error ? error.message : "Failed to initialize",
+				});
+			});
 		},
 		cancel: () => {
 			closeStream?.();

--- a/packages/questpie/src/server/modules/core/config/app.ts
+++ b/packages/questpie/src/server/modules/core/config/app.ts
@@ -98,6 +98,33 @@ function projectRealtimeEqualityFields(
 }
 
 const capturedRealtimeBatches = new WeakSet<object>();
+const realtimeCaptureWarningAt = new WeakMap<object, number>();
+const REALTIME_CAPTURE_WARNING_INTERVAL_MS = 60_000;
+
+function hasPostgresErrorCode(error: unknown, code: string): boolean {
+	let current = error;
+	const seen = new Set<object>();
+	while (current && typeof current === "object" && !seen.has(current)) {
+		seen.add(current);
+		if ((current as { code?: unknown }).code === code) return true;
+		current = (current as { cause?: unknown }).cause;
+	}
+	return false;
+}
+
+function handleRealtimeCaptureError(
+	logger: GlobalCollectionHookContext["logger"],
+	error: unknown,
+): void {
+	if (hasPostgresErrorCode(error, "42P01") || !logger) return;
+
+	const now = Date.now();
+	const lastWarningAt = realtimeCaptureWarningAt.get(logger) ?? 0;
+	if (now - lastWarningAt < REALTIME_CAPTURE_WARNING_INTERVAL_MS) return;
+
+	realtimeCaptureWarningAt.set(logger, now);
+	logger.warn("[Core] Realtime change capture failed:", error);
+}
 
 function shouldCaptureRealtimeChange(
 	ctx: GlobalCollectionHookContext,
@@ -152,8 +179,8 @@ const realtimeHook = {
 			);
 
 			publishRealtimeAfterCommit(ctx, realtime, change);
-		} catch {
-			// Realtime log table may not exist yet
+		} catch (error) {
+			handleRealtimeCaptureError(ctx.logger, error);
 		}
 	},
 	afterDelete: async (ctx: GlobalCollectionHookContext) => {
@@ -178,8 +205,8 @@ const realtimeHook = {
 			);
 
 			publishRealtimeAfterCommit(ctx, realtime, change);
-		} catch {
-			// Realtime log table may not exist yet
+		} catch (error) {
+			handleRealtimeCaptureError(ctx.logger, error);
 		}
 	},
 };
@@ -354,8 +381,8 @@ const globalRealtimeHook = {
 			);
 
 			publishRealtimeAfterCommit(ctx, realtime, change);
-		} catch {
-			// Realtime log table may not exist yet
+		} catch (error) {
+			handleRealtimeCaptureError(ctx.logger, error);
 		}
 	},
 };

--- a/packages/questpie/src/server/modules/core/integrated/realtime/service.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/service.ts
@@ -1,6 +1,7 @@
 import { asc, desc, gt, lt } from "drizzle-orm";
 
 import type { DrizzleClientFromQuestpieConfig } from "#questpie/server/config/types.js";
+import type { LoggerAdapter } from "#questpie/server/modules/core/integrated/logger/types.js";
 
 import type { RealtimeAdapter } from "./adapter.js";
 import { questpieRealtimeLogTable } from "./collection.js";
@@ -8,6 +9,7 @@ import type {
 	RealtimeChangeEvent,
 	RealtimeChangePayload,
 	RealtimeConfig,
+	RealtimeErrorListener,
 	RealtimeNotice,
 	RealtimeOperation,
 	RealtimeResourceType,
@@ -26,6 +28,7 @@ const DEFAULT_RETENTION_DAYS = 3;
 
 type ListenerEntry = {
 	listener: RealtimeListener;
+	errorListener?: RealtimeErrorListener;
 	topics: import("./types").RealtimeTopics;
 	whereFilters: Record<string, unknown>;
 	hasComplexWhere: boolean;
@@ -149,6 +152,7 @@ export class RealtimeService {
 		private db: DrizzleClientFromQuestpieConfig<any>,
 		config: RealtimeConfig = {},
 		private pgConnectionString?: string,
+		private logger?: Pick<LoggerAdapter, "error" | "warn">,
 	) {
 		// Auto-configure adapter if connection string is provided
 		if (config.adapter) {
@@ -174,6 +178,46 @@ export class RealtimeService {
 	 */
 	setSubscriptionContext(context: RealtimeSubscriptionContext): void {
 		this.subscriptionContext = context;
+	}
+
+	private reportTransportFailure(message: string, error: unknown): void {
+		this.logger?.error(message, error);
+		const listeners = Array.from(this.listeners);
+		for (const entry of listeners) {
+			try {
+				entry.errorListener?.(error);
+			} catch (listenerError) {
+				this.logger?.error(
+					"[Realtime] Error listener failed while reporting a transport failure",
+					listenerError,
+				);
+			}
+		}
+	}
+
+	private ensureStartedSafely(): void {
+		if (this.started || this.startPromise) return;
+		void this.ensureStarted().catch((error) => {
+			this.reportTransportFailure("[Realtime] Transport startup failed", error);
+		});
+	}
+
+	private drainSafely(): void {
+		void this.drain().catch((error) => {
+			this.reportTransportFailure("[Realtime] Outbox drain failed", error);
+		});
+	}
+
+	private cleanupSafely(force = false): void {
+		void this.scheduleRetentionCleanup(force).catch((error) => {
+			this.logger?.warn("[Realtime] Outbox cleanup failed", error);
+		});
+	}
+
+	private stopSafely(): void {
+		void this.stop().catch((error) => {
+			this.logger?.error("[Realtime] Transport shutdown failed", error);
+		});
 	}
 
 	private addIndexedListener(
@@ -246,7 +290,7 @@ export class RealtimeService {
 			createdAt: row.createdAt,
 		};
 
-		void this.scheduleRetentionCleanup();
+		this.cleanupSafely();
 		return event;
 	}
 
@@ -267,6 +311,7 @@ export class RealtimeService {
 	subscribe(
 		listener: RealtimeListener,
 		topics?: import("./types").RealtimeTopics,
+		errorListener?: RealtimeErrorListener,
 	): () => void {
 		const resolvedTopics = topics ?? {
 			resourceType: "collection",
@@ -311,6 +356,7 @@ export class RealtimeService {
 
 		const entry: ListenerEntry = {
 			listener,
+			errorListener,
 			topics: resolvedTopics,
 			whereFilters: whereAnalysis.filters,
 			hasComplexWhere: whereAnalysis.hasComplex,
@@ -333,7 +379,7 @@ export class RealtimeService {
 			this.addIndexedListener(this.watchedGlobalListeners, resource, entry);
 		}
 
-		void this.ensureStarted();
+		this.ensureStartedSafely();
 
 		return () => {
 			this.listeners.delete(entry);
@@ -365,7 +411,7 @@ export class RealtimeService {
 			}
 
 			if (this.listeners.size === 0) {
-				void this.stop();
+				this.stopSafely();
 			}
 		};
 	}
@@ -430,18 +476,18 @@ export class RealtimeService {
 			if (this.adapter) {
 				await this.adapter.start();
 				this.unsubscribeAdapter = this.adapter.subscribe(() => {
-					void this.drain();
+					this.drainSafely();
 				});
 			} else if (this.pollIntervalMs > 0) {
 				this.pollTimer = setInterval(() => {
-					void this.drain();
+					this.drainSafely();
 				}, this.pollIntervalMs);
 			}
 
 			this.lastSeq = latestSeq;
 			this.started = true;
-			void this.drain();
-			void this.scheduleRetentionCleanup(true);
+			this.drainSafely();
+			this.cleanupSafely(true);
 		})()
 			.catch(async (error) => {
 				this.started = false;
@@ -459,8 +505,11 @@ export class RealtimeService {
 				if (this.adapter) {
 					try {
 						await this.adapter.stop();
-					} catch {
-						// Ignore stop failures during failed startup cleanup
+					} catch (stopError) {
+						this.logger?.warn(
+							"[Realtime] Transport cleanup after failed startup failed",
+							stopError,
+						);
 					}
 				}
 
@@ -483,8 +532,11 @@ export class RealtimeService {
 		if (this.startPromise) {
 			try {
 				await this.startPromise;
-			} catch {
-				// startup already failed, continue cleanup
+			} catch (error) {
+				this.logger?.warn(
+					"[Realtime] Transport startup failed before shutdown",
+					error,
+				);
 			}
 		}
 
@@ -609,10 +661,14 @@ export class RealtimeService {
 
 		// Notify all collected listeners
 		for (const entry of notifiedListeners) {
-			entry.listener(event);
+			try {
+				entry.listener(event);
+			} catch (error) {
+				this.logger?.error("[Realtime] Realtime listener failed", error);
+			}
 		}
 
-		void this.scheduleRetentionCleanup();
+		this.cleanupSafely();
 	}
 
 	private async scheduleRetentionCleanup(force = false): Promise<void> {
@@ -633,8 +689,9 @@ export class RealtimeService {
 			await this.db
 				.delete(questpieRealtimeLogTable)
 				.where(lt(questpieRealtimeLogTable.createdAt, cutoff));
-		} catch {
+		} catch (error) {
 			// Best-effort cleanup; keep realtime delivery resilient to cleanup failures.
+			this.logger?.warn("[Realtime] Outbox cleanup failed", error);
 		} finally {
 			this.retentionCleanupInProgress = false;
 		}

--- a/packages/questpie/src/server/modules/core/integrated/realtime/types.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/types.ts
@@ -40,6 +40,9 @@ export type RealtimeChangeEvent = {
 	createdAt: Date;
 };
 
+/** Called when realtime delivery fails and the subscriber should reconnect. */
+export type RealtimeErrorListener = (error: unknown) => void;
+
 export type RealtimeNotice = Pick<
 	RealtimeChangeEvent,
 	"seq" | "resourceType" | "resource" | "operation"

--- a/packages/questpie/src/server/modules/core/services/realtime.ts
+++ b/packages/questpie/src/server/modules/core/services/realtime.ts
@@ -17,6 +17,7 @@ export default service({
 			app.db as any,
 			app.config.realtime,
 			app._pgConnectionString,
+			app.logger,
 		);
 
 		// Set subscription context for dependency resolution

--- a/packages/questpie/test/integration/realtime-transactional-capture.test.ts
+++ b/packages/questpie/test/integration/realtime-transactional-capture.test.ts
@@ -384,4 +384,52 @@ describe("realtime transactional change capture", () => {
 			after: null,
 		});
 	});
+
+	it("H11: silently ignores only a missing realtime table", async () => {
+		const missingTable = new Error("realtime insert failed", {
+			cause: Object.assign(new Error("relation does not exist"), {
+				code: "42P01",
+			}),
+		});
+		const appendSpy = spyOn(
+			setup.app.realtime,
+			"appendChange",
+		).mockImplementation(async () => {
+			throw missingTable;
+		});
+
+		try {
+			await setup.app.collections.posts.create({ title: "No table yet" }, ctx);
+		} finally {
+			appendSpy.mockRestore();
+		}
+
+		expect(
+			setup.app.mocks.logger.getLogsContaining(
+				"Realtime change capture failed",
+			),
+		).toHaveLength(0);
+	});
+
+	it("H11: rate-limits warnings for non-42P01 capture failures", async () => {
+		const appendSpy = spyOn(
+			setup.app.realtime,
+			"appendChange",
+		).mockImplementation(async () => {
+			throw Object.assign(new Error("database unavailable"), { code: "08006" });
+		});
+
+		try {
+			await setup.app.collections.posts.create({ title: "First" }, ctx);
+			await setup.app.collections.posts.create({ title: "Second" }, ctx);
+		} finally {
+			appendSpy.mockRestore();
+		}
+
+		expect(
+			setup.app.mocks.logger.getLogsContaining(
+				"Realtime change capture failed",
+			),
+		).toHaveLength(1);
+	});
 });

--- a/packages/questpie/test/integration/realtime.test.ts
+++ b/packages/questpie/test/integration/realtime.test.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck // TODO: Temporary until test utils are fully typed
-import { afterEach, describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it, spyOn } from "bun:test";
 
 import {
 	createAdapterRoutes,
@@ -55,6 +55,12 @@ class LifecycleTrackingRealtimeAdapter extends MockRealtimeAdapter {
 
 	async stop(): Promise<void> {
 		this.stopCalls += 1;
+	}
+}
+
+class FailingStartRealtimeAdapter extends MockRealtimeAdapter {
+	async start(): Promise<void> {
+		throw new Error("adapter start failed");
 	}
 }
 
@@ -1118,6 +1124,42 @@ describe("realtime", () => {
 	// ==========================================================================
 
 	describe("edge cases", () => {
+		it("isolates a throwing listener so later listeners still receive the event", async () => {
+			const adapter = new MockRealtimeAdapter();
+			const items = collection("items").fields(({ f }) => ({
+				name: f.textarea().required(),
+			}));
+
+			setup = await buildMockApp(
+				{ collections: { items } },
+				{ realtime: { adapter } },
+			);
+			await runTestDbMigrations(setup.app);
+
+			let healthyListenerCalls = 0;
+			setup.app.realtime.subscribe(() => {
+				throw new Error("listener failed");
+			}, { resourceType: "collection", resource: "items" });
+			setup.app.realtime.subscribe(() => {
+				healthyListenerCalls += 1;
+			}, { resourceType: "collection", resource: "items" });
+
+			const event: RealtimeChangeEvent = {
+				seq: 1,
+				resourceType: "collection",
+				resource: "items",
+				operation: "create",
+				payload: { before: null, after: { name: "Safe" } },
+				createdAt: new Date(),
+			};
+
+			expect(() => setup.app.realtime.emit(event)).not.toThrow();
+			expect(healthyListenerCalls).toBe(1);
+			expect(
+				setup.app.mocks.logger.getLogsContaining("Realtime listener failed"),
+			).toHaveLength(1);
+		});
+
 		it("restarts adapter after all subscribers disconnect", async () => {
 			const adapter = new LifecycleTrackingRealtimeAdapter();
 			const items = collection("items").fields(({ f }) => ({
@@ -1752,6 +1794,95 @@ describe("realtime", () => {
 	// ==========================================================================
 
 	describe("E2E SSE streaming", () => {
+		it("sends an error event and closes when the transport cannot start", async () => {
+			const adapter = new FailingStartRealtimeAdapter();
+			const items = collection("items")
+				.fields(({ f }) => ({ name: f.textarea().required() }))
+				.access({ read: true });
+
+			setup = await buildMockApp(
+				{ collections: { items } },
+				{ realtime: { adapter } },
+			);
+			await runTestDbMigrations(setup.app);
+
+			const routes = createAdapterRoutes(setup.app, { accessMode: "user" });
+			const response = await routes.realtime.subscribe(
+				createRealtimeRequest([collectionTopic("items")]),
+				{},
+				undefined,
+			);
+			const reader = createSSEReader(response.body!);
+
+			let transportError: SSEEvent | undefined;
+			for (let attempt = 0; attempt < 3; attempt += 1) {
+				const event = await reader.readEvent();
+				if (event.event === "error") {
+					transportError = event;
+					break;
+				}
+			}
+
+			expect(transportError?.data).toMatchObject({
+				topicId: "*",
+				message: "adapter start failed",
+			});
+			expect(
+				setup.app.mocks.logger.getLogsContaining("Transport startup failed"),
+			).toHaveLength(1);
+			await expect(reader.readEvent()).rejects.toThrow(
+				"SSE stream closed before event",
+			);
+		});
+
+		it("sends an error event and closes when an outbox drain fails", async () => {
+			const adapter = new MockRealtimeAdapter();
+			const items = collection("items")
+				.fields(({ f }) => ({ name: f.textarea().required() }))
+				.access({ read: true });
+
+			setup = await buildMockApp(
+				{ collections: { items } },
+				{ realtime: { adapter } },
+			);
+			await runTestDbMigrations(setup.app);
+
+			const routes = createAdapterRoutes(setup.app, { accessMode: "user" });
+			const response = await routes.realtime.subscribe(
+				createRealtimeRequest([collectionTopic("items")]),
+				{},
+				undefined,
+			);
+			const reader = createSSEReader(response.body!);
+			expect((await reader.readSnapshot()).event).toBe("snapshot");
+			await new Promise((resolve) => setTimeout(resolve, 20));
+
+			const readSpy = spyOn(
+				setup.app.realtime,
+				"readSince",
+			).mockRejectedValue(new Error("drain failed"));
+			try {
+				await adapter.notify({
+					seq: 999,
+					resourceType: "collection",
+					resource: "items",
+					operation: "create",
+					createdAt: new Date(),
+				});
+
+				const transportError = await reader.readEvent();
+				expect(transportError).toMatchObject({
+					event: "error",
+					data: { topicId: "*", message: "drain failed" },
+				});
+				await expect(reader.readEvent()).rejects.toThrow(
+					"SSE stream closed before event",
+				);
+			} finally {
+				readSpy.mockRestore();
+			}
+		});
+
 		it("should stream multiple snapshots on rapid updates", async () => {
 			const adapter = new MockRealtimeAdapter();
 			const counters = collection("counters")


### PR DESCRIPTION
## Summary
- attach catch-and-log handling to realtime startup, drain, cleanup, shutdown, refresh, and initialization promises
- isolate throwing listeners so one subscriber cannot skip delivery for the rest
- surface startup/drain failures to SSE clients as an error event and close the stream for reconnect
- silently ignore only PostgreSQL 42P01 during outbox capture and rate-limit warnings for other failures
- add a patch changeset

## Stack
Stacked on #135 (which is stacked on #134 and #128). Keep this draft until the parent PRs land and it can be retargeted to main.

## Verification
- `cd packages/questpie && bun test test/ --test-name-pattern "realtime"` — 54 pass, 0 fail
- `cd packages/questpie && bunx tsc --noEmit -p tsconfig.json`
- focused startup/drain/listener/42P01 suite — 5 pass, 0 fail
- targeted oxlint — 0 errors; existing warnings only
- `git diff --check`