### PR TITLE
feat(realtime): share equivalent refresh work

### DIFF
--- a/.changeset/share-realtime-refresh-work.md
+++ b/.changeset/share-realtime-refresh-work.md
@@ -1,0 +1,5 @@
+---
+"questpie": patch
+---
+
+Share equivalent realtime refresh work safely per session, suppress unchanged snapshots, and route updates from pre/post projections.

--- a/packages/questpie/src/server/adapters/routes/realtime.ts
+++ b/packages/questpie/src/server/adapters/routes/realtime.ts
@@ -8,6 +8,10 @@
 import type { Questpie } from "../../config/questpie.js";
 import type { QuestpieConfig } from "../../config/types.js";
 import { ApiError } from "../../errors/index.js";
+import {
+	getRealtimeRefreshScheduler,
+	resolveRealtimeAccessKey,
+} from "../../modules/core/integrated/realtime/refresh-scheduler.js";
 import { computeRealtimeSnapshot } from "../../modules/core/integrated/realtime/snapshot.js";
 import {
 	encodeSseEvent,
@@ -47,13 +51,28 @@ type TopicInput = {
 type ValidatedTopic = TopicInput & {
 	type: "collection" | "global";
 	crud: any;
+	accessCacheKey?: (context: any) =>
+		| string
+		| null
+		| undefined
+		| Promise<string | null | undefined>;
 };
 
-type TopicState = {
-	refreshInFlight: boolean;
-	refreshQueued: boolean;
-	lastSeq: number;
-};
+function stableValue(value: unknown): unknown {
+	if (Array.isArray(value)) return value.map(stableValue);
+	if (!value || typeof value !== "object") return value;
+	return Object.fromEntries(
+		Object.entries(value as Record<string, unknown>)
+			.sort(([left], [right]) => left.localeCompare(right))
+			.map(([key, entry]) => [key, stableValue(entry)]),
+	);
+}
+
+function schedulerKey(topic: ValidatedTopic, accessKey: string): string {
+	const { crud: _crud, accessCacheKey: _accessCacheKey, type: _type, ...input } =
+		topic;
+	return `${JSON.stringify(stableValue(input))}:${accessKey}`;
+}
 
 function isPermanentAccessError(error: unknown): boolean {
 	return (
@@ -151,6 +170,8 @@ export async function realtimeSubscribe(
 	const globalCruds = new Map<string, any>();
 	const collectionApi = app.collections as Record<string, any>;
 	const globalApi = app.globals as Record<string, any>;
+	const collectionDefinitions = app.getCollections() as Record<string, any>;
+	const globalDefinitions = app.getGlobals() as Record<string, any>;
 
 	for (const topic of topics) {
 		if (!topic.id || typeof topic.id !== "string") {
@@ -192,14 +213,28 @@ export async function realtimeSubscribe(
 				continue;
 			}
 			collectionCruds.set(topic.resource, crud);
-			validatedTopics.push({ ...topic, type: "collection", crud });
+			validatedTopics.push({
+				...topic,
+				type: "collection",
+				crud,
+				accessCacheKey:
+					collectionDefinitions[topic.resource]?.state.options.realtime
+						?.accessCacheKey,
+			});
 		} else if (topic.resourceType === "global") {
 			try {
 				const crud =
 					globalCruds.get(topic.resource) ?? globalApi[topic.resource];
 				if (!crud) throw new Error("Global not found");
 				globalCruds.set(topic.resource, crud);
-				validatedTopics.push({ ...topic, type: "global", crud });
+				validatedTopics.push({
+					...topic,
+					type: "global",
+					crud,
+					accessCacheKey:
+						globalDefinitions[topic.resource]?.state.options.realtime
+							?.accessCacheKey,
+				});
 			} catch {
 				topicErrors.push({
 					id: topic.id,
@@ -256,33 +291,28 @@ export async function realtimeSubscribe(
 			let closed = false;
 			let closeRequested = false;
 
-			// Per-topic state
-			const topicState = new Map<string, TopicState>();
 			const requestClose = () => {
 				closeRequested = true;
 				closeStream?.();
 			};
 			const transport = new SseClientTransport(controller, highWaterMarkBytes);
 			await transport.start({ onError: requestClose });
+			const edgeSessionId = globalThis.crypto.randomUUID();
 			const sink = await transport.openSession({
-				sessionId: globalThis.crypto.randomUUID(),
+				sessionId: edgeSessionId,
 				principal: resolved.appContext.principal ?? null,
 				resolvePrincipal: async () => resolved.appContext.principal ?? null,
 			});
 			const snapshotWriter = new SseLatestSnapshotWriter(sink);
+			const refreshScheduler = getRealtimeRefreshScheduler(app, app.realtime!);
 			flushPending = () => {
 				void snapshotWriter.flush().catch(requestClose);
 			};
 
 			// Helper to send SSE event
-			const send = async (event: string, data: unknown, topicId?: string) => {
+			const send = async (event: string, data: unknown) => {
 				if (closed) return;
-				const frame = encodeSseEvent(event, data);
-				if (event === "snapshot" && topicId) {
-					await snapshotWriter.write(topicId, frame);
-					return;
-				}
-				await sink.write(frame, "latest-snapshot");
+				await sink.write(encodeSseEvent(event, data), "latest-snapshot");
 			};
 
 			// Send per-topic error
@@ -295,76 +325,45 @@ export async function realtimeSubscribe(
 				if (!unsubscribe) return;
 
 				topicUnsubscribers.delete(topicId);
-				topicState.delete(topicId);
 				unsubscribe();
 				if (topicUnsubscribers.size === 0) requestClose();
 			};
 
-			// Refresh a single topic
-			const refresh = async (topicId: string, seq?: number) => {
-				const topic = validatedTopicsById.get(topicId);
-				const state = topicState.get(topicId);
-				if (!topic || !state || closed) return;
-
-				if (typeof seq === "number") {
-					state.lastSeq = Math.max(state.lastSeq, seq);
-				}
-
-				if (state.refreshInFlight) {
-					state.refreshQueued = true;
-					return;
-				}
-
-				state.refreshInFlight = true;
-
-				// Use topic-specific locale if provided, otherwise fall back to request locale
+			// Subscribe to each topic
+			for (const topic of validatedTopicsById.values()) {
 				const topicContext =
 					topic.locale && topic.locale !== resolved.appContext.locale
 						? { ...resolved.appContext, locale: topic.locale }
 						: resolved.appContext;
-
-				try {
-					do {
-						state.refreshQueued = false;
-						const data = await computeRealtimeSnapshot(topic, topicContext);
-
-						await send("snapshot", { topicId, seq: state.lastSeq, data }, topicId);
-					} while (state.refreshQueued && !closed);
-				} catch (error) {
-					await sendTopicError(
-						topicId,
-						error instanceof Error ? error.message : "Unknown error",
-					);
-					if (isPermanentAccessError(error)) teardownTopic(topicId);
-				} finally {
-					state.refreshInFlight = false;
-				}
-			};
-
-			// Subscribe to each topic
-			for (const topic of validatedTopics) {
-				topicState.set(topic.id, {
-					refreshInFlight: false,
-					refreshQueued: false,
-					lastSeq: 0,
-				});
-
-				const unsub = app.realtime!.subscribe(
-					(event) => {
-						void refresh(topic.id, event.seq).catch((error) => {
-							void sendTopicError(
-								topic.id,
-								error instanceof Error ? error.message : "Refresh failed",
-							).catch(requestClose);
-						});
-					},
-					{
+				const accessKey = await resolveRealtimeAccessKey(
+					edgeSessionId,
+					topicContext,
+					topic.accessCacheKey,
+				);
+				const unsub = refreshScheduler.subscribe({
+					key: schedulerKey(topic, accessKey),
+					topicId: topic.id,
+					topics: {
 						resourceType: topic.resourceType,
 						resource: topic.resource,
 						where: topic.where,
 						with: topic.with,
 					},
-					(error) => {
+					compute: () => computeRealtimeSnapshot(topic, topicContext),
+					onFrame: async (frame) => {
+						await snapshotWriter.write(topic.id, frame);
+					},
+					onError: (error) => {
+						void sendTopicError(
+							topic.id,
+							error instanceof Error ? error.message : "Refresh failed",
+						)
+							.catch(requestClose)
+							.finally(() => {
+								if (isPermanentAccessError(error)) teardownTopic(topic.id);
+							});
+					},
+					onTransportError: (error) => {
 						void send("error", {
 							topicId: "*",
 							message:
@@ -375,7 +374,7 @@ export async function realtimeSubscribe(
 							.catch(() => {})
 							.finally(requestClose);
 					},
-				);
+				});
 				topicUnsubscribers.set(topic.id, unsub);
 			}
 
@@ -407,7 +406,6 @@ export async function realtimeSubscribe(
 					unsub();
 				}
 				topicUnsubscribers.clear();
-				topicState.clear();
 				void transport.stop().catch(() => {});
 			};
 			closeStream = close;
@@ -417,30 +415,6 @@ export async function realtimeSubscribe(
 			if (request.signal) {
 				request.signal.addEventListener("abort", close);
 			}
-
-			// Send initial snapshots
-			void (async () => {
-				const latestSeq = (await app.realtime?.getLatestSeq()) ?? 0;
-
-				// Initialize all topic states with latest seq
-				for (const topic of validatedTopics) {
-					const state = topicState.get(topic.id);
-					if (state) {
-						state.lastSeq = latestSeq;
-					}
-				}
-
-				// Fetch initial snapshots for all topics
-				await Promise.all(
-					validatedTopics.map((topic) => refresh(topic.id, latestSeq)),
-				);
-			})().catch((error) => {
-				void send("error", {
-					topicId: "*",
-					message:
-						error instanceof Error ? error.message : "Failed to initialize",
-				}).catch(requestClose);
-			});
 		},
 		pull: () => {
 			flushPending?.();

--- a/packages/questpie/src/server/collection/builder/types.ts
+++ b/packages/questpie/src/server/collection/builder/types.ts
@@ -107,6 +107,15 @@ export interface UploadOptions {
  */
 export interface CollectionOptions {
 	/**
+	 * Realtime sharing policy. Cross-session sharing is disabled unless this
+	 * resolver returns the same deterministic key for equivalent outputs.
+	 */
+	realtime?: {
+		accessCacheKey?: (
+			context: AppContext,
+		) => string | null | undefined | Promise<string | null | undefined>;
+	};
+	/**
 	 * Postgres schema name to place this collection's tables in.
 	 *
 	 * When unset (default), tables live in the `public` schema — current behavior.

--- a/packages/questpie/src/server/global/builder/types.ts
+++ b/packages/questpie/src/server/global/builder/types.ts
@@ -30,6 +30,15 @@ export type GlobalScopeResolver = (
  */
 export interface GlobalOptions {
 	/**
+	 * Realtime sharing policy. Cross-session sharing is disabled unless this
+	 * resolver returns the same deterministic key for equivalent outputs.
+	 */
+	realtime?: {
+		accessCacheKey?: (
+			context: AppContext,
+		) => string | null | undefined | Promise<string | null | undefined>;
+	};
+	/**
 	 * Postgres schema name to place this global's tables in.
 	 *
 	 * When unset (default), tables live in the `public` schema. When set,

--- a/packages/questpie/src/server/modules/core/integrated/realtime/refresh-scheduler.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/refresh-scheduler.ts
@@ -1,0 +1,259 @@
+import { encodeSseEvent } from "./sse-client-transport.js";
+import type {
+	RealtimeChangeEvent,
+	RealtimeErrorListener,
+	RealtimeTopics,
+} from "./types.js";
+
+type RealtimeSource = {
+	getLatestSeq(): Promise<number>;
+	subscribe(
+		listener: (event: RealtimeChangeEvent) => void,
+		topics: RealtimeTopics,
+		errorListener?: RealtimeErrorListener,
+	): () => void;
+};
+
+type AccessContext = {
+	session?: { session?: { id?: unknown } } | null;
+	principal?: {
+		kind: string;
+		session?: { id?: unknown };
+		tokenId?: unknown;
+	} | null;
+	locale?: string;
+	stage?: string;
+	accessMode?: string;
+};
+
+export type RealtimeAccessCacheKeyResolver<TContext = AccessContext> = (
+	context: TContext,
+) => string | null | undefined | Promise<string | null | undefined>;
+
+export async function resolveRealtimeAccessKey<TContext extends AccessContext>(
+	edgeSessionId: string,
+	context: TContext,
+	resolver?: RealtimeAccessCacheKeyResolver<TContext>,
+): Promise<string> {
+	let identity: string | undefined;
+	if (resolver) {
+		try {
+			const sharedKey = await resolver(context);
+			if (sharedKey) identity = `shared:${sharedKey}`;
+		} catch {
+			// An invalid opt-in must fail safe to the session-scoped default.
+		}
+	}
+
+	if (!identity) {
+		const principal = context.principal;
+		const sessionId = principal?.session?.id ?? context.session?.session?.id;
+		if (typeof sessionId === "string" && sessionId) {
+			identity = `session:${sessionId}`;
+		} else if (
+			principal?.kind === "oauth" &&
+			typeof principal.tokenId === "string" &&
+			principal.tokenId
+		) {
+			identity = `oauth:${principal.tokenId}`;
+		} else {
+			identity = `edge:${edgeSessionId}`;
+		}
+	}
+
+	return JSON.stringify([
+		identity,
+		context.locale ?? "",
+		context.stage ?? "",
+		context.accessMode ?? "",
+	]);
+}
+
+type Subscriber = {
+	onFrame: (frame: Uint8Array) => Promise<void> | void;
+	onError: RealtimeErrorListener;
+	onTransportError?: RealtimeErrorListener;
+};
+
+type SchedulerGroup = {
+	key: string;
+	topicId: string;
+	topics: RealtimeTopics;
+	compute: () => Promise<unknown>;
+	subscribers: Set<Subscriber>;
+	unsubscribe: () => void;
+	lastSeq: number;
+	lastHash?: string;
+	lastFrame?: Uint8Array;
+	refreshInFlight: boolean;
+	refreshQueued: boolean;
+	disposed: boolean;
+};
+
+export type RefreshSubscriptionInput = {
+	key: string;
+	topicId: string;
+	topics: RealtimeTopics;
+	compute: () => Promise<unknown>;
+	onFrame: (frame: Uint8Array) => Promise<void> | void;
+	onError: RealtimeErrorListener;
+	onTransportError?: RealtimeErrorListener;
+};
+
+const sha256 = async (value: string): Promise<string> => {
+	const digest = await globalThis.crypto.subtle.digest(
+		"SHA-256",
+		new TextEncoder().encode(value),
+	);
+	return Array.from(new Uint8Array(digest), (byte) =>
+		byte.toString(16).padStart(2, "0"),
+	).join("");
+};
+
+/** App-scoped compute-once/deliver-many scheduler for live-query snapshots. */
+export class RealtimeRefreshScheduler {
+	private readonly groups = new Map<string, SchedulerGroup>();
+	private readonly pendingComputations: Array<() => void> = [];
+	private activeComputations = 0;
+
+	constructor(
+		private readonly realtime: RealtimeSource,
+		private readonly maxConcurrency = 10,
+	) {}
+
+	subscribe(input: RefreshSubscriptionInput): () => void {
+		let group = this.groups.get(input.key);
+		let created = false;
+		if (!group) {
+			created = true;
+			group = {
+				key: input.key,
+				topicId: input.topicId,
+				topics: input.topics,
+				compute: input.compute,
+				subscribers: new Set(),
+				unsubscribe: () => {},
+				lastSeq: 0,
+				refreshInFlight: false,
+				refreshQueued: false,
+				disposed: false,
+			};
+			this.groups.set(input.key, group);
+			group.unsubscribe = this.realtime.subscribe(
+				(event) => this.requestRefresh(group!, event.seq),
+				input.topics,
+				(error) => this.reportTransportError(group!, error),
+			);
+		}
+
+		const subscriber: Subscriber = {
+			onFrame: input.onFrame,
+			onError: input.onError,
+			onTransportError: input.onTransportError,
+		};
+		group.subscribers.add(subscriber);
+
+		if (group.lastFrame) {
+			void Promise.resolve(input.onFrame(group.lastFrame)).catch(input.onError);
+		} else if (created) {
+			void this.initialize(group);
+		}
+
+		return () => {
+			if (!group!.subscribers.delete(subscriber)) return;
+			if (group!.subscribers.size > 0) return;
+			group!.disposed = true;
+			group!.unsubscribe();
+			this.groups.delete(group!.key);
+		};
+	}
+
+	private async initialize(group: SchedulerGroup): Promise<void> {
+		try {
+			const latestSeq = await this.realtime.getLatestSeq();
+			this.requestRefresh(group, latestSeq);
+		} catch (error) {
+			this.reportError(group, error);
+		}
+	}
+
+	private requestRefresh(group: SchedulerGroup, seq: number): void {
+		if (group.disposed) return;
+		group.lastSeq = Math.max(group.lastSeq, seq);
+		if (group.refreshInFlight) {
+			group.refreshQueued = true;
+			return;
+		}
+		group.refreshInFlight = true;
+		void this.refresh(group);
+	}
+
+	private async refresh(group: SchedulerGroup): Promise<void> {
+		try {
+			do {
+				group.refreshQueued = false;
+				const data = await this.runBounded(group.compute);
+				if (group.disposed) return;
+				const serialized = JSON.stringify(data);
+				const hash = await sha256(serialized);
+				if (hash === group.lastHash) continue;
+
+				group.lastHash = hash;
+				group.lastFrame = encodeSseEvent("snapshot", {
+					topicId: group.topicId,
+					seq: group.lastSeq,
+					data,
+				});
+				const frame = group.lastFrame;
+				for (const subscriber of group.subscribers) {
+					void Promise.resolve(subscriber.onFrame(frame)).catch(
+						subscriber.onError,
+					);
+				}
+			} while (group.refreshQueued && !group.disposed);
+		} catch (error) {
+			this.reportError(group, error);
+		} finally {
+			group.refreshInFlight = false;
+		}
+	}
+
+	private reportError(group: SchedulerGroup, error: unknown): void {
+		for (const subscriber of group.subscribers) subscriber.onError(error);
+	}
+
+	private reportTransportError(group: SchedulerGroup, error: unknown): void {
+		for (const subscriber of group.subscribers) {
+			(subscriber.onTransportError ?? subscriber.onError)(error);
+		}
+	}
+
+	private async runBounded<T>(compute: () => Promise<T>): Promise<T> {
+		if (this.activeComputations >= this.maxConcurrency) {
+			await new Promise<void>((resolve) =>
+				this.pendingComputations.push(resolve),
+			);
+		}
+		this.activeComputations += 1;
+		try {
+			return await compute();
+		} finally {
+			this.activeComputations -= 1;
+			this.pendingComputations.shift()?.();
+		}
+	}
+}
+
+const schedulers = new WeakMap<object, RealtimeRefreshScheduler>();
+
+export function getRealtimeRefreshScheduler(
+	owner: object,
+	realtime: RealtimeSource,
+): RealtimeRefreshScheduler {
+	let scheduler = schedulers.get(owner);
+	if (!scheduler) {
+		scheduler = new RealtimeRefreshScheduler(realtime);
+		schedulers.set(owner, scheduler);
+	}
+	return scheduler;
+}

--- a/packages/questpie/src/server/modules/core/integrated/realtime/service.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/service.ts
@@ -41,35 +41,22 @@ type ListenerEntry = {
 	};
 };
 
-/**
- * Extract simple equality filters from WHERE clause
- * Only extracts { field: value } and { field: { eq: value } }
- * Ignores complex operators, relations, AND/OR/NOT
- */
-function extractSimpleEquality(where: any): Record<string, any> {
-	if (!where || typeof where !== "object") return {};
-
-	const result: Record<string, any> = {};
-
-	for (const [key, value] of Object.entries(where)) {
-		// Skip logical operators and relations
-		if (["AND", "OR", "NOT", "RAW"].includes(key)) continue;
-
-		// Simple equality: { field: value }
-		if (
-			typeof value === "string" ||
-			typeof value === "number" ||
-			typeof value === "boolean"
-		) {
-			result[key] = value;
+/** Compare a durable scalar projection with a normalized equality filter. */
+function projectionMatch(
+	projection: Record<string, unknown> | null | undefined,
+	filters: Record<string, unknown>,
+): "match" | "miss" | "unknown" {
+	if (projection === null) return "miss";
+	if (!projection || typeof projection !== "object") return "unknown";
+	let missing = false;
+	for (const [key, value] of Object.entries(filters)) {
+		if (!(key in projection)) {
+			missing = true;
+			continue;
 		}
-		// Operator syntax: { field: { eq: value } }
-		else if (value && typeof value === "object" && "eq" in value) {
-			result[key] = value.eq;
-		}
+		if (projection[key] !== value) return "miss";
 	}
-
-	return result;
+	return missing ? "unknown" : "match";
 }
 
 /**
@@ -643,16 +630,6 @@ export class RealtimeService {
 	}
 
 	private emit(event: RealtimeChangeEvent): void {
-		// Extract simple equality filters from event payload for matching
-		const afterProjection = event.payload?.after;
-		const eventFilters = event.payload
-			? extractSimpleEquality(
-					afterProjection && typeof afterProjection === "object"
-						? afterProjection
-						: event.payload,
-				)
-			: {};
-
 		const candidates = new Set<ListenerEntry>();
 		if (event.resourceType === "collection") {
 			this.collectIndexedCandidates(
@@ -698,14 +675,6 @@ export class RealtimeService {
 				continue;
 			}
 
-			// For update/delete/bulk operations we do not have previous state in the
-			// event stream, so strict payload-only filtering can miss transitions where
-			// a record leaves the subscriber filter set. Always refresh these subscribers.
-			if (event.operation !== "create") {
-				notifiedListeners.add(entry);
-				continue;
-			}
-
 			// Complex WHERE clauses cannot be safely evaluated from payload-only filters.
 			// Refresh to avoid false negatives for OR/nested/operator-heavy conditions.
 			if (entry.hasComplexWhere) {
@@ -713,11 +682,22 @@ export class RealtimeService {
 				continue;
 			}
 
-			const allFiltersMatch = Object.entries(entry.whereFilters).every(
-				([key, value]) => eventFilters[key] === value,
+			const before = projectionMatch(
+				event.payload?.before,
+				entry.whereFilters,
 			);
+			const after = projectionMatch(
+				event.payload?.after,
+				entry.whereFilters,
+			);
+			const definitelyUnrelated =
+				(event.operation === "create" && after === "miss") ||
+				(event.operation === "delete" && before === "miss") ||
+				(event.operation === "update" &&
+					before === "miss" &&
+					after === "miss");
 
-			if (allFiltersMatch) {
+			if (!definitelyUnrelated) {
 				notifiedListeners.add(entry);
 			}
 		}

--- a/packages/questpie/test/integration/realtime.test.ts
+++ b/packages/questpie/test/integration/realtime.test.ts
@@ -11,7 +11,7 @@ import {
 } from "../../src/exports/index.js";
 import { sharedSseKeepAliveTicker } from "../../src/server/modules/core/integrated/realtime/sse-keep-alive.js";
 import { buildMockApp } from "../utils/mocks/mock-app-builder";
-import { createTestContext } from "../utils/test-context";
+import { createMockSession, createTestContext } from "../utils/test-context";
 import { runTestDbMigrations } from "../utils/test-db";
 
 // ============================================================================
@@ -749,6 +749,14 @@ describe("realtime", () => {
 
 			expect(filteredEvents.length).toBe(1);
 			expect(filteredEvents[0].operation).toBe("update");
+
+			filteredEvents.length = 0;
+			await setup.app.collections.posts.updateById(
+				{ id: post.id, data: { status: "archived" } },
+				ctx,
+			);
+			await new Promise((resolve) => setTimeout(resolve, 100));
+			expect(filteredEvents).toHaveLength(0);
 
 			unsub?.();
 		});
@@ -1861,6 +1869,169 @@ describe("realtime", () => {
 	});
 
 	// ==========================================================================
+	// Shared refresh scheduler
+	// ==========================================================================
+
+	describe("shared refresh scheduler", () => {
+		it("runs one pipeline for 100 same-session identical-topic connections", async () => {
+			const adapter = new MockRealtimeAdapter();
+			let pipelineRuns = 0;
+			const items = collection("items")
+				.fields(({ f }) => ({ name: f.textarea().required() }))
+				.hooks({ beforeRead: () => void (pipelineRuns += 1) })
+				.access({ read: true });
+			setup = await buildMockApp(
+				{ collections: { items } },
+				{ realtime: { adapter } },
+			);
+			await runTestDbMigrations(setup.app);
+
+			const session = createMockSession({ id: "same-user" });
+			const appContext = createTestContext({
+				session: session as any,
+				accessMode: "user",
+			});
+			const routes = createAdapterRoutes(setup.app, { accessMode: "user" });
+			const responses = await Promise.all(
+				Array.from({ length: 100 }, () =>
+					routes.realtime.subscribe(createRealtimeRequest([collectionTopic("items")]), {}, {
+						appContext,
+					}),
+				),
+			);
+			const readers = responses.map((response) => createSSEReader(response.body!));
+			await Promise.all(readers.map((reader) => reader.readSnapshot()));
+
+			expect(pipelineRuns).toBe(1);
+			expect(setup.app.realtime.listeners.size).toBe(1);
+			await Promise.all(readers.map((reader) => reader.close()));
+			expect(setup.app.realtime.listeners.size).toBe(0);
+		});
+
+		it("separates different sessions unless the entity explicitly shares", async () => {
+			const adapter = new MockRealtimeAdapter();
+			let privateRuns = 0;
+			let publicRuns = 0;
+			const privateItems = collection("privateItems")
+				.fields(({ f }) => ({ name: f.textarea().required() }))
+				.hooks({ beforeRead: () => void (privateRuns += 1) })
+				.access({ read: true });
+			const publicItems = collection("publicItems")
+				.fields(({ f }) => ({ name: f.textarea().required() }))
+				.options({ realtime: { accessCacheKey: () => "public-read" } })
+				.hooks({ beforeRead: () => void (publicRuns += 1) })
+				.access({ read: true });
+			setup = await buildMockApp(
+				{ collections: { privateItems, publicItems } },
+				{ realtime: { adapter } },
+			);
+			await runTestDbMigrations(setup.app);
+
+			const routes = createAdapterRoutes(setup.app, { accessMode: "user" });
+			const contexts = ["alice", "bob"].map((id) => ({
+				appContext: createTestContext({
+					session: createMockSession({ id }) as any,
+					accessMode: "user",
+				}),
+			}));
+			const open = async (resource: string, context: any) => {
+				const response = await routes.realtime.subscribe(
+					createRealtimeRequest([collectionTopic(resource)]),
+					{},
+					context,
+				);
+				const reader = createSSEReader(response.body!);
+				await reader.readSnapshot();
+				return reader;
+			};
+
+			const privateReaders = await Promise.all(
+				contexts.map((context) => open("privateItems", context)),
+			);
+			const publicReaders = await Promise.all(
+				contexts.map((context) => open("publicItems", context)),
+			);
+
+			expect(privateRuns).toBe(2);
+			expect(publicRuns).toBe(1);
+			await Promise.all(
+				[...privateReaders, ...publicReaders].map((reader) => reader.close()),
+			);
+		});
+
+		it("isolates row, field, and afterRead output between principals", async () => {
+			const adapter = new MockRealtimeAdapter();
+			const documents = collection("documents")
+				.fields(({ f }) => ({
+					ownerId: f.textarea().required(),
+					title: f.textarea().required(),
+					secret: f.textarea().required(),
+				}))
+				.hooks({
+					afterRead: ({ data, session }) => {
+						data.title = `${data.title}:${session?.user.id}`;
+					},
+				})
+				.access({
+					read: ({ session }) => ({ ownerId: session?.user.id }),
+					create: true,
+					fields: {
+						secret: {
+							read: ({ user }) => user?.id === "bob",
+						},
+					},
+				});
+			setup = await buildMockApp(
+				{ collections: { documents } },
+				{ realtime: { adapter } },
+			);
+			await runTestDbMigrations(setup.app);
+			const system = createTestContext();
+			await setup.app.collections.documents.create(
+				{ ownerId: "alice", title: "Alice", secret: "alice-secret" },
+				system,
+			);
+			await setup.app.collections.documents.create(
+				{ ownerId: "bob", title: "Bob", secret: "bob-secret" },
+				system,
+			);
+
+			const routes = createAdapterRoutes(setup.app, { accessMode: "user" });
+			const readFor = async (id: string, role: string) => {
+				const response = await routes.realtime.subscribe(
+					createRealtimeRequest([collectionTopic("documents")]),
+					{},
+					{
+						appContext: createTestContext({
+							session: createMockSession({ id, role }) as any,
+							accessMode: "user",
+						}),
+					},
+				);
+				const reader = createSSEReader(response.body!);
+				return { reader, snapshot: await reader.readSnapshot() };
+			};
+
+			const [alice, bob] = await Promise.all([
+				readFor("alice", "user"),
+				readFor("bob", "admin"),
+			]);
+			expect(alice.snapshot.data.data.docs).toEqual([
+				expect.objectContaining({ ownerId: "alice", title: "Alice:alice" }),
+			]);
+			expect(alice.snapshot.data.data.docs[0]).not.toHaveProperty("secret");
+			expect(bob.snapshot.data.data.docs).toEqual([
+				expect.objectContaining({
+					ownerId: "bob",
+					title: "Bob:bob",
+					secret: "bob-secret",
+				}),
+			]);
+			await Promise.all([alice.reader.close(), bob.reader.close()]);
+		});
+	});
+
+	// ==========================================================================
 	// Keepalive
 	// ==========================================================================
 
@@ -2035,7 +2206,7 @@ describe("realtime", () => {
 			}
 		});
 
-		it("should stream multiple snapshots on rapid updates", async () => {
+		it("coalesces rapid updates into a latest snapshot", async () => {
 			const adapter = new MockRealtimeAdapter();
 			const counters = collection("counters")
 				.fields(({ f }) => ({
@@ -2082,25 +2253,9 @@ describe("realtime", () => {
 			await setup.app.collections.counters.create({ name: "B", value: 2 }, ctx);
 			await setup.app.collections.counters.create({ name: "C", value: 3 }, ctx);
 
-			// Should receive snapshots reflecting the changes
-			let snapshotCount = 0;
-			const startTime = Date.now();
-
-			while (snapshotCount < 3 && Date.now() - startTime < 5000) {
-				try {
-					const snapshot = await reader.readSnapshot();
-					if (snapshot.event === "snapshot") {
-						snapshotCount++;
-						// Each snapshot should have more docs
-						expect(snapshot.data.data.docs.length).toBeGreaterThanOrEqual(0);
-					}
-				} catch {
-					break;
-				}
-			}
-
-			// We should have received at least one update
-			expect(snapshotCount).toBeGreaterThanOrEqual(1);
+			const snapshot = await reader.readSnapshot();
+			expect(snapshot.event).toBe("snapshot");
+			expect(snapshot.data.data.docs.length).toBeGreaterThanOrEqual(1);
 
 			controller.abort();
 			reader.close();

--- a/packages/questpie/test/units/realtime-refresh-scheduler.test.ts
+++ b/packages/questpie/test/units/realtime-refresh-scheduler.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+	RealtimeRefreshScheduler,
+	resolveRealtimeAccessKey,
+} from "../../src/server/modules/core/integrated/realtime/refresh-scheduler.js";
+import type {
+	RealtimeChangeEvent,
+	RealtimeTopics,
+} from "../../src/server/modules/core/integrated/realtime/types.js";
+
+class FakeRealtimeSource {
+	listeners = new Set<(event: RealtimeChangeEvent) => void>();
+
+	async getLatestSeq() {
+		return 4;
+	}
+
+	subscribe(
+		listener: (event: RealtimeChangeEvent) => void,
+		_topics: RealtimeTopics,
+	) {
+		this.listeners.add(listener);
+		return () => this.listeners.delete(listener);
+	}
+
+	emit(seq: number) {
+		const event: RealtimeChangeEvent = {
+			seq,
+			resourceType: "collection",
+			resource: "posts",
+			operation: "update",
+			createdAt: new Date(),
+		};
+		for (const listener of this.listeners) listener(event);
+	}
+}
+
+const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe("realtime scheduler", () => {
+	it("computes once for 100 equivalent subscribers and fans out one frame", async () => {
+		const realtime = new FakeRealtimeSource();
+		const scheduler = new RealtimeRefreshScheduler(realtime);
+		let computes = 0;
+		const frames = Array.from({ length: 100 }, () => [] as Uint8Array[]);
+
+		const unsubscribers = frames.map((received) =>
+			scheduler.subscribe({
+				key: "posts:session-1",
+				topicId: "posts",
+				topics: { resourceType: "collection", resource: "posts" },
+				compute: async () => ({ docs: [], totalDocs: ++computes }),
+				onFrame: async (frame) => {
+					received.push(frame);
+				},
+				onError: () => {},
+			}),
+		);
+
+		await tick();
+		expect(computes).toBe(1);
+		expect(frames.every((received) => received.length === 1)).toBe(true);
+		expect(realtime.listeners.size).toBe(1);
+
+		for (const unsubscribe of unsubscribers) unsubscribe();
+		expect(realtime.listeners.size).toBe(0);
+	});
+
+	it("does not share row, field, or afterRead output across access keys", async () => {
+		for (const variant of [
+			"row access",
+			"field access",
+			"afterRead",
+		] as const) {
+			const realtime = new FakeRealtimeSource();
+			const scheduler = new RealtimeRefreshScheduler(realtime);
+			const payloads: string[] = [];
+
+			for (const principal of ["alice", "bob"] as const) {
+				scheduler.subscribe({
+					key: `posts:${principal}`,
+					topicId: "posts",
+					topics: { resourceType: "collection", resource: "posts" },
+					compute: async () => ({ variant, principal }),
+					onFrame: async (frame) =>
+						payloads.push(new TextDecoder().decode(frame)),
+					onError: () => {},
+				});
+			}
+
+			await tick();
+			expect(payloads).toHaveLength(2);
+			expect(
+				payloads.some((payload) => payload.includes('"principal":"alice"')),
+			).toBe(true);
+			expect(
+				payloads.some((payload) => payload.includes('"principal":"bob"')),
+			).toBe(true);
+		}
+	});
+
+	it("suppresses an unchanged snapshot after a matching change", async () => {
+		const realtime = new FakeRealtimeSource();
+		const scheduler = new RealtimeRefreshScheduler(realtime);
+		let frames = 0;
+		let computes = 0;
+		scheduler.subscribe({
+			key: "posts:session-1",
+			topicId: "posts",
+			topics: { resourceType: "collection", resource: "posts" },
+			compute: async () => {
+				computes += 1;
+				return { docs: [{ id: "1", title: "same" }] };
+			},
+			onFrame: async () => {
+				frames += 1;
+			},
+			onError: () => {},
+		});
+
+		await tick();
+		realtime.emit(5);
+		await tick();
+
+		expect(computes).toBe(2);
+		expect(frames).toBe(1);
+	});
+
+	it("bounds refresh computation concurrency", async () => {
+		const realtime = new FakeRealtimeSource();
+		const scheduler = new RealtimeRefreshScheduler(realtime, 2);
+		let active = 0;
+		let maximum = 0;
+
+		for (let index = 0; index < 6; index += 1) {
+			scheduler.subscribe({
+				key: `topic-${index}`,
+				topicId: `topic-${index}`,
+				topics: { resourceType: "collection", resource: "posts" },
+				compute: async () => {
+					active += 1;
+					maximum = Math.max(maximum, active);
+					await new Promise((resolve) => setTimeout(resolve, 5));
+					active -= 1;
+					return { index };
+				},
+				onFrame: async () => {},
+				onError: () => {},
+			});
+		}
+
+		await new Promise((resolve) => setTimeout(resolve, 30));
+		expect(maximum).toBe(2);
+	});
+});
+
+describe("realtime scheduler access keys", () => {
+	it("uses session identity by default and only shares through an explicit key", async () => {
+		const base = {
+			locale: "en",
+			stage: "published",
+			accessMode: "user" as const,
+		};
+		const alice = {
+			...base,
+			principal: {
+				kind: "user" as const,
+				user: { id: "alice" },
+				session: { id: "session-a" },
+			},
+		};
+		const bob = {
+			...base,
+			principal: {
+				kind: "user" as const,
+				user: { id: "bob" },
+				session: { id: "session-b" },
+			},
+		};
+
+		const aliceDefault = await resolveRealtimeAccessKey("edge-a", alice);
+		const bobDefault = await resolveRealtimeAccessKey("edge-b", bob);
+		expect(aliceDefault).not.toBe(bobDefault);
+
+		const resolver = async () => "public-read";
+		expect(await resolveRealtimeAccessKey("edge-a", alice, resolver)).toBe(
+			await resolveRealtimeAccessKey("edge-b", bob, resolver),
+		);
+	});
+});


### PR DESCRIPTION
## Summary
- add an app-scoped, concurrency-bounded refresh scheduler that computes and serializes once for equivalent subscribers
- default sharing to session-scoped access keys and require an explicit collection/global resolver for cross-principal sharing
- suppress unchanged snapshots and use pre/post scalar projections to skip definitely unrelated update/delete refreshes

## Safety evidence
- 100 same-session identical-topic SSE connections execute one CRUD pipeline and one realtime listener
- different sessions execute separate pipelines; explicit `public-read` opt-in shares safely
- adversarial row access, field redaction, and afterRead output remain isolated across principals

## Verification
- `cd packages/questpie && bun test test/ --test-name-pattern "realtime|scheduler"` (73 pass, 0 fail)
- `cd packages/questpie && bunx tsc --noEmit -p tsconfig.json`
- `cd packages/questpie && bun run build`
- targeted oxlint: 0 errors (2 pre-existing underscore warnings)