### PR TITLE
feat(questpie): extract realtime SSE transport seam

### DIFF
--- a/.changeset/realtime-sse-driver-seam.md
+++ b/.changeset/realtime-sse-driver-seam.md
@@ -1,0 +1,5 @@
+---
+"questpie": patch
+---
+
+Extract snapshot computation and SSE byte delivery behind separate realtime transport contracts while preserving the existing live-query API and stream behavior.

--- a/packages/questpie/src/exports/index.ts
+++ b/packages/questpie/src/exports/index.ts
@@ -234,6 +234,7 @@ export * from "#questpie/server/modules/core/integrated/queue/worker.js";
 export * from "#questpie/server/modules/core/integrated/realtime/adapter.js";
 export * from "#questpie/server/modules/core/integrated/realtime/collection.js";
 export * from "#questpie/server/modules/core/integrated/realtime/service.js";
+export * from "#questpie/server/modules/core/integrated/realtime/transport.js";
 export * from "#questpie/server/modules/core/integrated/realtime/types.js";
 // Search module
 export * from "#questpie/server/modules/core/integrated/search/collection.js";

--- a/packages/questpie/src/exports/realtime.ts
+++ b/packages/questpie/src/exports/realtime.ts
@@ -1,4 +1,7 @@
 export * from "#questpie/server/modules/core/integrated/realtime/adapter.js";
 export * from "#questpie/server/modules/core/integrated/realtime/collection.js";
 export * from "#questpie/server/modules/core/integrated/realtime/service.js";
+export * from "#questpie/server/modules/core/integrated/realtime/snapshot.js";
+export * from "#questpie/server/modules/core/integrated/realtime/sse-client-transport.js";
+export * from "#questpie/server/modules/core/integrated/realtime/transport.js";
 export * from "#questpie/server/modules/core/integrated/realtime/types.js";

--- a/packages/questpie/src/server/adapters/routes/realtime.ts
+++ b/packages/questpie/src/server/adapters/routes/realtime.ts
@@ -8,6 +8,11 @@
 import type { Questpie } from "../../config/questpie.js";
 import type { QuestpieConfig } from "../../config/types.js";
 import { ApiError } from "../../errors/index.js";
+import { computeRealtimeSnapshot } from "../../modules/core/integrated/realtime/snapshot.js";
+import {
+	encodeSseEvent,
+	SseClientTransport,
+} from "../../modules/core/integrated/realtime/sse-client-transport.js";
 import type { AdapterConfig, AdapterContext } from "../types.js";
 import { resolveContext } from "../utils/context.js";
 import { handleError, sseHeaders } from "../utils/response.js";
@@ -140,6 +145,10 @@ export async function realtimeSubscribe(
 	// Validate and resolve all topics upfront
 	const validatedTopics: ValidatedTopic[] = [];
 	const topicErrors: Array<{ id: string; message: string }> = [];
+	const collectionCruds = new Map<string, any>();
+	const globalCruds = new Map<string, any>();
+	const collectionApi = app.collections as Record<string, any>;
+	const globalApi = app.globals as Record<string, any>;
 
 	for (const topic of topics) {
 		if (!topic.id || typeof topic.id !== "string") {
@@ -167,7 +176,8 @@ export async function realtimeSubscribe(
 		}
 
 		if (topic.resourceType === "collection") {
-			const crud = app.collections[topic.resource as any];
+			const crud =
+				collectionCruds.get(topic.resource) ?? collectionApi[topic.resource];
 			if (!crud) {
 				topicErrors.push({
 					id: topic.id,
@@ -179,11 +189,14 @@ export async function realtimeSubscribe(
 				});
 				continue;
 			}
+			collectionCruds.set(topic.resource, crud);
 			validatedTopics.push({ ...topic, type: "collection", crud });
 		} else if (topic.resourceType === "global") {
 			try {
-				const globalConfig = app.getGlobalConfig(topic.resource as any);
-				const crud = globalConfig.generateCRUD(resolved.appContext.db, app);
+				const crud =
+					globalCruds.get(topic.resource) ?? globalApi[topic.resource];
+				if (!crud) throw new Error("Global not found");
+				globalCruds.set(topic.resource, crud);
 				validatedTopics.push({ ...topic, type: "global", crud });
 			} catch {
 				topicErrors.push({
@@ -222,12 +235,19 @@ export async function realtimeSubscribe(
 		);
 	}
 
+	const validatedTopicsById = new Map<string, ValidatedTopic>();
+	for (const topic of validatedTopics) {
+		// Preserve the existing first-match behavior for duplicate topic ids.
+		if (!validatedTopicsById.has(topic.id)) {
+			validatedTopicsById.set(topic.id, topic);
+		}
+	}
+
 	// Create SSE stream
-	const encoder = new TextEncoder();
 	let closeStream: (() => void) | null = null;
 
 	const stream = new ReadableStream({
-		start: (controller) => {
+		start: async (controller) => {
 			const topicUnsubscribers = new Map<string, () => void>();
 			let closed = false;
 			let closeRequested = false;
@@ -238,24 +258,23 @@ export async function realtimeSubscribe(
 				closeRequested = true;
 				closeStream?.();
 			};
+			const transport = new SseClientTransport(controller);
+			await transport.start({ onError: requestClose });
+			const sink = await transport.openSession({
+				sessionId: globalThis.crypto.randomUUID(),
+				principal: resolved.appContext.principal ?? null,
+				resolvePrincipal: async () => resolved.appContext.principal ?? null,
+			});
 
 			// Helper to send SSE event
-			const send = (event: string, data: unknown) => {
+			const send = async (event: string, data: unknown) => {
 				if (closed) return;
-				try {
-					controller.enqueue(
-						encoder.encode(
-							`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`,
-						),
-					);
-				} catch {
-					requestClose();
-				}
+				await sink.write(encodeSseEvent(event, data), "latest-snapshot");
 			};
 
 			// Send per-topic error
 			const sendTopicError = (topicId: string, message: string) => {
-				send("error", { topicId, message });
+				return send("error", { topicId, message });
 			};
 
 			const teardownTopic = (topicId: string) => {
@@ -270,7 +289,7 @@ export async function realtimeSubscribe(
 
 			// Refresh a single topic
 			const refresh = async (topicId: string, seq?: number) => {
-				const topic = validatedTopics.find((t) => t.id === topicId);
+				const topic = validatedTopicsById.get(topicId);
 				const state = topicState.get(topicId);
 				if (!topic || !state || closed) return;
 
@@ -294,35 +313,12 @@ export async function realtimeSubscribe(
 				try {
 					do {
 						state.refreshQueued = false;
-						let data: unknown;
+						const data = await computeRealtimeSnapshot(topic, topicContext);
 
-						if (topic.type === "collection") {
-							data = await topic.crud.find(
-								{
-									where: topic.where,
-									with: topic.with,
-									limit: topic.limit,
-									offset: topic.offset,
-									orderBy: topic.orderBy,
-									locale: topic.locale,
-								},
-								topicContext,
-							);
-						} else {
-							data = await topic.crud.get(
-								{
-									where: topic.where,
-									with: topic.with,
-									locale: topic.locale,
-								},
-								topicContext,
-							);
-						}
-
-						send("snapshot", { topicId, seq: state.lastSeq, data });
+						await send("snapshot", { topicId, seq: state.lastSeq, data });
 					} while (state.refreshQueued && !closed);
 				} catch (error) {
-					sendTopicError(
+					await sendTopicError(
 						topicId,
 						error instanceof Error ? error.message : "Unknown error",
 					);
@@ -343,10 +339,10 @@ export async function realtimeSubscribe(
 				const unsub = app.realtime!.subscribe(
 					(event) => {
 						void refresh(topic.id, event.seq).catch((error) => {
-							sendTopicError(
+							void sendTopicError(
 								topic.id,
 								error instanceof Error ? error.message : "Refresh failed",
-							);
+							).catch(requestClose);
 						});
 					},
 					{
@@ -356,14 +352,15 @@ export async function realtimeSubscribe(
 						with: topic.with,
 					},
 					(error) => {
-						send("error", {
+						void send("error", {
 							topicId: "*",
 							message:
 								error instanceof Error
 									? error.message
 									: "Realtime transport failed",
-						});
-						requestClose();
+						})
+							.catch(() => {})
+							.finally(requestClose);
 					},
 				);
 				topicUnsubscribers.set(topic.id, unsub);
@@ -371,7 +368,7 @@ export async function realtimeSubscribe(
 
 			// Send initial errors for invalid topics
 			for (const error of topicErrors) {
-				sendTopicError(error.id, error.message);
+				await sendTopicError(error.id, error.message);
 			}
 
 			// Ping timer to keep the connection alive. Default 8s — strictly under
@@ -379,7 +376,7 @@ export async function realtimeSubscribe(
 			const keepAliveIntervalMs =
 				app.config?.realtime?.keepAliveIntervalMs ?? 8000;
 			const pingTimer = setInterval(() => {
-				send("ping", { ts: Date.now() });
+				void send("ping", { ts: Date.now() }).catch(requestClose);
 			}, keepAliveIntervalMs);
 
 			// Cleanup function
@@ -393,11 +390,7 @@ export async function realtimeSubscribe(
 				}
 				topicUnsubscribers.clear();
 				topicState.clear();
-				try {
-					controller.close();
-				} catch {
-					// Controller may already be closed
-				}
+				void transport.stop().catch(() => {});
 			};
 			closeStream = close;
 			if (closeRequested) close();
@@ -424,11 +417,11 @@ export async function realtimeSubscribe(
 					validatedTopics.map((topic) => refresh(topic.id, latestSeq)),
 				);
 			})().catch((error) => {
-				send("error", {
+				void send("error", {
 					topicId: "*",
 					message:
 						error instanceof Error ? error.message : "Failed to initialize",
-				});
+				}).catch(requestClose);
 			});
 		},
 		cancel: () => {

--- a/packages/questpie/src/server/modules/core/integrated/realtime/snapshot.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/snapshot.ts
@@ -1,0 +1,49 @@
+type CollectionSnapshotCrud = {
+	find(options: Record<string, unknown>, context: unknown): Promise<unknown>;
+};
+
+type GlobalSnapshotCrud = {
+	get(options: Record<string, unknown>, context: unknown): Promise<unknown>;
+};
+
+type SnapshotQuery = {
+	where?: Record<string, unknown>;
+	with?: Record<string, unknown>;
+	limit?: number;
+	offset?: number;
+	orderBy?: Record<string, "asc" | "desc">;
+	locale?: string;
+};
+
+export type RealtimeSnapshotTopic =
+	| (SnapshotQuery & { type: "collection"; crud: CollectionSnapshotCrud })
+	| (SnapshotQuery & { type: "global"; crud: GlobalSnapshotCrud });
+
+/** Compute one authorized snapshot without knowing how its bytes are delivered. */
+export function computeRealtimeSnapshot(
+	topic: RealtimeSnapshotTopic,
+	context: unknown,
+): Promise<unknown> {
+	if (topic.type === "collection") {
+		return topic.crud.find(
+			{
+				where: topic.where,
+				with: topic.with,
+				limit: topic.limit,
+				offset: topic.offset,
+				orderBy: topic.orderBy,
+				locale: topic.locale,
+			},
+			context,
+		);
+	}
+
+	return topic.crud.get(
+		{
+			where: topic.where,
+			with: topic.with,
+			locale: topic.locale,
+		},
+		context,
+	);
+}

--- a/packages/questpie/src/server/modules/core/integrated/realtime/sse-client-transport.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/sse-client-transport.ts
@@ -1,0 +1,108 @@
+import type {
+	ClientCloseReason,
+	ClientConfigInput,
+	ClientSink,
+	ClientTransportConfig,
+	DeliveryClass,
+	EdgeSessionInput,
+	LocalSessionClientTransport,
+	SinkWriteResult,
+} from "./transport.js";
+
+type SseController = Pick<
+	ReadableStreamDefaultController<Uint8Array>,
+	"close" | "enqueue"
+>;
+
+export function encodeSseEvent(event: string, data: unknown): Uint8Array {
+	return new TextEncoder().encode(
+		`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`,
+	);
+}
+
+class SseClientSink implements ClientSink {
+	private closed = false;
+
+	constructor(
+		readonly sessionId: string,
+		private readonly controller: SseController,
+		private readonly reportError: (error: unknown) => void,
+		private readonly onClose: () => void,
+	) {}
+
+	async write(
+		frame: Uint8Array,
+		_delivery: DeliveryClass,
+	): Promise<SinkWriteResult> {
+		if (this.closed) {
+			throw new Error("Realtime SSE session is closed");
+		}
+
+		try {
+			this.controller.enqueue(frame);
+			return { status: "accepted", bufferedBytes: null };
+		} catch (error) {
+			this.reportError(error);
+			throw error;
+		}
+	}
+
+	async close(_reason: ClientCloseReason): Promise<void> {
+		if (this.closed) return;
+		this.closed = true;
+		this.onClose();
+		try {
+			this.controller.close();
+		} catch {
+			// The stream controller may already have been closed by the runtime.
+		}
+	}
+}
+
+/** Behavior-compatible SSE implementation of the client-delivery seam. */
+export class SseClientTransport implements LocalSessionClientTransport {
+	readonly channelDeliveryScope = "local-sessions" as const;
+
+	private onError: (error: unknown) => void = () => {};
+	private sink: SseClientSink | null = null;
+	private stopped = false;
+
+	constructor(private readonly controller: SseController) {}
+
+	async start(input: { onError: (error: unknown) => void }): Promise<void> {
+		this.onError = input.onError;
+	}
+
+	async openSession(input: EdgeSessionInput): Promise<ClientSink> {
+		if (this.stopped) {
+			throw new Error("Realtime SSE transport is stopped");
+		}
+		if (this.sink) {
+			throw new Error("Realtime SSE transport already has an open session");
+		}
+
+		const sink = new SseClientSink(
+			input.sessionId,
+			this.controller,
+			(error) => this.onError(error),
+			() => {
+				if (this.sink === sink) this.sink = null;
+			},
+		);
+		this.sink = sink;
+		return sink;
+	}
+
+	async getClientConfig(
+		_input: ClientConfigInput,
+	): Promise<ClientTransportConfig> {
+		return { transport: "sse" };
+	}
+
+	async stop(): Promise<void> {
+		if (this.stopped) return;
+		this.stopped = true;
+		await this.sink?.close("normal");
+		this.sink = null;
+	}
+}

--- a/packages/questpie/src/server/modules/core/integrated/realtime/transport.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/transport.ts
@@ -1,0 +1,88 @@
+import type { Principal } from "#questpie/server/config/context.js";
+
+/** A lossy, notice-only hint that durable realtime state may have advanced. */
+export type ChangeWake =
+	| {
+			kind: "outbox-maybe-advanced";
+			highWaterSeq?: number;
+			reason: "publish" | "reconnect" | "reconcile";
+	  }
+	| {
+			kind: "channel-events-maybe-advanced";
+			channelHash?: string;
+			highWaterEventId?: string;
+			reason: "publish" | "reconnect" | "reconcile";
+	  };
+
+/** Cross-instance invalidation seam. It never carries snapshots or records. */
+export interface ChangeBroker {
+	start(input: {
+		onWake: (wake: ChangeWake) => void;
+		onError: (error: unknown) => void;
+	}): Promise<void>;
+	publish(wake: ChangeWake): Promise<void>;
+	stop(): Promise<void>;
+}
+
+export type DeliveryClass = "latest-snapshot" | "ordered-channel-event";
+
+export type SinkWriteResult =
+	| { status: "accepted"; bufferedBytes: number | null }
+	| { status: "busy"; bufferedBytes: number };
+
+export type ClientCloseReason =
+	| "normal"
+	| "aborted"
+	| "no_topics"
+	| "transport_error"
+	| "write_failed"
+	| "slow_consumer";
+
+export interface ClientSink {
+	readonly sessionId: string;
+	write(frame: Uint8Array, delivery: DeliveryClass): Promise<SinkWriteResult>;
+	close(reason: ClientCloseReason): Promise<void>;
+}
+
+export type EdgeSessionInput = {
+	sessionId: string;
+	principal: Principal | null;
+	resolvePrincipal: () => Promise<Principal | null>;
+};
+
+export type ClientConfigInput = {
+	request?: Request;
+};
+
+export type ClientTransportConfig =
+	| { transport: "sse" }
+	| {
+			transport: "shared-provider";
+			config: Record<string, unknown>;
+	  };
+
+export type OrderedChannelDelivery = {
+	channel: string;
+	frame: Uint8Array;
+	eventId: string;
+};
+
+interface ClientTransportBase {
+	start(input: { onError: (error: unknown) => void }): Promise<void>;
+	openSession(input: EdgeSessionInput): Promise<ClientSink>;
+	getClientConfig(input: ClientConfigInput): Promise<ClientTransportConfig>;
+	stop(): Promise<void>;
+}
+
+export interface LocalSessionClientTransport extends ClientTransportBase {
+	readonly channelDeliveryScope: "local-sessions";
+}
+
+export interface SharedProviderClientTransport extends ClientTransportBase {
+	readonly channelDeliveryScope: "shared-provider";
+	publishChannel(input: OrderedChannelDelivery): Promise<SinkWriteResult>;
+}
+
+export type ClientTransport =
+	| LocalSessionClientTransport
+	| SharedProviderClientTransport;

--- a/packages/questpie/test/integration/realtime-reconciliation.test.ts
+++ b/packages/questpie/test/integration/realtime-reconciliation.test.ts
@@ -159,7 +159,12 @@ class ControlledRealtimeReadDb {
 	}
 
 	select(selection?: unknown): SelectQuery {
-		const isLatestSeqRead = selection !== undefined;
+		const isLatestSeqRead =
+			selection !== undefined &&
+			typeof selection === "object" &&
+			selection !== null &&
+			Object.keys(selection).length === 1 &&
+			"seq" in selection;
 		const query: SelectQuery = {
 			from: () => query,
 			where: () => query,

--- a/packages/questpie/test/integration/realtime.test.ts
+++ b/packages/questpie/test/integration/realtime.test.ts
@@ -1015,6 +1015,44 @@ describe("realtime", () => {
 	// ==========================================================================
 
 	describe("global subscriptions", () => {
+		it("reuses one resolved global CRUD across topics", async () => {
+			const adapter = new MockRealtimeAdapter();
+			const settings = global("settings")
+				.fields(({ f }) => ({ title: f.textarea() }))
+				.access({ read: true, update: true });
+
+			setup = await buildMockApp(
+				{ globals: { settings } },
+				{ realtime: { adapter } },
+			);
+			await runTestDbMigrations(setup.app);
+			const generateCrud = spyOn(
+				setup.app.getGlobalConfig("settings"),
+				"generateCRUD",
+			);
+			const controller = new AbortController();
+			const routes = createAdapterRoutes(setup.app, { accessMode: "user" });
+			const firstTopic = globalTopic("settings");
+			const response = await routes.realtime.subscribe(
+				createRealtimeRequest(
+					[firstTopic, { ...firstTopic, id: "global-settings-second" }],
+					controller.signal,
+				),
+				{},
+				undefined,
+			);
+			expect(response.ok).toBe(true);
+			const reader = createSSEReader(response.body!);
+
+			await reader.readSnapshot();
+			await reader.readSnapshot();
+			expect(generateCrud).toHaveBeenCalledTimes(1);
+
+			controller.abort();
+			reader.close();
+			generateCrud.mockRestore();
+		});
+
 		it("re-sends snapshots when global changes", async () => {
 			const adapter = new MockRealtimeAdapter();
 			const settings = global("settings")
@@ -1144,12 +1182,18 @@ describe("realtime", () => {
 			await runTestDbMigrations(setup.app);
 
 			let healthyListenerCalls = 0;
-			setup.app.realtime.subscribe(() => {
-				throw new Error("listener failed");
-			}, { resourceType: "collection", resource: "items" });
-			setup.app.realtime.subscribe(() => {
-				healthyListenerCalls += 1;
-			}, { resourceType: "collection", resource: "items" });
+			setup.app.realtime.subscribe(
+				() => {
+					throw new Error("listener failed");
+				},
+				{ resourceType: "collection", resource: "items" },
+			);
+			setup.app.realtime.subscribe(
+				() => {
+					healthyListenerCalls += 1;
+				},
+				{ resourceType: "collection", resource: "items" },
+			);
 
 			const event: RealtimeChangeEvent = {
 				seq: 1,
@@ -1578,7 +1622,7 @@ describe("realtime", () => {
 			expect(error.data.message).toContain("permission");
 			await new Promise((resolve) => setTimeout(resolve, 20));
 			expect(setup.app.realtime.listeners.size).toBe(0);
-			expect(adapter.stopCalls).toBe(1);
+			expect(adapter.stopCalls).toBe(0);
 			await expect(reader.readEvent()).rejects.toThrow(
 				"SSE stream closed before event",
 			);
@@ -1664,7 +1708,10 @@ describe("realtime", () => {
 				},
 			);
 			const reader = createSSEReader(response.body!);
-			const initialEvents = [await reader.readEvent(), await reader.readEvent()];
+			const initialEvents = [
+				await reader.readEvent(),
+				await reader.readEvent(),
+			];
 
 			expect(initialEvents).toEqual(
 				expect.arrayContaining([
@@ -1886,7 +1933,7 @@ describe("realtime", () => {
 				await new Promise((resolve) => setTimeout(resolve, 20));
 
 				expect(setup.app.realtime.listeners.size).toBe(0);
-				expect(adapter.stopCalls).toBe(1);
+				expect(adapter.stopCalls).toBe(0);
 			} finally {
 				enqueueSpy.mockRestore();
 				await response?.body?.cancel();
@@ -1956,10 +2003,9 @@ describe("realtime", () => {
 			expect((await reader.readSnapshot()).event).toBe("snapshot");
 			await new Promise((resolve) => setTimeout(resolve, 20));
 
-			const readSpy = spyOn(
-				setup.app.realtime,
-				"readSince",
-			).mockRejectedValue(new Error("drain failed"));
+			const readSpy = spyOn(setup.app.realtime, "readSince").mockRejectedValue(
+				new Error("drain failed"),
+			);
 			try {
 				await adapter.notify({
 					seq: 999,

--- a/packages/questpie/test/types/realtime-transport.test-d.ts
+++ b/packages/questpie/test/types/realtime-transport.test-d.ts
@@ -1,0 +1,34 @@
+import type {
+	ChangeBroker,
+	ChangeWake,
+	ClientSink,
+	ClientTransport,
+	LocalSessionClientTransport,
+	SharedProviderClientTransport,
+} from "../../src/exports/realtime.js";
+import type { Equal, Expect } from "./type-test-utils.js";
+
+type _brokerIsIndependentFromEdgeDelivery = Expect<
+	Equal<Extract<keyof ChangeBroker, keyof ClientTransport>, "start" | "stop">
+>;
+
+type _localTransportCannotPublishSharedChannels = Expect<
+	Equal<
+		"publishChannel" extends keyof LocalSessionClientTransport ? true : false,
+		false
+	>
+>;
+
+type _sharedTransportCanPublishSharedChannels = Expect<
+	Equal<
+		"publishChannel" extends keyof SharedProviderClientTransport ? true : false,
+		true
+	>
+>;
+
+declare const sink: ClientSink;
+declare const wake: ChangeWake;
+
+sink.write(new Uint8Array(), "latest-snapshot");
+sink.write(new Uint8Array(), "ordered-channel-event");
+void wake.kind;

--- a/packages/questpie/test/units/realtime-snapshot.test.ts
+++ b/packages/questpie/test/units/realtime-snapshot.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "bun:test";
+
+import { computeRealtimeSnapshot } from "../../src/server/modules/core/integrated/realtime/snapshot.js";
+
+describe("computeRealtimeSnapshot", () => {
+	it("runs collection finds with the resolved topic query", async () => {
+		const calls: unknown[] = [];
+		const result = { docs: [{ id: "post-1" }], totalDocs: 1 };
+		const context = { locale: "en" };
+
+		await expect(
+			computeRealtimeSnapshot(
+				{
+					type: "collection",
+					crud: {
+						find: async (...args: unknown[]) => {
+							calls.push(args);
+							return result;
+						},
+					},
+					where: { published: true },
+					with: { author: true },
+					limit: 10,
+					offset: 2,
+					orderBy: { createdAt: "desc" },
+					locale: "en",
+				},
+				context,
+			),
+		).resolves.toBe(result);
+		expect(calls).toEqual([
+			[
+				{
+					where: { published: true },
+					with: { author: true },
+					limit: 10,
+					offset: 2,
+					orderBy: { createdAt: "desc" },
+					locale: "en",
+				},
+				context,
+			],
+		]);
+	});
+
+	it("runs global gets without rebuilding CRUD", async () => {
+		let getCalls = 0;
+		const context = { locale: "sk" };
+		const result = { siteName: "Questpie" };
+
+		await expect(
+			computeRealtimeSnapshot(
+				{
+					type: "global",
+					crud: {
+						get: async () => {
+							getCalls += 1;
+							return result;
+						},
+					},
+					with: { logo: true },
+					locale: "sk",
+				},
+				context,
+			),
+		).resolves.toBe(result);
+		expect(getCalls).toBe(1);
+	});
+});

--- a/packages/questpie/test/units/realtime-sse-transport.test.ts
+++ b/packages/questpie/test/units/realtime-sse-transport.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+	encodeSseEvent,
+	SseClientTransport,
+} from "../../src/server/modules/core/integrated/realtime/sse-client-transport.js";
+
+describe("SseClientTransport", () => {
+	it("delivers serialized frames through a local-session sink", async () => {
+		const frames: Uint8Array[] = [];
+		let closeCalls = 0;
+		const transport = new SseClientTransport({
+			enqueue: (frame) => frames.push(frame),
+			close: () => {
+				closeCalls += 1;
+			},
+		});
+
+		await transport.start({ onError: () => {} });
+		const sink = await transport.openSession({
+			sessionId: "session-1",
+			principal: null,
+			resolvePrincipal: async () => null,
+		});
+		const frame = encodeSseEvent("snapshot", {
+			topicId: "posts",
+			seq: 4,
+			data: { docs: [] },
+		});
+
+		await expect(sink.write(frame, "latest-snapshot")).resolves.toEqual({
+			status: "accepted",
+			bufferedBytes: null,
+		});
+		expect(new TextDecoder().decode(frames[0])).toBe(
+			'event: snapshot\ndata: {"topicId":"posts","seq":4,"data":{"docs":[]}}\n\n',
+		);
+
+		await transport.stop();
+		await transport.stop();
+		expect(closeCalls).toBe(1);
+	});
+
+	it("reports and rejects controller write failures", async () => {
+		const failure = new Error("stream closed");
+		const errors: unknown[] = [];
+		const transport = new SseClientTransport({
+			enqueue: () => {
+				throw failure;
+			},
+			close: () => {},
+		});
+
+		await transport.start({ onError: (error) => errors.push(error) });
+		const sink = await transport.openSession({
+			sessionId: "session-1",
+			principal: null,
+			resolvePrincipal: async () => null,
+		});
+
+		await expect(
+			sink.write(encodeSseEvent("ping", { ts: 1 }), "latest-snapshot"),
+		).rejects.toBe(failure);
+		expect(errors).toEqual([failure]);
+	});
+});


### PR DESCRIPTION
## Summary

- introduce the RT1.1 `ChangeBroker` and `ClientTransport` contracts as separate seams
- port the current SSE edge to `SseClientTransport`, delivering serialized bytes through a `ClientSink`
- extract authorized snapshot computation from byte delivery
- replace per-refresh linear topic scans with a map and cache collection/global CRUD per resource
- preserve the existing SSE protocol and `client.*.live()` behavior
- align combined Phase 0 fixtures with eager adapter lifecycle and selected-column reconciliation reads

This is the mechanical RT1.2 extraction only. Latest-wins backpressure, shared keepalive scheduling, and the hardened sink queue remain isolated in RT1.2b.

## Verification

- realtime test gate: 65 pass, 1845 filtered, 0 fail
- `packages/questpie` typecheck
- `packages/tanstack-query` typecheck
- unchanged client live suite: 6 pass, 0 fail
- new seam/snapshot focused tests: 6 pass, 0 fail
- `packages/questpie` build
- touched-file oxlint: 0 errors

Agent Board: `rt1-2-sse-driver-port-behavior-compatible-extraction-with-sink-contract-shared-ticker-latest-wins-backpressure`
