### PR TITLE
feat(questpie): add dynamic client auth headers

### DIFF
--- a/.changeset/fresh-auth-headers.md
+++ b/.changeset/fresh-auth-headers.md
@@ -1,0 +1,5 @@
+---
+"questpie": patch
+---
+
+Add a dynamic authentication-header resolver shared by data, upload, and realtime client requests.

--- a/packages/questpie/src/client/auth.ts
+++ b/packages/questpie/src/client/auth.ts
@@ -1,0 +1,3 @@
+export type AuthHeaders = Record<string, string>;
+
+export type GetAuthHeaders = () => AuthHeaders | Promise<AuthHeaders>;

--- a/packages/questpie/src/client/index.ts
+++ b/packages/questpie/src/client/index.ts
@@ -37,12 +37,15 @@ import type {
 	With,
 } from "../server/collection/crud/types.js";
 import type { GlobalUpdateInput } from "../server/global/crud/types.js";
+import type { GetAuthHeaders } from "./auth.js";
 import {
 	buildCollectionTopic,
 	buildGlobalTopic,
 	createRealtimeAPI,
 	type RealtimeAPI,
 } from "./realtime/index.js";
+
+export type { AuthHeaders, GetAuthHeaders } from "./auth.js";
 
 // ============================================================================
 // Upload Types
@@ -237,6 +240,16 @@ export type QuestpieClientConfig = {
 	 * Default headers to include in all requests
 	 */
 	headers?: Record<string, string>;
+
+	/**
+	 * Resolve authentication headers for every request.
+	 *
+	 * The resolver runs immediately before data, upload, and realtime requests,
+	 * so rotated bearer tokens do not require recreating the client. Resolved
+	 * headers override matching static `headers`. Cookie credentials remain
+	 * enabled when this hook is omitted or used.
+	 */
+	getAuthHeaders?: GetAuthHeaders;
 
 	/**
 	 * Enable SuperJSON serialization for enhanced type support (Date, Map, Set, BigInt)
@@ -1014,10 +1027,12 @@ export function createClient<TApp extends QuestpieApp>(
 			? "application/superjson+json"
 			: "application/json";
 
+		const authHeaders = await config.getAuthHeaders?.();
 		const headers: Record<string, string> = {
 			"Content-Type": contentType,
 			...defaultHeaders,
 			...(options.headers as Record<string, string>),
+			...authHeaders,
 		};
 
 		if (useSuperJSON) {
@@ -1098,6 +1113,7 @@ export function createClient<TApp extends QuestpieApp>(
 		baseUrl: `${config.baseURL}${apiBasePath}`,
 		withCredentials: true,
 		debounceMs: 50,
+		getAuthHeaders: config.getAuthHeaders,
 	});
 
 	/**
@@ -1443,10 +1459,29 @@ export function createClient<TApp extends QuestpieApp>(
 							formData.append("path", options.path);
 						}
 
-						// Send request with credentials (cookies)
+						const send = (authHeaders?: Record<string, string>) => {
+							for (const [name, value] of Object.entries(authHeaders ?? {})) {
+								xhr.setRequestHeader(name, value);
+							}
+							xhr.send(formData);
+						};
+
+						// Keep cookie credentials enabled while allowing dynamic bearer auth.
 						xhr.open("POST", url);
 						xhr.withCredentials = true;
-						xhr.send(formData);
+						if (config.getAuthHeaders) {
+							try {
+								Promise.resolve(config.getAuthHeaders()).then(send, (error) => {
+									cleanup();
+									reject(error);
+								});
+							} catch (error) {
+								cleanup();
+								reject(error);
+							}
+						} else {
+							send();
+						}
 					});
 				},
 

--- a/packages/questpie/src/client/realtime/multiplexer.ts
+++ b/packages/questpie/src/client/realtime/multiplexer.ts
@@ -5,6 +5,8 @@
  * Solves the HTTP/1.1 connection limit problem (6 connections per domain).
  */
 
+import type { GetAuthHeaders } from "../auth.js";
+
 // ============================================================================
 // Types
 // ============================================================================
@@ -76,6 +78,7 @@ export class RealtimeMultiplexer {
 		private baseUrl: string,
 		private withCredentials = true,
 		private debounceMs = 50,
+		private getAuthHeaders?: GetAuthHeaders,
 	) {}
 
 	/**
@@ -204,9 +207,10 @@ export class RealtimeMultiplexer {
 			}));
 
 		try {
+			const authHeaders = await this.getAuthHeaders?.();
 			const response = await fetch(`${this.baseUrl}/realtime`, {
 				method: "POST",
-				headers: { "Content-Type": "application/json" },
+				headers: { "Content-Type": "application/json", ...authHeaders },
 				body: JSON.stringify({ topics: getTopicsPayload() }),
 				credentials: this.withCredentials ? "include" : "omit",
 				signal: this.abortController.signal,

--- a/packages/questpie/src/client/realtime/stream.ts
+++ b/packages/questpie/src/client/realtime/stream.ts
@@ -5,6 +5,7 @@
  * for the realtime SSE multiplexer.
  */
 
+import type { GetAuthHeaders } from "../auth.js";
 import { RealtimeMultiplexer, type TopicConfig } from "./multiplexer.js";
 
 // ============================================================================
@@ -186,6 +187,7 @@ export function createRealtimeAPI(opts: {
 	baseUrl: string;
 	withCredentials: boolean;
 	debounceMs: number;
+	getAuthHeaders?: GetAuthHeaders;
 }): RealtimeAPI {
 	let multiplexer: RealtimeMultiplexer | null = null;
 
@@ -195,6 +197,7 @@ export function createRealtimeAPI(opts: {
 				opts.baseUrl,
 				opts.withCredentials,
 				opts.debounceMs,
+				opts.getAuthHeaders,
 			);
 		}
 		return multiplexer;

--- a/packages/questpie/test/client/client-auth-headers.test.ts
+++ b/packages/questpie/test/client/client-auth-headers.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, describe, expect, it } from "bun:test";
+
+import { createClient } from "../../src/client/index.js";
+
+async function waitFor(assertion: () => boolean, timeoutMs = 3000) {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (assertion()) return;
+		await new Promise((resolve) => setTimeout(resolve, 10));
+	}
+	throw new Error("Timed out waiting for assertion");
+}
+
+describe("client dynamic auth headers", () => {
+	const originalFetch = globalThis.fetch;
+	const originalXMLHttpRequest = globalThis.XMLHttpRequest;
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+		globalThis.XMLHttpRequest = originalXMLHttpRequest;
+	});
+
+	it("resolves fresh auth headers for every data request", async () => {
+		const authorizationHeaders: Array<string | null> = [];
+		let token = 0;
+		const client = createClient<any>({
+			baseURL: "http://localhost:3000",
+			headers: { Authorization: "Bearer static" },
+			getAuthHeaders: async () => ({
+				Authorization: `Bearer data-${++token}`,
+			}),
+			fetch: async (_input, init) => {
+				authorizationHeaders.push(
+					new Headers(init?.headers).get("Authorization"),
+				);
+				return Response.json({ docs: [], totalDocs: 0 });
+			},
+		});
+
+		await client.collections.posts.find();
+		await client.collections.posts.find();
+
+		expect(authorizationHeaders).toEqual(["Bearer data-1", "Bearer data-2"]);
+	});
+
+	it("resolves fresh auth headers for every upload while retaining cookies", async () => {
+		const requests: Array<{
+			headers: Record<string, string>;
+			withCredentials: boolean;
+		}> = [];
+
+		class FakeXMLHttpRequest extends EventTarget {
+			upload = new EventTarget();
+			status = 200;
+			responseText = JSON.stringify({ ok: true });
+			withCredentials = false;
+			private headers: Record<string, string> = {};
+
+			open() {}
+
+			setRequestHeader(name: string, value: string) {
+				this.headers[name] = value;
+			}
+
+			send() {
+				requests.push({
+					headers: { ...this.headers },
+					withCredentials: this.withCredentials,
+				});
+				queueMicrotask(() => this.dispatchEvent(new Event("load")));
+			}
+
+			abort() {
+				this.dispatchEvent(new Event("abort"));
+			}
+		}
+
+		globalThis.XMLHttpRequest =
+			FakeXMLHttpRequest as unknown as typeof XMLHttpRequest;
+
+		const file = new File(["image"], "photo.jpg", { type: "image/jpeg" });
+		const cookieClient = createClient<any>({
+			baseURL: "http://localhost:3000",
+		});
+		await cookieClient.collections.assets.upload(file);
+
+		let token = 0;
+		const client = createClient<any>({
+			baseURL: "http://localhost:3000",
+			getAuthHeaders: () => ({
+				Authorization: `Bearer upload-${++token}`,
+			}),
+		});
+		await client.collections.assets.upload(file);
+		await client.collections.assets.upload(file);
+
+		expect(requests).toEqual([
+			{
+				headers: {},
+				withCredentials: true,
+			},
+			{
+				headers: { Authorization: "Bearer upload-1" },
+				withCredentials: true,
+			},
+			{
+				headers: { Authorization: "Bearer upload-2" },
+				withCredentials: true,
+			},
+		]);
+	});
+
+	it("resolves fresh auth headers for every realtime connection", async () => {
+		const requests: Array<{
+			authorization: string | null;
+			credentials: RequestCredentials | undefined;
+		}> = [];
+
+		globalThis.fetch = (async (_input, init) => {
+			let controller!: ReadableStreamDefaultController<Uint8Array>;
+			const body = new ReadableStream<Uint8Array>({
+				start(streamController) {
+					controller = streamController;
+				},
+			});
+			init?.signal?.addEventListener("abort", () => controller.close());
+			requests.push({
+				authorization: new Headers(init?.headers).get("Authorization"),
+				credentials: init?.credentials,
+			});
+			return new Response(body, {
+				status: 200,
+				headers: { "Content-Type": "text/event-stream" },
+			});
+		}) as typeof fetch;
+
+		let token = 0;
+		const client = createClient<any>({
+			baseURL: "http://localhost:3000",
+			getAuthHeaders: () => ({
+				Authorization: `Bearer realtime-${++token}`,
+			}),
+		});
+
+		const stopFirst = client.collections.posts.live({}, () => {});
+		await waitFor(() => requests.length === 1);
+		stopFirst();
+		await waitFor(() => client.realtime.topicCount === 0);
+
+		const stopSecond = client.collections.posts.live({}, () => {});
+		await waitFor(() => requests.length === 2);
+		stopSecond();
+		client.realtime.destroy();
+
+		expect(requests).toEqual([
+			{
+				authorization: "Bearer realtime-1",
+				credentials: "include",
+			},
+			{
+				authorization: "Bearer realtime-2",
+				credentials: "include",
+			},
+		]);
+	});
+});


### PR DESCRIPTION
## Summary

- add one dynamic `getAuthHeaders` resolver to `QuestpieClientConfig`
- resolve fresh headers for data requests, XHR uploads, and SSE connections while retaining cookie credentials
- export the shared resolver type for the upcoming WS/Pusher driver
- cover token rotation and the cookie-only upload default

## Verification

- `cd packages/questpie && bun test test/ --test-name-pattern "client|auth"` (87 pass, 0 fail)
- `cd packages/questpie && bunx tsc --noEmit -p tsconfig.json`
- `cd packages/questpie && bun test test/client/client-auth-headers.test.ts test/client/client-live.test.ts` (9 pass, 0 fail)
- `cd packages/questpie && bun run build`
- targeted oxlint: 0 errors
- touched-file format check and `git diff --check`

Board: `rt2-3-shared-dynamic-client-auth-getauthheaders-across-data-upload-sse-ws`
