### PR TITLE
fix(questpie): tear down dead realtime streams

### DIFF
--- a/.changeset/close-dead-realtime-streams.md
+++ b/.changeset/close-dead-realtime-streams.md
@@ -1,0 +1,5 @@
+---
+"questpie": patch
+---
+
+Tear down SSE realtime listeners and timers when a stream can no longer enqueue data. Permanently denied topics are now unsubscribed instead of retrying an access failure after every matching change.

--- a/packages/questpie/src/server/adapters/routes/realtime.ts
+++ b/packages/questpie/src/server/adapters/routes/realtime.ts
@@ -48,6 +48,13 @@ type TopicState = {
 	lastSeq: number;
 };
 
+function isPermanentAccessError(error: unknown): boolean {
+	return (
+		error instanceof ApiError &&
+		(error.code === "FORBIDDEN" || error.code === "UNAUTHORIZED")
+	);
+}
+
 // ============================================================================
 // Standalone Handler
 // ============================================================================
@@ -221,12 +228,16 @@ export async function realtimeSubscribe(
 
 	const stream = new ReadableStream({
 		start: (controller) => {
-			const unsubscribers: (() => void)[] = [];
+			const topicUnsubscribers = new Map<string, () => void>();
 			let closed = false;
-			let transportFailed = false;
+			let closeRequested = false;
 
 			// Per-topic state
 			const topicState = new Map<string, TopicState>();
+			const requestClose = () => {
+				closeRequested = true;
+				closeStream?.();
+			};
 
 			// Helper to send SSE event
 			const send = (event: string, data: unknown) => {
@@ -238,13 +249,23 @@ export async function realtimeSubscribe(
 						),
 					);
 				} catch {
-					// Controller may be closed
+					requestClose();
 				}
 			};
 
 			// Send per-topic error
 			const sendTopicError = (topicId: string, message: string) => {
 				send("error", { topicId, message });
+			};
+
+			const teardownTopic = (topicId: string) => {
+				const unsubscribe = topicUnsubscribers.get(topicId);
+				if (!unsubscribe) return;
+
+				topicUnsubscribers.delete(topicId);
+				topicState.delete(topicId);
+				unsubscribe();
+				if (topicUnsubscribers.size === 0) requestClose();
 			};
 
 			// Refresh a single topic
@@ -305,6 +326,7 @@ export async function realtimeSubscribe(
 						topicId,
 						error instanceof Error ? error.message : "Unknown error",
 					);
+					if (isPermanentAccessError(error)) teardownTopic(topicId);
 				} finally {
 					state.refreshInFlight = false;
 				}
@@ -334,7 +356,6 @@ export async function realtimeSubscribe(
 						with: topic.with,
 					},
 					(error) => {
-						transportFailed = true;
 						send("error", {
 							topicId: "*",
 							message:
@@ -342,10 +363,10 @@ export async function realtimeSubscribe(
 									? error.message
 									: "Realtime transport failed",
 						});
-						closeStream?.();
+						requestClose();
 					},
 				);
-				unsubscribers.push(unsub);
+				topicUnsubscribers.set(topic.id, unsub);
 			}
 
 			// Send initial errors for invalid topics
@@ -366,9 +387,12 @@ export async function realtimeSubscribe(
 				if (closed) return;
 				closed = true;
 				clearInterval(pingTimer);
-				for (const unsub of unsubscribers) {
+				request.signal.removeEventListener("abort", close);
+				for (const unsub of topicUnsubscribers.values()) {
 					unsub();
 				}
+				topicUnsubscribers.clear();
+				topicState.clear();
 				try {
 					controller.close();
 				} catch {
@@ -376,7 +400,7 @@ export async function realtimeSubscribe(
 				}
 			};
 			closeStream = close;
-			if (transportFailed) close();
+			if (closeRequested) close();
 
 			// Handle abort signal
 			if (request.signal) {

--- a/packages/questpie/test/integration/realtime.test.ts
+++ b/packages/questpie/test/integration/realtime.test.ts
@@ -1515,7 +1515,7 @@ describe("realtime", () => {
 
 	describe("access control", () => {
 		it("should send error event when user lacks read permission", async () => {
-			const adapter = new MockRealtimeAdapter();
+			const adapter = new LifecycleTrackingRealtimeAdapter();
 			const secrets = collection("secrets")
 				.fields(({ f }) => ({
 					content: f.textarea().required(),
@@ -1566,6 +1566,12 @@ describe("realtime", () => {
 			const error = await reader.readEvent();
 			expect(error.event).toBe("error");
 			expect(error.data.message).toContain("permission");
+			await new Promise((resolve) => setTimeout(resolve, 20));
+			expect(setup.app.realtime.listeners.size).toBe(0);
+			expect(adapter.stopCalls).toBe(1);
+			await expect(reader.readEvent()).rejects.toThrow(
+				"SSE stream closed before event",
+			);
 
 			controller.abort();
 			reader.close();
@@ -1618,6 +1624,54 @@ describe("realtime", () => {
 
 			controller.abort();
 			reader.close();
+		});
+
+		it("removes a denied topic while keeping authorized topics alive", async () => {
+			const adapter = new LifecycleTrackingRealtimeAdapter();
+			const secrets = collection("secrets")
+				.fields(({ f }) => ({ content: f.textarea().required() }))
+				.access({
+					read: ({ session }) => (session?.user as any)?.role === "admin",
+				});
+			const posts = collection("posts")
+				.fields(({ f }) => ({ title: f.textarea().required() }))
+				.access({ read: true });
+			setup = await buildMockApp(
+				{ collections: { secrets, posts } },
+				{ realtime: { adapter } },
+			);
+			await runTestDbMigrations(setup.app);
+
+			const routes = createAdapterRoutes(setup.app, { accessMode: "user" });
+			const response = await routes.realtime.subscribe(
+				createRealtimeRequest([
+					collectionTopic("secrets"),
+					collectionTopic("posts"),
+				]),
+				{},
+				{
+					appContext: createTestContext({ accessMode: "user", role: "user" }),
+				},
+			);
+			const reader = createSSEReader(response.body!);
+			const initialEvents = [await reader.readEvent(), await reader.readEvent()];
+
+			expect(initialEvents).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({
+						event: "error",
+						data: expect.objectContaining({ topicId: "col-secrets" }),
+					}),
+					expect.objectContaining({
+						event: "snapshot",
+						data: expect.objectContaining({ topicId: "col-posts" }),
+					}),
+				]),
+			);
+			expect(setup.app.realtime.listeners.size).toBe(1);
+			expect(adapter.stopCalls).toBe(0);
+
+			await reader.close();
 		});
 
 		it("should filter payload fields based on field-level access", async () => {
@@ -1794,6 +1848,41 @@ describe("realtime", () => {
 	// ==========================================================================
 
 	describe("E2E SSE streaming", () => {
+		it("tears down the connection when controller.enqueue fails", async () => {
+			const adapter = new LifecycleTrackingRealtimeAdapter();
+			const items = collection("items")
+				.fields(({ f }) => ({ name: f.textarea().required() }))
+				.access({ read: true });
+			setup = await buildMockApp(
+				{ collections: { items } },
+				{ realtime: { adapter } },
+			);
+			await runTestDbMigrations(setup.app);
+
+			const enqueueSpy = spyOn(
+				ReadableStreamDefaultController.prototype,
+				"enqueue",
+			).mockImplementation(() => {
+				throw new Error("connection is gone");
+			});
+			let response: Response | undefined;
+			try {
+				const routes = createAdapterRoutes(setup.app, { accessMode: "user" });
+				response = await routes.realtime.subscribe(
+					createRealtimeRequest([collectionTopic("items")]),
+					{},
+					undefined,
+				);
+				await new Promise((resolve) => setTimeout(resolve, 20));
+
+				expect(setup.app.realtime.listeners.size).toBe(0);
+				expect(adapter.stopCalls).toBe(1);
+			} finally {
+				enqueueSpy.mockRestore();
+				await response?.body?.cancel();
+			}
+		});
+
 		it("sends an error event and closes when the transport cannot start", async () => {
 			const adapter = new FailingStartRealtimeAdapter();
 			const items = collection("items")


### PR DESCRIPTION
## Summary

- tear down SSE listeners and keepalive timers when controller enqueue fails
- remove permanently forbidden or unauthorized topics after their error event
- keep authorized topics alive when only one topic loses access
- add a patch changeset

## Stack

Depends on #136.

## Verification

- bun test v1.3.14 (0d9b296a)
Found 13 operations
📄 Generated migration: 20250108_realtime_indexes_before.ts
⚡ Operations: 13 (embedded in migration)
Found 2 operations
📄 Generated migration: 20250109_drop_dead_realtime_indexes.ts
⚡ Operations: 2 (embedded in migration) (100 pass, 0 fail)
- 
- targeted oxlint: 0 errors (1 pre-existing warning)
- 