### PR TITLE
fix(realtime): harden SSE sink backpressure

### DIFF
--- a/.changeset/harden-realtime-sse-sinks.md
+++ b/.changeset/harden-realtime-sse-sinks.md
@@ -1,0 +1,5 @@
+---
+"questpie": patch
+---
+
+Bound realtime SSE buffering with latest-wins snapshot delivery and share keepalive scheduling across connections.

--- a/packages/questpie/src/server/adapters/routes/realtime.ts
+++ b/packages/questpie/src/server/adapters/routes/realtime.ts
@@ -12,7 +12,9 @@ import { computeRealtimeSnapshot } from "../../modules/core/integrated/realtime/
 import {
 	encodeSseEvent,
 	SseClientTransport,
+	SseLatestSnapshotWriter,
 } from "../../modules/core/integrated/realtime/sse-client-transport.js";
+import { sharedSseKeepAliveTicker } from "../../modules/core/integrated/realtime/sse-keep-alive.js";
 import type { AdapterConfig, AdapterContext } from "../types.js";
 import { resolveContext } from "../utils/context.js";
 import { handleError, sseHeaders } from "../utils/response.js";
@@ -73,7 +75,7 @@ function isPermanentAccessError(error: unknown): boolean {
  * Response: SSE stream with events:
  * - snapshot: { topicId, seq, data }
  * - error: { topicId, message }
- * - ping: { ts }
+ * Keepalive frames are SSE comments and are intentionally invisible to clients.
  */
 export async function realtimeSubscribe(
 	app: Questpie<any>,
@@ -245,8 +247,10 @@ export async function realtimeSubscribe(
 
 	// Create SSE stream
 	let closeStream: (() => void) | null = null;
+	let flushPending: (() => void) | null = null;
+	const highWaterMarkBytes = 1024 * 1024;
 
-	const stream = new ReadableStream({
+	const stream = new ReadableStream<Uint8Array>({
 		start: async (controller) => {
 			const topicUnsubscribers = new Map<string, () => void>();
 			let closed = false;
@@ -258,18 +262,27 @@ export async function realtimeSubscribe(
 				closeRequested = true;
 				closeStream?.();
 			};
-			const transport = new SseClientTransport(controller);
+			const transport = new SseClientTransport(controller, highWaterMarkBytes);
 			await transport.start({ onError: requestClose });
 			const sink = await transport.openSession({
 				sessionId: globalThis.crypto.randomUUID(),
 				principal: resolved.appContext.principal ?? null,
 				resolvePrincipal: async () => resolved.appContext.principal ?? null,
 			});
+			const snapshotWriter = new SseLatestSnapshotWriter(sink);
+			flushPending = () => {
+				void snapshotWriter.flush().catch(requestClose);
+			};
 
 			// Helper to send SSE event
-			const send = async (event: string, data: unknown) => {
+			const send = async (event: string, data: unknown, topicId?: string) => {
 				if (closed) return;
-				await sink.write(encodeSseEvent(event, data), "latest-snapshot");
+				const frame = encodeSseEvent(event, data);
+				if (event === "snapshot" && topicId) {
+					await snapshotWriter.write(topicId, frame);
+					return;
+				}
+				await sink.write(frame, "latest-snapshot");
 			};
 
 			// Send per-topic error
@@ -315,7 +328,7 @@ export async function realtimeSubscribe(
 						state.refreshQueued = false;
 						const data = await computeRealtimeSnapshot(topic, topicContext);
 
-						await send("snapshot", { topicId, seq: state.lastSeq, data });
+						await send("snapshot", { topicId, seq: state.lastSeq, data }, topicId);
 					} while (state.refreshQueued && !closed);
 				} catch (error) {
 					await sendTopicError(
@@ -371,19 +384,24 @@ export async function realtimeSubscribe(
 				await sendTopicError(error.id, error.message);
 			}
 
-			// Ping timer to keep the connection alive. Default 8s — strictly under
+			// Shared ping ticker keeps the connection alive. Default 8s — strictly under
 			// Bun's default 10s idleTimeout and typical proxy timeouts of 30-60s.
 			const keepAliveIntervalMs =
 				app.config?.realtime?.keepAliveIntervalMs ?? 8000;
-			const pingTimer = setInterval(() => {
-				void send("ping", { ts: Date.now() }).catch(requestClose);
-			}, keepAliveIntervalMs);
+			const removeKeepAlive = sharedSseKeepAliveTicker.register(
+				keepAliveIntervalMs,
+				(frame) => {
+					void sink.write(frame, "latest-snapshot").catch(requestClose);
+				},
+			);
 
 			// Cleanup function
 			const close = () => {
 				if (closed) return;
 				closed = true;
-				clearInterval(pingTimer);
+				removeKeepAlive();
+				flushPending = null;
+				snapshotWriter.clear();
 				request.signal.removeEventListener("abort", close);
 				for (const unsub of topicUnsubscribers.values()) {
 					unsub();
@@ -424,9 +442,15 @@ export async function realtimeSubscribe(
 				}).catch(requestClose);
 			});
 		},
+		pull: () => {
+			flushPending?.();
+		},
 		cancel: () => {
 			closeStream?.();
 		},
+	}, {
+		highWaterMark: highWaterMarkBytes,
+		size: (frame) => frame?.byteLength ?? 0,
 	});
 
 	return new Response(stream, {

--- a/packages/questpie/src/server/modules/core/integrated/realtime/sse-client-transport.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/sse-client-transport.ts
@@ -11,8 +11,15 @@ import type {
 
 type SseController = Pick<
 	ReadableStreamDefaultController<Uint8Array>,
-	"close" | "enqueue"
+	"close" | "desiredSize" | "enqueue"
 >;
+
+export function encodeSseComment(comment: string): Uint8Array {
+	const lines = comment.replaceAll("\r", "").split("\n");
+	return new TextEncoder().encode(
+		`${lines.map((line) => `: ${line}`).join("\n")}\n\n`,
+	);
+}
 
 export function encodeSseEvent(event: string, data: unknown): Uint8Array {
 	return new TextEncoder().encode(
@@ -26,6 +33,7 @@ class SseClientSink implements ClientSink {
 	constructor(
 		readonly sessionId: string,
 		private readonly controller: SseController,
+		private readonly highWaterMark: number,
 		private readonly reportError: (error: unknown) => void,
 		private readonly onClose: () => void,
 	) {}
@@ -37,10 +45,29 @@ class SseClientSink implements ClientSink {
 		if (this.closed) {
 			throw new Error("Realtime SSE session is closed");
 		}
+		if (
+			this.controller.desiredSize !== null &&
+			this.controller.desiredSize <= 0
+		) {
+			return {
+				status: "busy",
+				bufferedBytes: Math.max(
+					0,
+					this.highWaterMark - this.controller.desiredSize,
+				),
+			};
+		}
 
 		try {
 			this.controller.enqueue(frame);
-			return { status: "accepted", bufferedBytes: null };
+			const desiredSize = this.controller.desiredSize;
+			return {
+				status: "accepted",
+				bufferedBytes:
+					desiredSize === null
+						? null
+						: Math.max(0, this.highWaterMark - desiredSize),
+			};
 		} catch (error) {
 			this.reportError(error);
 			throw error;
@@ -59,6 +86,75 @@ class SseClientSink implements ClientSink {
 	}
 }
 
+/** Per-session latest-wins queue used when an SSE stream applies backpressure. */
+export class SseLatestSnapshotWriter {
+	private readonly pending = new Map<string, Uint8Array>();
+	private operation: Promise<void> = Promise.resolve();
+	private closed = false;
+	private pendingBytes = 0;
+
+	constructor(private readonly sink: ClientSink) {}
+
+	get bufferedBytes(): number {
+		return this.pendingBytes;
+	}
+
+	write(topicId: string, frame: Uint8Array): Promise<SinkWriteResult> {
+		return this.run(async () => {
+			if (this.closed) throw new Error("Realtime SSE snapshot writer is closed");
+			this.removePending(topicId);
+			const result = await this.sink.write(frame, "latest-snapshot");
+			if (!this.closed && result.status === "busy") {
+				this.setPending(topicId, frame);
+			}
+			return result.status === "busy"
+				? { ...result, bufferedBytes: result.bufferedBytes + this.pendingBytes }
+				: result;
+		});
+	}
+
+	flush(): Promise<void> {
+		return this.run(async () => {
+			if (this.closed) return;
+			for (const [topicId, frame] of this.pending) {
+				this.removePending(topicId);
+				const result = await this.sink.write(frame, "latest-snapshot");
+				if (result.status === "busy") {
+					this.setPending(topicId, frame);
+					break;
+				}
+			}
+		});
+	}
+
+	clear(): void {
+		this.closed = true;
+		this.pending.clear();
+		this.pendingBytes = 0;
+	}
+
+	private run<T>(operation: () => Promise<T>): Promise<T> {
+		const result = this.operation.then(operation);
+		this.operation = result.then(
+			() => {},
+			() => {},
+		);
+		return result;
+	}
+
+	private removePending(topicId: string): void {
+		const previous = this.pending.get(topicId);
+		if (!previous) return;
+		this.pending.delete(topicId);
+		this.pendingBytes -= previous.byteLength;
+	}
+
+	private setPending(topicId: string, frame: Uint8Array): void {
+		this.pending.set(topicId, frame);
+		this.pendingBytes += frame.byteLength;
+	}
+}
+
 /** Behavior-compatible SSE implementation of the client-delivery seam. */
 export class SseClientTransport implements LocalSessionClientTransport {
 	readonly channelDeliveryScope = "local-sessions" as const;
@@ -67,7 +163,10 @@ export class SseClientTransport implements LocalSessionClientTransport {
 	private sink: SseClientSink | null = null;
 	private stopped = false;
 
-	constructor(private readonly controller: SseController) {}
+	constructor(
+		private readonly controller: SseController,
+		private readonly highWaterMark = 1024 * 1024,
+	) {}
 
 	async start(input: { onError: (error: unknown) => void }): Promise<void> {
 		this.onError = input.onError;
@@ -84,6 +183,7 @@ export class SseClientTransport implements LocalSessionClientTransport {
 		const sink = new SseClientSink(
 			input.sessionId,
 			this.controller,
+			this.highWaterMark,
 			(error) => this.onError(error),
 			() => {
 				if (this.sink === sink) this.sink = null;

--- a/packages/questpie/src/server/modules/core/integrated/realtime/sse-keep-alive.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/sse-keep-alive.ts
@@ -1,0 +1,97 @@
+import { encodeSseComment } from "./sse-client-transport.js";
+
+type TimerApi = {
+	now: () => number;
+	setTimeout: (callback: () => void, delayMs: number) => unknown;
+	clearTimeout: (timer: unknown) => void;
+};
+
+type Registration = {
+	intervalMs: number;
+	nextAt: number;
+	onPing: (frame: Uint8Array) => void;
+};
+
+const defaultTimerApi: TimerApi = {
+	now: Date.now,
+	setTimeout: (callback, delayMs) => setTimeout(callback, delayMs),
+	clearTimeout: (timer) => clearTimeout(timer as ReturnType<typeof setTimeout>),
+};
+
+/** Process-wide keepalive scheduler with at most one active timer. */
+export class SharedSseKeepAliveTicker {
+	private readonly registrations = new Set<Registration>();
+	private timer: unknown;
+	private timerDueAt: number | null = null;
+
+	constructor(private readonly timerApi: TimerApi = defaultTimerApi) {}
+
+	get size(): number {
+		return this.registrations.size;
+	}
+
+	register(
+		intervalMs: number,
+		onPing: (frame: Uint8Array) => void,
+	): () => void {
+		const normalizedIntervalMs = Math.max(1, intervalMs);
+		const registration: Registration = {
+			intervalMs: normalizedIntervalMs,
+			nextAt: this.timerApi.now() + normalizedIntervalMs,
+			onPing,
+		};
+		this.registrations.add(registration);
+		this.schedule();
+
+		return () => {
+			if (!this.registrations.delete(registration)) return;
+			this.schedule();
+		};
+	}
+
+	private schedule(): void {
+		let nextAt = Infinity;
+		for (const registration of this.registrations) {
+			nextAt = Math.min(nextAt, registration.nextAt);
+		}
+
+		if (nextAt === Infinity) {
+			this.clearTimer();
+			return;
+		}
+		if (this.timerDueAt !== null && this.timerDueAt <= nextAt) return;
+
+		this.clearTimer();
+		this.timerDueAt = nextAt;
+		this.timer = this.timerApi.setTimeout(
+			() => this.tick(),
+			Math.max(0, nextAt - this.timerApi.now()),
+		);
+	}
+
+	private tick(): void {
+		this.timer = undefined;
+		this.timerDueAt = null;
+		const now = this.timerApi.now();
+		const frame = encodeSseComment(`ping ${now}`);
+
+		for (const registration of this.registrations) {
+			if (registration.nextAt > now) continue;
+			registration.nextAt = now + registration.intervalMs;
+			try {
+				registration.onPing(frame);
+			} catch {
+				// A connection owns its teardown; one callback must not stop the ticker.
+			}
+		}
+		this.schedule();
+	}
+
+	private clearTimer(): void {
+		if (this.timer !== undefined) this.timerApi.clearTimeout(this.timer);
+		this.timer = undefined;
+		this.timerDueAt = null;
+	}
+}
+
+export const sharedSseKeepAliveTicker = new SharedSseKeepAliveTicker();

--- a/packages/questpie/test/integration/realtime.test.ts
+++ b/packages/questpie/test/integration/realtime.test.ts
@@ -9,6 +9,7 @@ import {
 	type RealtimeAdapter,
 	type RealtimeChangeEvent,
 } from "../../src/exports/index.js";
+import { sharedSseKeepAliveTicker } from "../../src/server/modules/core/integrated/realtime/sse-keep-alive.js";
 import { buildMockApp } from "../utils/mocks/mock-app-builder";
 import { createTestContext } from "../utils/test-context";
 import { runTestDbMigrations } from "../utils/test-db";
@@ -77,6 +78,7 @@ class FailingStartRealtimeAdapter extends MockRealtimeAdapter {
 type SSEEvent = {
 	event: string;
 	data: any;
+	comment?: string;
 };
 
 type TopicInput = {
@@ -147,17 +149,21 @@ const createSSEReader = (stream: ReadableStream<Uint8Array>) => {
 
 				let event = "message";
 				let data = "";
+				let comment: string | undefined;
 				for (const line of chunk.split("\n")) {
 					if (line.startsWith("event:")) {
 						event = line.slice(6).trim();
 					} else if (line.startsWith("data:")) {
 						data += line.slice(5).trim();
+					} else if (line.startsWith(":")) {
+						comment = line.slice(1).trim();
 					}
 				}
 
 				return {
 					event,
 					data: data ? JSON.parse(data) : null,
+					comment,
 				};
 			}
 
@@ -177,7 +183,7 @@ const createSSEReader = (stream: ReadableStream<Uint8Array>) => {
 	): Promise<SSEEvent> => {
 		while (true) {
 			const event = await readEvent(timeoutMs);
-			if (event.event === "ping") {
+			if (event.comment !== undefined) {
 				continue;
 			}
 			// If topicId specified, filter by it
@@ -1859,7 +1865,7 @@ describe("realtime", () => {
 	// ==========================================================================
 
 	describe("keepalive", () => {
-		it("honors realtime.keepAliveIntervalMs for SSE pings", async () => {
+		it("honors realtime.keepAliveIntervalMs with SSE comment pings", async () => {
 			const adapter = new MockRealtimeAdapter();
 			const items = collection("items")
 				.fields(({ f }) => ({
@@ -1889,11 +1895,11 @@ describe("realtime", () => {
 			// With a 50ms keepalive, two pings must arrive well within the
 			// 2s default timeout (default cadence of 8s would time out here).
 			const firstPing = await reader.readEvent();
-			expect(firstPing.event).toBe("ping");
-			expect(typeof firstPing.data.ts).toBe("number");
+			expect(firstPing.comment).toMatch(/^ping \d+$/);
+			expect(firstPing.data).toBeNull();
 
 			const secondPing = await reader.readEvent();
-			expect(secondPing.event).toBe("ping");
+			expect(secondPing.comment).toMatch(/^ping \d+$/);
 
 			controller.abort();
 			reader.close();
@@ -1933,6 +1939,7 @@ describe("realtime", () => {
 				await new Promise((resolve) => setTimeout(resolve, 20));
 
 				expect(setup.app.realtime.listeners.size).toBe(0);
+				expect(sharedSseKeepAliveTicker.size).toBe(0);
 				expect(adapter.stopCalls).toBe(0);
 			} finally {
 				enqueueSpy.mockRestore();

--- a/packages/questpie/test/units/realtime-sse-transport.test.ts
+++ b/packages/questpie/test/units/realtime-sse-transport.test.ts
@@ -1,20 +1,33 @@
 import { describe, expect, it } from "bun:test";
 
 import {
+	encodeSseComment,
 	encodeSseEvent,
+	SseLatestSnapshotWriter,
 	SseClientTransport,
 } from "../../src/server/modules/core/integrated/realtime/sse-client-transport.js";
+import { SharedSseKeepAliveTicker } from "../../src/server/modules/core/integrated/realtime/sse-keep-alive.js";
 
 describe("SseClientTransport", () => {
 	it("delivers serialized frames through a local-session sink", async () => {
 		const frames: Uint8Array[] = [];
 		let closeCalls = 0;
-		const transport = new SseClientTransport({
-			enqueue: (frame) => frames.push(frame),
-			close: () => {
-				closeCalls += 1;
+		let desiredSize = 16;
+		const transport = new SseClientTransport(
+			{
+				get desiredSize() {
+					return desiredSize;
+				},
+				enqueue: (frame) => {
+					frames.push(frame);
+					desiredSize = 8;
+				},
+				close: () => {
+					closeCalls += 1;
+				},
 			},
-		});
+			16,
+		);
 
 		await transport.start({ onError: () => {} });
 		const sink = await transport.openSession({
@@ -30,7 +43,7 @@ describe("SseClientTransport", () => {
 
 		await expect(sink.write(frame, "latest-snapshot")).resolves.toEqual({
 			status: "accepted",
-			bufferedBytes: null,
+			bufferedBytes: 8,
 		});
 		expect(new TextDecoder().decode(frames[0])).toBe(
 			'event: snapshot\ndata: {"topicId":"posts","seq":4,"data":{"docs":[]}}\n\n',
@@ -45,6 +58,7 @@ describe("SseClientTransport", () => {
 		const failure = new Error("stream closed");
 		const errors: unknown[] = [];
 		const transport = new SseClientTransport({
+			desiredSize: null,
 			enqueue: () => {
 				throw failure;
 			},
@@ -62,5 +76,102 @@ describe("SseClientTransport", () => {
 			sink.write(encodeSseEvent("ping", { ts: 1 }), "latest-snapshot"),
 		).rejects.toBe(failure);
 		expect(errors).toEqual([failure]);
+	});
+
+	it("returns busy without enqueueing when the stream is backpressured", async () => {
+		const frames: Uint8Array[] = [];
+		const transport = new SseClientTransport(
+			{
+				desiredSize: 0,
+				enqueue: (frame) => frames.push(frame),
+				close: () => {},
+			},
+			16,
+		);
+
+		await transport.start({ onError: () => {} });
+		const sink = await transport.openSession({
+			sessionId: "session-1",
+			principal: null,
+			resolvePrincipal: async () => null,
+		});
+
+		await expect(
+			sink.write(
+				encodeSseEvent("snapshot", { topicId: "posts" }),
+				"latest-snapshot",
+			),
+		).resolves.toEqual({ status: "busy", bufferedBytes: 16 });
+		expect(frames).toHaveLength(0);
+	});
+
+	it("keeps only the latest pending snapshot per topic", async () => {
+		const accepted: string[] = [];
+		let busy = true;
+		const sink = {
+			sessionId: "session-1",
+			write: async (frame: Uint8Array) => {
+				if (busy) return { status: "busy" as const, bufferedBytes: 10 };
+				accepted.push(new TextDecoder().decode(frame));
+				return { status: "accepted" as const, bufferedBytes: 0 };
+			},
+			close: async () => {},
+		};
+		const writer = new SseLatestSnapshotWriter(sink);
+
+		await writer.write("posts", new TextEncoder().encode("posts-v1"));
+		await writer.write("posts", new TextEncoder().encode("posts-v2"));
+		await writer.write("pages", new TextEncoder().encode("pages-v1"));
+		expect(writer.bufferedBytes).toBe(16);
+
+		busy = false;
+		await writer.flush();
+
+		expect(accepted).toEqual(["posts-v2", "pages-v1"]);
+		expect(writer.bufferedBytes).toBe(0);
+	});
+});
+
+describe("SharedSseKeepAliveTicker", () => {
+	it("uses one timer for all registered sessions and emits comment frames", () => {
+		const scheduled: Array<() => void> = [];
+		let cleared = 0;
+		let now = 100;
+		const ticker = new SharedSseKeepAliveTicker({
+			now: () => now,
+			setTimeout: (callback) => {
+				scheduled.push(callback);
+				return scheduled.length;
+			},
+			clearTimeout: () => {
+				cleared += 1;
+			},
+		});
+		const frames: string[] = [];
+
+		const removeFirst = ticker.register(50, (frame) => {
+			frames.push(new TextDecoder().decode(frame));
+		});
+		const removeSecond = ticker.register(50, (frame) => {
+			frames.push(new TextDecoder().decode(frame));
+		});
+		expect(scheduled).toHaveLength(1);
+		expect(ticker.size).toBe(2);
+
+		now = 150;
+		scheduled.shift()!();
+		expect(frames).toEqual([": ping 150\n\n", ": ping 150\n\n"]);
+		expect(scheduled).toHaveLength(1);
+
+		removeFirst();
+		removeSecond();
+		expect(ticker.size).toBe(0);
+		expect(cleared).toBe(1);
+	});
+
+	it("sanitizes comment data", () => {
+		expect(new TextDecoder().decode(encodeSseComment("ping\nunsafe"))).toBe(
+			": ping\n: unsafe\n\n",
+		);
 	});
 });


### PR DESCRIPTION
## Summary
- apply byte-aware SSE backpressure with latest-wins pending snapshots per topic
- replace per-connection keepalive intervals with one shared ticker and SSE comment frames
- report buffered bytes and tear down listeners/ticker registrations on write failure

## Verification
- `cd packages/questpie && bun test test/ --test-name-pattern "sink|backpressure|realtime"` (67 pass, 0 fail)
- `cd packages/questpie && bunx tsc --noEmit -p tsconfig.json`
- `cd packages/questpie && bun run build`
- focused keepalive/backpressure/teardown tests (4 pass, 0 fail)