### PR TITLE
feat(realtime): add ordered channel event ledger

### DIFF
--- a/.changeset/order-channel-events.md
+++ b/.changeset/order-channel-events.md
@@ -1,0 +1,5 @@
+---
+"questpie": patch
+---
+
+Persist typed channel publishes in a bounded transaction-safe event ledger with per-channel ordering, replay and gap recovery, local slow-consumer protection, and cross-instance shared-provider coordination.

--- a/packages/questpie/src/exports/realtime.ts
+++ b/packages/questpie/src/exports/realtime.ts
@@ -4,6 +4,7 @@ export {
 	type RealtimeAdmissionConfig,
 } from "#questpie/server/modules/core/integrated/realtime/admission.js";
 export * from "#questpie/server/modules/core/integrated/realtime/collection.js";
+export * from "#questpie/server/modules/core/integrated/realtime/channel-event-ledger.js";
 export * from "#questpie/server/modules/core/integrated/realtime/service.js";
 export * from "#questpie/server/modules/core/integrated/realtime/snapshot.js";
 export * from "#questpie/server/modules/core/integrated/realtime/sse-client-transport.js";

--- a/packages/questpie/src/server/channels/service.ts
+++ b/packages/questpie/src/server/channels/service.ts
@@ -3,9 +3,10 @@ import type { z } from "zod";
 import type { AppContext } from "#questpie/server/config/app-context.js";
 import type { Principal } from "#questpie/server/config/context.js";
 import type {
-	OrderedChannelDelivery,
-	SinkWriteResult,
-} from "#questpie/server/modules/core/integrated/realtime/transport.js";
+	AppendChannelEventInput,
+	AppendChannelEventOptions,
+	ChannelEventReceipt,
+} from "#questpie/server/modules/core/integrated/realtime/channel-event-ledger.js";
 
 import {
 	type AnyChannelDefinition,
@@ -37,7 +38,10 @@ export class ChannelRuntimeError extends Error {
 }
 
 export interface ChannelPublisher {
-	publishChannel(delivery: OrderedChannelDelivery): Promise<SinkWriteResult>;
+	appendChannelEvent(
+		input: AppendChannelEventInput,
+		options?: AppendChannelEventOptions,
+	): Promise<ChannelEventReceipt>;
 }
 
 export type ChannelServiceContext = AppContext & {
@@ -87,8 +91,6 @@ function isSystemContext(context: StoredChannelServiceContext): boolean {
 export class ChannelsService<
 	TChannels extends ChannelDefinitions = ChannelDefinitions,
 > {
-	private readonly encoder = new TextEncoder();
-
 	constructor(
 		private readonly definitions: TChannels,
 		private readonly publisher: ChannelPublisher,
@@ -201,13 +203,15 @@ export class ChannelsService<
 			);
 		}
 
-		const eventId = crypto.randomUUID();
-		await this.publisher.publishChannel({
-			channel: resolvedName,
-			eventId,
-			frame: this.encoder.encode(JSON.stringify({ event, data: parsed.data })),
-		});
-		return Object.freeze({ eventId });
+		return this.publisher.appendChannelEvent(
+			{
+				channel: resolvedName,
+				event,
+				schemaIdentity: `${String(channel)}:${event}`,
+				data: parsed.data,
+			},
+			{ db: this.context.db as AppendChannelEventOptions["db"] },
+		);
 	}
 
 	async publishBatch(

--- a/packages/questpie/src/server/config/questpie.ts
+++ b/packages/questpie/src/server/config/questpie.ts
@@ -38,7 +38,12 @@ import type { KVService } from "#questpie/server/modules/core/integrated/kv/serv
 import type { LoggerService } from "#questpie/server/modules/core/integrated/logger/service.js";
 import type { MailerService } from "#questpie/server/modules/core/integrated/mailer/service.js";
 import type { QueueClient } from "#questpie/server/modules/core/integrated/queue/types.js";
-import { questpieRealtimeLogTable } from "#questpie/server/modules/core/integrated/realtime/collection.js";
+import {
+	questpieChannelDispatchTable,
+	questpieChannelEventTable,
+	questpieChannelHeadTable,
+	questpieRealtimeLogTable,
+} from "#questpie/server/modules/core/integrated/realtime/collection.js";
 import type { RealtimeService } from "#questpie/server/modules/core/integrated/realtime/service.js";
 import type { SearchService } from "#questpie/server/modules/core/integrated/search/types.js";
 import { resolveAutoSeedCategories } from "#questpie/server/seed/types.js";
@@ -1214,6 +1219,9 @@ export class Questpie<TConfig extends QuestpieConfig = QuestpieConfig> {
 
 		// 3. Always include realtime log table since realtime service is always initialized
 		schema.questpie_realtime_log = questpieRealtimeLogTable;
+		schema.questpie_channel_head = questpieChannelHeadTable;
+		schema.questpie_channel_event = questpieChannelEventTable;
+		schema.questpie_channel_dispatch = questpieChannelDispatchTable;
 
 		// 4. Add search tables if adapter provides local storage schemas
 		// Local adapters (Postgres, PgVector) return their tables for migration generation.

--- a/packages/questpie/src/server/modules/core/integrated/realtime/channel-event-ledger.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/channel-event-ledger.ts
@@ -1,0 +1,713 @@
+import { createHash } from "node:crypto";
+
+import { and, asc, eq, gt, isNull, lt, lte, or, sql } from "drizzle-orm";
+
+import {
+	onAfterCommit,
+	withTransactionOrExisting,
+} from "#questpie/server/collection/crud/shared/transaction.js";
+import type { DrizzleClientFromQuestpieConfig } from "#questpie/server/config/types.js";
+import type { LoggerAdapter } from "#questpie/server/modules/core/integrated/logger/types.js";
+
+import {
+	questpieChannelDispatchTable,
+	questpieChannelEventTable,
+	questpieChannelHeadTable,
+} from "./collection.js";
+import type {
+	ChannelGapFrame,
+	ChangeBroker,
+	ClientSink,
+	ClientTransport,
+	OrderedChannelDelivery,
+	OrderedChannelEventFrame,
+} from "./transport.js";
+
+const DEFAULT_RETENTION_MS = 24 * 60 * 60 * 1000;
+const DEFAULT_RETENTION_BYTES = 64 * 1024 * 1024;
+const DEFAULT_MAX_BUFFERED_EVENTS = 100;
+const DEFAULT_MAX_BUFFERED_BYTES = 1024 * 1024;
+const DEFAULT_LEASE_MS = 30_000;
+const DEFAULT_RETRY_MS = 25;
+const DEFAULT_BATCH_SIZE = 500;
+
+export type ChannelEventLedgerConfig = {
+	/** Maximum age of replayable events. Set to 0 to disable time cleanup. */
+	retentionMs: number;
+	/** Maximum total retained payload bytes. Set to 0 to disable size cleanup. */
+	retentionBytes: number;
+	/** Maximum ordered events queued behind a busy local sink. */
+	maxBufferedEvents: number;
+	/** Maximum ordered bytes queued behind a busy local sink. */
+	maxBufferedBytes: number;
+	/** Shared-provider per-channel coordinator lease duration. */
+	coordinatorLeaseMs: number;
+	/** Retry delay for a busy local sink. */
+	busyRetryMs: number;
+	/** Maximum rows read in one channel-local batch. */
+	batchSize: number;
+};
+
+export type AppendChannelEventInput = {
+	channel: string;
+	event: string;
+	schemaIdentity: string;
+	data: unknown;
+};
+
+export type AppendChannelEventOptions = {
+	db?: DrizzleClientFromQuestpieConfig<any>;
+};
+
+export type ChannelEventReceipt = Readonly<{
+	eventId: string;
+}>;
+
+export type LocalChannelSubscriptionInput = {
+	subscriptionId: string;
+	channel: string;
+	sink: ClientSink;
+	lastEventId?: string | null;
+};
+
+type ChannelEventRow = typeof questpieChannelEventTable.$inferSelect;
+
+type LocalSubscription = {
+	id: string;
+	channel: string;
+	channelHash: string;
+	sink: ClientSink;
+	cursor: number;
+	readSeq: number;
+	pending: ChannelEventRow[];
+	pendingBytes: number;
+	drainPromise: Promise<void> | null;
+	drainPending: boolean;
+	closed: boolean;
+	retryTimer: ReturnType<typeof setTimeout> | null;
+};
+
+export function hashResolvedChannel(channel: string): string {
+	return createHash("sha256").update(channel).digest("hex");
+}
+
+function channelEventId(channelHash: string, seq: number): string {
+	return `${channelHash}:${seq}`;
+}
+
+function parseChannelEventId(
+	eventId: string,
+): { channelHash: string; seq: number } | null {
+	const match = /^([a-f0-9]{64}):(\d+)$/.exec(eventId);
+	if (!match) return null;
+	const seq = Number(match[2]);
+	if (!Number.isSafeInteger(seq) || seq < 0) return null;
+	return { channelHash: match[1], seq };
+}
+
+function byteLength(value: unknown): number {
+	return new TextEncoder().encode(JSON.stringify(value)).byteLength;
+}
+
+function hasPostgresErrorCode(error: unknown, code: string): boolean {
+	let current = error;
+	const seen = new Set<object>();
+	while (current && typeof current === "object" && !seen.has(current)) {
+		seen.add(current);
+		if ((current as { code?: unknown }).code === code) return true;
+		current = (current as { cause?: unknown }).cause;
+	}
+	return false;
+}
+
+/**
+ * Durable ordered-channel log and delivery coordinator.
+ *
+ * ChangeBroker wakes are deliberately notice-only. Every delivery path drains
+ * this ledger, so duplicate or missing wakes cannot duplicate or stall events.
+ */
+export class ChannelEventLedger {
+	private readonly config: ChannelEventLedgerConfig;
+	private readonly instanceId = crypto.randomUUID();
+	private readonly encoder = new TextEncoder();
+	private readonly localSubscriptions = new Map<string, LocalSubscription>();
+	private readonly subscriptionsByChannel = new Map<
+		string,
+		Set<LocalSubscription>
+	>();
+	private sharedDrainPending = false;
+	private sharedDrainPromise: Promise<void> | null = null;
+	private cleanupInProgress = false;
+
+	constructor(
+		private readonly db: DrizzleClientFromQuestpieConfig<any>,
+		private readonly changeBroker: ChangeBroker | undefined,
+		private readonly clientTransport: ClientTransport | undefined,
+		config: Partial<ChannelEventLedgerConfig> = {},
+		private readonly logger?: Pick<LoggerAdapter, "error" | "warn">,
+		private readonly ensureDeliveryStarted?: () => Promise<void>,
+	) {
+		this.config = {
+			retentionMs: config.retentionMs ?? DEFAULT_RETENTION_MS,
+			retentionBytes: config.retentionBytes ?? DEFAULT_RETENTION_BYTES,
+			maxBufferedEvents:
+				config.maxBufferedEvents ?? DEFAULT_MAX_BUFFERED_EVENTS,
+			maxBufferedBytes: config.maxBufferedBytes ?? DEFAULT_MAX_BUFFERED_BYTES,
+			coordinatorLeaseMs: config.coordinatorLeaseMs ?? DEFAULT_LEASE_MS,
+			busyRetryMs: config.busyRetryMs ?? DEFAULT_RETRY_MS,
+			batchSize: config.batchSize ?? DEFAULT_BATCH_SIZE,
+		};
+	}
+
+	async append(
+		input: AppendChannelEventInput,
+		options: AppendChannelEventOptions = {},
+	): Promise<ChannelEventReceipt> {
+		const channelHash = hashResolvedChannel(input.channel);
+		const db = options.db ?? this.db;
+		let eventId = "";
+
+		await withTransactionOrExisting(db, async (tx) => {
+			await tx
+				.insert(questpieChannelHeadTable)
+				.values({ channelHash, channel: input.channel })
+				.onConflictDoNothing();
+
+			// The UPDATE takes a row lock. Contending publishers cannot receive a
+			// sequence until the previous publisher commits, so seq order is commit order.
+			const [head] = await tx
+				.update(questpieChannelHeadTable)
+				.set({
+					lastSeq: sql`${questpieChannelHeadTable.lastSeq} + 1`,
+					updatedAt: new Date(),
+				})
+				.where(eq(questpieChannelHeadTable.channelHash, channelHash))
+				.returning({ seq: questpieChannelHeadTable.lastSeq });
+			if (!head) throw new Error("Failed to lock channel sequence head");
+
+			const seq = Number(head.seq);
+			eventId = channelEventId(channelHash, seq);
+			await tx.insert(questpieChannelEventTable).values({
+				channelHash,
+				seq,
+				eventId,
+				channel: input.channel,
+				event: input.event,
+				schemaIdentity: input.schemaIdentity,
+				payload: input.data,
+				sizeBytes: byteLength(input),
+			});
+			await tx
+				.insert(questpieChannelDispatchTable)
+				.values({ channelHash })
+				.onConflictDoNothing();
+
+			onAfterCommit(async () => {
+				void this.notifyAfterCommit(channelHash, eventId).catch((error) => {
+					this.logger?.error(
+						"[Realtime] Channel after-commit notification failed",
+						error,
+					);
+				});
+			});
+		});
+
+		return Object.freeze({ eventId });
+	}
+
+	private async notifyAfterCommit(
+		channelHash: string,
+		eventId: string,
+	): Promise<void> {
+		await this.ensureDeliveryStarted?.();
+		await Promise.all([
+			this.changeBroker?.publish({
+				kind: "channel-events-maybe-advanced",
+				channelHash,
+				highWaterEventId: eventId,
+				reason: "publish",
+			}),
+			this.drain(channelHash),
+		]);
+	}
+
+	async subscribeLocal(
+		input: LocalChannelSubscriptionInput,
+	): Promise<() => void> {
+		if (
+			this.clientTransport &&
+			this.clientTransport.channelDeliveryScope !== "local-sessions"
+		) {
+			throw new Error("Local channel subscriptions require a local transport");
+		}
+		if (this.localSubscriptions.has(input.subscriptionId)) {
+			throw new Error(`Channel subscription "${input.subscriptionId}" exists`);
+		}
+
+		const channelHash = hashResolvedChannel(input.channel);
+		const [head] = await this.db
+			.select({ lastSeq: questpieChannelHeadTable.lastSeq })
+			.from(questpieChannelHeadTable)
+			.where(eq(questpieChannelHeadTable.channelHash, channelHash))
+			.limit(1);
+		const latestSeq = Number(head?.lastSeq ?? 0);
+		let cursor = latestSeq;
+
+		if (input.lastEventId) {
+			const parsed = parseChannelEventId(input.lastEventId);
+			const [oldest] = await this.db
+				.select({
+					seq: questpieChannelEventTable.seq,
+					eventId: questpieChannelEventTable.eventId,
+				})
+				.from(questpieChannelEventTable)
+				.where(eq(questpieChannelEventTable.channelHash, channelHash))
+				.orderBy(asc(questpieChannelEventTable.seq))
+				.limit(1);
+			const outsideRetention =
+				!parsed ||
+				parsed.channelHash !== channelHash ||
+				parsed.seq > latestSeq ||
+				(parsed.seq < latestSeq &&
+					(!oldest || parsed.seq < Number(oldest.seq) - 1));
+			if (outsideRetention) {
+				await this.writeGap(input, oldest?.eventId ?? null);
+				return () => {};
+			}
+			cursor = parsed.seq;
+		}
+
+		const subscription: LocalSubscription = {
+			id: input.subscriptionId,
+			channel: input.channel,
+			channelHash,
+			sink: input.sink,
+			cursor,
+			readSeq: cursor,
+			pending: [],
+			pendingBytes: 0,
+			drainPromise: null,
+			drainPending: false,
+			closed: false,
+			retryTimer: null,
+		};
+		this.localSubscriptions.set(subscription.id, subscription);
+		const channelSubscriptions =
+			this.subscriptionsByChannel.get(channelHash) ?? new Set();
+		channelSubscriptions.add(subscription);
+		this.subscriptionsByChannel.set(channelHash, channelSubscriptions);
+		await this.drainLocalSubscription(subscription);
+
+		return () => this.removeLocalSubscription(subscription);
+	}
+
+	async drain(channelHash?: string): Promise<void> {
+		try {
+			if (this.clientTransport?.channelDeliveryScope === "shared-provider") {
+				await this.drainShared(channelHash);
+				return;
+			}
+			const subscriptions = channelHash
+				? [...(this.subscriptionsByChannel.get(channelHash) ?? [])]
+				: [...this.localSubscriptions.values()];
+			await Promise.all(
+				subscriptions.map((subscription) =>
+					this.drainLocalSubscription(subscription),
+				),
+			);
+		} catch (error) {
+			// Apps can boot before their generated migration is applied. Match the
+			// existing outbox contract: only an absent realtime table is ignored.
+			if (hasPostgresErrorCode(error, "42P01")) return;
+			throw error;
+		}
+	}
+
+	async cleanup(): Promise<void> {
+		if (this.cleanupInProgress) return;
+		if (this.config.retentionMs <= 0 && this.config.retentionBytes <= 0) return;
+		this.cleanupInProgress = true;
+		try {
+			const rows = await this.db
+				.select()
+				.from(questpieChannelEventTable)
+				.orderBy(asc(questpieChannelEventTable.createdAt));
+			const dispatchRows =
+				this.clientTransport?.channelDeliveryScope === "shared-provider"
+					? await this.db.select().from(questpieChannelDispatchTable)
+					: [];
+			const publishedByChannel = new Map(
+				dispatchRows.map((row) => [row.channelHash, Number(row.publishedSeq)]),
+			);
+			const cutoff = Date.now() - this.config.retentionMs;
+			let retainedBytes = rows.reduce((sum, row) => sum + row.sizeBytes, 0);
+			for (const row of rows) {
+				const providerCursor = publishedByChannel.get(row.channelHash);
+				if (providerCursor !== undefined && Number(row.seq) > providerCursor) {
+					continue;
+				}
+				const expired =
+					this.config.retentionMs > 0 && row.createdAt.getTime() < cutoff;
+				const overSize =
+					this.config.retentionBytes > 0 &&
+					retainedBytes > this.config.retentionBytes;
+				if (!expired && !overSize) continue;
+				await this.db
+					.delete(questpieChannelEventTable)
+					.where(
+						and(
+							eq(questpieChannelEventTable.channelHash, row.channelHash),
+							eq(questpieChannelEventTable.seq, row.seq),
+						),
+					);
+				retainedBytes -= row.sizeBytes;
+			}
+		} catch (error) {
+			if (!hasPostgresErrorCode(error, "42P01")) throw error;
+		} finally {
+			this.cleanupInProgress = false;
+		}
+	}
+
+	destroy(): void {
+		for (const subscription of this.localSubscriptions.values()) {
+			this.removeLocalSubscription(subscription);
+		}
+	}
+
+	private async writeGap(
+		input: LocalChannelSubscriptionInput,
+		oldestEventId: string | null,
+	): Promise<void> {
+		const frame: ChannelGapFrame = {
+			type: "channel_gap",
+			channel: input.channel,
+			requestedEventId: input.lastEventId ?? "",
+			oldestEventId,
+		};
+		await input.sink.write(
+			this.encodeLocalFrame(frame),
+			"ordered-channel-event",
+		);
+	}
+
+	private async readEvents(
+		channelHash: string,
+		afterSeq: number,
+	): Promise<ChannelEventRow[]> {
+		return this.db
+			.select()
+			.from(questpieChannelEventTable)
+			.where(
+				and(
+					eq(questpieChannelEventTable.channelHash, channelHash),
+					gt(questpieChannelEventTable.seq, afterSeq),
+				),
+			)
+			.orderBy(asc(questpieChannelEventTable.seq))
+			.limit(this.config.batchSize);
+	}
+
+	private async drainLocalSubscription(
+		subscription: LocalSubscription,
+	): Promise<void> {
+		if (subscription.closed) return;
+		if (subscription.drainPromise) {
+			subscription.drainPending = true;
+			return subscription.drainPromise;
+		}
+		const operation = this.runLocalDrain(subscription);
+		subscription.drainPromise = operation;
+		try {
+			await operation;
+		} finally {
+			if (subscription.drainPromise === operation) {
+				subscription.drainPromise = null;
+			}
+		}
+	}
+
+	private async runLocalDrain(subscription: LocalSubscription): Promise<void> {
+		try {
+			do {
+				subscription.drainPending = false;
+				if (!(await this.flushLocalPending(subscription))) {
+					await this.fillLocalPending(subscription);
+					return;
+				}
+				while (!subscription.closed) {
+					const rows = await this.readEvents(
+						subscription.channelHash,
+						subscription.readSeq,
+					);
+					if (rows.length === 0) break;
+					for (const row of rows) {
+						if (!this.enqueueLocal(subscription, row)) return;
+						subscription.readSeq = Number(row.seq);
+					}
+					if (!(await this.flushLocalPending(subscription))) {
+						await this.fillLocalPending(subscription);
+						return;
+					}
+					if (rows.length < this.config.batchSize) break;
+				}
+			} while (subscription.drainPending && !subscription.closed);
+		} catch (error) {
+			this.logger?.error("[Realtime] Ordered channel delivery failed", error);
+			await this.closeLocalSubscription(subscription, "write_failed");
+		}
+	}
+
+	private async fillLocalPending(
+		subscription: LocalSubscription,
+	): Promise<void> {
+		while (!subscription.closed) {
+			const rows = await this.readEvents(
+				subscription.channelHash,
+				subscription.readSeq,
+			);
+			if (rows.length === 0) return;
+			for (const row of rows) {
+				if (!this.enqueueLocal(subscription, row)) return;
+				subscription.readSeq = Number(row.seq);
+			}
+			if (rows.length < this.config.batchSize) return;
+		}
+	}
+
+	private enqueueLocal(
+		subscription: LocalSubscription,
+		row: ChannelEventRow,
+	): boolean {
+		const frameBytes = this.encodeLocalFrame(this.toLocalFrame(row)).byteLength;
+		if (
+			subscription.pending.length + 1 > this.config.maxBufferedEvents ||
+			subscription.pendingBytes + frameBytes > this.config.maxBufferedBytes
+		) {
+			void this.closeLocalSubscription(subscription, "slow_consumer");
+			return false;
+		}
+		subscription.pending.push(row);
+		subscription.pendingBytes += frameBytes;
+		return true;
+	}
+
+	private async flushLocalPending(
+		subscription: LocalSubscription,
+	): Promise<boolean> {
+		while (!subscription.closed && subscription.pending.length > 0) {
+			const row = subscription.pending[0];
+			const encodedFrame = this.encodeLocalFrame(this.toLocalFrame(row));
+			const result = await subscription.sink.write(
+				encodedFrame,
+				"ordered-channel-event",
+			);
+			if (result.status === "busy") {
+				if (
+					result.bufferedBytes + subscription.pendingBytes >
+					this.config.maxBufferedBytes
+				) {
+					await this.closeLocalSubscription(subscription, "slow_consumer");
+					return false;
+				}
+				this.scheduleLocalRetry(subscription);
+				return false;
+			}
+			subscription.pending.shift();
+			subscription.pendingBytes -= encodedFrame.byteLength;
+			subscription.cursor = Number(row.seq);
+		}
+		return true;
+	}
+
+	private toLocalFrame(row: ChannelEventRow): OrderedChannelEventFrame {
+		return {
+			type: "channel_event",
+			channel: row.channel,
+			event: row.event,
+			eventId: row.eventId,
+			data: row.payload,
+		};
+	}
+
+	private scheduleLocalRetry(subscription: LocalSubscription): void {
+		if (subscription.retryTimer || subscription.closed) return;
+		subscription.retryTimer = setTimeout(() => {
+			subscription.retryTimer = null;
+			void this.drainLocalSubscription(subscription);
+		}, this.config.busyRetryMs);
+	}
+
+	private encodeLocalFrame(
+		frame: OrderedChannelEventFrame | ChannelGapFrame,
+	): Uint8Array {
+		if (this.clientTransport?.channelDeliveryScope === "local-sessions") {
+			const encoded = this.clientTransport.encodeChannelFrame?.(frame);
+			if (encoded) return encoded;
+		}
+		return this.encoder.encode(JSON.stringify(frame));
+	}
+
+	private removeLocalSubscription(subscription: LocalSubscription): void {
+		if (subscription.closed) return;
+		subscription.closed = true;
+		if (subscription.retryTimer) clearTimeout(subscription.retryTimer);
+		this.localSubscriptions.delete(subscription.id);
+		const channelSubscriptions = this.subscriptionsByChannel.get(
+			subscription.channelHash,
+		);
+		channelSubscriptions?.delete(subscription);
+		if (channelSubscriptions?.size === 0) {
+			this.subscriptionsByChannel.delete(subscription.channelHash);
+		}
+	}
+
+	private async closeLocalSubscription(
+		subscription: LocalSubscription,
+		reason: "slow_consumer" | "write_failed",
+	): Promise<void> {
+		if (subscription.closed) return;
+		this.removeLocalSubscription(subscription);
+		await subscription.sink.close(reason);
+	}
+
+	private async drainShared(channelHash?: string): Promise<void> {
+		if (
+			!this.clientTransport ||
+			this.clientTransport.channelDeliveryScope !== "shared-provider"
+		) {
+			return;
+		}
+		if (this.sharedDrainPromise) {
+			this.sharedDrainPending = true;
+			return this.sharedDrainPromise;
+		}
+		const operation = this.runSharedDrain(channelHash);
+		this.sharedDrainPromise = operation;
+		try {
+			await operation;
+		} finally {
+			if (this.sharedDrainPromise === operation) {
+				this.sharedDrainPromise = null;
+			}
+		}
+	}
+
+	private async runSharedDrain(channelHash?: string): Promise<void> {
+		let requestedChannelHash = channelHash;
+		do {
+			this.sharedDrainPending = false;
+			const heads = requestedChannelHash
+				? await this.db
+						.select()
+						.from(questpieChannelHeadTable)
+						.where(
+							eq(questpieChannelHeadTable.channelHash, requestedChannelHash),
+						)
+				: await this.db.select().from(questpieChannelHeadTable);
+			for (const head of heads) await this.drainSharedChannel(head.channelHash);
+			// A wake racing this drain may target a different channel. The retry
+			// therefore reconciles all heads instead of trusting the first hint.
+			requestedChannelHash = undefined;
+		} while (this.sharedDrainPending);
+	}
+
+	private async drainSharedChannel(channelHash: string): Promise<void> {
+		if (
+			!this.clientTransport ||
+			this.clientTransport.channelDeliveryScope !== "shared-provider"
+		) {
+			return;
+		}
+		const now = new Date();
+		const leaseExpiresAt = new Date(
+			now.getTime() + this.config.coordinatorLeaseMs,
+		);
+		const [lease] = await this.db
+			.update(questpieChannelDispatchTable)
+			.set({
+				leaseOwner: this.instanceId,
+				leaseExpiresAt,
+				updatedAt: now,
+			})
+			.where(
+				and(
+					eq(questpieChannelDispatchTable.channelHash, channelHash),
+					or(
+						isNull(questpieChannelDispatchTable.leaseOwner),
+						lt(questpieChannelDispatchTable.leaseExpiresAt, now),
+						eq(questpieChannelDispatchTable.leaseOwner, this.instanceId),
+					),
+				),
+			)
+			.returning({ publishedSeq: questpieChannelDispatchTable.publishedSeq });
+		if (!lease) return;
+
+		let cursor = Number(lease.publishedSeq);
+		try {
+			while (true) {
+				const rows = await this.readEvents(channelHash, cursor);
+				if (rows.length === 0) break;
+				for (const row of rows) {
+					const renewed = await this.renewLease(channelHash);
+					if (!renewed) return;
+					const delivery: OrderedChannelDelivery = {
+						channel: row.channel,
+						eventId: row.eventId,
+						frame: this.encoder.encode(
+							JSON.stringify({ event: row.event, data: row.payload }),
+						),
+					};
+					const result = await this.clientTransport.publishChannel(delivery);
+					if (result.status === "busy") return;
+					cursor = Number(row.seq);
+					const [advanced] = await this.db
+						.update(questpieChannelDispatchTable)
+						.set({ publishedSeq: cursor, updatedAt: new Date() })
+						.where(
+							and(
+								eq(questpieChannelDispatchTable.channelHash, channelHash),
+								eq(questpieChannelDispatchTable.leaseOwner, this.instanceId),
+								lte(questpieChannelDispatchTable.publishedSeq, cursor),
+							),
+						)
+						.returning({
+							channelHash: questpieChannelDispatchTable.channelHash,
+						});
+					if (!advanced) return;
+				}
+				if (rows.length < this.config.batchSize) break;
+			}
+		} catch (error) {
+			this.logger?.error("[Realtime] Shared channel delivery failed", error);
+			throw error;
+		} finally {
+			await this.db
+				.update(questpieChannelDispatchTable)
+				.set({ leaseOwner: null, leaseExpiresAt: null, updatedAt: new Date() })
+				.where(
+					and(
+						eq(questpieChannelDispatchTable.channelHash, channelHash),
+						eq(questpieChannelDispatchTable.leaseOwner, this.instanceId),
+					),
+				);
+		}
+	}
+
+	private async renewLease(channelHash: string): Promise<boolean> {
+		const [row] = await this.db
+			.update(questpieChannelDispatchTable)
+			.set({
+				leaseExpiresAt: new Date(Date.now() + this.config.coordinatorLeaseMs),
+				updatedAt: new Date(),
+			})
+			.where(
+				and(
+					eq(questpieChannelDispatchTable.channelHash, channelHash),
+					eq(questpieChannelDispatchTable.leaseOwner, this.instanceId),
+				),
+			)
+			.returning({ channelHash: questpieChannelDispatchTable.channelHash });
+		return !!row;
+	}
+}

--- a/packages/questpie/src/server/modules/core/integrated/realtime/collection.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/collection.ts
@@ -1,4 +1,15 @@
-import { bigserial, index, jsonb, pgTable, text } from "drizzle-orm/pg-core";
+import {
+	bigint,
+	bigserial,
+	index,
+	integer,
+	jsonb,
+	pgTable,
+	primaryKey,
+	text,
+	timestamp,
+	uniqueIndex,
+} from "drizzle-orm/pg-core";
 
 import { systemTimestamp } from "#questpie/server/db/system-columns.js";
 
@@ -19,4 +30,50 @@ export const questpieRealtimeLogTable = pgTable(
 		createdAt: systemTimestamp("created_at").defaultNow().notNull(),
 	},
 	(t) => [index("idx_realtime_log_created_at").on(t.createdAt)],
+);
+
+/** Per-resolved-channel sequence head. Updating this row serializes publishers. */
+export const questpieChannelHeadTable = pgTable("questpie_channel_head", {
+	channelHash: text("channel_hash").primaryKey(),
+	channel: text("channel").notNull(),
+	lastSeq: bigint("last_seq", { mode: "number" }).default(0).notNull(),
+	updatedAt: systemTimestamp("updated_at").defaultNow().notNull(),
+});
+
+/** Durable ordered channel event ledger. */
+export const questpieChannelEventTable = pgTable(
+	"questpie_channel_event",
+	{
+		channelHash: text("channel_hash").notNull(),
+		seq: bigint("seq", { mode: "number" }).notNull(),
+		eventId: text("event_id").notNull(),
+		channel: text("channel").notNull(),
+		event: text("event").notNull(),
+		schemaIdentity: text("schema_identity").notNull(),
+		payload: jsonb("payload").notNull(),
+		sizeBytes: integer("size_bytes").notNull(),
+		createdAt: systemTimestamp("created_at").defaultNow().notNull(),
+	},
+	(table) => [
+		primaryKey({ columns: [table.channelHash, table.seq] }),
+		uniqueIndex("uq_channel_event_event_id").on(table.eventId),
+		index("idx_channel_event_created_at").on(table.createdAt),
+	],
+);
+
+/** Durable shared-provider cursor and per-channel coordinator lease. */
+export const questpieChannelDispatchTable = pgTable(
+	"questpie_channel_dispatch",
+	{
+		channelHash: text("channel_hash").primaryKey(),
+		publishedSeq: bigint("published_seq", { mode: "number" })
+			.default(0)
+			.notNull(),
+		leaseOwner: text("lease_owner"),
+		leaseExpiresAt: timestamp("lease_expires_at", {
+			withTimezone: true,
+			mode: "date",
+		}),
+		updatedAt: systemTimestamp("updated_at").defaultNow().notNull(),
+	},
 );

--- a/packages/questpie/src/server/modules/core/integrated/realtime/service.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/service.ts
@@ -5,6 +5,13 @@ import type { LoggerAdapter } from "#questpie/server/modules/core/integrated/log
 
 import type { RealtimeAdapter } from "./adapter.js";
 import { PgNotifyAdapter } from "./adapters/pg-notify.js";
+import {
+	type AppendChannelEventInput,
+	type AppendChannelEventOptions,
+	ChannelEventLedger,
+	type ChannelEventReceipt,
+	type LocalChannelSubscriptionInput,
+} from "./channel-event-ledger.js";
 import { questpieRealtimeLogTable } from "./collection.js";
 import type {
 	ChangeBroker,
@@ -154,6 +161,9 @@ export class RealtimeService {
 	private retentionCleanupIntervalMs: number;
 	private nextRetentionCleanupAt = 0;
 	private retentionCleanupInProgress = false;
+	private readonly channelEventLedger: ChannelEventLedger;
+	private channelPollTimer: ReturnType<typeof setInterval> | null = null;
+	private nextChannelCleanupAt = 0;
 
 	constructor(
 		// TODO: this should be typed better
@@ -164,6 +174,14 @@ export class RealtimeService {
 	) {
 		this.changeBroker = config.changeBroker;
 		this.clientTransport = config.clientTransport;
+		this.channelEventLedger = new ChannelEventLedger(
+			this.db,
+			this.changeBroker,
+			this.clientTransport,
+			config.channelEvents,
+			this.logger,
+			() => this.initialize(),
+		);
 		// Auto-configure adapter if connection string is provided
 		if (config.adapter) {
 			// User provided custom adapter
@@ -338,13 +356,34 @@ export class RealtimeService {
 		this.publisherStartPromise = (async () => {
 			await this.adapter?.startPublisher?.();
 			await this.changeBroker?.start({
-				onWake: () => this.drainSafely(),
+				onWake: (wake) => {
+					if (wake.kind === "channel-events-maybe-advanced") {
+						void this.channelEventLedger
+							.drain(wake.channelHash)
+							.catch((error) =>
+								this.reportTransportFailure(
+									"[Realtime] Channel ledger drain failed",
+									error,
+								),
+							);
+						return;
+					}
+					this.drainSafely();
+				},
 				onError: (error) =>
 					this.reportTransportFailure("[Realtime] Change broker failed", error),
 				onStateChange: (state) => {
 					if (state === "connected") {
 						this.setReconciliationPollInterval(this.configuredPollIntervalMs);
 						this.drainSafely();
+						void this.channelEventLedger
+							.drain()
+							.catch((error) =>
+								this.reportTransportFailure(
+									"[Realtime] Channel reconnect drain failed",
+									error,
+								),
+							);
 					} else if (state === "unavailable" || state === "failed") {
 						this.setReconciliationPollInterval(
 							this.configuredPollIntervalMs > 0
@@ -362,6 +401,8 @@ export class RealtimeService {
 					),
 			});
 			this.publisherStarted = true;
+			this.startChannelPollTimer();
+			await this.channelEventLedger.drain();
 		})().finally(() => {
 			this.publisherStartPromise = null;
 		});
@@ -410,9 +451,30 @@ export class RealtimeService {
 		return this.clientTransport.publishChannel(input);
 	}
 
+	async appendChannelEvent(
+		input: AppendChannelEventInput,
+		options: AppendChannelEventOptions = {},
+	): Promise<ChannelEventReceipt> {
+		const receipt = await this.channelEventLedger.append(input, options);
+		this.cleanupChannelEventsSafely();
+		return receipt;
+	}
+
+	async subscribeChannel(
+		input: LocalChannelSubscriptionInput,
+	): Promise<() => void> {
+		await this.initialize();
+		return this.channelEventLedger.subscribeLocal(input);
+	}
+
 	private setReconciliationPollInterval(intervalMs: number): void {
 		if (this.pollIntervalMs === intervalMs) return;
 		this.pollIntervalMs = intervalMs;
+		if (this.channelPollTimer) {
+			clearInterval(this.channelPollTimer);
+			this.channelPollTimer = null;
+		}
+		if (this.publisherStarted) this.startChannelPollTimer();
 		if (!this.started) return;
 		if (this.pollTimer) {
 			clearInterval(this.pollTimer);
@@ -426,6 +488,34 @@ export class RealtimeService {
 		this.pollTimer = setInterval(() => {
 			this.drainSafely();
 		}, this.pollIntervalMs);
+	}
+
+	private startChannelPollTimer(): void {
+		if (
+			!this.clientTransport ||
+			this.pollIntervalMs <= 0 ||
+			this.channelPollTimer
+		) {
+			return;
+		}
+		this.channelPollTimer = setInterval(() => {
+			void this.channelEventLedger.drain().catch((error) => {
+				this.reportTransportFailure(
+					"[Realtime] Channel reconciliation failed",
+					error,
+				);
+			});
+			this.cleanupChannelEventsSafely();
+		}, this.pollIntervalMs);
+	}
+
+	private cleanupChannelEventsSafely(force = false): void {
+		const now = Date.now();
+		if (!force && now < this.nextChannelCleanupAt) return;
+		this.nextChannelCleanupAt = now + 60 * 60 * 1000;
+		void this.channelEventLedger.cleanup().catch((error) => {
+			this.logger?.warn("[Realtime] Channel ledger cleanup failed", error);
+		});
 	}
 
 	/**
@@ -706,6 +796,10 @@ export class RealtimeService {
 			clearInterval(this.pollTimer);
 			this.pollTimer = null;
 		}
+		if (this.channelPollTimer) {
+			clearInterval(this.channelPollTimer);
+			this.channelPollTimer = null;
+		}
 
 		if (this.unsubscribeAdapter) {
 			this.unsubscribeAdapter();
@@ -720,6 +814,7 @@ export class RealtimeService {
 		if (this.adapter) {
 			await this.adapter.stop();
 		}
+		this.channelEventLedger.destroy();
 		await this.changeBroker?.stop();
 		await this.clientTransport?.stop();
 		this.publisherStarted = false;

--- a/packages/questpie/src/server/modules/core/integrated/realtime/sse-client-transport.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/sse-client-transport.ts
@@ -3,9 +3,11 @@ import type {
 	ClientConfigInput,
 	ClientSink,
 	ClientTransportConfig,
+	ChannelGapFrame,
 	DeliveryClass,
 	EdgeSessionInput,
 	LocalSessionClientTransport,
+	OrderedChannelEventFrame,
 	SinkWriteResult,
 } from "./transport.js";
 
@@ -219,6 +221,12 @@ export class SseClientTransport implements LocalSessionClientTransport {
 		_input: ClientConfigInput,
 	): Promise<ClientTransportConfig> {
 		return { transport: "sse" };
+	}
+
+	encodeChannelFrame(
+		frame: OrderedChannelEventFrame | ChannelGapFrame,
+	): Uint8Array {
+		return encodeSseEvent(frame.type, frame);
 	}
 
 	async stop(): Promise<void> {

--- a/packages/questpie/src/server/modules/core/integrated/realtime/transport.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/transport.ts
@@ -87,6 +87,21 @@ export type OrderedChannelDelivery = {
 	eventId: string;
 };
 
+export type OrderedChannelEventFrame = {
+	type: "channel_event";
+	channel: string;
+	event: string;
+	eventId: string;
+	data: unknown;
+};
+
+export type ChannelGapFrame = {
+	type: "channel_gap";
+	channel: string;
+	requestedEventId: string;
+	oldestEventId: string | null;
+};
+
 interface ClientTransportBase {
 	start(input: { onError: (error: unknown) => void }): Promise<void>;
 	openSession(input: EdgeSessionInput): Promise<ClientSink>;
@@ -96,6 +111,9 @@ interface ClientTransportBase {
 
 export interface LocalSessionClientTransport extends ClientTransportBase {
 	readonly channelDeliveryScope: "local-sessions";
+	encodeChannelFrame?(
+		frame: OrderedChannelEventFrame | ChannelGapFrame,
+	): Uint8Array;
 }
 
 export interface SharedProviderClientTransport extends ClientTransportBase {

--- a/packages/questpie/src/server/modules/core/integrated/realtime/types.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/types.ts
@@ -100,6 +100,10 @@ export interface RealtimeConfig {
 	changeBroker?: ChangeBroker;
 	/** Edge delivery seam shared by live queries and typed channels. */
 	clientTransport?: ClientTransport;
+	/** Durable ordered-channel retention, backpressure, and lease tuning. */
+	channelEvents?: Partial<
+		import("./channel-event-ledger.js").ChannelEventLedgerConfig
+	>;
 
 	/**
 	 * Reconciliation poll interval in ms. Polling runs alongside adapters so a

--- a/packages/questpie/test/integration/ordered-channel-ledger.test.ts
+++ b/packages/questpie/test/integration/ordered-channel-ledger.test.ts
@@ -1,0 +1,369 @@
+import {
+	afterAll,
+	afterEach,
+	beforeAll,
+	describe,
+	expect,
+	test,
+} from "bun:test";
+
+import { asc } from "drizzle-orm";
+
+import { withTransaction } from "../../src/server/collection/crud/shared/transaction.js";
+import {
+	ChannelEventLedger,
+	hashResolvedChannel,
+} from "../../src/server/modules/core/integrated/realtime/channel-event-ledger.js";
+import {
+	questpieChannelDispatchTable,
+	questpieChannelEventTable,
+	questpieChannelHeadTable,
+} from "../../src/server/modules/core/integrated/realtime/collection.js";
+import type {
+	ClientCloseReason,
+	ClientSink,
+	DeliveryClass,
+	EdgeSessionInput,
+	OrderedChannelDelivery,
+	SharedProviderClientTransport,
+	SinkWriteResult,
+} from "../../src/server/modules/core/integrated/realtime/transport.js";
+import { buildMockApp } from "../utils/mocks/mock-app-builder.js";
+import { createTestDb, runTestDbMigrations } from "../utils/test-db.js";
+
+type TestSink = ClientSink & {
+	frames: Array<Record<string, any>>;
+	closeReasons: ClientCloseReason[];
+	busy: boolean;
+};
+
+function createSink(sessionId: string, busy = false): TestSink {
+	const decoder = new TextDecoder();
+	return {
+		sessionId,
+		frames: [],
+		closeReasons: [],
+		busy,
+		async write(frame: Uint8Array, _delivery: DeliveryClass) {
+			if (this.busy) return { status: "busy", bufferedBytes: 1 };
+			this.frames.push(JSON.parse(decoder.decode(frame)));
+			return { status: "accepted", bufferedBytes: 0 };
+		},
+		async close(reason: ClientCloseReason) {
+			this.closeReasons.push(reason);
+		},
+	};
+}
+
+class SharedTestTransport implements SharedProviderClientTransport {
+	readonly channelDeliveryScope = "shared-provider" as const;
+	readonly deliveries: OrderedChannelDelivery[] = [];
+
+	async start(): Promise<void> {}
+	async openSession(_input: EdgeSessionInput): Promise<ClientSink> {
+		return createSink("shared");
+	}
+	async getClientConfig() {
+		return { transport: "shared-provider" as const, config: {} };
+	}
+	async generateAuth() {
+		return { auth: "test" };
+	}
+	async publishChannel(
+		delivery: OrderedChannelDelivery,
+	): Promise<SinkWriteResult> {
+		this.deliveries.push(delivery);
+		return { status: "accepted", bufferedBytes: null };
+	}
+	async stop(): Promise<void> {}
+}
+
+describe("ordered channel event ledger", () => {
+	let testDb: Awaited<ReturnType<typeof createTestDb>>;
+	let setup: Awaited<ReturnType<typeof buildMockApp>>;
+	const ledgers = new Set<ChannelEventLedger>();
+
+	beforeAll(async () => {
+		testDb = await createTestDb();
+		setup = await buildMockApp({}, { db: { pglite: testDb } });
+		await runTestDbMigrations(setup.app);
+	});
+
+	afterEach(async () => {
+		for (const ledger of ledgers) ledger.destroy();
+		ledgers.clear();
+		await setup.app.db.delete(questpieChannelEventTable);
+		await setup.app.db.delete(questpieChannelDispatchTable);
+		await setup.app.db.delete(questpieChannelHeadTable);
+	});
+
+	afterAll(async () => {
+		await setup.cleanup();
+		await testDb.close();
+	});
+
+	function ledger(
+		transport?: SharedProviderClientTransport,
+		config: ConstructorParameters<typeof ChannelEventLedger>[3] = {},
+	): ChannelEventLedger {
+		const value = new ChannelEventLedger(
+			setup.app.db,
+			undefined,
+			transport,
+			config,
+		);
+		ledgers.add(value);
+		return value;
+	}
+
+	test("orders concurrent channel transactions by their locked commit sequence", async () => {
+		const events = ledger();
+		const sink = createSink("ordered");
+		await events.subscribeLocal({
+			subscriptionId: "ordered-room",
+			channel: "private-room-1",
+			sink,
+		});
+		const receipts = await Promise.all([
+			events.append({
+				channel: "private-room-1",
+				event: "message",
+				schemaIdentity: "room:message",
+				data: { order: "a" },
+			}),
+			events.append({
+				channel: "private-room-1",
+				event: "message",
+				schemaIdentity: "room:message",
+				data: { order: "b" },
+			}),
+		]);
+		const rows = await setup.app.db
+			.select()
+			.from(questpieChannelEventTable)
+			.orderBy(asc(questpieChannelEventTable.seq));
+		await events.drain();
+
+		expect(rows.map((row: any) => Number(row.seq))).toEqual([1, 2]);
+		expect(sink.frames.map((frame) => frame.data.order)).toEqual(
+			rows.map((row: any) => row.payload.order),
+		);
+		expect(new Set(receipts.map((receipt) => receipt.eventId)).size).toBe(2);
+	});
+
+	test("rollback creates no deliverable event id gap", async () => {
+		const events = ledger();
+		await expect(
+			withTransaction(setup.app.db, async (tx) => {
+				await events.append(
+					{
+						channel: "private-room-1",
+						event: "message",
+						schemaIdentity: "room:message",
+						data: { rolledBack: true },
+					},
+					{ db: tx },
+				);
+				throw new Error("rollback");
+			}),
+		).rejects.toThrow("rollback");
+
+		const receipt = await events.append({
+			channel: "private-room-1",
+			event: "message",
+			schemaIdentity: "room:message",
+			data: { rolledBack: false },
+		});
+		expect(receipt.eventId).toEndWith(":1");
+		expect(
+			await setup.app.db.select().from(questpieChannelEventTable),
+		).toHaveLength(1);
+	});
+
+	test("two local instances deliver to every local sink exactly once", async () => {
+		const first = ledger();
+		const second = ledger();
+		const firstSink = createSink("first");
+		const secondSink = createSink("second");
+		await first.subscribeLocal({
+			subscriptionId: "first-room",
+			channel: "private-room-1",
+			sink: firstSink,
+		});
+		await second.subscribeLocal({
+			subscriptionId: "second-room",
+			channel: "private-room-1",
+			sink: secondSink,
+		});
+
+		await first.append({
+			channel: "private-room-1",
+			event: "message",
+			schemaIdentity: "room:message",
+			data: { id: 1 },
+		});
+		await Promise.all([first.drain(), second.drain()]);
+		await Promise.all([first.drain(), second.drain()]);
+
+		expect(firstSink.frames.map((frame) => frame.data.id)).toEqual([1]);
+		expect(secondSink.frames.map((frame) => frame.data.id)).toEqual([1]);
+	});
+
+	test("shared-provider coordinators publish globally once and in order", async () => {
+		const transport = new SharedTestTransport();
+		const first = ledger(transport);
+		const second = ledger(transport);
+		await first.append({
+			channel: "private-room-1",
+			event: "message",
+			schemaIdentity: "room:message",
+			data: { order: 1 },
+		});
+		await first.append({
+			channel: "private-room-1",
+			event: "message",
+			schemaIdentity: "room:message",
+			data: { order: 2 },
+		});
+		await Promise.all([first.drain(), second.drain()]);
+		await Promise.all([second.drain(), first.drain()]);
+
+		expect(
+			transport.deliveries.map(
+				(delivery) =>
+					JSON.parse(new TextDecoder().decode(delivery.frame)).data.order,
+			),
+		).toEqual([1, 2]);
+	});
+
+	test("duplicate drains dedupe and reconciliation heals a missed wake", async () => {
+		const publisher = ledger();
+		const reconciler = ledger();
+		const sink = createSink("reconciler");
+		await reconciler.subscribeLocal({
+			subscriptionId: "room",
+			channel: "private-room-1",
+			sink,
+		});
+		await publisher.append({
+			channel: "private-room-1",
+			event: "message",
+			schemaIdentity: "room:message",
+			data: { id: "missed" },
+		});
+		expect(sink.frames).toHaveLength(0);
+
+		await reconciler.drain();
+		await Promise.all([reconciler.drain(), reconciler.drain()]);
+		expect(sink.frames.map((frame) => frame.data.id)).toEqual(["missed"]);
+	});
+
+	test("reconnect replays retained events after the last applied event id", async () => {
+		const events = ledger();
+		const first = await events.append({
+			channel: "private-room-1",
+			event: "message",
+			schemaIdentity: "room:message",
+			data: { id: 1 },
+		});
+		for (const id of [2, 3]) {
+			await events.append({
+				channel: "private-room-1",
+				event: "message",
+				schemaIdentity: "room:message",
+				data: { id },
+			});
+		}
+		const sink = createSink("resume");
+		await events.subscribeLocal({
+			subscriptionId: "resume-room",
+			channel: "private-room-1",
+			sink,
+			lastEventId: first.eventId,
+		});
+
+		expect(sink.frames.map((frame) => frame.data.id)).toEqual([2, 3]);
+	});
+
+	test("expired resume cursor emits channel_gap and closes only that subscription", async () => {
+		const events = ledger(undefined, { retentionBytes: 9, retentionMs: 0 });
+		const first = await events.append({
+			channel: "private-room-1",
+			event: "message",
+			schemaIdentity: "room:message",
+			data: { id: 1 },
+		});
+		for (const id of [2, 3]) {
+			await events.append({
+				channel: "private-room-1",
+				event: "message",
+				schemaIdentity: "room:message",
+				data: { id },
+			});
+		}
+		await events.cleanup();
+		const sink = createSink("expired");
+		await events.subscribeLocal({
+			subscriptionId: "expired-room",
+			channel: "private-room-1",
+			sink,
+			lastEventId: first.eventId,
+		});
+
+		expect(sink.frames).toEqual([
+			expect.objectContaining({ type: "channel_gap" }),
+		]);
+		await events.append({
+			channel: "private-room-1",
+			event: "message",
+			schemaIdentity: "room:message",
+			data: { id: 4 },
+		});
+		await events.drain();
+		expect(sink.frames).toHaveLength(1);
+		expect(sink.closeReasons).toEqual([]);
+	});
+
+	test("slow local sink closes instead of dropping and continuing", async () => {
+		const events = ledger(undefined, {
+			maxBufferedEvents: 2,
+			maxBufferedBytes: 1024,
+			busyRetryMs: 60_000,
+		});
+		const sink = createSink("slow", true);
+		await events.subscribeLocal({
+			subscriptionId: "slow-room",
+			channel: "private-room-1",
+			sink,
+		});
+		for (const id of [1, 2, 3]) {
+			await events.append({
+				channel: "private-room-1",
+				event: "message",
+				schemaIdentity: "room:message",
+				data: { id },
+			});
+			await events.drain();
+		}
+
+		expect(sink.frames).toHaveLength(0);
+		expect(sink.closeReasons).toEqual(["slow_consumer"]);
+	});
+
+	test("retention cleanup runs with zero subscribers across instances", async () => {
+		const first = ledger(undefined, { retentionBytes: 1, retentionMs: 0 });
+		const second = ledger(undefined, { retentionBytes: 1, retentionMs: 0 });
+		await first.append({
+			channel: "private-room-1",
+			event: "message",
+			schemaIdentity: "room:message",
+			data: { id: 1 },
+		});
+
+		await Promise.all([first.cleanup(), second.cleanup()]);
+		expect(await setup.app.db.select().from(questpieChannelEventTable)).toEqual(
+			[],
+		);
+		expect(hashResolvedChannel("private-room-1")).toHaveLength(64);
+	});
+});

--- a/packages/questpie/test/units/channel-builder.test.ts
+++ b/packages/questpie/test/units/channel-builder.test.ts
@@ -85,15 +85,15 @@ describe("channel ChannelsService", () => {
 		};
 		const deliveries: Array<{
 			channel: string;
-			eventId: string;
-			frame: Uint8Array;
+			event: string;
+			data: unknown;
 		}> = [];
 		const service = new ChannelsService(
 			definitions,
 			{
-				publishChannel: async (delivery) => {
+				appendChannelEvent: async (delivery) => {
 					deliveries.push(delivery);
-					return { status: "accepted" as const, bufferedBytes: null };
+					return { eventId: "event-1" };
 				},
 			},
 			userContext,
@@ -125,7 +125,7 @@ describe("channel ChannelsService", () => {
 		expect(receipt.eventId).toBeString();
 		expect(deliveries).toHaveLength(1);
 		expect(deliveries[0]?.channel).toBe("private-chat-room-allowed");
-		expect(JSON.parse(new TextDecoder().decode(deliveries[0]?.frame))).toEqual({
+		expect(deliveries[0]).toMatchObject({
 			event: "message",
 			data: { text: "hello" },
 		});
@@ -137,9 +137,9 @@ describe("channel ChannelsService", () => {
 		};
 		let publishes = 0;
 		const publisher = {
-			publishChannel: async () => {
+			appendChannelEvent: async () => {
 				publishes += 1;
-				return { status: "accepted" as const, bufferedBytes: null };
+				return { eventId: `event-${publishes}` };
 			},
 		};
 
@@ -178,10 +178,7 @@ describe("channel ChannelsService", () => {
 		const service = new ChannelsService(
 			definitions,
 			{
-				publishChannel: async () => ({
-					status: "accepted" as const,
-					bufferedBytes: null,
-				}),
+				appendChannelEvent: async () => ({ eventId: "event-1" }),
 			},
 			userContext,
 		);
@@ -201,13 +198,13 @@ describe("channel ChannelsService", () => {
 		const definitions = {
 			news: channel("news").events({ updated: z.object({ id: z.string() }) }),
 		};
-		const frames: string[] = [];
+		const frames: unknown[] = [];
 		const service = new ChannelsService(
 			definitions,
 			{
-				publishChannel: async ({ frame }) => {
-					frames.push(new TextDecoder().decode(frame));
-					return { status: "accepted" as const, bufferedBytes: null };
+				appendChannelEvent: async ({ data }) => {
+					frames.push(data);
+					return { eventId: `event-${frames.length}` };
 				},
 			},
 			{ accessMode: "system" } as any,
@@ -217,9 +214,6 @@ describe("channel ChannelsService", () => {
 			{ channel: "news", event: "updated", data: { id: "1" } },
 			{ channel: "news", event: "updated", data: { id: "2" } },
 		]);
-		expect(frames.map((frame) => JSON.parse(frame).data.id)).toEqual([
-			"1",
-			"2",
-		]);
+		expect(frames.map((frame: any) => frame.id)).toEqual(["1", "2"]);
 	});
 });


### PR DESCRIPTION
## Summary
- persist framework channel publishes in the business transaction with a locked per-channel sequence head
- drain durable events through local-session cursors or a leased shared-provider coordinator
- add replay, dedupe, explicit channel gaps, bounded slow-consumer queues, and time/size retention
- register the ledger tables in generated schema and expose tuning through realtime config

## Verification
- task pattern: 10 passed, 2 gated Soketi skips, 0 failed
- full package suite: 1968 passed, 2 gated Soketi skips, 0 failed (6245 expects)
- package check-types including tsconfig.fullapp.json: passed
- package build: passed
- targeted oxlint: 0 warnings, 0 errors
- git diff --check: passed

Board task: rt3-1b-ordered-channel-event-ledger-per-channel-sequencing-replay-dedupe-slow-consumer-recovery