### PR TITLE
fix(questpie): broadcast redis realtime wakes

### DIFF
--- a/.changeset/fix-redis-realtime-broadcast.md
+++ b/.changeset/fix-redis-realtime-broadcast.md
@@ -1,0 +1,5 @@
+---
+"questpie": patch
+---
+
+Fix Redis realtime delivery so every app instance receives each wake. The adapter now uses an independent XREAD cursor per instance, caps its stream with approximate MAXLEN trimming, recovers from read failures, and waits for its read loop during shutdown.

--- a/apps/docs/content/docs/adapters/realtime.mdx
+++ b/apps/docs/content/docs/adapters/realtime.mdx
@@ -16,7 +16,7 @@ Read [Configuration](/docs/concepts/configuration) (where adapters are wired in 
 - **Records every change to an outbox.** Each create/update/delete (and bulk variant) appends a row to the `questpie_realtime_log` table, a durable, ordered change log keyed by an auto-incrementing `seq`.
 - **Fans out across instances.** The adapter broadcasts a tiny *notice* ("seq N on collection posts changed") to every process, which then drains the outbox and pushes snapshots to its own SSE subscribers.
 - **Zero-config default.** Turn `realtime` on with `true` and you get a working transport, polling on a non-Postgres setup, or an auto-wired `pg_notify` listener when a Postgres connection is available.
-- **Push transports for scale.** `pgNotifyAdapter` rides the database you already run; `redisStreamsAdapter` uses a Redis consumer group; `cloudflareRealtimeAdapter` is backed by a Durable Object.
+- **Push transports for scale.** `pgNotifyAdapter` rides the database you already run; `redisStreamsAdapter` gives every instance an independent Redis Stream tail; `cloudflareRealtimeAdapter` is backed by a Durable Object.
 - **Privacy-safe by design.** Only a `RealtimeNotice` crosses the wire, never row data. Each subscriber re-runs its own access-controlled query to build its snapshot, so one user's data can't leak through the transport.
 - **Swap with one config line.** The transport is a single `realtime.adapter` value, no app-code change to move from polling to Redis.
 
@@ -147,7 +147,7 @@ On a Postgres app, `realtime: true` already auto-wires `pg_notify` on the defaul
 
 ## `redisStreamsAdapter`, Redis Streams
 
-For Redis-backed fan-out across many instances, use Redis Streams with a consumer group. The `client` is **required**, QUESTPIE doesn't ship a Redis driver, so you bring your own (a small command-shaped object modeled on `node-redis`):
+For Redis-backed fan-out across many instances, use Redis Streams with an independent `XREAD` cursor per app instance. The `client` is **required**, QUESTPIE doesn't ship a Redis driver, so you bring your own (a small command-shaped object modeled on `node-redis`):
 
 ```ts title="src/questpie/server/questpie.config.ts"
 import { runtimeConfig } from "questpie/app";
@@ -165,43 +165,49 @@ export default runtimeConfig({
     adapter: redisStreamsAdapter({
       client: redis,
       // stream: "questpie:realtime",   // default
-      // group: "questpie-realtime",    // default
-      // consumer: "consumer-<uuid>",   // default: random per process
       // blockMs: 5000, batchSize: 100, // defaults
+      // maxLen: 10_000,                // approximate stream cap
     }),
   },
 });
 ```
 
-`RedisStreamsAdapterOptions` is `{ client (required), stream?, group?, consumer?, blockMs?, batchSize? }`.
+`RedisStreamsAdapterOptions` is `{ client (required), reader?, stream?, blockMs?, batchSize?, maxLen?, retryDelayMs?, onError? }`.
 
 | Option | Type | Default | Notes |
 |---|---|---|---|
-| `client` | `RedisStreamsClient` | none **required** | Your Redis client. Must implement `xAdd` + `xReadGroup`; `xGroupCreate` / `xAck` / `quit` / `disconnect` are optional. |
+| `client` | `RedisStreamsClient` | none **required** | Publishing client. Must implement `xAdd` + `xRead`; node-redis clients are automatically duplicated for the blocking reader. |
+| `reader` | `RedisStreamsClient` | auto | Optional already-connected blocking-read client for structural clients without `duplicate()`. |
 | `stream` | `string` | `"questpie:realtime"` | The Redis stream key notices are `XADD`-ed to. |
-| `group` | `string` | `"questpie-realtime"` | Consumer group name. Created with `MKSTREAM`; a `BUSYGROUP` (group already exists) is swallowed. |
-| `consumer` | `string` | `consumer-<random uuid>` | Per-process consumer id. The random default lets every instance read the stream without stealing each other's messages. |
-| `blockMs` | `number` | `5000` | How long `XREADGROUP` blocks waiting for new messages. |
-| `batchSize` | `number` | `100` | `COUNT` per `XREADGROUP` call. |
+| `blockMs` | `number` | `5000` | How long `XREAD` blocks waiting for new messages. |
+| `batchSize` | `number` | `100` | `COUNT` per `XREAD` call. |
+| `maxLen` | `number` | `10000` | Approximate `MAXLEN ~` cap applied by every `XADD`. |
+| `retryDelayMs` | `number` | `500` | Backoff after a read-loop failure. |
+| `onError` | `(error) => void` | `console.warn` | Error hook for read/listener failures. |
 
 Behavior:
 
-- **Uses `XADD` / `XREADGROUP` / `XACK`.** `notify()` `XADD`s the notice fields (`seq`, `resourceType`, `resource`, `operation`) as strings; the read loop acknowledges each delivered message.
-- **Resilient read loop.** On a read error it backs off 500ms and retries while running; `stop()` ends the loop.
+- **Broadcasts instead of load-balancing.** Every adapter tails from `$` with its own `XREAD` cursor, so all running app instances receive each new wake. There is no shared consumer group or pending-entry list.
+- **Bounds the stream.** `notify()` uses `XADD MAXLEN ~ 10000` by default and stores only the notice fields (`seq`, `resourceType`, `resource`, `operation`).
+- **Resilient lifecycle.** A failed loop iteration is reported, backed off, and retried. `stop()` awaits the blocking read's exit before a later `start()` can create another loop.
 - **Driver-agnostic.** Any client matching the `RedisStreamsClient` shape works, the type is modeled on `node-redis` command names but isn't tied to it.
 
 <Callout type="info" title="`RedisStreamsClient` is a structural contract">
 ```ts
 type RedisStreamsClient = {
-  xAdd(stream, id, fields): Promise<string>;
-  xGroupCreate?(stream, group, id, options?: { MKSTREAM?: boolean }): Promise<unknown>;
-  xReadGroup(...args: any[]): Promise<unknown>;
-  xAck?(stream, group, id | id[]): Promise<unknown>;
+  xAdd(stream, id, fields, options?): Promise<string>;
+  xRead(streams: Array<{ key: string; id: string }>, options?): Promise<unknown>;
+  duplicate?(): RedisStreamsClient;
+  connect?(): Promise<unknown>;
+  close?(): Promise<void>;
   quit?(): Promise<void>;
   disconnect?(): void;
+  destroy?(): void;
+  on?(event: "error", handler): unknown;
+  off?(event: "error", handler): unknown;
 };
 ```
-Only `xAdd` and `xReadGroup` are mandatory.
+Only `xAdd` and `xRead` are mandatory. Pass `reader` when a custom client cannot duplicate itself; blocking reads should not share the publishing connection.
 </Callout>
 
 ## `cloudflareRealtimeAdapter`, Durable Objects

--- a/packages/questpie/src/server/modules/core/integrated/realtime/adapters/redis-streams.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/adapters/redis-streams.ts
@@ -6,66 +6,119 @@ export type RedisStreamsClient = {
 		stream: string,
 		id: string,
 		fields: Record<string, string>,
+		options?: {
+			TRIM?: {
+				strategy: "MAXLEN";
+				strategyModifier: "~";
+				threshold: number;
+			};
+		},
 	) => Promise<string>;
-	xGroupCreate?: (
-		stream: string,
-		group: string,
-		id: string,
-		options?: { MKSTREAM?: boolean },
+	xRead: (
+		streams: Array<{ key: string; id: string }>,
+		options?: { COUNT?: number; BLOCK?: number },
 	) => Promise<unknown>;
-	xReadGroup: (...args: any[]) => Promise<unknown>;
-	xAck?: (
-		stream: string,
-		group: string,
-		id: string | string[],
-	) => Promise<unknown>;
+	duplicate?: () => RedisStreamsClient;
+	connect?: () => Promise<unknown>;
+	close?: () => Promise<void>;
 	quit?: () => Promise<void>;
 	disconnect?: () => void;
+	destroy?: () => void;
+	on?: (event: "error", handler: (error: unknown) => void) => unknown;
+	off?: (event: "error", handler: (error: unknown) => void) => unknown;
 };
 
 export type RedisStreamsAdapterOptions = {
 	client: RedisStreamsClient;
+	/** Dedicated blocking-read connection. Node-redis clients are duplicated automatically. */
+	reader?: RedisStreamsClient;
 	stream?: string;
+	/** @deprecated Consumer groups are no longer used because they load-balance wakes. */
 	group?: string;
+	/** @deprecated Each adapter instance now owns an independent XREAD cursor. */
 	consumer?: string;
 	blockMs?: number;
 	batchSize?: number;
+	maxLen?: number;
+	retryDelayMs?: number;
+	onError?: (error: unknown) => void;
 };
 
 export class RedisStreamsAdapter implements RealtimeAdapter {
 	private client: RedisStreamsClient;
+	private providedReader?: RedisStreamsClient;
+	private reader: RedisStreamsClient | null = null;
+	private ownsReader = false;
+	private readerErrorHandler?: (error: unknown) => void;
 	private stream: string;
-	private group: string;
-	private consumer: string;
 	private blockMs: number;
 	private batchSize: number;
+	private maxLen: number;
+	private retryDelayMs: number;
+	private onError?: (error: unknown) => void;
 	private listeners = new Set<(notice: RealtimeNotice) => void>();
 	private running = false;
+	private readLoopPromise: Promise<void> | null = null;
+	private stopPromise: Promise<void> | null = null;
 
 	constructor(options: RedisStreamsAdapterOptions) {
 		this.client = options.client;
+		this.providedReader = options.reader;
 		this.stream = options.stream ?? "questpie:realtime";
-		this.group = options.group ?? "questpie-realtime";
-		this.consumer =
-			options.consumer ??
-			`consumer-${
-				globalThis.crypto?.randomUUID?.() ?? Math.random().toString(36).slice(2)
-			}`;
 		this.blockMs = options.blockMs ?? 5000;
 		this.batchSize = options.batchSize ?? 100;
+		this.maxLen = options.maxLen ?? 10_000;
+		this.retryDelayMs = options.retryDelayMs ?? 500;
+		this.onError = options.onError;
 	}
 
 	async start(): Promise<void> {
 		if (this.running) return;
+		if (this.stopPromise) await this.stopPromise;
+		if (this.running) return;
+
+		await this.ensureReader();
 		this.running = true;
-		await this.ensureGroup();
-		this.readLoop().catch(() => {
-			this.running = false;
+		this.readLoopPromise = this.runReadLoop().catch((error) => {
+			this.reportError("[Realtime] Redis Streams read loop stopped", error);
 		});
 	}
 
 	async stop(): Promise<void> {
+		if (this.stopPromise) return this.stopPromise;
 		this.running = false;
+		const readLoopPromise = this.readLoopPromise;
+		const reader = this.reader;
+		const ownsReader = this.ownsReader;
+		const forceCloseReader = ownsReader
+			? (reader?.destroy ?? reader?.disconnect)
+			: undefined;
+		this.stopPromise = (async () => {
+			try {
+				forceCloseReader?.call(reader);
+			} catch (error) {
+				this.reportError(
+					"[Realtime] Redis Streams reader shutdown failed",
+					error,
+				);
+			}
+			if (readLoopPromise) await readLoopPromise;
+			if (ownsReader && !forceCloseReader) {
+				if (reader?.close) await reader.close();
+				else await reader?.quit?.();
+			}
+		})().finally(() => {
+			if (this.readerErrorHandler) {
+				reader?.off?.("error", this.readerErrorHandler);
+				this.readerErrorHandler = undefined;
+			}
+			if (this.reader === reader) {
+				this.reader = null;
+				this.ownsReader = false;
+			}
+			this.stopPromise = null;
+		});
+		return this.stopPromise;
 	}
 
 	subscribe(handler: (notice: RealtimeNotice) => void): () => void {
@@ -76,66 +129,128 @@ export class RedisStreamsAdapter implements RealtimeAdapter {
 	}
 
 	async notify(event: RealtimeChangeEvent): Promise<void> {
-		await this.client.xAdd(this.stream, "*", {
-			seq: String(event.seq),
-			resourceType: event.resourceType,
-			resource: event.resource,
-			operation: event.operation,
-		});
-	}
-
-	private async ensureGroup(): Promise<void> {
-		if (!this.client.xGroupCreate) return;
-		try {
-			await this.client.xGroupCreate(this.stream, this.group, "$", {
-				MKSTREAM: true,
-			});
-		} catch (error: any) {
-			const message = String(error?.message || "");
-			if (!message.includes("BUSYGROUP")) {
-				throw error;
-			}
-		}
+		await this.client.xAdd(
+			this.stream,
+			"*",
+			{
+				seq: String(event.seq),
+				resourceType: event.resourceType,
+				resource: event.resource,
+				operation: event.operation,
+			},
+			{
+				TRIM: {
+					strategy: "MAXLEN",
+					strategyModifier: "~",
+					threshold: this.maxLen,
+				},
+			},
+		);
 	}
 
 	private async readLoop(): Promise<void> {
+		const reader = this.reader;
+		if (!reader) throw new Error("Redis Streams reader is not initialized");
+
+		let lastId = "$";
 		while (this.running) {
-			let response: unknown;
 			try {
-				response = await this.client.xReadGroup(
-					"GROUP",
-					this.group,
-					this.consumer,
-					"COUNT",
-					this.batchSize,
-					"BLOCK",
-					this.blockMs,
-					"STREAMS",
-					this.stream,
-					">",
+				const response = await reader.xRead(
+					[{ key: this.stream, id: lastId }],
+					{ COUNT: this.batchSize, BLOCK: this.blockMs },
 				);
-			} catch {
 				if (!this.running) break;
-				await new Promise((resolve) => setTimeout(resolve, 500));
-				continue;
-			}
 
-			const messages = this.normalizeResponse(response);
-			if (messages.length === 0) continue;
+				const messages = this.normalizeResponse(response);
+				for (const message of messages) {
+					lastId = message.id;
+					const notice = this.noticeFromFields(message.fields);
+					if (!notice) continue;
 
-			for (const message of messages) {
-				const notice = this.noticeFromFields(message.fields);
-				if (notice) {
 					for (const listener of this.listeners) {
-						listener(notice);
+						try {
+							listener(notice);
+						} catch (error) {
+							this.reportError(
+								"[Realtime] Redis Streams listener failed",
+								error,
+							);
+						}
 					}
 				}
-
-				if (this.client.xAck) {
-					await this.client.xAck(this.stream, this.group, message.id);
-				}
+			} catch (error) {
+				if (!this.running) break;
+				this.reportError(
+					"[Realtime] Redis Streams read failed; retrying",
+					error,
+				);
+				await new Promise((resolve) => setTimeout(resolve, this.retryDelayMs));
 			}
 		}
+	}
+
+	private async ensureReader(): Promise<void> {
+		if (this.reader) return;
+		if (this.providedReader) {
+			this.reader = this.providedReader;
+			this.attachReaderErrorHandler();
+			return;
+		}
+
+		if (this.client.duplicate) {
+			this.reader = this.client.duplicate();
+			this.ownsReader = true;
+			this.attachReaderErrorHandler();
+			try {
+				await this.reader.connect?.();
+			} catch (error) {
+				if (this.readerErrorHandler) {
+					this.reader.off?.("error", this.readerErrorHandler);
+					this.readerErrorHandler = undefined;
+				}
+				this.reader = null;
+				this.ownsReader = false;
+				throw error;
+			}
+			return;
+		}
+
+		this.reader = this.client;
+		this.attachReaderErrorHandler();
+	}
+
+	private attachReaderErrorHandler(): void {
+		if (!this.reader?.on || this.readerErrorHandler) return;
+		this.readerErrorHandler = (error) =>
+			this.reportError(
+				"[Realtime] Redis Streams reader connection error",
+				error,
+			);
+		this.reader.on("error", this.readerErrorHandler);
+	}
+
+	private async runReadLoop(): Promise<void> {
+		try {
+			await this.readLoop();
+		} finally {
+			this.running = false;
+			this.readLoopPromise = null;
+		}
+	}
+
+	private reportError(message: string, error: unknown): void {
+		if (this.onError) {
+			try {
+				this.onError(error);
+				return;
+			} catch (callbackError) {
+				console.warn(
+					"[Realtime] Redis Streams error callback failed",
+					callbackError,
+				);
+			}
+		}
+		console.warn(message, error);
 	}
 
 	private normalizeResponse(response: any): Array<{ id: string; fields: any }> {

--- a/packages/questpie/test/adapters/redis-streams.test.ts
+++ b/packages/questpie/test/adapters/redis-streams.test.ts
@@ -1,0 +1,275 @@
+import { afterEach, describe, expect, it } from "bun:test";
+
+import {
+	RedisStreamsAdapter,
+	type RedisStreamsClient,
+} from "../../src/exports/adapters/redis-streams.js";
+import type { RealtimeChangeEvent } from "../../src/exports/realtime.js";
+import { buildMockApp } from "../utils/mocks/mock-app-builder.js";
+import { createTestDb, runTestDbMigrations } from "../utils/test-db.js";
+
+type StreamMessage = {
+	id: string;
+	message: Record<string, string>;
+};
+
+class FakeRedisStream {
+	private messages: StreamMessage[] = [];
+	private waiters = new Set<{
+		lastId: string;
+		resolve: (value: unknown) => void;
+	}>();
+	private nextId = 1;
+	public xAddOptions: unknown[] = [];
+	public readFailures: unknown[] = [];
+
+	get waiterCount(): number {
+		return this.waiters.size;
+	}
+
+	createClient(): RedisStreamsClient {
+		return {
+			xAdd: async (_stream, _id, fields, options) => {
+				this.xAddOptions.push(options);
+				const message = {
+					id: `${this.nextId++}-0`,
+					message: fields,
+				};
+				this.messages.push(message);
+				for (const waiter of this.waiters) {
+					this.waiters.delete(waiter);
+					waiter.resolve(this.response([message]));
+				}
+				return message.id;
+			},
+			xRead: async (streams, options) => {
+				const failure = this.readFailures.shift();
+				if (failure) throw failure;
+
+				const lastId = streams[0]?.id ?? "$";
+				const existing =
+					lastId === "$"
+						? []
+						: this.messages.filter((message) => message.id > lastId);
+				if (existing.length > 0) return this.response(existing);
+
+				return new Promise((resolve) => {
+					const waiter = { lastId, resolve };
+					this.waiters.add(waiter);
+					setTimeout(() => {
+						if (!this.waiters.delete(waiter)) return;
+						resolve(null);
+					}, options?.BLOCK ?? 10);
+				});
+			},
+		};
+	}
+
+	private response(messages: StreamMessage[]): unknown {
+		return [{ name: "questpie:realtime", messages }];
+	}
+}
+
+const change: RealtimeChangeEvent = {
+	seq: 1,
+	resourceType: "collection",
+	resource: "posts",
+	operation: "create",
+	createdAt: new Date(),
+};
+
+describe("redis streams adapter", () => {
+	const adapters: RedisStreamsAdapter[] = [];
+
+	afterEach(async () => {
+		await Promise.all(adapters.splice(0).map((adapter) => adapter.stop()));
+	});
+
+	it("wakes two realtime service instances from one published change", async () => {
+		const redis = new FakeRedisStream();
+		const firstAdapter = new RedisStreamsAdapter({
+			client: redis.createClient(),
+			blockMs: 10,
+		});
+		const secondAdapter = new RedisStreamsAdapter({
+			client: redis.createClient(),
+			blockMs: 10,
+		});
+		adapters.push(firstAdapter, secondAdapter);
+		const db = await createTestDb();
+		const first = await buildMockApp(
+			{},
+			{ db: { pglite: db }, realtime: { adapter: firstAdapter } },
+		);
+		const second = await buildMockApp(
+			{},
+			{ db: { pglite: db }, realtime: { adapter: secondAdapter } },
+		);
+
+		try {
+			await runTestDbMigrations(first.app);
+			const received = Promise.all([
+				new Promise((resolve) =>
+					first.app.realtime.subscribe(resolve, {
+						resourceType: "collection",
+						resource: "posts",
+					}),
+				),
+				new Promise((resolve) =>
+					second.app.realtime.subscribe(resolve, {
+						resourceType: "collection",
+						resource: "posts",
+					}),
+				),
+			]);
+			for (let attempt = 0; redis.waiterCount < 2 && attempt < 100; attempt++) {
+				await new Promise((resolve) => setTimeout(resolve, 1));
+			}
+			expect(redis.waiterCount).toBe(2);
+
+			const event = await first.app.realtime.appendChange(change);
+			await first.app.realtime.notify(event);
+
+			expect(await received).toEqual([
+				expect.objectContaining({ seq: event.seq, resource: "posts" }),
+				expect.objectContaining({ seq: event.seq, resource: "posts" }),
+			]);
+		} finally {
+			await Promise.all([first.cleanup(), second.cleanup()]);
+			await db.close();
+		}
+	});
+
+	it("broadcasts one wake to every subscribed instance", async () => {
+		const redis = new FakeRedisStream();
+		const first = new RedisStreamsAdapter({
+			client: redis.createClient(),
+			blockMs: 10,
+		});
+		const second = new RedisStreamsAdapter({
+			client: redis.createClient(),
+			blockMs: 10,
+		});
+		adapters.push(first, second);
+
+		const received = Promise.all([
+			new Promise((resolve) => first.subscribe(resolve)),
+			new Promise((resolve) => second.subscribe(resolve)),
+		]);
+		await Promise.all([first.start(), second.start()]);
+
+		await first.notify(change);
+
+		expect(await received).toEqual([
+			expect.objectContaining({ seq: 1, resource: "posts" }),
+			expect.objectContaining({ seq: 1, resource: "posts" }),
+		]);
+		expect(redis.xAddOptions).toEqual([
+			{
+				TRIM: {
+					strategy: "MAXLEN",
+					strategyModifier: "~",
+					threshold: 10_000,
+				},
+			},
+		]);
+	});
+
+	it("logs a read failure, backs off, and resumes the per-instance tail", async () => {
+		const redis = new FakeRedisStream();
+		const readFailure = new Error("redis read failed");
+		redis.readFailures.push(readFailure);
+		const errors: unknown[] = [];
+		const adapter = new RedisStreamsAdapter({
+			client: redis.createClient(),
+			blockMs: 10,
+			retryDelayMs: 1,
+			onError: (error) => errors.push(error),
+		});
+		adapters.push(adapter);
+
+		const received = new Promise((resolve) => adapter.subscribe(resolve));
+		await adapter.start();
+		await new Promise((resolve) => setTimeout(resolve, 5));
+		await adapter.notify(change);
+
+		expect(await received).toMatchObject({ seq: 1, resource: "posts" });
+		expect(errors).toEqual([readFailure]);
+	});
+
+	it("duplicates node-redis clients so blocking reads never hold the publisher", async () => {
+		const redis = new FakeRedisStream();
+		const publisher = redis.createClient();
+		const reader = redis.createClient();
+		let publisherReads = 0;
+		let readerConnects = 0;
+		let readerDestroys = 0;
+		publisher.xRead = async () => {
+			publisherReads += 1;
+			return null;
+		};
+		publisher.duplicate = () => ({
+			...reader,
+			connect: async () => {
+				readerConnects += 1;
+			},
+			destroy: () => {
+				readerDestroys += 1;
+			},
+		});
+		const adapter = new RedisStreamsAdapter({ client: publisher, blockMs: 10 });
+		adapters.push(adapter);
+
+		const received = new Promise((resolve) => adapter.subscribe(resolve));
+		await adapter.start();
+		await adapter.notify(change);
+
+		expect(await received).toMatchObject({ seq: 1, resource: "posts" });
+		expect(publisherReads).toBe(0);
+		expect(readerConnects).toBe(1);
+		await adapter.stop();
+		expect(readerDestroys).toBe(1);
+	});
+
+	it("waits for the blocking read to exit before restarting", async () => {
+		const releases: Array<() => void> = [];
+		let activeReads = 0;
+		let maxActiveReads = 0;
+		const client: RedisStreamsClient = {
+			xAdd: async () => "1-0",
+			xRead: async () => {
+				activeReads += 1;
+				maxActiveReads = Math.max(maxActiveReads, activeReads);
+				return new Promise((resolve) => {
+					releases.push(() => {
+						activeReads -= 1;
+						resolve(null);
+					});
+				});
+			},
+		};
+		const adapter = new RedisStreamsAdapter({ client });
+		adapters.push(adapter);
+
+		await adapter.start();
+		expect(activeReads).toBe(1);
+		let stopped = false;
+		const stopping = adapter.stop().then(() => {
+			stopped = true;
+		});
+		const restarting = adapter.start();
+		await Promise.resolve();
+		expect(stopped).toBe(false);
+		expect(activeReads).toBe(1);
+
+		releases.shift()?.();
+		await stopping;
+		await restarting;
+		expect(activeReads).toBe(1);
+		expect(maxActiveReads).toBe(1);
+
+		const finalStop = adapter.stop();
+		releases.shift()?.();
+		await finalStop;
+	});
+});


### PR DESCRIPTION
## Summary
- replace the shared Redis consumer group with an independent XREAD cursor per app instance so wakes broadcast instead of load-balance
- cap the stream with approximate XADD MAXLEN 10000 trimming
- isolate the blocking reader from publishing by automatically duplicating node-redis clients
- recover the read loop with logged backoff and serialize stop/restart so loops cannot overlap
- keep group/consumer as deprecated no-op options for source compatibility and update docs

## Verification
- `cd packages/questpie && bun test test/ --test-name-pattern "redis|realtime"` — 42 pass, 0 fail
- `cd packages/questpie && bunx tsc --noEmit -p tsconfig.json`
- dedicated Redis adapter suite — 5 pass, including two RealtimeService instances receiving one wake
- targeted oxlint — 0 warnings, 0 errors
- `git diff --check`