### PR TITLE
feat(questpie): add factory key derivation policy

### DIFF
--- a/.changeset/derive-channel-registry-keys.md
+++ b/.changeset/derive-channel-registry-keys.md
@@ -1,0 +1,5 @@
+---
+"questpie": patch
+---
+
+Add an opt-in codegen key strategy for factory categories whose first string argument is runtime metadata rather than the registry key. Factory arguments can now be validated and checked for duplicates across app files and generated modules.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -308,14 +308,15 @@ Every discovered entity (collection, view, block, component, route, etc.) gets a
 | Category with `factoryFunctions`, **named exports**, no string arg           | Export name                                       | `export const heroBlock = block(config)` → key: `heroBlock`                               |
 | Category with `factoryFunctions`, **default export**, factory has string arg | **Factory string arg** (kebab→camelCase)          | `views/table.ts` exports `default view("collection-table", ...)` → key: `collectionTable` |
 | Category with `factoryFunctions`, **default export**, no string arg          | Filename (camelCase)                              | `views/custom.ts` exports `default view(config)` → key: `custom`                          |
+| Category with `factoryKeyStrategy: "export-or-filename"`, named/default      | Export name / filename                            | Channels keep `channel("chat-room-[roomId]")` as wire metadata; key: `chatRoom`           |
 | Category **without** `factoryFunctions`                                      | Filename (camelCase)                              | `fields/boolean.ts` → key: `boolean`                                                      |
 | Recursive category (routes)                                                  | Path segments (camelCase, joined by keySeparator) | `routes/webhooks/stripe.ts` → key: `webhooks/stripe`                                      |
 
-**Why factory arg, not filename?** The factory string arg is the entity's **identity** — it's used at runtime for lookup, serialization, and API contracts. The filename is just file organization. A view named `"collection-table"` could live in `views/table.ts`, `views/default-list.ts`, or any file — the identity is the string passed to `view()`.
+**Why factory arg by default?** For collections, views, blocks, and components the factory string arg is the entity's **identity**—it is used for lookup, serialization, and API contracts. Categories whose argument is a different contract can opt into `factoryKeyStrategy: "export-or-filename"`; channels use this because the builder argument is a stable wire pattern while the filename/export is the typed API key.
 
 Only hyphen-case is camelized; underscores are preserved. Use `global("siteSettings")` or `global("site-settings")` when the generated key should be `siteSettings` — `global("site_settings")` generates `site_settings`.
 
-**Consistency guarantee**: `collection("posts")` → `posts`, `block("hero")` → `hero`, `view("collection-table")` → `collectionTable`, `component("icon")` → `icon`. The factory arg is always the source of truth for the key when available.
+**Default consistency guarantee**: `collection("posts")` → `posts`, `block("hero")` → `hero`, `view("collection-table")` → `collectionTable`, `component("icon")` → `icon`. The factory arg remains the source of truth unless the category explicitly selects `export-or-filename`.
 
 **`keyFromProperty`** (`CategoryDeclaration.keyFromProperty`): Some categories (admin-client views) use a runtime property (e.g. `.name`) as the object key at runtime: `[_view.name]: _view`. This is separate from the discover key — the discover key drives types and imports, `keyFromProperty` drives the runtime object emission in `module.ts`. When `keyFromProperty` is set, types for that category are skipped in module-template (the file-derived key would mismatch the runtime key).
 

--- a/packages/questpie/src/cli/codegen/channel-pattern.ts
+++ b/packages/questpie/src/cli/codegen/channel-pattern.ts
@@ -1,0 +1,53 @@
+const LITERAL_CHARACTER = /^[A-Za-z0-9_\-=@,.;]$/;
+const PARAMETER_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+/**
+ * Validate a channel wire pattern before code generation.
+ *
+ * The source pattern may contain repo-native `[param]` placeholders. Literal
+ * characters follow the Pusher-compatible alphabet. The resolved channel name
+ * is validated again at runtime because parameter lengths determine whether the
+ * provider's 164-character limit is met.
+ */
+export function validateChannelWirePattern(
+	pattern: string,
+): string | undefined {
+	if (pattern.length === 0) return "wire pattern cannot be empty";
+
+	const parameters = new Set<string>();
+	let index = 0;
+	while (index < pattern.length) {
+		const character = pattern[index]!;
+
+		if (character === "[") {
+			const close = pattern.indexOf("]", index + 1);
+			if (close === -1) return "wire pattern has an unclosed bracket parameter";
+
+			const parameter = pattern.slice(index + 1, close);
+			if (!PARAMETER_NAME.test(parameter)) {
+				return `wire pattern parameter "${parameter}" must be a TypeScript identifier`;
+			}
+			if (parameters.has(parameter)) {
+				return `wire pattern parameter "${parameter}" is declared more than once`;
+			}
+			parameters.add(parameter);
+			index = close + 1;
+			continue;
+		}
+
+		if (character === "]") {
+			return "wire pattern has an unmatched closing bracket";
+		}
+		if (character === "/") {
+			return "wire pattern cannot contain a slash";
+		}
+		if (/\s/.test(character)) {
+			return "wire pattern cannot contain whitespace";
+		}
+		if (!LITERAL_CHARACTER.test(character)) {
+			return `wire pattern contains unsupported character ${JSON.stringify(character)}`;
+		}
+
+		index += 1;
+	}
+}

--- a/packages/questpie/src/cli/codegen/discover.ts
+++ b/packages/questpie/src/cli/codegen/discover.ts
@@ -16,6 +16,7 @@ import type {
 	DiscoveredFile,
 	DiscoverPattern,
 	DiscoveryResult,
+	FactoryArgumentMetadata,
 } from "./types.js";
 
 // ============================================================================
@@ -153,6 +154,10 @@ interface DiscoveryCategory {
 	keySeparator?: "." | "/";
 	/** Factory function names for multi-export discovery. */
 	factoryFunctions?: string[];
+	/** Registry-key policy for factory-aware categories. */
+	factoryKeyStrategy?: CategoryDeclaration["factoryKeyStrategy"];
+	/** Validation/uniqueness policy for the first factory argument. */
+	factoryArgument?: CategoryDeclaration["factoryArgument"];
 }
 
 /**
@@ -170,6 +175,8 @@ function toDiscoveryCategory(
 		prefix: decl.prefix,
 		keySeparator: decl.keySeparator,
 		factoryFunctions: decl.factoryFunctions,
+		factoryKeyStrategy: decl.factoryKeyStrategy,
+		factoryArgument: decl.factoryArgument,
 	};
 }
 
@@ -224,6 +231,8 @@ export interface DiscoverFilesOptions {
 	categories?: Record<string, CategoryDeclaration>;
 	/** Merged discover patterns from all contributing plugins. */
 	discover?: Record<string, DiscoverPattern>;
+	/** Factory-argument metadata extracted from generated dependency modules. */
+	externalFactoryArguments?: FactoryArgumentMetadata[];
 }
 
 /**
@@ -288,6 +297,12 @@ export async function discoverFiles(
 					map.set(file.key, file);
 				}
 			}
+
+			validateFactoryArguments(
+				category,
+				map,
+				options.externalFactoryArguments ?? [],
+			);
 
 			result.categories.set(name, map);
 		}
@@ -705,14 +720,17 @@ async function processFile(
 		const results: DiscoveredFile[] = [];
 		const namedMatches = matches.filter((m) => !m.isDefault);
 		const defaultMatch = matches.find((m) => m.isDefault);
-		// For named exports: prefer factory string arg (camelCase'd), fall back to export name.
-		// For default exports: key from factory string arg if available, else filename.
-		// See AGENTS.md "Codegen Key Derivation" for the full decision table.
+		const keyFromExport = category.factoryKeyStrategy === "export-or-filename";
 		const fileKey = deriveFileKey(relPath, category);
 		if (namedMatches.length > 0) {
 			// Named factory exports found — each becomes a separate entity
 			for (const m of namedMatches) {
-				const key = m.entityKey ? kebabToCamelCase(m.entityKey) : m.exportName;
+				assertFactoryArgument(category, relPath, m);
+				const key = keyFromExport
+					? m.exportName
+					: m.entityKey
+						? kebabToCamelCase(m.entityKey)
+						: m.exportName;
 				results.push({
 					absolutePath,
 					key,
@@ -721,13 +739,17 @@ async function processFile(
 					source: relPath,
 					exportType: "named",
 					namedExportName: m.exportName,
+					factoryArgument: m.entityKey ?? undefined,
 				});
 			}
 		} else if (defaultMatch) {
 			// Only a default factory export — single entity.
-			const effectiveKey = defaultMatch.entityKey
-				? kebabToCamelCase(defaultMatch.entityKey)
-				: fileKey;
+			assertFactoryArgument(category, relPath, defaultMatch);
+			const effectiveKey = keyFromExport
+				? fileKey
+				: defaultMatch.entityKey
+					? kebabToCamelCase(defaultMatch.entityKey)
+					: fileKey;
 			results.push({
 				absolutePath,
 				key: effectiveKey,
@@ -735,6 +757,7 @@ async function processFile(
 				varName: toVarName(category.prefix, effectiveKey),
 				source: relPath,
 				exportType: "default",
+				factoryArgument: defaultMatch.entityKey ?? undefined,
 			});
 		}
 
@@ -757,6 +780,79 @@ async function processFile(
 			isBundle: exportInfo.isBundle,
 		},
 	];
+}
+
+function assertFactoryArgument(
+	category: DiscoveryCategory,
+	relPath: string,
+	match: FactoryExportMatch,
+): void {
+	const policy = category.factoryArgument;
+	if (!policy) return;
+
+	const exportLabel = match.isDefault
+		? "default export"
+		: `export "${match.exportName}"`;
+	if (match.entityKey === null) {
+		if (policy.requireLiteral) {
+			throw new Error(
+				`Codegen ${category.category} ${policy.label} must be a string literal in ${relPath} (${exportLabel}).`,
+			);
+		}
+		return;
+	}
+
+	const reason = policy.validate?.(match.entityKey);
+	if (reason) {
+		throw new Error(
+			`Invalid ${category.category} ${policy.label} in ${relPath} (${exportLabel}): ${reason}.`,
+		);
+	}
+}
+
+function validateFactoryArguments(
+	category: DiscoveryCategory,
+	files: Map<string, DiscoveredFile>,
+	external: FactoryArgumentMetadata[],
+): void {
+	const policy = category.factoryArgument;
+	if (!policy) return;
+
+	const entries = [
+		...[...files.values()]
+			.filter((file) => file.factoryArgument !== undefined)
+			.map((file) => ({
+				value: file.factoryArgument!,
+				source: file.namedExportName
+					? `${file.source} (export ${file.namedExportName})`
+					: file.source,
+			})),
+		...external
+			.filter((entry) => entry.category === category.category)
+			.map((entry) => ({ value: entry.value, source: entry.source })),
+	];
+
+	const seen = new Map<string, string>();
+	for (const entry of entries) {
+		const reason = policy.validate?.(entry.value);
+		if (reason) {
+			throw new Error(
+				`Invalid ${category.category} ${policy.label} in ${entry.source}: ${reason}.`,
+			);
+		}
+
+		if (!policy.unique) continue;
+		const existing = seen.get(entry.value);
+		if (existing) {
+			throw new Error(
+				`Codegen conflict: duplicate ${category.category} ${policy.label} ${JSON.stringify(entry.value)} found in:\n` +
+					`  - ${existing}\n` +
+					`  - ${entry.source}\n` +
+					`Each ${policy.label} must be unique across the app and modules.`,
+			);
+		}
+		seen.set(entry.value, entry.source);
+	}
 }
 
 /**

--- a/packages/questpie/src/cli/codegen/discover.ts
+++ b/packages/questpie/src/cli/codegen/discover.ts
@@ -818,15 +818,17 @@ function validateFactoryArguments(
 	const policy = category.factoryArgument;
 	if (!policy) return;
 
+	const localEntries = [...files.values()]
+		.filter((file) => file.factoryArgument !== undefined)
+		.map((file) => ({
+			value: file.factoryArgument!,
+			source: file.namedExportName
+				? `${file.source} (export ${file.namedExportName})`
+				: file.source,
+		}))
+		.sort((a, b) => a.source.localeCompare(b.source));
 	const entries = [
-		...[...files.values()]
-			.filter((file) => file.factoryArgument !== undefined)
-			.map((file) => ({
-				value: file.factoryArgument!,
-				source: file.namedExportName
-					? `${file.source} (export ${file.namedExportName})`
-					: file.source,
-			})),
+		...localEntries,
 		...external
 			.filter((entry) => entry.category === category.category)
 			.map((entry) => ({ value: entry.value, source: entry.source })),

--- a/packages/questpie/src/cli/codegen/index.ts
+++ b/packages/questpie/src/cli/codegen/index.ts
@@ -16,6 +16,7 @@ import { dirname, join, relative, resolve } from "node:path";
 import { discoverFiles } from "./discover.js";
 import { generateClientEnvModules } from "./env-client-template.js";
 import { generateFactoryTemplate } from "./factory-template.js";
+import { loadModuleFactoryArguments } from "./module-metadata.js";
 import { generateModuleTemplate } from "./module-template.js";
 import { generateTemplate } from "./template.js";
 import type {
@@ -441,9 +442,11 @@ export async function runCodegen(
 	}
 
 	// 2. Discover files using the resolved target's categories and discover patterns
+	const externalFactoryArguments = await loadModuleFactoryArguments(rootDir);
 	const discovered = await discoverFiles(rootDir, outDir, {
 		categories: target.categories,
 		discover: target.discover,
+		externalFactoryArguments,
 	});
 
 	// 2b. Warn about files with named exports (not default)
@@ -767,9 +770,12 @@ export async function runAllTargets(
 
 			if (target.generate) {
 				// Custom generator — run discovery, transforms, then the generator
+				const externalFactoryArguments =
+					await loadModuleFactoryArguments(targetRootDir);
 				const discovered = await discoverFiles(targetRootDir, targetOutDir, {
 					categories: target.categories,
 					discover: target.discover,
+					externalFactoryArguments,
 				});
 
 				// Build and run transforms

--- a/packages/questpie/src/cli/codegen/module-metadata.ts
+++ b/packages/questpie/src/cli/codegen/module-metadata.ts
@@ -1,0 +1,62 @@
+import { join } from "node:path";
+
+import type { FactoryArgumentMetadata } from "./types.js";
+
+export const CODEGEN_MODULE_METADATA_SYMBOL =
+	"questpie.codegen.module-metadata.v1";
+
+type StoredFactoryArgument = Omit<FactoryArgumentMetadata, "source"> & {
+	source: string;
+};
+
+type ModuleLike = {
+	name?: string;
+	modules?: ModuleLike[];
+	[key: symbol]: unknown;
+};
+
+type StoredModuleMetadata = {
+	factoryArguments?: StoredFactoryArgument[];
+};
+
+/** Extract source-qualified factory metadata from a generated module tree. */
+export function extractFactoryArgumentsFromModules(
+	modules: ModuleLike[],
+): FactoryArgumentMetadata[] {
+	const symbol = Symbol.for(CODEGEN_MODULE_METADATA_SYMBOL);
+	const seen = new Set<ModuleLike>();
+	const result: FactoryArgumentMetadata[] = [];
+
+	function walk(module: ModuleLike): void {
+		if (seen.has(module)) return;
+		seen.add(module);
+
+		for (const child of module.modules ?? []) walk(child);
+
+		const metadata = module[symbol] as StoredModuleMetadata | undefined;
+		for (const entry of metadata?.factoryArguments ?? []) {
+			result.push({
+				...entry,
+				source: `${module.name ?? "anonymous-module"}:${entry.source}`,
+			});
+		}
+	}
+
+	for (const module of modules) walk(module);
+	return result;
+}
+
+/** Load generated metadata from the root's modules.ts when it is importable. */
+export async function loadModuleFactoryArguments(
+	rootDir: string,
+): Promise<FactoryArgumentMetadata[]> {
+	try {
+		const modulesExport = await import(join(rootDir, "modules.ts"));
+		const modules = modulesExport.default;
+		return Array.isArray(modules)
+			? extractFactoryArgumentsFromModules(modules)
+			: [];
+	} catch {
+		return [];
+	}
+}

--- a/packages/questpie/src/cli/codegen/module-template.ts
+++ b/packages/questpie/src/cli/codegen/module-template.ts
@@ -26,11 +26,13 @@ import {
 	safeKey,
 	sortedValues,
 } from "./category-emit.js";
+import { CODEGEN_MODULE_METADATA_SYMBOL } from "./module-metadata.js";
 import type {
 	CategoryDeclaration,
 	DiscoveredFile,
 	DiscoverPattern,
 	DiscoveryResult,
+	FactoryArgumentMetadata,
 } from "./types.js";
 
 // ============================================================================
@@ -101,6 +103,21 @@ export function generateModuleTemplate(
 	} = options;
 
 	const modulesFile = discovered.singles.get("modules") ?? null;
+	const factoryArguments: FactoryArgumentMetadata[] = [];
+	for (const [category, declaration] of categoryMeta) {
+		if (!declaration.factoryArgument) continue;
+		for (const file of discovered.categories.get(category)?.values() ?? []) {
+			if (file.factoryArgument === undefined) continue;
+			factoryArguments.push({
+				category,
+				key: file.key,
+				value: file.factoryArgument,
+				source: file.namedExportName
+					? `${file.source} (export ${file.namedExportName})`
+					: file.source,
+			});
+		}
+	}
 
 	// Derive a PascalCase type prefix from the module name
 	// "questpie-admin" → "Admin", "questpie-audit" → "Audit"
@@ -314,6 +331,9 @@ export function generateModuleTemplate(
 
 	lines.push(`export type ${typePrefix}Module = {`);
 	lines.push(`\tname: "${moduleName}";`);
+	if (factoryArguments.length > 0) {
+		lines.push("\t[key: symbol]: unknown;");
+	}
 	if (modulesFile) {
 		lines.push(`\tmodules: typeof ${modulesFile.varName};`);
 	}
@@ -368,6 +388,11 @@ export function generateModuleTemplate(
 
 	lines.push(`const _module: ${typePrefix}Module = {`);
 	lines.push(`\tname: "${moduleName}" as const,`);
+	if (factoryArguments.length > 0) {
+		lines.push(
+			`\t[Symbol.for(${JSON.stringify(CODEGEN_MODULE_METADATA_SYMBOL)})]: { factoryArguments: ${JSON.stringify(factoryArguments)} },`,
+		);
+	}
 
 	// Sub-modules
 	if (modulesFile) {

--- a/packages/questpie/src/cli/codegen/types.ts
+++ b/packages/questpie/src/cli/codegen/types.ts
@@ -32,6 +32,8 @@ export interface DiscoveredFile {
 	exportType: "default" | "named" | "unknown";
 	/** Name of the first named export found (when exportType is "named"). */
 	namedExportName?: string;
+	/** Literal first factory argument, retained as metadata when present. */
+	factoryArgument?: string;
 	/**
 	 * All named exports found in the file.
 	 * Populated when resolve is "named" or "all".
@@ -63,6 +65,15 @@ export interface DiscoveredFile {
 	 * instead of being destructured into flat keys.
 	 */
 	configKey?: string;
+}
+
+/** Factory-argument metadata contributed by a generated module. */
+export interface FactoryArgumentMetadata {
+	category: string;
+	key: string;
+	value: string;
+	/** Module-qualified source location for actionable conflict errors. */
+	source: string;
 }
 
 // ============================================================================
@@ -355,16 +366,36 @@ export interface CategoryDeclaration {
 	 * 2. Cross-reference with export statements (`export const`, `export { }`,
 	 *    `export default`)
 	 *
-	 * Entity key is ALWAYS derived from the filename, never from the factory
-	 * call's string argument. For single-factory files (1 export), the key
-	 * equals `deriveFileKey(filename)`. For multi-export files, the export
-	 * name is used as fallback.
+	 * By default the first literal string argument is the entity key, with the
+	 * named export or filename as fallback. Set `factoryKeyStrategy` to
+	 * `"export-or-filename"` when the argument has a different runtime meaning.
 	 *
 	 * @example ["collection"] — for collections category
 	 * @example ["block"] — for blocks category
 	 * @example ["view", "listView"] — multiple factory names
 	 */
 	factoryFunctions?: string[];
+
+	/**
+	 * Registry-key policy for factory-aware categories.
+	 *
+	 * - "factory-argument" (default): first string argument, then export/filename
+	 * - "export-or-filename": named export name or default-export filename; the
+	 *   factory argument remains metadata and never becomes the registry key
+	 */
+	factoryKeyStrategy?: "factory-argument" | "export-or-filename";
+
+	/** Optional constraints for the first factory argument. */
+	factoryArgument?: {
+		/** Human-readable value name used in errors, e.g. "wire pattern". */
+		label: string;
+		/** Reject factories whose first argument is not a string literal. */
+		requireLiteral?: boolean;
+		/** Require the value to be unique across the app and generated modules. */
+		unique?: boolean;
+		/** Return an actionable error reason, or undefined when valid. */
+		validate?: (value: string) => string | undefined;
+	};
 
 	// ── Registry / factory type integration ─────────────────────
 

--- a/packages/questpie/test/codegen/config-features.test.ts
+++ b/packages/questpie/test/codegen/config-features.test.ts
@@ -21,6 +21,11 @@ import {
 	coreCodegenPlugin,
 	resolveTargetGraph,
 } from "../../src/cli/codegen/index.js";
+import {
+	CODEGEN_MODULE_METADATA_SYMBOL,
+	extractFactoryArgumentsFromModules,
+	loadModuleFactoryArguments,
+} from "../../src/cli/codegen/module-metadata.js";
 import { generateTemplate as _generateTemplate } from "../../src/cli/codegen/template.js";
 import type {
 	CodegenPlugin,
@@ -227,6 +232,66 @@ describe("extractPluginsFromModules", () => {
 		const result = extractPluginsFromModules(modules);
 		expect(result).toHaveLength(1);
 		expect(result[0].name).toBe("only-plugin");
+	});
+});
+
+describe("extractFactoryArgumentsFromModules", () => {
+	it("qualifies generated source metadata and traverses each module once", () => {
+		const symbol = Symbol.for(CODEGEN_MODULE_METADATA_SYMBOL);
+		const child = {
+			name: "questpie-chat",
+			[symbol]: {
+				factoryArguments: [
+					{
+						category: "channels",
+						key: "chatRoom",
+						value: "chat-room-[roomId]",
+						source: "channels/chat-room.ts",
+					},
+				],
+			},
+		};
+		const root = { name: "root", modules: [child, child] };
+
+		expect(extractFactoryArgumentsFromModules([root])).toEqual([
+			{
+				category: "channels",
+				key: "chatRoom",
+				value: "chat-room-[roomId]",
+				source: "questpie-chat:channels/chat-room.ts",
+			},
+		]);
+	});
+
+	it("loads metadata from modules.ts for root codegen", async () => {
+		const rootDir = await mkdtemp(join(tmpdir(), "questpie-module-meta-"));
+		try {
+			await writeFile(
+				join(rootDir, "modules.ts"),
+				[
+					`const symbol = Symbol.for(${JSON.stringify(CODEGEN_MODULE_METADATA_SYMBOL)});`,
+					"export default [{",
+					'  name: "questpie-chat",',
+					"  [symbol]: { factoryArguments: [{",
+					'    category: "channels", key: "chatRoom",',
+					'    value: "chat-room-[roomId]", source: "channels/chat-room.ts"',
+					"  }] }",
+					"}];",
+				].join("\n"),
+				"utf-8",
+			);
+
+			expect(await loadModuleFactoryArguments(rootDir)).toEqual([
+				{
+					category: "channels",
+					key: "chatRoom",
+					value: "chat-room-[roomId]",
+					source: "questpie-chat:channels/chat-room.ts",
+				},
+			]);
+		} finally {
+			await rm(rootDir, { recursive: true, force: true });
+		}
 	});
 });
 

--- a/packages/questpie/test/codegen/discover.test.ts
+++ b/packages/questpie/test/codegen/discover.test.ts
@@ -11,6 +11,7 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import { validateChannelWirePattern } from "../../src/cli/codegen/channel-pattern.js";
 import type { DiscoverFilesOptions } from "../../src/cli/codegen/discover.js";
 import {
 	detectExportType,
@@ -1145,5 +1146,154 @@ describe("multi-export factory discovery", () => {
 		const result = await discoverFiles(rootDir, outDir, factoryOpts);
 		const blocks = result.categories.get("blocks")!;
 		expect(blocks.get("hero")!.importPath).toBe(blocks.get("cta")!.importPath);
+	});
+});
+
+describe("factory argument metadata policy", () => {
+	let rootDir: string;
+	let outDir: string;
+
+	beforeEach(async () => {
+		rootDir = await mkdtemp(join(tmpdir(), "questpie-factory-policy-"));
+		outDir = join(rootDir, ".generated");
+		await mkdir(outDir, { recursive: true });
+	});
+
+	afterEach(async () => {
+		await rm(rootDir, { recursive: true, force: true });
+	});
+
+	async function write(relPath: string, content: string): Promise<void> {
+		const full = join(rootDir, relPath);
+		await mkdir(join(full, ".."), { recursive: true });
+		await writeFile(full, content, "utf-8");
+	}
+
+	const channelCategory = {
+		dirs: ["channels"],
+		prefix: "chan",
+		factoryFunctions: ["channel"],
+		factoryKeyStrategy: "export-or-filename" as const,
+		factoryArgument: {
+			label: "wire pattern",
+			requireLiteral: true,
+			unique: true,
+			validate: validateChannelWirePattern,
+		},
+	};
+
+	it("uses the filename for a default export and keeps the wire pattern as metadata", async () => {
+		await write(
+			"channels/chat-room.ts",
+			'export default channel("chat-room-[roomId]");',
+		);
+
+		const result = await discoverFiles(rootDir, outDir, {
+			categories: { channels: channelCategory },
+		});
+		const channels = result.categories.get("channels")!;
+
+		expect([...channels.keys()]).toEqual(["chatRoom"]);
+		expect(channels.get("chatRoom")!.factoryArgument).toBe(
+			"chat-room-[roomId]",
+		);
+	});
+
+	it("uses named exports as keys for multiple definitions in one file", async () => {
+		await write(
+			"channels/rooms.ts",
+			[
+				'export const chatRoom = channel("chat-room-[roomId]");',
+				'export const typingRoom = channel("typing-room-[roomId]");',
+			].join("\n"),
+		);
+
+		const result = await discoverFiles(rootDir, outDir, {
+			categories: { channels: channelCategory },
+		});
+		const channels = result.categories.get("channels")!;
+
+		expect([...channels.keys()]).toEqual(["chatRoom", "typingRoom"]);
+		expect(channels.get("chatRoom")!.factoryArgument).toBe(
+			"chat-room-[roomId]",
+		);
+	});
+
+	it("rejects duplicate wire patterns with both app file locations", async () => {
+		await write(
+			"channels/chat-room.ts",
+			'export default channel("chat-room-[roomId]");',
+		);
+		await write(
+			"channels/legacy-chat.ts",
+			'export default channel("chat-room-[roomId]");',
+		);
+
+		await expect(
+			discoverFiles(rootDir, outDir, {
+				categories: { channels: channelCategory },
+			}),
+		).rejects.toThrow(
+			/channels\/chat-room\.ts[\s\S]*channels\/legacy-chat\.ts/,
+		);
+	});
+
+	it("rejects a duplicate wire pattern contributed by a module", async () => {
+		await write(
+			"channels/chat-room.ts",
+			'export default channel("chat-room-[roomId]");',
+		);
+
+		await expect(
+			discoverFiles(rootDir, outDir, {
+				categories: { channels: channelCategory },
+				externalFactoryArguments: [
+					{
+						category: "channels",
+						key: "moduleChatRoom",
+						value: "chat-room-[roomId]",
+						source: "@acme/chat:channels/chat-room.ts",
+					},
+				],
+			}),
+		).rejects.toThrow(
+			/channels\/chat-room\.ts[\s\S]*@acme\/chat:channels\/chat-room\.ts/,
+		);
+	});
+
+	it("rejects non-literal and transport-unsafe wire patterns", async () => {
+		await write("channels/dynamic.ts", "export default channel(dynamicName);");
+
+		await expect(
+			discoverFiles(rootDir, outDir, {
+				categories: { channels: channelCategory },
+			}),
+		).rejects.toThrow(/wire pattern must be a string literal/);
+
+		await write(
+			"channels/dynamic.ts",
+			'export default channel("chat/room-[roomId]");',
+		);
+
+		await expect(
+			discoverFiles(rootDir, outDir, {
+				categories: { channels: channelCategory },
+			}),
+		).rejects.toThrow(/wire pattern.*slash/i);
+	});
+});
+
+describe("validateChannelWirePattern", () => {
+	it("accepts Pusher-compatible literals and bracket parameters", () => {
+		expect(
+			validateChannelWirePattern("chat-room_[roomId]@=,.;"),
+		).toBeUndefined();
+	});
+
+	it("rejects malformed parameters and unsafe characters", () => {
+		expect(validateChannelWirePattern("chat/[roomId]")).toContain("slash");
+		expect(validateChannelWirePattern("chat [roomId]")).toContain("whitespace");
+		expect(validateChannelWirePattern("chat-[room-id]")).toContain("parameter");
+		expect(validateChannelWirePattern("chat-[roomId")).toContain("bracket");
 	});
 });

--- a/packages/questpie/test/codegen/module-template.test.ts
+++ b/packages/questpie/test/codegen/module-template.test.ts
@@ -36,6 +36,7 @@ function makeFile(
 		importPath?: string;
 		exportType?: "default" | "named" | "unknown";
 		namedExportName?: string;
+		factoryArgument?: string;
 		source?: string;
 		isBundle?: boolean;
 	} = {},
@@ -47,6 +48,7 @@ function makeFile(
 		importPath: opts.importPath ?? `../${key}`,
 		exportType: opts.exportType ?? "default",
 		namedExportName: opts.namedExportName,
+		factoryArgument: opts.factoryArgument,
 		source: opts.source ?? `${key}.ts`,
 		isBundle: opts.isBundle,
 	};
@@ -725,5 +727,40 @@ describe("generateModuleTemplate — extra imports", () => {
 
 	it("emits extra type declarations", () => {
 		expect(output).toContain("export type CustomType = string;");
+	});
+});
+
+describe("generateModuleTemplate — factory argument metadata", () => {
+	it("emits source metadata under the codegen symbol for module conflict checks", () => {
+		const result = emptyResult(["channels"]);
+		result.categories.get("channels")!.set(
+			"chatRoom",
+			makeFile("chatRoom", {
+				source: "channels/chat-room.ts",
+				factoryArgument: "chat-room-[roomId]",
+			}),
+		);
+
+		const { code } = generateModuleTemplate({
+			moduleName: "questpie-chat",
+			discovered: result,
+			categoryMeta: new Map([
+				[
+					"channels",
+					{
+						dirs: ["channels"],
+						prefix: "chan",
+						factoryFunctions: ["channel"],
+						factoryArgument: { label: "wire pattern", unique: true },
+					} satisfies CategoryDeclaration,
+				],
+			]),
+		});
+
+		expect(code).toContain(
+			'[Symbol.for("questpie.codegen.module-metadata.v1")]',
+		);
+		expect(code).toContain('"value":"chat-room-[roomId]"');
+		expect(code).toContain('"source":"channels/chat-room.ts"');
 	});
 });


### PR DESCRIPTION
## Outcome

- adds opt-in `factoryKeyStrategy: "export-or-filename"` while preserving current factory-argument keys by default
- retains the literal first factory argument as validated category metadata
- validates channel wire patterns against the Pusher-compatible alphabet and bracket-param grammar
- rejects duplicate metadata values across app files and generated dependency modules with both source locations
- emits module metadata under a symbol so normal runtime string-key merging is unaffected
- documents the policy and includes a patch changeset

This PR provides the generic codegen mechanism. RT3.2 will register the actual core `channels` category with this policy.

## Verification

- RED first: missing validator/module failed the new contract suite
- focused contracts: 10 pass, 0 fail
- full `test/codegen`: 260 pass, 0 fail
- board verify pattern: 6 pass, 1876 filtered, 0 fail
- `bunx tsc --noEmit -p packages/questpie/tsconfig.json`
- targeted oxlint: 0 errors (one pre-existing unused type-import warning)
- `git diff --check`
