### PR TITLE
RT2.1: add Pusher/Soketi realtime transport

### DIFF
--- a/.changeset/add-pusher-realtime-transport.md
+++ b/.changeset/add-pusher-realtime-transport.md
@@ -1,0 +1,5 @@
+---
+"questpie": patch
+---
+
+Add an optional Pusher/Soketi realtime preset with notice-only cross-instance wakes, private per-session invalidations, provider auth/config routes, and ordered shared-channel delivery.

--- a/bun.lock
+++ b/bun.lock
@@ -517,6 +517,8 @@
         "nodemailer": "^9.0.0",
         "pg": "^8.13.1",
         "pg-boss": "^12.5.4",
+        "pusher": "^5.3.4",
+        "pusher-js": "^8.5.0",
         "tsdown": "^0.18.3",
       },
       "peerDependencies": {
@@ -527,6 +529,8 @@
         "nodemailer": "^9.0.0",
         "pg": "^8.13.1",
         "pg-boss": "^12.5.4",
+        "pusher": "^5.3.4",
+        "pusher-js": "^8.5.0",
       },
       "optionalPeers": [
         "@react-email/components",
@@ -536,6 +540,8 @@
         "nodemailer",
         "pg",
         "pg-boss",
+        "pusher",
+        "pusher-js",
       ],
     },
     "packages/sandbox": {
@@ -1718,6 +1724,8 @@
 
     "@types/node": ["@types/node@24.12.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-8oljBDGun9cIsZRJR6fkihn0TSXJI0UDOOhncYaERq6M0JMDoPLxyscwruJcb4GKS6dvK/d8xebYBg27h/duaQ=="],
 
+    "@types/node-fetch": ["@types/node-fetch@2.6.13", "", { "dependencies": { "@types/node": "*", "form-data": "^4.0.4" } }, "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw=="],
+
     "@types/nodemailer": ["@types/nodemailer@8.0.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-PxpaInm8V1JQDd4j0ds5HfvWQk8JupS1C0Picb96QJsrrRDjBH+DlK7L4ZdNSqNULhiZRQHc40nLVShaGxXAMw=="],
 
     "@types/pg": ["@types/pg@8.20.0", "", { "dependencies": { "@types/node": "*", "pg-protocol": "*", "pg-types": "^2.2.0" } }, "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow=="],
@@ -1813,6 +1821,8 @@
     "ast-types": ["ast-types@0.16.1", "", { "dependencies": { "tslib": "^2.0.1" } }, "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg=="],
 
     "astring": ["astring@1.9.0", "", { "bin": { "astring": "bin/astring" } }, "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg=="],
+
+    "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
 
     "atomic-sleep": ["atomic-sleep@1.0.0", "", {}, "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="],
 
@@ -1927,6 +1937,8 @@
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
     "colorette": ["colorette@2.0.20", "", {}, "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="],
+
+    "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
 
     "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
 
@@ -2090,6 +2102,8 @@
 
     "delaunator": ["delaunator@5.1.0", "", { "dependencies": { "robust-predicates": "^3.0.2" } }, "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ=="],
 
+    "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
+
     "denque": ["denque@2.1.0", "", {}, "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw=="],
 
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
@@ -2169,6 +2183,8 @@
     "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
 
     "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
+
+    "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
 
     "es-toolkit": ["es-toolkit@1.46.1", "", {}, "sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ=="],
 
@@ -2276,6 +2292,8 @@
 
     "find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
 
+    "form-data": ["form-data@4.0.6", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.4", "mime-types": "^2.1.35" } }, "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ=="],
+
     "format": ["format@0.2.2", "", {}, "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww=="],
 
     "formdata-polyfill": ["formdata-polyfill@4.0.10", "", { "dependencies": { "fetch-blob": "^3.1.2" } }, "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g=="],
@@ -2350,7 +2368,9 @@
 
     "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
 
-    "hasown": ["hasown@2.0.3", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg=="],
+    "has-tostringtag": ["has-tostringtag@1.0.2", "", { "dependencies": { "has-symbols": "^1.0.3" } }, "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw=="],
+
+    "hasown": ["hasown@2.0.4", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A=="],
 
     "hast-util-from-parse5": ["hast-util-from-parse5@8.0.3", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "devlop": "^1.0.0", "hastscript": "^9.0.0", "property-information": "^7.0.0", "vfile": "^6.0.0", "vfile-location": "^5.0.0", "web-namespaces": "^2.0.0" } }, "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg=="],
 
@@ -2439,6 +2459,8 @@
     "is-alphanumerical": ["is-alphanumerical@2.0.1", "", { "dependencies": { "is-alphabetical": "^2.0.0", "is-decimal": "^2.0.0" } }, "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw=="],
 
     "is-arrayish": ["is-arrayish@0.2.1", "", {}, "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="],
+
+    "is-base64": ["is-base64@1.1.0", "", { "bin": { "is-base64": "bin/is-base64", "is_base64": "bin/is-base64" } }, "sha512-Nlhg7Z2dVC4/PTvIFkgVVNvPHSO2eR/Yd0XzhGiXCXEvWnptXlXa/clQ8aePPiMuxEGcWfzWbGw2Fe3d+Y3v1g=="],
 
     "is-binary-path": ["is-binary-path@2.1.0", "", { "dependencies": { "binary-extensions": "^2.0.0" } }, "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw=="],
 
@@ -3030,6 +3052,10 @@
 
     "punycode.js": ["punycode.js@2.3.1", "", {}, "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA=="],
 
+    "pusher": ["pusher@5.3.4", "", { "dependencies": { "@types/node-fetch": "^2.5.7", "abort-controller": "^3.0.0", "is-base64": "^1.1.0", "node-fetch": "^2.7.0", "tweetnacl": "^1.0.0", "tweetnacl-util": "^0.15.0" } }, "sha512-gA7NpPRsQW9qpry/Ov+o9KKIPaRMziiDoEtiZ6EF0+QiSdsnT49+dH7+hf0Dvd4d+HEGQDHp6VXtrVM5DDrpmw=="],
+
+    "pusher-js": ["pusher-js@8.5.0", "", { "dependencies": { "tweetnacl": "^1.0.3" } }, "sha512-V7uzGi9bqOOOyM/6IkJdpFyjGZj7llz1v0oWnYkZKcYLvbz6VcHVLmzKqkvegjuMumpfIEKGLmWHwFb39XFCpw=="],
+
     "qs": ["qs@6.15.1", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg=="],
 
     "quansync": ["quansync@0.2.11", "", {}, "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA=="],
@@ -3381,6 +3407,10 @@
     "turbo": ["turbo@2.9.12", "", { "optionalDependencies": { "@turbo/darwin-64": "2.9.12", "@turbo/darwin-arm64": "2.9.12", "@turbo/linux-64": "2.9.12", "@turbo/linux-arm64": "2.9.12", "@turbo/windows-64": "2.9.12", "@turbo/windows-arm64": "2.9.12" }, "bin": { "turbo": "bin/turbo" } }, "sha512-lCPgus1NuTiBdaITWqzSH/Ff6HVL8HHGBtOXHg1dHRfcshN79XkygSdh0M6g8b0td91ILLG5MTkLOkp5UvyPJw=="],
 
     "tw-animate-css": ["tw-animate-css@1.4.0", "", {}, "sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ=="],
+
+    "tweetnacl": ["tweetnacl@1.0.3", "", {}, "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="],
+
+    "tweetnacl-util": ["tweetnacl-util@0.15.1", "", {}, "sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw=="],
 
     "type-fest": ["type-fest@5.6.0", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA=="],
 
@@ -3740,7 +3770,11 @@
 
     "files-sdk/ai": ["ai@6.0.177", "", { "dependencies": { "@ai-sdk/gateway": "3.0.112", "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.27", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-1xQtbeWwNcLyyM86ixZhkKvT+WRXc1lvarIKqPVtsyn8F9NDikwUMBqYu+aQKDgMht50SMXh4qboYuU8MeHZZA=="],
 
+    "form-data/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
     "fumadocs-core/shiki": ["shiki@3.23.0", "", { "dependencies": { "@shikijs/core": "3.23.0", "@shikijs/engine-javascript": "3.23.0", "@shikijs/engine-oniguruma": "3.23.0", "@shikijs/langs": "3.23.0", "@shikijs/themes": "3.23.0", "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA=="],
+
+    "get-intrinsic/hasown": ["hasown@2.0.3", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg=="],
 
     "h3/rou3": ["rou3@0.8.1", "", {}, "sha512-ePa+XGk00/3HuCqrEnK3LxJW7I0SdNg6EFzKUJG73hMAdDcOUC/i/aSz7LSDwLrGr33kal/rqOGydzwl6U7zBA=="],
 
@@ -3789,6 +3823,8 @@
     "prop-types/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 
     "prosemirror-markdown/@types/markdown-it": ["@types/markdown-it@14.1.2", "", { "dependencies": { "@types/linkify-it": "^5", "@types/mdurl": "^2" } }, "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog=="],
+
+    "pusher/node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
 
     "react-syntax-highlighter/highlight.js": ["highlight.js@10.7.3", "", {}, "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="],
 
@@ -4028,6 +4064,8 @@
 
     "files-sdk/ai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.27", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw=="],
 
+    "form-data/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
     "fumadocs-core/shiki/@shikijs/core": ["@shikijs/core@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA=="],
 
     "fumadocs-core/shiki/@shikijs/engine-javascript": ["@shikijs/engine-javascript@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "oniguruma-to-es": "^4.3.4" } }, "sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA=="],
@@ -4085,6 +4123,8 @@
     "prosemirror-markdown/@types/markdown-it/@types/linkify-it": ["@types/linkify-it@5.0.0", "", {}, "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q=="],
 
     "prosemirror-markdown/@types/markdown-it/@types/mdurl": ["@types/mdurl@2.0.0", "", {}, "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg=="],
+
+    "pusher/node-fetch/whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
     "read-yaml-file/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 
@@ -4237,6 +4277,10 @@
     "autopilot/nitro/env-runner/httpxy": ["httpxy@0.5.3", "", {}, "sha512-SMS9V6Sn7VWaS11lYhoAr0ceoaiolTWf4jYdJn0NJhCdKMu9R2H9Fh0LBDWBHQF6HRLI1PmaePYsjanSpE5PEw=="],
 
     "city-portal-example/nitro/env-runner/httpxy": ["httpxy@0.5.3", "", {}, "sha512-SMS9V6Sn7VWaS11lYhoAr0ceoaiolTWf4jYdJn0NJhCdKMu9R2H9Fh0LBDWBHQF6HRLI1PmaePYsjanSpE5PEw=="],
+
+    "pusher/node-fetch/whatwg-url/tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
+
+    "pusher/node-fetch/whatwg-url/webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
 
     "read-yaml-file/js-yaml/argparse/sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
 

--- a/packages/questpie/package.json
+++ b/packages/questpie/package.json
@@ -35,6 +35,7 @@
 		"./adapters/pgvector-search": "./src/exports/adapters/pgvector-search.ts",
 		"./adapters/plunk": "./src/exports/adapters/plunk.ts",
 		"./adapters/postgres-search": "./src/exports/adapters/postgres-search.ts",
+		"./adapters/pusher": "./src/exports/adapters/pusher.ts",
 		"./adapters/redis-kv": "./src/exports/adapters/redis-kv.ts",
 		"./adapters/redis-streams": "./src/exports/adapters/redis-streams.ts",
 		"./adapters/resend": "./src/exports/adapters/resend.ts",
@@ -84,6 +85,7 @@
 			"./adapters/pgvector-search": "./dist/adapters/pgvector-search.mjs",
 			"./adapters/plunk": "./dist/adapters/plunk.mjs",
 			"./adapters/postgres-search": "./dist/adapters/postgres-search.mjs",
+			"./adapters/pusher": "./dist/adapters/pusher.mjs",
 			"./adapters/redis-kv": "./dist/adapters/redis-kv.mjs",
 			"./adapters/redis-streams": "./dist/adapters/redis-streams.mjs",
 			"./adapters/resend": "./dist/adapters/resend.mjs",
@@ -153,6 +155,8 @@
 		"nodemailer": "^9.0.0",
 		"pg": "^8.13.1",
 		"pg-boss": "^12.5.4",
+		"pusher": "^5.3.4",
+		"pusher-js": "^8.5.0",
 		"tsdown": "^0.18.3"
 	},
 	"peerDependencies": {
@@ -162,7 +166,9 @@
 		"drizzle-kit": "1.0.0-beta.6-4414a19",
 		"nodemailer": "^9.0.0",
 		"pg": "^8.13.1",
-		"pg-boss": "^12.5.4"
+		"pg-boss": "^12.5.4",
+		"pusher": "^5.3.4",
+		"pusher-js": "^8.5.0"
 	},
 	"peerDependenciesMeta": {
 		"@react-email/components": {
@@ -184,6 +190,12 @@
 			"optional": true
 		},
 		"pg-boss": {
+			"optional": true
+		},
+		"pusher": {
+			"optional": true
+		},
+		"pusher-js": {
 			"optional": true
 		}
 	}

--- a/packages/questpie/src/exports/adapters/pusher.ts
+++ b/packages/questpie/src/exports/adapters/pusher.ts
@@ -1,0 +1,166 @@
+import { createHash } from "node:crypto";
+
+import Pusher from "pusher";
+import PusherJs from "pusher-js";
+
+import {
+	PusherChangeBroker,
+	PusherClientTransport,
+	type PusherClientEventsConfig,
+	type PusherProvider,
+	type PusherSubscriber,
+} from "#questpie/server/modules/core/integrated/realtime/pusher-transport.js";
+import type { ChangeBrokerState } from "#questpie/server/modules/core/integrated/realtime/transport.js";
+
+export * from "#questpie/server/modules/core/integrated/realtime/pusher-transport.js";
+
+const PusherJsConstructor =
+	(PusherJs as unknown as { Pusher?: typeof PusherJs }).Pusher ?? PusherJs;
+
+export type PusherRealtimeOptions = {
+	appId: string;
+	key: string;
+	secret: string;
+	cluster?: string;
+	host?: string;
+	port?: number;
+	useTLS?: boolean;
+	wsHost?: string;
+	wsPort?: number;
+	wssPort?: number;
+	brokerChannel?: string;
+	authEndpoint?: string;
+	clientEvents?: PusherClientEventsConfig;
+};
+
+function assertSuccessfulResponse(response: {
+	ok: boolean;
+	status: number;
+}): void {
+	if (!response.ok) {
+		throw new Error(`Pusher request failed with HTTP ${response.status}`);
+	}
+}
+
+function createProvider(client: Pusher): PusherProvider {
+	return {
+		trigger: async (channel, event, data) => {
+			const response = await client.trigger(channel, event, data);
+			assertSuccessfulResponse(response);
+		},
+		authorizeChannel: (socketId, channel, presence) =>
+			client.authorizeChannel(socketId, channel, presence),
+		authenticateUser: (socketId, user) =>
+			client.authenticateUser(socketId, user),
+		terminateUserConnections: async (userId) => {
+			const response = await client.terminateUserConnections(userId);
+			assertSuccessfulResponse(response);
+		},
+		getPresenceMemberCount: async (channel) => {
+			const response = await client.get({
+				path: `/channels/${encodeURIComponent(channel)}`,
+				params: { info: "user_count" },
+			});
+			assertSuccessfulResponse(response);
+			const body = (await response.json()) as { user_count?: unknown };
+			return typeof body.user_count === "number" ? body.user_count : 0;
+		},
+	};
+}
+
+function toBrokerState(value: string): ChangeBrokerState | null {
+	if (
+		value === "connecting" ||
+		value === "connected" ||
+		value === "unavailable" ||
+		value === "failed" ||
+		value === "disconnected"
+	) {
+		return value;
+	}
+	return null;
+}
+
+function createSubscriber(options: PusherRealtimeOptions): PusherSubscriber {
+	let client: PusherJs | null = null;
+	return {
+		start: async (input) => {
+			client = new PusherJsConstructor(options.key, {
+				cluster: options.cluster ?? "mt1",
+				forceTLS: options.useTLS ?? true,
+				enabledTransports: ["ws"],
+				...(options.wsHost || options.host
+					? { wsHost: options.wsHost ?? options.host }
+					: {}),
+				...(options.wsPort || options.port
+					? { wsPort: options.wsPort ?? options.port }
+					: {}),
+				...(options.wssPort ? { wssPort: options.wssPort } : {}),
+			});
+			client.connection.bind("state_change", (change: { current: string }) => {
+				const state = toBrokerState(change.current);
+				if (state) input.onStateChange(state);
+			});
+			client.connection.bind("error", input.onError);
+			const channel = client.subscribe(input.channel);
+			channel.bind(input.event, input.onMessage);
+			channel.bind("pusher:subscription_error", input.onError);
+		},
+		stop: async () => {
+			client?.disconnect();
+			client = null;
+		},
+	};
+}
+
+/**
+ * Create the managed-WS realtime preset without loading its optional peers from
+ * the root `questpie` entrypoint.
+ */
+export function pusherRealtime(options: PusherRealtimeOptions): {
+	changeBroker: PusherChangeBroker;
+	clientTransport: PusherClientTransport;
+} {
+	const serverOptions: Pusher.Options = options.host
+		? {
+				appId: options.appId,
+				key: options.key,
+				secret: options.secret,
+				host: options.host,
+				...(options.port ? { port: String(options.port) } : {}),
+				useTLS: options.useTLS ?? true,
+			}
+		: {
+				appId: options.appId,
+				key: options.key,
+				secret: options.secret,
+				cluster: options.cluster ?? "mt1",
+				useTLS: options.useTLS ?? true,
+			};
+	const provider = createProvider(new Pusher(serverOptions));
+	const brokerChannel =
+		options.brokerChannel ??
+		`questpie-broker-${createHash("sha256")
+			.update(`${options.appId}:${options.key}`)
+			.digest("hex")
+			.slice(0, 24)}`;
+	return {
+		changeBroker: new PusherChangeBroker({
+			provider,
+			subscriber: createSubscriber(options),
+			channel: brokerChannel,
+		}),
+		clientTransport: new PusherClientTransport({
+			provider,
+			key: options.key,
+			identityKey: options.secret,
+			cluster: options.cluster,
+			wsHost: options.wsHost ?? options.host,
+			wsPort: options.wsPort ?? options.port,
+			wssPort: options.wssPort,
+			forceTLS: options.useTLS,
+			authEndpoint: options.authEndpoint,
+			clientEvents: options.clientEvents,
+		}),
+	};
+}

--- a/packages/questpie/src/server/modules/core/.generated/module.ts
+++ b/packages/questpie/src/server/modules/core/.generated/module.ts
@@ -40,6 +40,8 @@ import _route_globals_name_versions from "../routes/globals/[name]/versions";
 import _route_health from "../routes/health";
 import _route_jwks from "../routes/jwks";
 import _route_realtime from "../routes/realtime";
+import _route_realtime_auth_POST from "../routes/realtime/auth.post";
+import _route_realtime_config from "../routes/realtime/config";
 import _route_search from "../routes/search";
 import _route_search_reindex_collection from "../routes/search/reindex/[collection]";
 
@@ -127,6 +129,8 @@ export type CoreRoutes = {
 	health: typeof _route_health extends { __brand: "route" } ? RouteDefinition<unknown, unknown, RouteParamsFromKey<"health">> : typeof _route_health;
 	jwks: typeof _route_jwks extends { __brand: "route" } ? RouteDefinition<unknown, unknown, RouteParamsFromKey<"jwks">> : typeof _route_jwks;
 	realtime: typeof _route_realtime extends { __brand: "route" } ? RouteDefinition<unknown, unknown, RouteParamsFromKey<"realtime">> : typeof _route_realtime;
+	"realtime/auth:POST": typeof _route_realtime_auth_POST extends { __brand: "route" } ? RouteDefinition<unknown, unknown, RouteParamsFromKey<"realtime/auth:POST">> : typeof _route_realtime_auth_POST;
+	"realtime/config": typeof _route_realtime_config extends { __brand: "route" } ? RouteDefinition<unknown, unknown, RouteParamsFromKey<"realtime/config">> : typeof _route_realtime_config;
 	search: typeof _route_search extends { __brand: "route" } ? RouteDefinition<unknown, unknown, RouteParamsFromKey<"search">> : typeof _route_search;
 	"search/reindex/[collection]": typeof _route_search_reindex_collection extends { __brand: "route" } ? RouteDefinition<unknown, unknown, RouteParamsFromKey<"search/reindex/[collection]">> : typeof _route_search_reindex_collection;
 };
@@ -226,6 +230,8 @@ const _module: CoreModule = {
 		health: _route_health,
 		jwks: _route_jwks,
 		realtime: _route_realtime,
+		"realtime/auth:POST": _route_realtime_auth_POST,
+		"realtime/config": _route_realtime_config,
 		search: _route_search,
 		"search/reindex/[collection]": _route_search_reindex_collection,
 	} as CoreRoutes,

--- a/packages/questpie/src/server/modules/core/integrated/realtime/pusher-transport.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/pusher-transport.ts
@@ -1,0 +1,541 @@
+import { createHmac, createHash } from "node:crypto";
+
+import type { Principal } from "#questpie/server/config/context.js";
+
+import type {
+	ChangeBroker,
+	ChangeBrokerState,
+	ChangeWake,
+	ClientConfigInput,
+	ClientSink,
+	ClientTransportConfig,
+	DeliveryClass,
+	EdgeSessionInput,
+	OrderedChannelDelivery,
+	SharedProviderClientTransport,
+	SinkWriteResult,
+} from "./transport.js";
+
+const CHANNEL_PATTERN = /^[A-Za-z0-9_\-=@,.;]+$/;
+const SOCKET_ID_PATTERN = /^\d+\.\d+$/;
+const MAX_CHANNEL_LENGTH = 164;
+const MAX_PRESENCE_ID_LENGTH = 128;
+const MAX_PRESENCE_DATA_BYTES = 1024;
+const MAX_PRESENCE_MEMBERS = 100;
+
+export type PusherAuthResponse = {
+	auth: string;
+	channel_data?: string;
+	shared_secret?: string;
+};
+
+export type PusherUserAuthResponse = {
+	auth: string;
+	user_data: string;
+};
+
+export interface PusherProvider {
+	trigger(channel: string, event: string, data: unknown): Promise<unknown>;
+	authorizeChannel(
+		socketId: string,
+		channel: string,
+		presence?: { user_id: string; user_info?: Record<string, unknown> },
+	): PusherAuthResponse;
+	authenticateUser(
+		socketId: string,
+		user: { id: string; user_info?: Record<string, unknown> },
+	): PusherUserAuthResponse;
+	terminateUserConnections(userId: string): Promise<unknown>;
+	getPresenceMemberCount(channel: string): Promise<number>;
+}
+
+export interface PusherSubscriber {
+	start(input: {
+		channel: string;
+		event: string;
+		onMessage: (message: unknown) => void;
+		onError: (error: unknown) => void;
+		onStateChange: (state: ChangeBrokerState) => void;
+	}): Promise<void>;
+	stop(): Promise<void>;
+}
+
+export type PusherClientEventsConfig = {
+	enabled: true;
+	/** Required because Pusher enables client events for the entire provider app. */
+	acknowledgeProviderWideRisk: true;
+	/** SDK affordance only. A raw provider client can bypass this allowlist. */
+	allowedChannels: string[];
+};
+
+export type PusherClientTransportOptions = {
+	provider: PusherProvider;
+	key: string;
+	identityKey: string;
+	cluster?: string;
+	wsHost?: string;
+	wsPort?: number;
+	wssPort?: number;
+	forceTLS?: boolean;
+	authEndpoint?: string;
+	clientEvents?: PusherClientEventsConfig;
+};
+
+export type PusherChangeBrokerOptions = {
+	provider: Pick<PusherProvider, "trigger">;
+	subscriber: PusherSubscriber;
+	channel: string;
+};
+
+function normalizeChangeWake(value: unknown): ChangeWake | null {
+	if (!value || typeof value !== "object") return null;
+	const fields = value as Record<string, unknown>;
+	const wake = value as Partial<ChangeWake>;
+	if (
+		wake.kind !== "outbox-maybe-advanced" &&
+		wake.kind !== "channel-events-maybe-advanced"
+	) {
+		return null;
+	}
+	if (
+		wake.reason !== "publish" &&
+		wake.reason !== "reconnect" &&
+		wake.reason !== "reconcile"
+	) {
+		return null;
+	}
+	if (wake.kind === "outbox-maybe-advanced") {
+		return {
+			kind: wake.kind,
+			...(typeof wake.highWaterSeq === "number"
+				? { highWaterSeq: wake.highWaterSeq }
+				: {}),
+			reason: wake.reason,
+		};
+	}
+	return {
+		kind: wake.kind,
+		...(typeof fields.channelHash === "string"
+			? { channelHash: fields.channelHash }
+			: {}),
+		...(typeof fields.highWaterEventId === "string"
+			? { highWaterEventId: fields.highWaterEventId }
+			: {}),
+		reason: wake.reason,
+	};
+}
+
+export function assertPusherChannelName(channel: string): void {
+	if (
+		channel.length === 0 ||
+		channel.length > MAX_CHANNEL_LENGTH ||
+		!CHANNEL_PATTERN.test(channel)
+	) {
+		throw new Error(
+			`Invalid Pusher channel name: expected 1-${MAX_CHANNEL_LENGTH} provider-safe characters`,
+		);
+	}
+}
+
+function assertSocketId(socketId: string): void {
+	if (!SOCKET_ID_PATTERN.test(socketId)) {
+		throw new Error("Invalid Pusher socket id");
+	}
+}
+
+function principalIdentity(principal: Principal | null): string {
+	if (!principal) return "anonymous";
+	if (principal.kind === "system") return "system";
+	if (principal.kind === "oauth") return `oauth:${principal.tokenId}`;
+	return `user-session:${principal.session.id}`;
+}
+
+function stableUserIdentity(principal: Principal): string {
+	if (principal.kind === "system") return "system";
+	if (principal.kind === "oauth") return `oauth:${principal.user.id}`;
+	return `user:${principal.user.id}`;
+}
+
+function byteLength(value: unknown): number {
+	return new TextEncoder().encode(JSON.stringify(value)).byteLength;
+}
+
+function wakeKey(wake: ChangeWake): string {
+	return wake.kind === "outbox-maybe-advanced"
+		? wake.kind
+		: `${wake.kind}:${wake.channelHash ?? "*"}`;
+}
+
+/** Pusher-protocol cross-instance wake broker. Payloads are notice-only. */
+export class PusherChangeBroker implements ChangeBroker {
+	private onWake: (wake: ChangeWake) => void = () => {};
+	private onError: (error: unknown) => void = () => {};
+	private onStateChange: (state: ChangeBrokerState) => void = () => {};
+	private pending = new Map<string, ChangeWake>();
+	private waiters: Array<{
+		resolve: () => void;
+		reject: (error: unknown) => void;
+	}> = [];
+	private flushScheduled = false;
+	private started = false;
+
+	constructor(private readonly options: PusherChangeBrokerOptions) {
+		assertPusherChannelName(options.channel);
+	}
+
+	async start(input: {
+		onWake: (wake: ChangeWake) => void;
+		onError: (error: unknown) => void;
+		onStateChange?: (state: ChangeBrokerState) => void;
+	}): Promise<void> {
+		if (this.started) return;
+		this.onWake = input.onWake;
+		this.onError = input.onError;
+		this.onStateChange = input.onStateChange ?? (() => {});
+		await this.options.subscriber.start({
+			channel: this.options.channel,
+			event: "questpie-wake",
+			onMessage: (message) => {
+				const wake = normalizeChangeWake(message);
+				if (wake) this.onWake(wake);
+			},
+			onError: (error) => this.onError(error),
+			onStateChange: (state) => {
+				this.onStateChange(state);
+				if (state === "connected") {
+					this.onWake({
+						kind: "outbox-maybe-advanced",
+						reason: "reconnect",
+					});
+				}
+			},
+		});
+		this.started = true;
+	}
+
+	publish(wake: ChangeWake): Promise<void> {
+		if (!this.started) {
+			return Promise.reject(new Error("Pusher change broker is not started"));
+		}
+		const normalized = normalizeChangeWake(wake);
+		if (!normalized) {
+			return Promise.reject(new Error("Invalid realtime change wake"));
+		}
+		this.pending.set(wakeKey(normalized), normalized);
+		const promise = new Promise<void>((resolve, reject) => {
+			this.waiters.push({ resolve, reject });
+		});
+		if (!this.flushScheduled) {
+			this.flushScheduled = true;
+			queueMicrotask(() => void this.flush());
+		}
+		return promise;
+	}
+
+	private async flush(): Promise<void> {
+		this.flushScheduled = false;
+		const wakes = [...this.pending.values()];
+		const waiters = this.waiters;
+		this.pending.clear();
+		this.waiters = [];
+		try {
+			await Promise.all(
+				wakes.map((wake) =>
+					this.options.provider.trigger(
+						this.options.channel,
+						"questpie-wake",
+						wake,
+					),
+				),
+			);
+			for (const waiter of waiters) waiter.resolve();
+		} catch (error) {
+			this.onError(error);
+			for (const waiter of waiters) waiter.reject(error);
+		}
+		if (this.pending.size > 0 && !this.flushScheduled) {
+			this.flushScheduled = true;
+			queueMicrotask(() => void this.flush());
+		}
+	}
+
+	async stop(): Promise<void> {
+		if (!this.started) return;
+		this.started = false;
+		await this.options.subscriber.stop();
+	}
+}
+
+type PusherSession = {
+	sessionId: string;
+	principalIdentity: string;
+	opaquePrincipalId?: string;
+	resolvePrincipal: () => Promise<Principal | null>;
+};
+
+class PusherSessionSink implements ClientSink {
+	private closed = false;
+	private queued = false;
+
+	constructor(
+		readonly sessionId: string,
+		private readonly channel: string,
+		private readonly provider: PusherProvider,
+		private readonly onError: (error: unknown) => void,
+		private readonly onClose: () => void,
+	) {}
+
+	async write(
+		_frame: Uint8Array,
+		delivery: DeliveryClass,
+	): Promise<SinkWriteResult> {
+		if (this.closed) throw new Error("Pusher realtime session is closed");
+		if (delivery !== "latest-snapshot") {
+			throw new Error("Ordered channel events must use publishChannel()");
+		}
+		if (!this.queued) {
+			this.queued = true;
+			queueMicrotask(() => {
+				this.queued = false;
+				if (this.closed) return;
+				void this.provider
+					.trigger(this.channel, "questpie:invalidate", {
+						sessionId: this.sessionId,
+					})
+					.catch(this.onError);
+			});
+		}
+		return { status: "accepted", bufferedBytes: null };
+	}
+
+	async close(): Promise<void> {
+		if (this.closed) return;
+		this.closed = true;
+		this.onClose();
+	}
+}
+
+/** Managed-Pusher edge transport. Live-query writes become private refetch wakes. */
+export class PusherClientTransport implements SharedProviderClientTransport {
+	readonly channelDeliveryScope = "shared-provider" as const;
+
+	private onError: (error: unknown) => void = () => {};
+	private readonly sessions = new Map<string, PusherSession>();
+	private readonly sinks = new Map<string, PusherSessionSink>();
+	private readonly revokedPrincipalIds = new Set<string>();
+	private started = false;
+	private stopped = false;
+
+	constructor(private readonly options: PusherClientTransportOptions) {
+		if (
+			options.clientEvents?.enabled &&
+			options.clientEvents.acknowledgeProviderWideRisk !== true
+		) {
+			throw new Error(
+				"Pusher client events require acknowledgement of their provider-wide security scope",
+			);
+		}
+	}
+
+	async start(input: { onError: (error: unknown) => void }): Promise<void> {
+		if (this.stopped) throw new Error("Pusher client transport is stopped");
+		this.onError = input.onError;
+		this.started = true;
+	}
+
+	getSessionChannel(sessionId: string): string {
+		const digest = createHash("sha256")
+			.update(sessionId)
+			.digest("hex")
+			.slice(0, 32);
+		return `private-questpie-rt-${digest}`;
+	}
+
+	async openSession(input: EdgeSessionInput): Promise<ClientSink> {
+		if (this.stopped) throw new Error("Pusher client transport is stopped");
+		if (!this.started) await this.start({ onError: this.onError });
+		const channel = this.getSessionChannel(input.sessionId);
+		assertPusherChannelName(channel);
+		if (this.sessions.has(channel)) {
+			throw new Error("Pusher realtime session already exists");
+		}
+		const opaquePrincipalId = input.principal
+			? this.opaquePrincipalId(input.principal)
+			: undefined;
+		if (opaquePrincipalId && this.revokedPrincipalIds.has(opaquePrincipalId)) {
+			throw new Error("Realtime principal is revoked");
+		}
+		this.sessions.set(channel, {
+			sessionId: input.sessionId,
+			principalIdentity: principalIdentity(input.principal),
+			opaquePrincipalId,
+			resolvePrincipal: input.resolvePrincipal,
+		});
+		const sink = new PusherSessionSink(
+			input.sessionId,
+			channel,
+			this.options.provider,
+			(error) => this.onError(error),
+			() => {
+				this.sessions.delete(channel);
+				this.sinks.delete(input.sessionId);
+			},
+		);
+		this.sinks.set(input.sessionId, sink);
+		return sink;
+	}
+
+	async getClientConfig(
+		_input: ClientConfigInput,
+	): Promise<ClientTransportConfig> {
+		return {
+			transport: "shared-provider",
+			config: {
+				provider: "pusher",
+				key: this.options.key,
+				...(this.options.cluster ? { cluster: this.options.cluster } : {}),
+				...(this.options.wsHost ? { wsHost: this.options.wsHost } : {}),
+				...(this.options.wsPort ? { wsPort: this.options.wsPort } : {}),
+				...(this.options.wssPort ? { wssPort: this.options.wssPort } : {}),
+				forceTLS: this.options.forceTLS ?? true,
+				heartbeat: "provider-managed",
+				authEndpoint: this.options.authEndpoint ?? "realtime/auth",
+				userAuthentication: true,
+				...(this.options.clientEvents
+					? {
+							clientEvents: {
+								enabled: true,
+								allowedChannels: this.options.clientEvents.allowedChannels,
+								security: "provider-app-scoped",
+							},
+						}
+					: {}),
+			},
+		};
+	}
+
+	async generateAuth(input: {
+		socketId: string;
+		channel: string;
+		principal: Principal | null;
+	}): Promise<PusherAuthResponse> {
+		assertSocketId(input.socketId);
+		assertPusherChannelName(input.channel);
+		const session = this.sessions.get(input.channel);
+		if (!session) throw new Error("Realtime session is not authorized");
+		const currentPrincipal = await session.resolvePrincipal();
+		const expected = session.principalIdentity;
+		if (
+			principalIdentity(input.principal) !== expected ||
+			principalIdentity(currentPrincipal) !== expected ||
+			(session.opaquePrincipalId !== undefined &&
+				this.revokedPrincipalIds.has(session.opaquePrincipalId))
+		) {
+			throw new Error("Realtime session is not authorized");
+		}
+		return this.options.provider.authorizeChannel(
+			input.socketId,
+			input.channel,
+		);
+	}
+
+	private opaquePrincipalId(principal: Principal): string {
+		return createHmac("sha256", this.options.identityKey)
+			.update(stableUserIdentity(principal))
+			.digest("hex");
+	}
+
+	async generateUserAuth(input: {
+		socketId: string;
+		principal: Principal;
+	}): Promise<PusherUserAuthResponse> {
+		assertSocketId(input.socketId);
+		const id = this.opaquePrincipalId(input.principal);
+		if (this.revokedPrincipalIds.has(id)) {
+			throw new Error("Realtime principal is revoked");
+		}
+		return this.options.provider.authenticateUser(input.socketId, {
+			id,
+		});
+	}
+
+	async generatePresenceAuth(input: {
+		socketId: string;
+		channel: string;
+		principal: Principal;
+		member?: { user_info?: Record<string, unknown> };
+	}): Promise<PusherAuthResponse> {
+		assertSocketId(input.socketId);
+		assertPusherChannelName(input.channel);
+		if (!input.channel.startsWith("presence-")) {
+			throw new Error("Presence auth requires a presence channel");
+		}
+		const userId = this.opaquePrincipalId(input.principal);
+		if (this.revokedPrincipalIds.has(userId)) {
+			throw new Error("Realtime principal is revoked");
+		}
+		if (userId.length > MAX_PRESENCE_ID_LENGTH) {
+			throw new Error(
+				`Presence member id exceeds ${MAX_PRESENCE_ID_LENGTH} characters`,
+			);
+		}
+		const presence = {
+			user_id: userId,
+			...(input.member?.user_info ? { user_info: input.member.user_info } : {}),
+		};
+		if (byteLength(presence) > MAX_PRESENCE_DATA_BYTES) {
+			throw new Error(
+				`Presence member object exceeds ${MAX_PRESENCE_DATA_BYTES} bytes`,
+			);
+		}
+		const memberCount = await this.options.provider.getPresenceMemberCount(
+			input.channel,
+		);
+		if (memberCount >= MAX_PRESENCE_MEMBERS) {
+			throw new Error(
+				`Presence channel is limited to ${MAX_PRESENCE_MEMBERS} members`,
+			);
+		}
+		return this.options.provider.authorizeChannel(
+			input.socketId,
+			input.channel,
+			presence,
+		);
+	}
+
+	async revokePrincipal(principal: Principal): Promise<void> {
+		const id = this.opaquePrincipalId(principal);
+		this.revokedPrincipalIds.add(id);
+		const sessions = [...this.sessions.entries()]
+			.filter(([, session]) => session.opaquePrincipalId === id)
+			.map(([, session]) => this.sinks.get(session.sessionId))
+			.filter((sink): sink is PusherSessionSink => sink !== undefined);
+		await Promise.all(sessions.map((sink) => sink.close()));
+		await this.options.provider.terminateUserConnections(id);
+	}
+
+	restorePrincipal(principal: Principal): void {
+		this.revokedPrincipalIds.delete(this.opaquePrincipalId(principal));
+	}
+
+	async publishChannel(
+		input: OrderedChannelDelivery,
+	): Promise<SinkWriteResult> {
+		assertPusherChannelName(input.channel);
+		await this.options.provider.trigger(input.channel, "questpie:channel", {
+			eventId: input.eventId,
+			data: new TextDecoder().decode(input.frame),
+		});
+		return { status: "accepted", bufferedBytes: null };
+	}
+
+	async stop(): Promise<void> {
+		if (this.stopped) return;
+		this.stopped = true;
+		this.started = false;
+		await Promise.all([...this.sinks.values()].map((sink) => sink.close()));
+		this.sinks.clear();
+		this.sessions.clear();
+		this.revokedPrincipalIds.clear();
+	}
+}

--- a/packages/questpie/src/server/modules/core/integrated/realtime/service.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/service.ts
@@ -7,6 +7,18 @@ import type { RealtimeAdapter } from "./adapter.js";
 import { PgNotifyAdapter } from "./adapters/pg-notify.js";
 import { questpieRealtimeLogTable } from "./collection.js";
 import type {
+	ChangeBroker,
+	ClientAuthInput,
+	ClientAuthResponse,
+	ClientConfigInput,
+	ClientSink,
+	ClientTransport,
+	ClientTransportConfig,
+	EdgeSessionInput,
+	OrderedChannelDelivery,
+	SinkWriteResult,
+} from "./transport.js";
+import type {
 	RealtimeChangeEvent,
 	RealtimeChangePayload,
 	RealtimeConfig,
@@ -117,12 +129,15 @@ function analyzeWhere(where: any): {
 
 export class RealtimeService {
 	private adapter?: RealtimeAdapter;
+	private changeBroker?: ChangeBroker;
+	private clientTransport?: ClientTransport;
 	private listeners = new Set<ListenerEntry>();
 	private directCollectionListeners = new Map<string, Set<ListenerEntry>>();
 	private directGlobalListeners = new Map<string, Set<ListenerEntry>>();
 	private watchedCollectionListeners = new Map<string, Set<ListenerEntry>>();
 	private watchedGlobalListeners = new Map<string, Set<ListenerEntry>>();
 	private pollIntervalMs: number;
+	private readonly configuredPollIntervalMs: number;
 	private batchSize: number;
 	private draining = false;
 	private drainPending = false;
@@ -147,11 +162,13 @@ export class RealtimeService {
 		private pgConnectionString?: string,
 		private logger?: Pick<LoggerAdapter, "error" | "warn">,
 	) {
+		this.changeBroker = config.changeBroker;
+		this.clientTransport = config.clientTransport;
 		// Auto-configure adapter if connection string is provided
 		if (config.adapter) {
 			// User provided custom adapter
 			this.adapter = config.adapter;
-		} else if (this.pgConnectionString) {
+		} else if (this.pgConnectionString && !this.changeBroker) {
 			// Create the default publisher at service construction so write-only
 			// instances can broadcast before they ever receive a local subscription.
 			this.adapter = new PgNotifyAdapter({
@@ -163,9 +180,10 @@ export class RealtimeService {
 		this.batchSize = config.batchSize ?? 500;
 		this.pollIntervalMs =
 			config.pollIntervalMs ??
-			(this.adapter || this.pgConnectionString
+			(this.adapter || this.changeBroker || this.pgConnectionString
 				? DEFAULT_ADAPTER_RECONCILIATION_INTERVAL_MS
 				: 2000);
+		this.configuredPollIntervalMs = this.pollIntervalMs;
 		this.retentionDays =
 			config.retentionDays === undefined
 				? DEFAULT_RETENTION_DAYS
@@ -298,9 +316,16 @@ export class RealtimeService {
 	}
 
 	async notify(event: RealtimeChangeEvent): Promise<void> {
-		if (!this.adapter) return;
+		if (!this.adapter && !this.changeBroker) return;
 		await this.initialize();
-		await this.adapter.notify(event);
+		await Promise.all([
+			this.adapter?.notify(event),
+			this.changeBroker?.publish({
+				kind: "outbox-maybe-advanced",
+				highWaterSeq: event.seq,
+				reason: "publish",
+			}),
+		]);
 	}
 
 	async initialize(): Promise<void> {
@@ -312,11 +337,95 @@ export class RealtimeService {
 
 		this.publisherStartPromise = (async () => {
 			await this.adapter?.startPublisher?.();
+			await this.changeBroker?.start({
+				onWake: () => this.drainSafely(),
+				onError: (error) =>
+					this.reportTransportFailure("[Realtime] Change broker failed", error),
+				onStateChange: (state) => {
+					if (state === "connected") {
+						this.setReconciliationPollInterval(this.configuredPollIntervalMs);
+						this.drainSafely();
+					} else if (state === "unavailable" || state === "failed") {
+						this.setReconciliationPollInterval(
+							this.configuredPollIntervalMs > 0
+								? Math.min(this.configuredPollIntervalMs, 2000)
+								: 0,
+						);
+					}
+				},
+			});
+			await this.clientTransport?.start({
+				onError: (error) =>
+					this.reportTransportFailure(
+						"[Realtime] Client transport failed",
+						error,
+					),
+			});
 			this.publisherStarted = true;
 		})().finally(() => {
 			this.publisherStartPromise = null;
 		});
 		await this.publisherStartPromise;
+	}
+
+	async getClientTransportConfig(
+		input: ClientConfigInput,
+	): Promise<ClientTransportConfig> {
+		await this.initialize();
+		if (!this.clientTransport) return { transport: "sse" };
+		return this.clientTransport.getClientConfig(input);
+	}
+
+	async openClientSession(input: EdgeSessionInput): Promise<ClientSink> {
+		await this.initialize();
+		if (!this.clientTransport) {
+			throw new Error("No configured realtime client transport");
+		}
+		return this.clientTransport.openSession(input);
+	}
+
+	async generateClientAuth(
+		input: ClientAuthInput,
+	): Promise<ClientAuthResponse> {
+		await this.initialize();
+		if (
+			!this.clientTransport ||
+			this.clientTransport.channelDeliveryScope !== "shared-provider"
+		) {
+			throw new Error("Realtime provider auth is not configured");
+		}
+		return this.clientTransport.generateAuth(input);
+	}
+
+	async publishChannel(
+		input: OrderedChannelDelivery,
+	): Promise<SinkWriteResult> {
+		await this.initialize();
+		if (
+			!this.clientTransport ||
+			this.clientTransport.channelDeliveryScope !== "shared-provider"
+		) {
+			throw new Error("Shared-provider channel delivery is not configured");
+		}
+		return this.clientTransport.publishChannel(input);
+	}
+
+	private setReconciliationPollInterval(intervalMs: number): void {
+		if (this.pollIntervalMs === intervalMs) return;
+		this.pollIntervalMs = intervalMs;
+		if (!this.started) return;
+		if (this.pollTimer) {
+			clearInterval(this.pollTimer);
+			this.pollTimer = null;
+		}
+		this.startPollTimer();
+	}
+
+	private startPollTimer(): void {
+		if (this.pollIntervalMs <= 0 || this.pollTimer) return;
+		this.pollTimer = setInterval(() => {
+			this.drainSafely();
+		}, this.pollIntervalMs);
 	}
 
 	/**
@@ -513,11 +622,7 @@ export class RealtimeService {
 					}) ?? null;
 			}
 
-			if (this.pollIntervalMs > 0) {
-				this.pollTimer = setInterval(() => {
-					this.drainSafely();
-				}, this.pollIntervalMs);
-			}
+			this.startPollTimer();
 
 			this.lastSeq = latestSeq;
 			this.started = true;
@@ -615,6 +720,8 @@ export class RealtimeService {
 		if (this.adapter) {
 			await this.adapter.stop();
 		}
+		await this.changeBroker?.stop();
+		await this.clientTransport?.stop();
 		this.publisherStarted = false;
 	}
 

--- a/packages/questpie/src/server/modules/core/integrated/realtime/transport.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/transport.ts
@@ -19,10 +19,18 @@ export interface ChangeBroker {
 	start(input: {
 		onWake: (wake: ChangeWake) => void;
 		onError: (error: unknown) => void;
+		onStateChange?: (state: ChangeBrokerState) => void;
 	}): Promise<void>;
 	publish(wake: ChangeWake): Promise<void>;
 	stop(): Promise<void>;
 }
+
+export type ChangeBrokerState =
+	| "connecting"
+	| "connected"
+	| "unavailable"
+	| "failed"
+	| "disconnected";
 
 export type DeliveryClass = "latest-snapshot" | "ordered-channel-event";
 
@@ -54,6 +62,18 @@ export type ClientConfigInput = {
 	request?: Request;
 };
 
+export type ClientAuthInput = {
+	socketId: string;
+	channel: string;
+	principal: Principal | null;
+};
+
+export type ClientAuthResponse = {
+	auth: string;
+	channel_data?: string;
+	shared_secret?: string;
+};
+
 export type ClientTransportConfig =
 	| { transport: "sse" }
 	| {
@@ -80,6 +100,7 @@ export interface LocalSessionClientTransport extends ClientTransportBase {
 
 export interface SharedProviderClientTransport extends ClientTransportBase {
 	readonly channelDeliveryScope: "shared-provider";
+	generateAuth(input: ClientAuthInput): Promise<ClientAuthResponse>;
 	publishChannel(input: OrderedChannelDelivery): Promise<SinkWriteResult>;
 }
 

--- a/packages/questpie/src/server/modules/core/integrated/realtime/types.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/types.ts
@@ -1,4 +1,5 @@
 import type { RealtimeAdapter } from "./adapter.js";
+import type { ChangeBroker, ClientTransport } from "./transport.js";
 
 export type RealtimeResourceType = "collection" | "global";
 
@@ -95,6 +96,10 @@ export interface RealtimeConfig {
 	 * Optional transport adapter (pg_notify, redis streams, etc.).
 	 */
 	adapter?: RealtimeAdapter;
+	/** Cross-instance notice seam used by Realtime v2 transports. */
+	changeBroker?: ChangeBroker;
+	/** Edge delivery seam shared by live queries and typed channels. */
+	clientTransport?: ClientTransport;
 
 	/**
 	 * Reconciliation poll interval in ms. Polling runs alongside adapters so a

--- a/packages/questpie/src/server/modules/core/routes/realtime/auth.post.ts
+++ b/packages/questpie/src/server/modules/core/routes/realtime/auth.post.ts
@@ -1,0 +1,55 @@
+import type { Principal } from "#questpie/server/config/context.js";
+import { route } from "#questpie/server/routes/define-route.js";
+import { routeApp } from "#questpie/server/routes/route-app.js";
+
+async function authParameters(request: Request): Promise<{
+	socketId: string;
+	channel: string;
+}> {
+	const contentType = request.headers.get("content-type") ?? "";
+	let socketId: unknown;
+	let channel: unknown;
+	if (contentType.includes("application/json")) {
+		const body = (await request.json()) as Record<string, unknown>;
+		socketId = body.socket_id ?? body.socketId;
+		channel = body.channel_name ?? body.channel;
+	} else {
+		const body = await request.formData();
+		socketId = body.get("socket_id");
+		channel = body.get("channel_name");
+	}
+	if (typeof socketId !== "string" || typeof channel !== "string") {
+		throw new Error("socket_id and channel_name are required");
+	}
+	return { socketId, channel };
+}
+
+/** Socket/channel-bound Pusher authorization for active realtime sessions. */
+export default route()
+	.post()
+	.access(true)
+	.raw()
+	.handler(async (ctx) => {
+		try {
+			const realtime = routeApp(ctx).realtime;
+			if (!realtime) {
+				return Response.json(
+					{ error: "Realtime provider auth is not configured" },
+					{ status: 404, headers: { "Cache-Control": "no-store" } },
+				);
+			}
+			const input = await authParameters(ctx.request);
+			const auth = await realtime.generateClientAuth({
+				...input,
+				principal: (ctx as { principal?: Principal }).principal ?? null,
+			});
+			return Response.json(auth, {
+				headers: { "Cache-Control": "no-store" },
+			});
+		} catch {
+			return Response.json(
+				{ error: "Realtime session is not authorized" },
+				{ status: 403, headers: { "Cache-Control": "no-store" } },
+			);
+		}
+	});

--- a/packages/questpie/src/server/modules/core/routes/realtime/config.ts
+++ b/packages/questpie/src/server/modules/core/routes/realtime/config.ts
@@ -1,0 +1,16 @@
+import { route } from "#questpie/server/routes/define-route.js";
+import { routeApp } from "#questpie/server/routes/route-app.js";
+
+/** Public provider metadata; secrets remain inside the server transport. */
+export default route()
+	.get()
+	.access(true)
+	.raw()
+	.handler(async (ctx) => {
+		const config = await routeApp(ctx).realtime?.getClientTransportConfig({
+			request: ctx.request,
+		});
+		return Response.json(config ?? { transport: "sse" }, {
+			headers: { "Cache-Control": "no-store" },
+		});
+	});

--- a/packages/questpie/test/fixtures/soketi/compose.yml
+++ b/packages/questpie/test/fixtures/soketi/compose.yml
@@ -1,0 +1,12 @@
+services:
+  soketi:
+    image: quay.io/soketi/soketi:1.6-16-debian
+    ports:
+      - "6001:6001"
+    environment:
+      SOKETI_DEFAULT_APP_ID: questpie-test
+      SOKETI_DEFAULT_APP_KEY: questpie-test-key
+      SOKETI_DEFAULT_APP_SECRET: questpie-test-secret
+      # Deliberately provider-wide for the hostile raw-client security test.
+      SOKETI_DEFAULT_APP_ENABLE_CLIENT_MESSAGES: "true"
+      SOKETI_DEBUG: "1"

--- a/packages/questpie/test/integration/realtime-pusher-routes.test.ts
+++ b/packages/questpie/test/integration/realtime-pusher-routes.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { createFetchHandler } from "../../src/server/adapters/http.js";
+import {
+	PusherClientTransport,
+	type PusherProvider,
+} from "../../src/server/modules/core/integrated/realtime/pusher-transport.js";
+import { buildMockApp } from "../utils/mocks/mock-app-builder";
+
+const provider: PusherProvider = {
+	trigger: async () => {},
+	authorizeChannel: (socketId, channel) => ({
+		auth: `${socketId}:${channel}`,
+	}),
+	authenticateUser: (socketId, user) => ({
+		auth: `${socketId}:${user.id}`,
+		user_data: JSON.stringify(user),
+	}),
+	terminateUserConnections: async () => {},
+	getPresenceMemberCount: async () => 0,
+};
+
+describe("pusher transport module routes", () => {
+	let setup: Awaited<ReturnType<typeof buildMockApp>>;
+
+	afterEach(async () => {
+		await setup.cleanup();
+	});
+
+	test("exposes secret-free config and no-store session-bound auth", async () => {
+		const transport = new PusherClientTransport({
+			provider,
+			key: "public-key",
+			identityKey: "never-expose-this-secret",
+			wsHost: "soketi.internal",
+			forceTLS: false,
+		});
+		setup = await buildMockApp(
+			{},
+			{ realtime: { clientTransport: transport, retentionDays: 0 } },
+		);
+		const sessionId = "018f1d92-7ab0-7d68-a230-000000000001";
+		await setup.app.realtime.openClientSession({
+			sessionId,
+			principal: null,
+			resolvePrincipal: async () => null,
+		});
+		const channel = transport.getSessionChannel(sessionId);
+		const handler = createFetchHandler(setup.app);
+
+		const configResponse = await handler(
+			new Request("http://localhost/realtime/config"),
+		);
+		expect(configResponse.status).toBe(200);
+		expect(configResponse.headers.get("cache-control")).toBe("no-store");
+		const serializedConfig = JSON.stringify(await configResponse.json());
+		expect(serializedConfig).toContain("public-key");
+		expect(serializedConfig).toContain("soketi.internal");
+		expect(serializedConfig).not.toContain("never-expose-this-secret");
+
+		const body = new FormData();
+		body.set("socket_id", "123.456");
+		body.set("channel_name", channel);
+		const authResponse = await handler(
+			new Request("http://localhost/realtime/auth", {
+				method: "POST",
+				body,
+			}),
+		);
+		expect(authResponse.status).toBe(200);
+		expect(authResponse.headers.get("cache-control")).toBe("no-store");
+		expect(await authResponse.json()).toEqual({
+			auth: `123.456:${channel}`,
+		});
+	});
+
+	test("rejects auth for an inactive private channel", async () => {
+		const transport = new PusherClientTransport({
+			provider,
+			key: "public-key",
+			identityKey: "test-secret",
+		});
+		setup = await buildMockApp(
+			{},
+			{ realtime: { clientTransport: transport, retentionDays: 0 } },
+		);
+		const handler = createFetchHandler(setup.app);
+		const response = await handler(
+			new Request("http://localhost/realtime/auth", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({
+					socket_id: "123.456",
+					channel_name: "private-questpie-rt-deadbeef",
+				}),
+			}),
+		);
+
+		expect(response.status).toBe(403);
+		expect(response.headers.get("cache-control")).toBe("no-store");
+	});
+});

--- a/packages/questpie/test/integration/realtime-soketi.test.ts
+++ b/packages/questpie/test/integration/realtime-soketi.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, test } from "bun:test";
+
+import Pusher from "pusher";
+import PusherJs, {
+	type ChannelAuthorizationHandler,
+	type Channel,
+} from "pusher-js";
+
+import { pusherRealtime } from "../../src/exports/adapters/pusher.js";
+
+const runSoketi = process.env.QUESTPIE_SOKETI_INTEGRATION === "1";
+const PusherJsConstructor =
+	(PusherJs as unknown as { Pusher?: typeof PusherJs }).Pusher ?? PusherJs;
+const credentials = {
+	appId: "questpie-test",
+	key: "questpie-test-key",
+	secret: "questpie-test-secret",
+	host: "127.0.0.1",
+	port: 6001,
+	useTLS: false,
+};
+
+function timeout<T>(promise: Promise<T>, message: string): Promise<T> {
+	return Promise.race([
+		promise,
+		new Promise<never>((_, reject) =>
+			setTimeout(() => reject(new Error(message)), 5000),
+		),
+	]);
+}
+
+function rawClient(server: Pusher): PusherJs {
+	const authorize: ChannelAuthorizationHandler = (params, callback) => {
+		callback(
+			null,
+			server.authorizeChannel(params.socketId, params.channelName),
+		);
+	};
+	return new PusherJsConstructor(credentials.key, {
+		cluster: "mt1",
+		forceTLS: false,
+		wsHost: credentials.host,
+		wsPort: credentials.port,
+		enabledTransports: ["ws"],
+		channelAuthorization: { customHandler: authorize },
+	});
+}
+
+function subscribed(channel: Channel): Promise<void> {
+	return timeout(
+		new Promise((resolve, reject) => {
+			channel.bind("pusher:subscription_succeeded", () => resolve());
+			channel.bind("pusher:subscription_error", reject);
+		}),
+		"Soketi subscription timed out",
+	);
+}
+
+describe.skipIf(!runSoketi)("soketi pusher transport conformance", () => {
+	test("delivers a notice wake between application instances", async () => {
+		const receiver = pusherRealtime(credentials).changeBroker;
+		const publisher = pusherRealtime(credentials).changeBroker;
+		const received = timeout(
+			new Promise<void>((resolve) => {
+				void receiver.start({
+					onWake: (wake) => {
+						if (wake.reason === "publish" && wake.highWaterSeq === 42)
+							resolve();
+					},
+					onError: () => {},
+				});
+			}),
+			"Soketi notice delivery timed out",
+		);
+		await publisher.start({ onWake: () => {}, onError: () => {} });
+		await new Promise((resolve) => setTimeout(resolve, 100));
+		await publisher.publish({
+			kind: "outbox-maybe-advanced",
+			highWaterSeq: 42,
+			reason: "publish",
+		});
+
+		await received;
+		await Promise.all([receiver.stop(), publisher.stop()]);
+	});
+
+	test("raw hostile client proves SDK channel allowlists are not authorization", async () => {
+		const server = new Pusher({
+			appId: credentials.appId,
+			key: credentials.key,
+			secret: credentials.secret,
+			host: credentials.host,
+			port: String(credentials.port),
+			useTLS: false,
+		});
+		const hostile = rawClient(server);
+		const receiver = rawClient(server);
+		const channelName = "private-not-in-framework-allowlist";
+		const hostileChannel = hostile.subscribe(channelName);
+		const receiverChannel = receiver.subscribe(channelName);
+		const event = timeout(
+			new Promise<{ attack: boolean }>((resolve) => {
+				receiverChannel.bind("client-hostile", resolve);
+			}),
+			"Hostile client event was not delivered",
+		);
+
+		await Promise.all([
+			subscribed(hostileChannel),
+			subscribed(receiverChannel),
+		]);
+		expect(hostileChannel.trigger("client-hostile", { attack: true })).toBe(
+			true,
+		);
+		expect(await event).toEqual({ attack: true });
+
+		hostile.disconnect();
+		receiver.disconnect();
+	});
+});

--- a/packages/questpie/test/units/realtime-pusher-transport.test.ts
+++ b/packages/questpie/test/units/realtime-pusher-transport.test.ts
@@ -1,0 +1,475 @@
+import { describe, expect, spyOn, test } from "bun:test";
+
+import {
+	PusherChangeBroker,
+	PusherClientTransport,
+	assertPusherChannelName,
+	type PusherProvider,
+	type PusherSubscriber,
+} from "#questpie/server/modules/core/integrated/realtime/pusher-transport.js";
+import { RealtimeService } from "#questpie/server/modules/core/integrated/realtime/service.js";
+import type {
+	ChangeBroker,
+	ChangeBrokerState,
+	ChangeWake,
+} from "#questpie/server/modules/core/integrated/realtime/transport.js";
+import type { RealtimeChangeEvent } from "#questpie/server/modules/core/integrated/realtime/types.js";
+
+type Trigger = {
+	channel: string;
+	event: string;
+	data: unknown;
+};
+
+function createProvider() {
+	const triggers: Trigger[] = [];
+	const provider: PusherProvider = {
+		trigger: async (channel, event, data) => {
+			triggers.push({ channel, event, data });
+		},
+		authorizeChannel: (socketId, channel, presence) => ({
+			auth: `${socketId}:${channel}`,
+			...(presence ? { channel_data: JSON.stringify(presence) } : {}),
+		}),
+		authenticateUser: (socketId, user) => ({
+			auth: `${socketId}:${user.id}`,
+			user_data: JSON.stringify(user),
+		}),
+		terminateUserConnections: async () => {},
+		getPresenceMemberCount: async () => 0,
+	};
+	return { provider, triggers };
+}
+
+function tick(): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+class DroppingChangeBroker implements ChangeBroker {
+	started = false;
+	published: ChangeWake[] = [];
+	private onWake: (wake: ChangeWake) => void = () => {};
+	private onStateChange: (state: ChangeBrokerState) => void = () => {};
+
+	async start(input: {
+		onWake: (wake: ChangeWake) => void;
+		onError: (error: unknown) => void;
+		onStateChange?: (state: ChangeBrokerState) => void;
+	}): Promise<void> {
+		this.started = true;
+		this.onWake = input.onWake;
+		this.onStateChange = input.onStateChange ?? (() => {});
+	}
+
+	async publish(wake: ChangeWake): Promise<void> {
+		this.published.push(wake);
+		// Accepted but intentionally lost before any subscriber observes it.
+	}
+
+	emit(wake: ChangeWake): void {
+		this.onWake(wake);
+	}
+
+	emitState(state: ChangeBrokerState): void {
+		this.onStateChange(state);
+	}
+
+	async stop(): Promise<void> {}
+}
+
+class RealtimeReadDb {
+	rows: RealtimeChangeEvent[] = [];
+
+	select(selection?: unknown) {
+		const latestOnly =
+			selection !== undefined &&
+			typeof selection === "object" &&
+			selection !== null &&
+			Object.keys(selection).length === 1;
+		const query = {
+			from: () => query,
+			where: () => query,
+			orderBy: () => query,
+			limit: async () =>
+				latestOnly
+					? this.rows.at(-1)
+						? [{ seq: this.rows.at(-1)!.seq }]
+						: []
+					: this.rows,
+		};
+		return query;
+	}
+}
+
+describe("pusher transport change broker", () => {
+	test("coalesces notice-only wakes and emits a reconcile wake after reconnect", async () => {
+		const { provider, triggers } = createProvider();
+		let onMessage: ((value: unknown) => void) | undefined;
+		let onStateChange: ((state: string) => void) | undefined;
+		const subscriber: PusherSubscriber = {
+			start: async (input) => {
+				onMessage = input.onMessage;
+				onStateChange = input.onStateChange;
+			},
+			stop: async () => {},
+		};
+		const wakes: unknown[] = [];
+		const states: string[] = [];
+		const broker = new PusherChangeBroker({
+			provider,
+			subscriber,
+			channel: "questpie-broker-test",
+		});
+
+		await broker.start({
+			onWake: (wake) => wakes.push(wake),
+			onError: () => {},
+			onStateChange: (state) => states.push(state),
+		});
+		const first = broker.publish({
+			kind: "outbox-maybe-advanced",
+			highWaterSeq: 10,
+			reason: "publish",
+		});
+		const second = broker.publish({
+			kind: "outbox-maybe-advanced",
+			highWaterSeq: 11,
+			reason: "publish",
+		});
+		await Promise.all([first, second]);
+
+		expect(triggers).toHaveLength(1);
+		expect(triggers[0]?.data).toEqual({
+			kind: "outbox-maybe-advanced",
+			highWaterSeq: 11,
+			reason: "publish",
+		});
+
+		onMessage?.({
+			kind: "outbox-maybe-advanced",
+			highWaterSeq: 12,
+			reason: "publish",
+			snapshot: "must be stripped",
+		});
+		onStateChange?.("connected");
+		expect(wakes).toEqual([
+			{
+				kind: "outbox-maybe-advanced",
+				highWaterSeq: 12,
+				reason: "publish",
+			},
+			{
+				kind: "outbox-maybe-advanced",
+				reason: "reconnect",
+			},
+		]);
+		expect(states).toEqual(["connected"]);
+	});
+
+	test("reports provider failures while publish remains off the caller path", async () => {
+		const errors: unknown[] = [];
+		const provider = createProvider().provider;
+		provider.trigger = async () => {
+			throw new Error("provider unavailable");
+		};
+		const broker = new PusherChangeBroker({
+			provider,
+			subscriber: { start: async () => {}, stop: async () => {} },
+			channel: "questpie-broker-test",
+		});
+		await broker.start({
+			onWake: () => {},
+			onError: (error) => errors.push(error),
+		});
+
+		const pending = broker.publish({
+			kind: "outbox-maybe-advanced",
+			reason: "publish",
+		});
+		expect(errors).toHaveLength(0);
+		await expect(pending).rejects.toThrow("provider unavailable");
+		expect(errors).toHaveLength(1);
+	});
+
+	test("pusher notice loss heals from the durable outbox poll", async () => {
+		const broker = new DroppingChangeBroker();
+		const db = new RealtimeReadDb();
+		let poll: (() => void) | undefined;
+		const intervalSpy = spyOn(globalThis, "setInterval").mockImplementation(
+			(handler, delay) => {
+				if (delay === 25_000) {
+					poll = () => {
+						if (typeof handler === "function") handler();
+					};
+				}
+				return 1 as unknown as ReturnType<typeof setInterval>;
+			},
+		);
+		const realtime = new RealtimeService(db as never, {
+			changeBroker: broker,
+			pollIntervalMs: 25_000,
+			retentionDays: 0,
+		});
+		try {
+			const delivered: RealtimeChangeEvent[] = [];
+			realtime.subscribe((event) => delivered.push(event), {
+				resourceType: "collection",
+				resource: "posts",
+			});
+			await tick();
+			const change: RealtimeChangeEvent = {
+				seq: 1,
+				resourceType: "collection",
+				resource: "posts",
+				operation: "create",
+				recordId: "post-1",
+				locale: null,
+				payload: {},
+				createdAt: new Date(),
+			};
+			db.rows = [change];
+			await realtime.notify(change);
+			expect(delivered).toEqual([]);
+			expect(broker.published).toEqual([
+				{
+					kind: "outbox-maybe-advanced",
+					highWaterSeq: 1,
+					reason: "publish",
+				},
+			]);
+
+			poll?.();
+			await tick();
+			expect(delivered).toEqual([change]);
+		} finally {
+			intervalSpy.mockRestore();
+			await realtime.destroy();
+		}
+	});
+
+	test("pusher unavailable state escalates reconciliation cadence", async () => {
+		const broker = new DroppingChangeBroker();
+		const delays: number[] = [];
+		const intervalSpy = spyOn(globalThis, "setInterval").mockImplementation(
+			(_handler, delay) => {
+				delays.push(Number(delay));
+				return delays.length as unknown as ReturnType<typeof setInterval>;
+			},
+		);
+		const realtime = new RealtimeService(new RealtimeReadDb() as never, {
+			changeBroker: broker,
+			pollIntervalMs: 15_000,
+			retentionDays: 0,
+		});
+		try {
+			realtime.subscribe(() => {}, {
+				resourceType: "collection",
+				resource: "posts",
+			});
+			await tick();
+			broker.emitState("unavailable");
+			expect(delays).toEqual([15_000, 2000]);
+			broker.emitState("connected");
+			expect(delays).toEqual([15_000, 2000, 15_000]);
+		} finally {
+			intervalSpy.mockRestore();
+			await realtime.destroy();
+		}
+	});
+});
+
+describe("pusher transport client delivery", () => {
+	test("validates final provider names at the 164-character boundary", () => {
+		expect(() => assertPusherChannelName("a".repeat(164))).not.toThrow();
+		expect(() => assertPusherChannelName("a".repeat(165))).toThrow("1-164");
+		expect(() => assertPusherChannelName("private-chat/room")).toThrow(
+			"provider-safe",
+		);
+	});
+
+	test("coalesces private invalidations without leaking snapshot bytes", async () => {
+		const { provider, triggers } = createProvider();
+		const transport = new PusherClientTransport({
+			provider,
+			key: "public-key",
+			identityKey: "test-secret",
+		});
+		await transport.start({ onError: () => {} });
+		const principal = {
+			kind: "user" as const,
+			user: { id: "user-1" } as any,
+			session: { id: "session-1" } as any,
+		};
+		const sink = await transport.openSession({
+			sessionId: "018f1d92-7ab0-7d68-a230-000000000001",
+			principal,
+			resolvePrincipal: async () => principal,
+		});
+
+		await Promise.all([
+			sink.write(
+				new TextEncoder().encode("TOP SECRET SNAPSHOT A"),
+				"latest-snapshot",
+			),
+			sink.write(
+				new TextEncoder().encode("TOP SECRET SNAPSHOT B"),
+				"latest-snapshot",
+			),
+		]);
+		await tick();
+
+		expect(triggers).toHaveLength(1);
+		expect(triggers[0]?.channel.startsWith("private-questpie-rt-")).toBe(true);
+		expect(triggers[0]?.event).toBe("questpie:invalidate");
+		const serialized = JSON.stringify(triggers[0]?.data);
+		expect(serialized).not.toContain("TOP SECRET");
+		expect(serialized).not.toContain("SNAPSHOT");
+		await expect(
+			sink.write(new Uint8Array(), "ordered-channel-event"),
+		).rejects.toThrow("publishChannel");
+	});
+
+	test("maps one ordered publish call to exactly one provider publish", async () => {
+		const { provider, triggers } = createProvider();
+		const transport = new PusherClientTransport({
+			provider,
+			key: "public-key",
+			identityKey: "test-secret",
+		});
+		await transport.start({ onError: () => {} });
+
+		const result = await transport.publishChannel({
+			channel: "private-chat-room-123",
+			eventId: "event-1",
+			frame: new TextEncoder().encode('{"message":"hello"}'),
+		});
+
+		expect(result).toEqual({ status: "accepted", bufferedBytes: null });
+		expect(triggers).toEqual([
+			{
+				channel: "private-chat-room-123",
+				event: "questpie:channel",
+				data: { eventId: "event-1", data: '{"message":"hello"}' },
+			},
+		]);
+	});
+
+	test("binds channel auth to an active session and its current principal", async () => {
+		const { provider } = createProvider();
+		const transport = new PusherClientTransport({
+			provider,
+			key: "public-key",
+			identityKey: "test-secret",
+		});
+		const principal = {
+			kind: "user" as const,
+			user: { id: "user-1" } as any,
+			session: { id: "session-1" } as any,
+		};
+		const sink = await transport.openSession({
+			sessionId: "018f1d92-7ab0-7d68-a230-000000000001",
+			principal,
+			resolvePrincipal: async () => principal,
+		});
+		const channel = transport.getSessionChannel(sink.sessionId);
+
+		await expect(
+			transport.generateAuth({ socketId: "123.456", channel, principal }),
+		).resolves.toEqual({ auth: `123.456:${channel}` });
+		await expect(
+			transport.generateAuth({
+				socketId: "123.456",
+				channel,
+				principal: { ...principal, session: { id: "other" } as any },
+			}),
+		).rejects.toThrow("not authorized");
+		await sink.close("normal");
+		await expect(
+			transport.generateAuth({ socketId: "123.456", channel, principal }),
+		).rejects.toThrow("not authorized");
+	});
+
+	test("keeps secrets out of config and requires the provider-wide client-event acknowledgement", async () => {
+		const { provider } = createProvider();
+		expect(
+			() =>
+				new PusherClientTransport({
+					provider,
+					key: "public-key",
+					identityKey: "test-secret",
+					clientEvents: { enabled: true },
+				} as any),
+		).toThrow("provider-wide");
+
+		const transport = new PusherClientTransport({
+			provider,
+			key: "public-key",
+			identityKey: "test-secret",
+			clientEvents: {
+				enabled: true,
+				acknowledgeProviderWideRisk: true,
+				allowedChannels: ["private-chat-room-*"],
+			},
+		});
+		const config = await transport.getClientConfig({});
+		const serialized = JSON.stringify(config);
+		expect(serialized).toContain("public-key");
+		expect(serialized).toContain("clientEvents");
+		expect(serialized).not.toContain("test-secret");
+	});
+
+	test("enforces presence limits and can revoke provider-authenticated users", async () => {
+		const terminated: string[] = [];
+		const { provider } = createProvider();
+		provider.getPresenceMemberCount = async () => 100;
+		provider.terminateUserConnections = async (id) => terminated.push(id);
+		const transport = new PusherClientTransport({
+			provider,
+			key: "public-key",
+			identityKey: "test-secret",
+		});
+		const principal = {
+			kind: "user" as const,
+			user: { id: "user-1" } as any,
+			session: { id: "session-1" } as any,
+		};
+
+		await expect(
+			transport.generatePresenceAuth({
+				socketId: "123.456",
+				channel: "presence-chat-room-1",
+				principal,
+				member: { user_info: { displayName: "Ada" } },
+			}),
+		).rejects.toThrow("100 members");
+
+		provider.getPresenceMemberCount = async () => 0;
+		const auth = await transport.generatePresenceAuth({
+			socketId: "123.456",
+			channel: "presence-chat-room-1",
+			principal,
+			member: { user_info: { displayName: "Ada" } },
+		});
+		const channelData = JSON.parse(auth.channel_data!);
+		expect(channelData.user_id).toHaveLength(64);
+		expect(channelData.user_id).not.toContain("user-1");
+
+		await transport.revokePrincipal(principal);
+		expect(terminated).toEqual([channelData.user_id]);
+		await expect(
+			transport.generateUserAuth({ socketId: "123.456", principal }),
+		).rejects.toThrow("revoked");
+		await expect(
+			transport.generatePresenceAuth({
+				socketId: "123.456",
+				channel: "presence-chat-room-1",
+				principal,
+			}),
+		).rejects.toThrow("revoked");
+
+		transport.restorePrincipal(principal);
+		await expect(
+			transport.generateUserAuth({ socketId: "123.456", principal }),
+		).resolves.toMatchObject({ auth: expect.any(String) });
+	});
+});


### PR DESCRIPTION
## Summary

- add the isolated `questpie/adapters/pusher` optional-peer preset implementing both `ChangeBroker` and shared-provider `ClientTransport`
- deliver coalesced notice-only broker wakes, private per-session invalidations, ordered channel publishes, provider-managed heartbeat, and degraded-state reconciliation escalation
- add socket/channel-bound no-store auth and secret-free config module routes
- enforce provider channel, presence, client-event opt-in, opaque identity, and revocation boundaries from the accepted security model
- add a pinned Dockerized Soketi fixture plus raw hostile-client conformance coverage

## Verification

- `cd packages/questpie && bun test` — 1952 pass, 2 gated, 0 fail
- `QUESTPIE_SOKETI_INTEGRATION=1 bun test test/integration/realtime-soketi.test.ts` — 2 pass, 0 fail against live Soketi
- source and full-app TypeScript checks pass
- `bun run build` passes
- changed-file oxlint: 0 warnings/errors
- changed-file format check and `git diff --check` pass

Stacked on RT2.0 / #149.