### PR TITLE
feat(realtime): enforce subscription admission

### DIFF
--- a/.changeset/enforce-realtime-admission.md
+++ b/.changeset/enforce-realtime-admission.md
@@ -1,0 +1,5 @@
+---
+"questpie": patch
+---
+
+Reject unauthorized or over-limit realtime subscriptions before allocating SSE resources, and bound live-query work and buffering.

--- a/packages/questpie/src/exports/realtime.ts
+++ b/packages/questpie/src/exports/realtime.ts
@@ -1,4 +1,8 @@
 export * from "#questpie/server/modules/core/integrated/realtime/adapter.js";
+export {
+	DEFAULT_REALTIME_ADMISSION,
+	type RealtimeAdmissionConfig,
+} from "#questpie/server/modules/core/integrated/realtime/admission.js";
 export * from "#questpie/server/modules/core/integrated/realtime/collection.js";
 export * from "#questpie/server/modules/core/integrated/realtime/service.js";
 export * from "#questpie/server/modules/core/integrated/realtime/snapshot.js";

--- a/packages/questpie/src/server/adapters/routes/realtime.ts
+++ b/packages/questpie/src/server/adapters/routes/realtime.ts
@@ -5,9 +5,17 @@
  * Accepts multiple topics via POST and streams updates for all of them.
  */
 
+import { executeAccessRule } from "../../collection/crud/shared/access-control.js";
 import type { Questpie } from "../../config/questpie.js";
 import type { QuestpieConfig } from "../../config/types.js";
 import { ApiError } from "../../errors/index.js";
+import {
+	admitRealtimeTopic,
+	createConcurrencyLimiter,
+	getRealtimeAdmissionRegistry,
+	realtimePrincipalKey,
+	resolveRealtimeAdmissionConfig,
+} from "../../modules/core/integrated/realtime/admission.js";
 import {
 	getRealtimeRefreshScheduler,
 	resolveRealtimeAccessKey,
@@ -15,6 +23,7 @@ import {
 import { computeRealtimeSnapshot } from "../../modules/core/integrated/realtime/snapshot.js";
 import {
 	encodeSseEvent,
+	RealtimeSnapshotBufferOverflowError,
 	SseClientTransport,
 	SseLatestSnapshotWriter,
 } from "../../modules/core/integrated/realtime/sse-client-transport.js";
@@ -51,12 +60,65 @@ type TopicInput = {
 type ValidatedTopic = TopicInput & {
 	type: "collection" | "global";
 	crud: any;
-	accessCacheKey?: (context: any) =>
-		| string
-		| null
-		| undefined
-		| Promise<string | null | undefined>;
+	definition: any;
+	accessWhere?: true | Record<string, unknown>;
+	requestedWhere?: Record<string, unknown>;
+	accessCacheKey?: (
+		context: any,
+	) => string | null | undefined | Promise<string | null | undefined>;
 };
+
+function mergeAccessWhere(
+	where: Record<string, unknown> | undefined,
+	access: true | Record<string, unknown>,
+): Record<string, unknown> | undefined {
+	if (access === true) return where;
+	return where ? { AND: [access, where] } : access;
+}
+
+async function evaluateTopicAccess(
+	app: Questpie<any>,
+	topic: ValidatedTopic,
+	context: any,
+): Promise<ValidatedTopic> {
+	if (context.accessMode === "system") return topic;
+	const rule = topic.definition.state.access?.read ?? app.defaultAccess?.read;
+	const result = await executeAccessRule(rule, {
+		app,
+		db: context.db,
+		session: context.session,
+		locale: context.locale,
+		row: null,
+		input: {
+			where: topic.requestedWhere,
+			with: topic.with,
+			limit: topic.limit,
+			offset: topic.offset,
+			orderBy: topic.orderBy,
+		},
+		request: context.request ?? context.req,
+		contextExtensions: context["~contextExtensions"],
+	});
+	if (result === false) {
+		throw ApiError.forbidden({
+			operation: "read",
+			resource: topic.resource,
+			reason: "User does not have permission to subscribe",
+		});
+	}
+	if (topic.type === "global" && result !== true) {
+		throw ApiError.forbidden({
+			operation: "read",
+			resource: topic.resource,
+			reason: "Global access rules must admit the topic explicitly",
+		});
+	}
+	return {
+		...topic,
+		accessWhere: result,
+		where: mergeAccessWhere(topic.requestedWhere, result),
+	};
+}
 
 function stableValue(value: unknown): unknown {
 	if (Array.isArray(value)) return value.map(stableValue);
@@ -69,8 +131,15 @@ function stableValue(value: unknown): unknown {
 }
 
 function schedulerKey(topic: ValidatedTopic, accessKey: string): string {
-	const { crud: _crud, accessCacheKey: _accessCacheKey, type: _type, ...input } =
-		topic;
+	const {
+		crud: _crud,
+		definition: _definition,
+		accessWhere: _accessWhere,
+		accessCacheKey: _accessCacheKey,
+		requestedWhere: _requestedWhere,
+		type: _type,
+		...input
+	} = topic;
 	return `${JSON.stringify(stableValue(input))}:${accessKey}`;
 }
 
@@ -149,6 +218,9 @@ export async function realtimeSubscribe(
 	}
 
 	const { topics } = body;
+	const admission = resolveRealtimeAdmissionConfig(
+		app.config?.realtime?.admission,
+	);
 
 	// Validate topics
 	if (!Array.isArray(topics) || topics.length === 0) {
@@ -173,7 +245,19 @@ export async function realtimeSubscribe(
 	const collectionDefinitions = app.getCollections() as Record<string, any>;
 	const globalDefinitions = app.getGlobals() as Record<string, any>;
 
-	for (const topic of topics) {
+	for (const [topicIndex, rawTopic] of topics.entries()) {
+		if (!rawTopic || typeof rawTopic !== "object" || Array.isArray(rawTopic)) {
+			topicErrors.push({ id: "unknown", message: "Topic must be an object" });
+			continue;
+		}
+		let topic = rawTopic;
+		if (topicIndex >= admission.maxTopicsPerConnection) {
+			topicErrors.push({
+				id: topic.id ?? "unknown",
+				message: `Connection accepts at most ${admission.maxTopicsPerConnection} topics`,
+			});
+			continue;
+		}
 		if (!topic.id || typeof topic.id !== "string") {
 			topicErrors.push({
 				id: topic.id ?? "unknown",
@@ -198,6 +282,13 @@ export async function realtimeSubscribe(
 			continue;
 		}
 
+		const topicAdmission = admitRealtimeTopic(topic, admission);
+		if (!topicAdmission.accepted) {
+			topicErrors.push({ id: topic.id, message: topicAdmission.message });
+			continue;
+		}
+		topic = topicAdmission.topic;
+
 		if (topic.resourceType === "collection") {
 			const crud =
 				collectionCruds.get(topic.resource) ?? collectionApi[topic.resource];
@@ -213,13 +304,14 @@ export async function realtimeSubscribe(
 				continue;
 			}
 			collectionCruds.set(topic.resource, crud);
+			const definition = collectionDefinitions[topic.resource];
 			validatedTopics.push({
 				...topic,
 				type: "collection",
 				crud,
-				accessCacheKey:
-					collectionDefinitions[topic.resource]?.state.options.realtime
-						?.accessCacheKey,
+				definition,
+				requestedWhere: topic.where,
+				accessCacheKey: definition?.state.options.realtime?.accessCacheKey,
 			});
 		} else if (topic.resourceType === "global") {
 			try {
@@ -227,13 +319,14 @@ export async function realtimeSubscribe(
 					globalCruds.get(topic.resource) ?? globalApi[topic.resource];
 				if (!crud) throw new Error("Global not found");
 				globalCruds.set(topic.resource, crud);
+				const definition = globalDefinitions[topic.resource];
 				validatedTopics.push({
 					...topic,
 					type: "global",
 					crud,
-					accessCacheKey:
-						globalDefinitions[topic.resource]?.state.options.realtime
-							?.accessCacheKey,
+					definition,
+					requestedWhere: topic.where,
+					accessCacheKey: definition?.state.options.realtime?.accessCacheKey,
 				});
 			} catch {
 				topicErrors.push({
@@ -272,157 +365,259 @@ export async function realtimeSubscribe(
 		);
 	}
 
-	const validatedTopicsById = new Map<string, ValidatedTopic>();
+	const accessValidatedTopics: ValidatedTopic[] = [];
 	for (const topic of validatedTopics) {
+		const topicContext =
+			topic.locale && topic.locale !== resolved.appContext.locale
+				? { ...resolved.appContext, locale: topic.locale }
+				: resolved.appContext;
+		try {
+			accessValidatedTopics.push(
+				await evaluateTopicAccess(app, topic, topicContext),
+			);
+		} catch (error) {
+			topicErrors.push({
+				id: topic.id,
+				message: error instanceof Error ? error.message : "Access denied",
+			});
+		}
+	}
+
+	if (accessValidatedTopics.length === 0) {
+		const errors = topicErrors
+			.map((error) => `${error.id}: ${error.message}`)
+			.join("; ");
+		return errorResponse(
+			ApiError.badRequest(
+				`No topics admitted. Errors: ${errors}`,
+				undefined,
+				"realtime.noAdmittedTopics",
+				{ errors },
+			),
+			request,
+			resolved.appContext.locale,
+		);
+	}
+
+	const validatedTopicsById = new Map<string, ValidatedTopic>();
+	for (const topic of accessValidatedTopics) {
 		// Preserve the existing first-match behavior for duplicate topic ids.
 		if (!validatedTopicsById.has(topic.id)) {
 			validatedTopicsById.set(topic.id, topic);
 		}
 	}
 
+	const admissionRegistry = getRealtimeAdmissionRegistry(
+		app,
+		admission.maxConnectionsPerPrincipal,
+	);
+	const releaseConnection = admissionRegistry.acquire(
+		realtimePrincipalKey(resolved.appContext),
+	);
+	if (!releaseConnection) {
+		return errorResponse(
+			ApiError.badRequest(
+				"Realtime connection limit exceeded",
+				undefined,
+				"realtime.connectionLimitExceeded",
+			),
+			request,
+			resolved.appContext.locale,
+		);
+	}
+
 	// Create SSE stream
 	let closeStream: (() => void) | null = null;
 	let flushPending: (() => void) | null = null;
-	const highWaterMarkBytes = 1024 * 1024;
+	let streamCancelled = false;
+	const highWaterMarkBytes = admission.maxBufferedSnapshotBytes;
 
-	const stream = new ReadableStream<Uint8Array>({
+	const streamSource: UnderlyingDefaultSource<Uint8Array> = {
 		start: async (controller) => {
-			const topicUnsubscribers = new Map<string, () => void>();
-			let closed = false;
-			let closeRequested = false;
+			let transport: SseClientTransport | null = null;
+			try {
+				const topicUnsubscribers = new Map<string, () => void>();
+				let closed = false;
+				let closeRequested = false;
 
-			const requestClose = () => {
-				closeRequested = true;
-				closeStream?.();
-			};
-			const transport = new SseClientTransport(controller, highWaterMarkBytes);
-			await transport.start({ onError: requestClose });
-			const edgeSessionId = globalThis.crypto.randomUUID();
-			const sink = await transport.openSession({
-				sessionId: edgeSessionId,
-				principal: resolved.appContext.principal ?? null,
-				resolvePrincipal: async () => resolved.appContext.principal ?? null,
-			});
-			const snapshotWriter = new SseLatestSnapshotWriter(sink);
-			const refreshScheduler = getRealtimeRefreshScheduler(app, app.realtime!);
-			flushPending = () => {
-				void snapshotWriter.flush().catch(requestClose);
-			};
-
-			// Helper to send SSE event
-			const send = async (event: string, data: unknown) => {
-				if (closed) return;
-				await sink.write(encodeSseEvent(event, data), "latest-snapshot");
-			};
-
-			// Send per-topic error
-			const sendTopicError = (topicId: string, message: string) => {
-				return send("error", { topicId, message });
-			};
-
-			const teardownTopic = (topicId: string) => {
-				const unsubscribe = topicUnsubscribers.get(topicId);
-				if (!unsubscribe) return;
-
-				topicUnsubscribers.delete(topicId);
-				unsubscribe();
-				if (topicUnsubscribers.size === 0) requestClose();
-			};
-
-			// Subscribe to each topic
-			for (const topic of validatedTopicsById.values()) {
-				const topicContext =
-					topic.locale && topic.locale !== resolved.appContext.locale
-						? { ...resolved.appContext, locale: topic.locale }
-						: resolved.appContext;
-				const accessKey = await resolveRealtimeAccessKey(
-					edgeSessionId,
-					topicContext,
-					topic.accessCacheKey,
-				);
-				const unsub = refreshScheduler.subscribe({
-					key: schedulerKey(topic, accessKey),
-					topicId: topic.id,
-					topics: {
-						resourceType: topic.resourceType,
-						resource: topic.resource,
-						where: topic.where,
-						with: topic.with,
-					},
-					compute: () => computeRealtimeSnapshot(topic, topicContext),
-					onFrame: async (frame) => {
-						await snapshotWriter.write(topic.id, frame);
-					},
-					onError: (error) => {
-						void sendTopicError(
-							topic.id,
-							error instanceof Error ? error.message : "Refresh failed",
-						)
-							.catch(requestClose)
-							.finally(() => {
-								if (isPermanentAccessError(error)) teardownTopic(topic.id);
-							});
-					},
-					onTransportError: (error) => {
-						void send("error", {
-							topicId: "*",
-							message:
-								error instanceof Error
-									? error.message
-									: "Realtime transport failed",
-						})
-							.catch(() => {})
-							.finally(requestClose);
-					},
+				const requestClose = () => {
+					closeRequested = true;
+					closeStream?.();
+				};
+				transport = new SseClientTransport(controller, highWaterMarkBytes);
+				await transport.start({ onError: requestClose });
+				const edgeSessionId = globalThis.crypto.randomUUID();
+				const sink = await transport.openSession({
+					sessionId: edgeSessionId,
+					principal: resolved.appContext.principal ?? null,
+					resolvePrincipal: async () => resolved.appContext.principal ?? null,
 				});
-				topicUnsubscribers.set(topic.id, unsub);
-			}
-
-			// Send initial errors for invalid topics
-			for (const error of topicErrors) {
-				await sendTopicError(error.id, error.message);
-			}
-
-			// Shared ping ticker keeps the connection alive. Default 8s — strictly under
-			// Bun's default 10s idleTimeout and typical proxy timeouts of 30-60s.
-			const keepAliveIntervalMs =
-				app.config?.realtime?.keepAliveIntervalMs ?? 8000;
-			const removeKeepAlive = sharedSseKeepAliveTicker.register(
-				keepAliveIntervalMs,
-				(frame) => {
-					void sink.write(frame, "latest-snapshot").catch(requestClose);
-				},
-			);
-
-			// Cleanup function
-			const close = () => {
-				if (closed) return;
-				closed = true;
-				removeKeepAlive();
-				flushPending = null;
-				snapshotWriter.clear();
-				request.signal.removeEventListener("abort", close);
-				for (const unsub of topicUnsubscribers.values()) {
-					unsub();
+				const snapshotWriter = new SseLatestSnapshotWriter(
+					sink,
+					admission.maxBufferedSnapshotBytes,
+				);
+				const refreshScheduler = getRealtimeRefreshScheduler(
+					app,
+					app.realtime!,
+				);
+				const limitSnapshotConcurrency = createConcurrencyLimiter(
+					admission.initialSnapshotConcurrency,
+				);
+				let removeKeepAlive = () => {};
+				flushPending = () => {
+					void snapshotWriter.flush().catch(requestClose);
+				};
+				const close = () => {
+					if (closed) return;
+					closed = true;
+					releaseConnection();
+					removeKeepAlive();
+					flushPending = null;
+					snapshotWriter.clear();
+					request.signal.removeEventListener("abort", close);
+					for (const unsub of topicUnsubscribers.values()) {
+						unsub();
+					}
+					topicUnsubscribers.clear();
+					void transport?.stop().catch(() => {});
+				};
+				closeStream = close;
+				if (closeRequested || streamCancelled || request.signal.aborted) {
+					close();
+					return;
 				}
-				topicUnsubscribers.clear();
-				void transport.stop().catch(() => {});
-			};
-			closeStream = close;
-			if (closeRequested) close();
-
-			// Handle abort signal
-			if (request.signal) {
 				request.signal.addEventListener("abort", close);
+
+				// Helper to send SSE event
+				const send = async (event: string, data: unknown) => {
+					if (closed) return;
+					await sink.write(encodeSseEvent(event, data), "latest-snapshot");
+				};
+
+				// Send per-topic error
+				const sendTopicError = (topicId: string, message: string) => {
+					return send("error", { topicId, message });
+				};
+
+				const teardownTopic = (topicId: string) => {
+					const unsubscribe = topicUnsubscribers.get(topicId);
+					if (!unsubscribe) return;
+
+					topicUnsubscribers.delete(topicId);
+					unsubscribe();
+					if (topicUnsubscribers.size === 0) requestClose();
+				};
+
+				// Subscribe to each topic
+				for (const topic of validatedTopicsById.values()) {
+					if (closed) break;
+					const topicContext =
+						topic.locale && topic.locale !== resolved.appContext.locale
+							? { ...resolved.appContext, locale: topic.locale }
+							: resolved.appContext;
+					const accessKey = await resolveRealtimeAccessKey(
+						edgeSessionId,
+						topicContext,
+						topic.accessCacheKey,
+					);
+					const unsub = refreshScheduler.subscribe({
+						key: schedulerKey(topic, accessKey),
+						topicId: topic.id,
+						topics: {
+							resourceType: topic.resourceType,
+							resource: topic.resource,
+							where: topic.where,
+							with: topic.with,
+						},
+						compute: () =>
+							limitSnapshotConcurrency(async () => {
+								const admittedTopic = await evaluateTopicAccess(
+									app,
+									topic,
+									topicContext,
+								);
+								return computeRealtimeSnapshot(admittedTopic, topicContext);
+							}),
+						onFrame: async (frame) => {
+							if (frame.byteLength > admission.maxBufferedSnapshotBytes) {
+								await sendTopicError(
+									topic.id,
+									`Snapshot exceeds ${admission.maxBufferedSnapshotBytes} bytes`,
+								);
+								teardownTopic(topic.id);
+								return;
+							}
+							await snapshotWriter.write(topic.id, frame);
+						},
+						onError: (error) => {
+							void sendTopicError(
+								topic.id,
+								error instanceof Error ? error.message : "Refresh failed",
+							)
+								.catch(requestClose)
+								.finally(() => {
+									if (
+										isPermanentAccessError(error) ||
+										error instanceof RealtimeSnapshotBufferOverflowError
+									) {
+										teardownTopic(topic.id);
+									}
+								});
+						},
+						onTransportError: (error) => {
+							void send("error", {
+								topicId: "*",
+								message:
+									error instanceof Error
+										? error.message
+										: "Realtime transport failed",
+							})
+								.catch(() => {})
+								.finally(requestClose);
+						},
+					});
+					topicUnsubscribers.set(topic.id, unsub);
+				}
+
+				// Send initial errors for invalid topics
+				for (const error of topicErrors) {
+					await sendTopicError(error.id, error.message);
+				}
+				if (closed) return;
+
+				// Shared ping ticker keeps the connection alive. Default 8s — strictly under
+				// Bun's default 10s idleTimeout and typical proxy timeouts of 30-60s.
+				const keepAliveIntervalMs =
+					app.config?.realtime?.keepAliveIntervalMs ?? 8000;
+				removeKeepAlive = sharedSseKeepAliveTicker.register(
+					keepAliveIntervalMs,
+					(frame) => {
+						void sink.write(frame, "latest-snapshot").catch(requestClose);
+					},
+				);
+
+				if (closeRequested || streamCancelled) close();
+			} catch (error) {
+				closeStream?.();
+				releaseConnection();
+				void transport?.stop().catch(() => {});
+				try {
+					controller.error(error);
+				} catch {
+					// The controller can already be errored by the runtime.
+				}
 			}
 		},
 		pull: () => {
 			flushPending?.();
 		},
 		cancel: () => {
+			streamCancelled = true;
+			releaseConnection();
 			closeStream?.();
 		},
-	}, {
+	};
+	const stream = new ReadableStream<Uint8Array>(streamSource, {
 		highWaterMark: highWaterMarkBytes,
 		size: (frame) => frame?.byteLength ?? 0,
 	});

--- a/packages/questpie/src/server/collection/crud/crud-generator.ts
+++ b/packages/questpie/src/server/collection/crud/crud-generator.ts
@@ -49,6 +49,7 @@ import {
 	matchesAccessConditions,
 	mergeFieldAccessRules,
 	mergeWhereWithAccess,
+	PRECHECKED_READ_ACCESS,
 	removeRestrictedReadFields,
 	validateFieldsWriteAccess,
 } from "#questpie/server/collection/crud/shared/access-control.js";
@@ -480,9 +481,18 @@ export class CRUDGenerator<TState extends CollectionBuilderState> {
 				// field-level read filtering below stays active.
 				const inheritAccess =
 					(options as Record<PropertyKey, unknown>)[INHERIT_ACCESS] === true;
+				const precheckedAccess = (options as Record<PropertyKey, unknown>)[
+					PRECHECKED_READ_ACCESS
+				] as AccessWhere | true | undefined;
 				const accessWhere = inheritAccess
 					? true
-					: await this.enforceAccessControl("read", normalized, null, options);
+					: (precheckedAccess ??
+						(await this.enforceAccessControl(
+							"read",
+							normalized,
+							null,
+							options,
+						)));
 
 				// Access explicitly denied
 				if (accessWhere === false) {

--- a/packages/questpie/src/server/collection/crud/shared/access-control.ts
+++ b/packages/questpie/src/server/collection/crud/shared/access-control.ts
@@ -20,6 +20,9 @@ import type {
 
 import { getDb, normalizeContext } from "./context.js";
 
+/** Internal, non-JSON marker for access already evaluated before CRUD hooks. */
+export const PRECHECKED_READ_ACCESS = Symbol("questpie.precheckedReadAccess");
+
 type FieldDefinitionLike = {
 	_state?: {
 		access?: FieldAccess;

--- a/packages/questpie/src/server/collection/crud/shared/index.ts
+++ b/packages/questpie/src/server/collection/crud/shared/index.ts
@@ -14,6 +14,7 @@ export {
 	matchesAccessConditions,
 	mergeFieldAccessRules,
 	mergeWhereWithAccess,
+	PRECHECKED_READ_ACCESS,
 	removeRestrictedReadFields,
 	validateFieldsWriteAccess,
 } from "./access-control.js";

--- a/packages/questpie/src/server/global/crud/global-crud-generator.ts
+++ b/packages/questpie/src/server/global/crud/global-crud-generator.ts
@@ -21,6 +21,7 @@ import {
 	normalizeContext,
 	normalizeJsonbInput,
 	onAfterCommit,
+	PRECHECKED_READ_ACCESS,
 	removeRestrictedReadFields,
 	splitLocalizedFields,
 	validateFieldsWriteAccess,
@@ -397,12 +398,11 @@ export class GlobalCRUDGenerator<TState extends GlobalBuilderState> {
 			const scopeId = isScoped ? this.resolveScopeId(normalized) : undefined;
 
 			// Enforce access control
-			const canRead = await this.enforceAccessControl(
-				"read",
-				normalized,
-				null,
-				options,
-			);
+			const canRead =
+				(options as Record<PropertyKey, unknown>)[PRECHECKED_READ_ACCESS] ===
+				true
+					? true
+					: await this.enforceAccessControl("read", normalized, null, options);
 			if (!canRead) {
 				throw ApiError.forbidden({
 					operation: "read",

--- a/packages/questpie/src/server/modules/core/integrated/realtime/admission.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/admission.ts
@@ -1,0 +1,178 @@
+export type RealtimeAdmissionConfig = {
+	maxTopicsPerConnection: number;
+	maxConnectionsPerPrincipal: number;
+	maxFindLimit: number;
+	maxWithDepth: number;
+	initialSnapshotConcurrency: number;
+	maxBufferedSnapshotBytes: number;
+};
+
+export const DEFAULT_REALTIME_ADMISSION: RealtimeAdmissionConfig = {
+	maxTopicsPerConnection: 20,
+	maxConnectionsPerPrincipal: 5,
+	maxFindLimit: 100,
+	maxWithDepth: 3,
+	initialSnapshotConcurrency: 4,
+	maxBufferedSnapshotBytes: 1024 * 1024,
+};
+
+export function resolveRealtimeAdmissionConfig(
+	config?: Partial<RealtimeAdmissionConfig>,
+): RealtimeAdmissionConfig {
+	const positiveInteger = (value: unknown, fallback: number) =>
+		Number.isFinite(value) && Number.isInteger(value) && (value as number) >= 1
+			? (value as number)
+			: fallback;
+	const nonNegativeInteger = (value: unknown, fallback: number) =>
+		Number.isFinite(value) && Number.isInteger(value) && (value as number) >= 0
+			? (value as number)
+			: fallback;
+
+	return {
+		maxTopicsPerConnection: positiveInteger(
+			config?.maxTopicsPerConnection,
+			DEFAULT_REALTIME_ADMISSION.maxTopicsPerConnection,
+		),
+		maxConnectionsPerPrincipal: positiveInteger(
+			config?.maxConnectionsPerPrincipal,
+			DEFAULT_REALTIME_ADMISSION.maxConnectionsPerPrincipal,
+		),
+		maxFindLimit: positiveInteger(
+			config?.maxFindLimit,
+			DEFAULT_REALTIME_ADMISSION.maxFindLimit,
+		),
+		maxWithDepth: nonNegativeInteger(
+			config?.maxWithDepth,
+			DEFAULT_REALTIME_ADMISSION.maxWithDepth,
+		),
+		initialSnapshotConcurrency: positiveInteger(
+			config?.initialSnapshotConcurrency,
+			DEFAULT_REALTIME_ADMISSION.initialSnapshotConcurrency,
+		),
+		maxBufferedSnapshotBytes: positiveInteger(
+			config?.maxBufferedSnapshotBytes,
+			DEFAULT_REALTIME_ADMISSION.maxBufferedSnapshotBytes,
+		),
+	};
+}
+
+type AdmissionTopic = {
+	id: string;
+	resourceType: "collection" | "global";
+	resource: string;
+	limit?: number;
+	with?: Record<string, unknown>;
+} & Record<string, unknown>;
+
+export type TopicAdmissionResult<TTopic extends AdmissionTopic> =
+	| { accepted: true; topic: TTopic & { limit: number } }
+	| { accepted: false; message: string };
+
+function withDepth(withConfig: Record<string, unknown> | undefined): number {
+	if (!withConfig) return 0;
+	let maximum = 0;
+	for (const value of Object.values(withConfig)) {
+		if (!value) continue;
+		let depth = 1;
+		if (typeof value === "object" && !Array.isArray(value)) {
+			const nested = (value as { with?: Record<string, unknown> }).with;
+			depth += withDepth(nested);
+		}
+		maximum = Math.max(maximum, depth);
+	}
+	return maximum;
+}
+
+export function admitRealtimeTopic<TTopic extends AdmissionTopic>(
+	topic: TTopic,
+	config: RealtimeAdmissionConfig,
+): TopicAdmissionResult<TTopic> {
+	if (topic.with && withDepth(topic.with) > config.maxWithDepth) {
+		return {
+			accepted: false,
+			message: `Topic exceeds maximum relation depth of ${config.maxWithDepth}`,
+		};
+	}
+
+	const limit = topic.limit ?? config.maxFindLimit;
+	if (!Number.isInteger(limit) || limit < 1 || limit > config.maxFindLimit) {
+		return {
+			accepted: false,
+			message: `Topic limit must be between 1 and ${config.maxFindLimit}`,
+		};
+	}
+
+	return { accepted: true, topic: { ...topic, limit } };
+}
+
+export class RealtimeAdmissionRegistry {
+	private readonly counts = new Map<string, number>();
+
+	constructor(private readonly maximum: number) {}
+
+	acquire(principalKey: string | null): (() => void) | null {
+		if (principalKey === null) return () => {};
+		const count = this.counts.get(principalKey) ?? 0;
+		if (count >= this.maximum) return null;
+		this.counts.set(principalKey, count + 1);
+		let released = false;
+		return () => {
+			if (released) return;
+			released = true;
+			const next = (this.counts.get(principalKey) ?? 1) - 1;
+			if (next === 0) this.counts.delete(principalKey);
+			else this.counts.set(principalKey, next);
+		};
+	}
+}
+
+const registries = new WeakMap<object, RealtimeAdmissionRegistry>();
+
+export function getRealtimeAdmissionRegistry(
+	owner: object,
+	maximum: number,
+): RealtimeAdmissionRegistry {
+	let registry = registries.get(owner);
+	if (!registry) {
+		registry = new RealtimeAdmissionRegistry(maximum);
+		registries.set(owner, registry);
+	}
+	return registry;
+}
+
+export function realtimePrincipalKey(context: {
+	principal?: {
+		kind: string;
+		user?: { id?: unknown };
+		tokenId?: unknown;
+	} | null;
+	session?: { user?: { id?: unknown }; session?: { id?: unknown } } | null;
+}): string | null {
+	const userId = context.principal?.user?.id ?? context.session?.user?.id;
+	if (typeof userId === "string" && userId) return `user:${userId}`;
+	const tokenId = context.principal?.tokenId;
+	if (typeof tokenId === "string" && tokenId) return `oauth:${tokenId}`;
+	const sessionId = context.session?.session?.id;
+	return typeof sessionId === "string" && sessionId
+		? `session:${sessionId}`
+		: null;
+}
+
+export function createConcurrencyLimiter(maximum: number) {
+	const limit =
+		Number.isFinite(maximum) && maximum >= 1 ? Math.floor(maximum) : 1;
+	let active = 0;
+	const pending: Array<() => void> = [];
+	return async <T>(operation: () => Promise<T>): Promise<T> => {
+		if (active >= limit) {
+			await new Promise<void>((resolve) => pending.push(resolve));
+		}
+		active += 1;
+		try {
+			return await operation();
+		} finally {
+			active -= 1;
+			pending.shift()?.();
+		}
+	};
+}

--- a/packages/questpie/src/server/modules/core/integrated/realtime/snapshot.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/snapshot.ts
@@ -1,3 +1,5 @@
+import { PRECHECKED_READ_ACCESS } from "#questpie/server/collection/crud/shared/access-control.js";
+
 type CollectionSnapshotCrud = {
 	find(options: Record<string, unknown>, context: unknown): Promise<unknown>;
 };
@@ -7,6 +9,7 @@ type GlobalSnapshotCrud = {
 };
 
 type SnapshotQuery = {
+	accessWhere?: true | Record<string, unknown>;
 	where?: Record<string, unknown>;
 	with?: Record<string, unknown>;
 	limit?: number;
@@ -27,6 +30,7 @@ export function computeRealtimeSnapshot(
 	if (topic.type === "collection") {
 		return topic.crud.find(
 			{
+				[PRECHECKED_READ_ACCESS]: topic.accessWhere,
 				where: topic.where,
 				with: topic.with,
 				limit: topic.limit,
@@ -40,6 +44,7 @@ export function computeRealtimeSnapshot(
 
 	return topic.crud.get(
 		{
+			[PRECHECKED_READ_ACCESS]: topic.accessWhere,
 			where: topic.where,
 			with: topic.with,
 			locale: topic.locale,

--- a/packages/questpie/src/server/modules/core/integrated/realtime/sse-client-transport.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/sse-client-transport.ts
@@ -47,7 +47,8 @@ class SseClientSink implements ClientSink {
 		}
 		if (
 			this.controller.desiredSize !== null &&
-			this.controller.desiredSize <= 0
+			(this.controller.desiredSize <= 0 ||
+				frame.byteLength > this.controller.desiredSize)
 		) {
 			return {
 				status: "busy",
@@ -86,6 +87,13 @@ class SseClientSink implements ClientSink {
 	}
 }
 
+export class RealtimeSnapshotBufferOverflowError extends Error {
+	constructor(readonly maximumBytes: number) {
+		super(`Realtime snapshot buffer exceeds ${maximumBytes} bytes`);
+		this.name = "RealtimeSnapshotBufferOverflowError";
+	}
+}
+
 /** Per-session latest-wins queue used when an SSE stream applies backpressure. */
 export class SseLatestSnapshotWriter {
 	private readonly pending = new Map<string, Uint8Array>();
@@ -93,7 +101,10 @@ export class SseLatestSnapshotWriter {
 	private closed = false;
 	private pendingBytes = 0;
 
-	constructor(private readonly sink: ClientSink) {}
+	constructor(
+		private readonly sink: ClientSink,
+		private readonly maximumBufferedBytes = 1024 * 1024,
+	) {}
 
 	get bufferedBytes(): number {
 		return this.pendingBytes;
@@ -101,11 +112,12 @@ export class SseLatestSnapshotWriter {
 
 	write(topicId: string, frame: Uint8Array): Promise<SinkWriteResult> {
 		return this.run(async () => {
-			if (this.closed) throw new Error("Realtime SSE snapshot writer is closed");
+			if (this.closed)
+				throw new Error("Realtime SSE snapshot writer is closed");
 			this.removePending(topicId);
 			const result = await this.sink.write(frame, "latest-snapshot");
 			if (!this.closed && result.status === "busy") {
-				this.setPending(topicId, frame);
+				this.setPending(topicId, frame, result.bufferedBytes);
 			}
 			return result.status === "busy"
 				? { ...result, bufferedBytes: result.bufferedBytes + this.pendingBytes }
@@ -120,7 +132,7 @@ export class SseLatestSnapshotWriter {
 				this.removePending(topicId);
 				const result = await this.sink.write(frame, "latest-snapshot");
 				if (result.status === "busy") {
-					this.setPending(topicId, frame);
+					this.setPending(topicId, frame, result.bufferedBytes);
 					break;
 				}
 			}
@@ -149,7 +161,17 @@ export class SseLatestSnapshotWriter {
 		this.pendingBytes -= previous.byteLength;
 	}
 
-	private setPending(topicId: string, frame: Uint8Array): void {
+	private setPending(
+		topicId: string,
+		frame: Uint8Array,
+		transportBufferedBytes: number,
+	): void {
+		if (
+			transportBufferedBytes + this.pendingBytes + frame.byteLength >
+			this.maximumBufferedBytes
+		) {
+			throw new RealtimeSnapshotBufferOverflowError(this.maximumBufferedBytes);
+		}
 		this.pending.set(topicId, frame);
 		this.pendingBytes += frame.byteLength;
 	}

--- a/packages/questpie/src/server/modules/core/integrated/realtime/types.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/types.ts
@@ -87,6 +87,8 @@ export type RealtimeSubscriptionContext = {
 };
 
 export interface RealtimeConfig {
+	/** Realtime edge-session admission limits. */
+	admission?: Partial<import("./admission.js").RealtimeAdmissionConfig>;
 	/**
 	 * Optional transport adapter (pg_notify, redis streams, etc.).
 	 */

--- a/packages/questpie/test/integration/realtime.test.ts
+++ b/packages/questpie/test/integration/realtime.test.ts
@@ -1582,15 +1582,21 @@ describe("realtime", () => {
 	// ==========================================================================
 
 	describe("access control", () => {
-		it("should send error event when user lacks read permission", async () => {
+		it("rejects an anonymous denial before hooks, listeners, or a sink", async () => {
 			const adapter = new LifecycleTrackingRealtimeAdapter();
+			let beforeOperationRuns = 0;
+			let beforeReadRuns = 0;
 			const secrets = collection("secrets")
 				.fields(({ f }) => ({
 					content: f.textarea().required(),
 					level: f.textarea().required(),
 				}))
+				.hooks({
+					beforeOperation: () => void (beforeOperationRuns += 1),
+					beforeRead: () => void (beforeReadRuns += 1),
+				})
 				.access({
-					read: ({ session }) => (session?.user as any)?.role === "admin",
+					read: ({ session }) => Boolean(session),
 					create: true,
 				});
 
@@ -1603,46 +1609,25 @@ describe("realtime", () => {
 			setup = await buildMockApp(testModule, { realtime: { adapter } });
 			await runTestDbMigrations(setup.app);
 
-			// First create some data as admin
-			const adminCtx = createTestContext({ accessMode: "user", role: "admin" });
-			await setup.app.collections.secrets.create(
-				{ content: "Secret content", level: "high" },
-				adminCtx,
-			);
-
 			const routes = createAdapterRoutes(setup.app, { accessMode: "user" });
-			const controller = new AbortController();
-
-			// Request without admin role should receive error in SSE stream
-			const request = createRealtimeRequest(
-				[collectionTopic("secrets")],
-				controller.signal,
-			);
+			const request = createRealtimeRequest([collectionTopic("secrets")]);
 
 			const response = await routes.realtime.subscribe(
 				request,
 				{},
 				{
-					appContext: createTestContext({ accessMode: "user", role: "user" }),
+					appContext: createTestContext({
+						accessMode: "user",
+						session: null,
+					}),
 				},
 			);
 
-			expect(response.ok).toBe(true);
-			const reader = createSSEReader(response.body!);
-
-			// Should receive error event due to access denied
-			const error = await reader.readEvent();
-			expect(error.event).toBe("error");
-			expect(error.data.message).toContain("permission");
-			await new Promise((resolve) => setTimeout(resolve, 20));
+			expect(response.ok).toBe(false);
+			expect(beforeOperationRuns).toBe(0);
+			expect(beforeReadRuns).toBe(0);
 			expect(setup.app.realtime.listeners.size).toBe(0);
-			expect(adapter.stopCalls).toBe(0);
-			await expect(reader.readEvent()).rejects.toThrow(
-				"SSE stream closed before event",
-			);
-
-			controller.abort();
-			reader.close();
+			expect(sharedSseKeepAliveTicker.size).toBe(0);
 		});
 
 		it("should allow access for authorized users", async () => {
@@ -1806,7 +1791,7 @@ describe("realtime", () => {
 			unsub?.();
 		});
 
-		it("should handle global access restrictions", async () => {
+		it("rejects a denied global before opening an SSE stream", async () => {
 			const adapter = new MockRealtimeAdapter();
 			const config = global("config")
 				.fields(({ f }) => ({
@@ -1828,13 +1813,7 @@ describe("realtime", () => {
 			await runTestDbMigrations(setup.app);
 
 			const routes = createAdapterRoutes(setup.app, { accessMode: "user" });
-			const controller = new AbortController();
-
-			// Non-admin request should receive error in SSE
-			const request = createRealtimeRequest(
-				[globalTopic("config")],
-				controller.signal,
-			);
+			const request = createRealtimeRequest([globalTopic("config")]);
 
 			const response = await routes.realtime.subscribe(
 				request,
@@ -1844,27 +1823,198 @@ describe("realtime", () => {
 				},
 			);
 
+			expect(response.ok).toBe(false);
+			expect(setup.app.realtime.listeners.size).toBe(0);
+		});
+	});
+
+	// ==========================================================================
+	// Admission control
+	// ==========================================================================
+
+	describe("admission control", () => {
+		it("enforces topic, query, and initial-concurrency caps for a mixed batch", async () => {
+			const adapter = new MockRealtimeAdapter();
+			let activeReads = 0;
+			let maximumActiveReads = 0;
+			const observedLimits: number[] = [];
+			const items = collection("items")
+				.fields(({ f }) => ({ name: f.textarea().required() }))
+				.hooks({
+					beforeRead: async ({ data }) => {
+						observedLimits.push(data.limit);
+						activeReads += 1;
+						maximumActiveReads = Math.max(maximumActiveReads, activeReads);
+						await new Promise((resolve) => setTimeout(resolve, 20));
+						activeReads -= 1;
+					},
+				})
+				.access({ read: true });
+			setup = await buildMockApp(
+				{ collections: { items } },
+				{ realtime: { adapter } },
+			);
+			await runTestDbMigrations(setup.app);
+
+			const topics = Array.from({ length: 21 }, (_, index) => ({
+				...collectionTopic("items", { where: { name: `item-${index}` } }),
+				id: `items-${index}`,
+			}));
+			topics[1].limit = 101;
+			topics[2].with = {
+				author: {
+					with: { team: { with: { company: { with: { owner: true } } } } },
+				},
+			};
+
+			const routes = createAdapterRoutes(setup.app, { accessMode: "user" });
+			const response = await routes.realtime.subscribe(
+				createRealtimeRequest(topics),
+				{},
+				undefined,
+			);
 			expect(response.ok).toBe(true);
 			const reader = createSSEReader(response.body!);
-
-			let receivedError = false;
-			try {
-				for (let i = 0; i < 5; i++) {
-					const event = await reader.readEvent(500);
-					if (event.event === "error") {
-						receivedError = true;
-						expect(event.data.message).toContain("access");
-						break;
-					}
-				}
-			} catch {
-				// Timeout is acceptable
+			const events: SSEEvent[] = [];
+			for (let index = 0; index < 21; index += 1) {
+				events.push(await reader.readEvent(5000));
 			}
 
-			expect(receivedError).toBe(true);
+			expect(events.filter((event) => event.event === "snapshot")).toHaveLength(
+				18,
+			);
+			expect(
+				events
+					.filter((event) => event.event === "error")
+					.map((event) => event.data.topicId),
+			).toEqual(expect.arrayContaining(["items-1", "items-2", "items-20"]));
+			expect(observedLimits).toHaveLength(18);
+			expect(observedLimits.every((limit) => limit === 100)).toBe(true);
+			expect(maximumActiveReads).toBe(4);
+			expect(setup.app.realtime.listeners.size).toBe(18);
 
-			controller.abort();
-			reader.close();
+			await reader.close();
+			expect(setup.app.realtime.listeners.size).toBe(0);
+		});
+
+		it("preserves the access where constraint alongside the requested filter", async () => {
+			const adapter = new MockRealtimeAdapter();
+			const documents = collection("documents")
+				.fields(({ f }) => ({
+					ownerId: f.textarea().required(),
+					status: f.textarea().required(),
+					title: f.textarea().required(),
+				}))
+				.access({
+					read: ({ input, session }) =>
+						input?.where?.status === "published"
+							? { ownerId: session?.user.id }
+							: false,
+					create: true,
+				});
+			setup = await buildMockApp(
+				{ collections: { documents } },
+				{ realtime: { adapter } },
+			);
+			await runTestDbMigrations(setup.app);
+			const system = createTestContext();
+			await setup.app.collections.documents.create(
+				{ ownerId: "alice", status: "published", title: "allowed" },
+				system,
+			);
+			await setup.app.collections.documents.create(
+				{ ownerId: "alice", status: "draft", title: "wrong status" },
+				system,
+			);
+			await setup.app.collections.documents.create(
+				{ ownerId: "bob", status: "published", title: "wrong owner" },
+				system,
+			);
+
+			const routes = createAdapterRoutes(setup.app, { accessMode: "user" });
+			const response = await routes.realtime.subscribe(
+				createRealtimeRequest([
+					collectionTopic("documents", { where: { status: "published" } }),
+				]),
+				{},
+				{
+					appContext: createTestContext({
+						accessMode: "user",
+						session: createMockSession({ id: "alice" }) as any,
+					}),
+				},
+			);
+			const reader = createSSEReader(response.body!);
+			const snapshot = await reader.readSnapshot();
+
+			expect(snapshot.data.data.docs).toEqual([
+				expect.objectContaining({ title: "allowed" }),
+			]);
+			await reader.close();
+		});
+
+		it("removes an oversized snapshot and releases its principal slot", async () => {
+			const adapter = new MockRealtimeAdapter();
+			const largeItems = collection("largeItems")
+				.fields(({ f }) => ({ content: f.textarea().required() }))
+				.access({ read: true, create: true });
+			const smallItems = collection("smallItems")
+				.fields(({ f }) => ({ content: f.textarea().required() }))
+				.access({ read: true });
+			setup = await buildMockApp(
+				{ collections: { largeItems, smallItems } },
+				{
+					realtime: {
+						adapter,
+						admission: { maxBufferedSnapshotBytes: 512 },
+					},
+				},
+			);
+			await runTestDbMigrations(setup.app);
+			await setup.app.collections.largeItems.create(
+				{ content: "x".repeat(2000) },
+				createTestContext(),
+			);
+
+			const session = createMockSession({ id: "same-user" });
+			const appContext = createTestContext({
+				accessMode: "user",
+				session: session as any,
+			});
+			const routes = createAdapterRoutes(setup.app, { accessMode: "user" });
+			const oversized = await routes.realtime.subscribe(
+				createRealtimeRequest([collectionTopic("largeItems")]),
+				{},
+				{ appContext },
+			);
+			const oversizedReader = createSSEReader(oversized.body!);
+			const error = await oversizedReader.readEvent();
+			expect(error.event).toBe("error");
+			expect(error.data.message).toContain("Snapshot exceeds 512 bytes");
+			await new Promise((resolve) => setTimeout(resolve, 20));
+			expect(setup.app.realtime.listeners.size).toBe(0);
+			expect(sharedSseKeepAliveTicker.size).toBe(0);
+
+			const replacements = await Promise.all(
+				Array.from({ length: 5 }, () =>
+					routes.realtime.subscribe(
+						createRealtimeRequest([collectionTopic("smallItems")]),
+						{},
+						{ appContext },
+					),
+				),
+			);
+			expect(replacements.every((response) => response.ok)).toBe(true);
+			const replacementReaders = replacements.map((response) =>
+				createSSEReader(response.body!),
+			);
+			await Promise.all(
+				replacementReaders.map((reader) => reader.readSnapshot()),
+			);
+			await Promise.all([
+				oversizedReader.close(),
+				...replacementReaders.map((reader) => reader.close()),
+			]);
 		});
 	});
 
@@ -1873,7 +2023,7 @@ describe("realtime", () => {
 	// ==========================================================================
 
 	describe("shared refresh scheduler", () => {
-		it("runs one pipeline for 100 same-session identical-topic connections", async () => {
+		it("runs one pipeline for the five admitted same-principal connections", async () => {
 			const adapter = new MockRealtimeAdapter();
 			let pipelineRuns = 0;
 			const items = collection("items")
@@ -1893,18 +2043,45 @@ describe("realtime", () => {
 			});
 			const routes = createAdapterRoutes(setup.app, { accessMode: "user" });
 			const responses = await Promise.all(
-				Array.from({ length: 100 }, () =>
-					routes.realtime.subscribe(createRealtimeRequest([collectionTopic("items")]), {}, {
-						appContext,
-					}),
+				Array.from({ length: 5 }, () =>
+					routes.realtime.subscribe(
+						createRealtimeRequest([collectionTopic("items")]),
+						{},
+						{
+							appContext,
+						},
+					),
 				),
 			);
-			const readers = responses.map((response) => createSSEReader(response.body!));
+			const readers = responses.map((response) =>
+				createSSEReader(response.body!),
+			);
 			await Promise.all(readers.map((reader) => reader.readSnapshot()));
+			const rejected = await routes.realtime.subscribe(
+				createRealtimeRequest([collectionTopic("items")]),
+				{},
+				{ appContext },
+			);
 
+			expect(rejected.ok).toBe(false);
 			expect(pipelineRuns).toBe(1);
 			expect(setup.app.realtime.listeners.size).toBe(1);
-			await Promise.all(readers.map((reader) => reader.close()));
+
+			await readers[0].close();
+			const replacement = await routes.realtime.subscribe(
+				createRealtimeRequest([collectionTopic("items")]),
+				{},
+				{ appContext },
+			);
+			expect(replacement.ok).toBe(true);
+			const replacementReader = createSSEReader(replacement.body!);
+			await replacementReader.readSnapshot();
+			expect(pipelineRuns).toBe(1);
+
+			await Promise.all([
+				...readers.slice(1).map((reader) => reader.close()),
+				replacementReader.close(),
+			]);
 			expect(setup.app.realtime.listeners.size).toBe(0);
 		});
 
@@ -2263,9 +2440,11 @@ describe("realtime", () => {
 
 		it("should handle client disconnection gracefully", async () => {
 			const adapter = new MockRealtimeAdapter();
-			const items = collection("items").fields(({ f }) => ({
-				name: f.textarea().required(),
-			}));
+			const items = collection("items")
+				.fields(({ f }) => ({
+					name: f.textarea().required(),
+				}))
+				.access({ read: true });
 
 			const testModule = {
 				collections: {

--- a/packages/questpie/test/units/realtime-admission.test.ts
+++ b/packages/questpie/test/units/realtime-admission.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+	DEFAULT_REALTIME_ADMISSION,
+	RealtimeAdmissionRegistry,
+	admitRealtimeTopic,
+	resolveRealtimeAdmissionConfig,
+} from "../../src/server/modules/core/integrated/realtime/admission.js";
+
+describe("realtime admission", () => {
+	it("applies the finite default limit and rejects query caps", () => {
+		expect(
+			admitRealtimeTopic(
+				{ id: "posts", resourceType: "collection", resource: "posts" },
+				DEFAULT_REALTIME_ADMISSION,
+			),
+		).toMatchObject({ accepted: true, topic: { limit: 100 } });
+		expect(
+			admitRealtimeTopic(
+				{
+					id: "posts",
+					resourceType: "collection",
+					resource: "posts",
+					limit: 101,
+				},
+				DEFAULT_REALTIME_ADMISSION,
+			),
+		).toMatchObject({ accepted: false });
+		expect(
+			admitRealtimeTopic(
+				{
+					id: "posts",
+					resourceType: "collection",
+					resource: "posts",
+					with: {
+						author: {
+							with: { team: { with: { company: { with: { owner: true } } } } },
+						},
+					},
+				},
+				DEFAULT_REALTIME_ADMISSION,
+			),
+		).toMatchObject({ accepted: false });
+	});
+
+	it("releases per-principal counters idempotently", () => {
+		const registry = new RealtimeAdmissionRegistry(2);
+		const first = registry.acquire("user-1");
+		const second = registry.acquire("user-1");
+		expect(first).not.toBeNull();
+		expect(second).not.toBeNull();
+		expect(registry.acquire("user-1")).toBeNull();
+
+		first!();
+		first!();
+		expect(registry.acquire("user-1")).not.toBeNull();
+	});
+
+	it("keeps configured admission limits finite", () => {
+		expect(
+			resolveRealtimeAdmissionConfig({
+				maxTopicsPerConnection: Number.POSITIVE_INFINITY,
+				maxWithDepth: -1,
+				initialSnapshotConcurrency: 0,
+			}),
+		).toMatchObject({
+			maxTopicsPerConnection: 20,
+			maxWithDepth: 3,
+			initialSnapshotConcurrency: 4,
+		});
+	});
+});

--- a/packages/questpie/test/units/realtime-sse-transport.test.ts
+++ b/packages/questpie/test/units/realtime-sse-transport.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "bun:test";
 import {
 	encodeSseComment,
 	encodeSseEvent,
+	RealtimeSnapshotBufferOverflowError,
 	SseLatestSnapshotWriter,
 	SseClientTransport,
 } from "../../src/server/modules/core/integrated/realtime/sse-client-transport.js";
@@ -12,7 +13,7 @@ describe("SseClientTransport", () => {
 	it("delivers serialized frames through a local-session sink", async () => {
 		const frames: Uint8Array[] = [];
 		let closeCalls = 0;
-		let desiredSize = 16;
+		let desiredSize = 128;
 		const transport = new SseClientTransport(
 			{
 				get desiredSize() {
@@ -20,13 +21,13 @@ describe("SseClientTransport", () => {
 				},
 				enqueue: (frame) => {
 					frames.push(frame);
-					desiredSize = 8;
+					desiredSize = 64;
 				},
 				close: () => {
 					closeCalls += 1;
 				},
 			},
-			16,
+			128,
 		);
 
 		await transport.start({ onError: () => {} });
@@ -43,7 +44,7 @@ describe("SseClientTransport", () => {
 
 		await expect(sink.write(frame, "latest-snapshot")).resolves.toEqual({
 			status: "accepted",
-			bufferedBytes: 8,
+			bufferedBytes: 64,
 		});
 		expect(new TextDecoder().decode(frames[0])).toBe(
 			'event: snapshot\ndata: {"topicId":"posts","seq":4,"data":{"docs":[]}}\n\n',
@@ -128,6 +129,20 @@ describe("SseClientTransport", () => {
 		await writer.flush();
 
 		expect(accepted).toEqual(["posts-v2", "pages-v1"]);
+		expect(writer.bufferedBytes).toBe(0);
+	});
+
+	it("rejects pending snapshots that would exceed the edge buffer cap", async () => {
+		const sink = {
+			sessionId: "session-1",
+			write: async () => ({ status: "busy" as const, bufferedBytes: 8 }),
+			close: async () => {},
+		};
+		const writer = new SseLatestSnapshotWriter(sink, 16);
+
+		await expect(
+			writer.write("posts", new Uint8Array(9)),
+		).rejects.toBeInstanceOf(RealtimeSnapshotBufferOverflowError);
 		expect(writer.bufferedBytes).toBe(0);
 	});
 });


### PR DESCRIPTION
## Summary
- pre-authorize collection/global topics before hooks, listeners, or SSE sink allocation and retain access WHERE through an internal non-JSON handoff
- enforce finite topic, principal-session, find, relation-depth, initial-concurrency, and snapshot-buffer limits
- keep valid topics in mixed batches, remove permanently denied/oversized topics, and release admission state on every teardown path
- add public admission config defaults, focused unit/integration coverage, and a patch changeset

## Verification
- `cd packages/questpie && bun test test/ --test-name-pattern "realtime|admission"` — 79 pass, 1850 filtered, 0 fail, 225 expects
- `cd packages/questpie && bunx tsc --noEmit -p tsconfig.json`
- `cd packages/questpie && bun run build`
- targeted `oxlint` — 0 errors (legacy touched files still report pre-existing warnings)
- targeted `oxfmt --check`

## Workspace note
The root workspace build reaches `apps/docs` and fails with `vite: command not found`; the affected `questpie` package build is green.