### PR TITLE
feat(realtime): add compatibility rollout modes

### DIFF
--- a/.changeset/roll-out-realtime-v2.md
+++ b/.changeset/roll-out-realtime-v2.md
@@ -1,0 +1,7 @@
+---
+"questpie": patch
+---
+
+Add explicit `legacy`, `v2`, and `dual` realtime rollout modes so existing adapters remain compatible, v2 invalidation can be canaried beside an adapter, and rollback is a config-only change with no schema or data loss.
+
+**Breaking behavior:** bulk update and bulk delete now append and publish one logical realtime event per operation instead of one event per affected record. Adapter consumers must handle `bulk_update` / `bulk_delete` and read `payload.count` plus `payload.recordIds` rather than relying on N per-record callbacks.

--- a/apps/docs/content/docs/adapters/meta.json
+++ b/apps/docs/content/docs/adapters/meta.json
@@ -1,4 +1,13 @@
 {
 	"title": "Adapters",
-	"pages": ["index", "queue", "search", "realtime", "storage", "email", "kv"]
+	"pages": [
+		"index",
+		"queue",
+		"search",
+		"realtime",
+		"realtime-v2-migration",
+		"storage",
+		"email",
+		"kv"
+	]
 }

--- a/apps/docs/content/docs/adapters/realtime-v2-migration.mdx
+++ b/apps/docs/content/docs/adapters/realtime-v2-migration.mdx
@@ -1,0 +1,116 @@
+---
+title: Realtime v2 migration and rollback
+description: Canary Realtime v2 beside an existing adapter, understand the bulk-event change, and roll back without changing schema or losing outbox data.
+---
+
+Realtime v2 keeps the existing `client.collections.*.live()`, `client.globals.*.live()`, raw `client.realtime`, TanStack `{ realtime: true }`, and `RealtimeConfig.adapter` APIs. The SSE wire remains protocol `1`; responses advertise it as `X-Questpie-Realtime-Protocol: 1`, which existing clients safely ignore.
+
+The rollout flag changes server transport selection only. It does not create, delete, or rewrite a table.
+
+## The breaking behavior to audit
+
+Bulk update and bulk delete emit **one durable event per logical operation**, not one event per affected record. A custom `RealtimeAdapter` or outbox consumer must handle:
+
+```ts
+{
+  operation: "bulk_update" | "bulk_delete",
+  payload: {
+    count: number,
+    recordIds: Array<string | number>,
+  },
+}
+```
+
+Do not count adapter notifications to count changed records. Use `payload.count`. Do not expect N per-record events from one bulk mutation.
+
+## Rollout modes
+
+`realtime.rollout.mode` accepts three values:
+
+| Mode       | Cross-instance invalidation                                                                           | Edge delivery                               | Use it for                                                |
+| ---------- | ----------------------------------------------------------------------------------------------------- | ------------------------------------------- | --------------------------------------------------------- |
+| `"legacy"` | Existing `adapter` or the poll/implicit-pg fallback                                                   | Existing SSE protocol                       | Baseline and immediate rollback                           |
+| `"v2"`     | `changeBroker`; an existing `adapter` remains the compatibility fallback when no broker is configured | Configured `clientTransport`, otherwise SSE | Normal operation; this is the default                     |
+| `"dual"`   | Existing `adapter` and `changeBroker` both publish the same durable outbox sequence                   | One v2 edge path only                       | Canary comparison without double-delivering client frames |
+
+Dual mode requires both `adapter` and `changeBroker`. It compares whether both invalidation publishes accepted the same durable sequence. A one-sided failure is reported through `onComparison` and logs a warning, while the healthy path continues. If both fail, normal reconciliation polling still provides the durable recovery path and the publish reports failure.
+
+## Recommended migration
+
+### 1. Deploy the new code on the legacy path
+
+Keep the current adapter and pin the baseline explicitly:
+
+```ts
+export default runtimeConfig({
+	realtime: {
+		adapter: existingAdapter,
+		rollout: { mode: "legacy" },
+	},
+});
+```
+
+Verify existing admin, Autopilot, `live()`, `liveIter()`, and TanStack realtime consumers. No client release is required.
+
+### 2. Canary both invalidation paths
+
+Add the v2 broker and compare outcomes. Client snapshots are still emitted once:
+
+```ts
+export default runtimeConfig({
+	realtime: {
+		adapter: existingAdapter,
+		changeBroker: nextBroker,
+		rollout: {
+			mode: "dual",
+			onComparison(result) {
+				if (!result.equivalent) {
+					metrics.increment("realtime.dual_run_mismatch", {
+						legacy: result.legacy,
+						v2: result.v2,
+					});
+				}
+			},
+		},
+	},
+});
+```
+
+Run dual mode long enough to cover deploys, reconnects, bulk mutations, and a broker interruption. The durable outbox remains the source of truth; dual mode compares invalidation acceptance, not application row payloads.
+
+### 3. Select v2
+
+After the canary is clean:
+
+```ts
+export default runtimeConfig({
+	realtime: {
+		changeBroker: nextBroker,
+		clientTransport: nextClientTransport,
+		rollout: { mode: "v2" },
+	},
+});
+```
+
+An app that only has `adapter` can also use the default `v2` mode. QUESTPIE maps that adapter onto the new invalidation/compute/delivery pipeline as a compatibility fallback, so existing configuration does not need a flag-day rewrite.
+
+## Rollback drill
+
+Rollback is a config change:
+
+1. Set `realtime.rollout.mode` to `"legacy"`.
+2. Keep the existing `adapter` configured.
+3. Redeploy or restart every instance.
+4. Confirm `POST /realtime` returns protocol header `1` and a known `live()` consumer receives a fresh snapshot.
+5. Confirm outbox lag returns to normal through the adapter or reconciliation poll.
+
+Do **not** roll back migrations or delete `questpie_realtime_log` / channel-ledger rows. Both modes consume the same durable data, so changing the flag loses neither schema nor committed events. If the adapter itself is unavailable, leave reconciliation polling enabled while restoring it.
+
+## Compatibility checklist
+
+- Existing `realtime: true` works.
+- Existing `realtime: { adapter }` works without adding a broker.
+- Existing SSE clients remain on protocol `1`.
+- Dual mode never sends two snapshot streams to one client.
+- Custom adapter consumers accept consolidated bulk events.
+- The rollback drill succeeds without a down migration or data deletion.

--- a/packages/questpie/src/server/adapters/utils/response.ts
+++ b/packages/questpie/src/server/adapters/utils/response.ts
@@ -23,6 +23,7 @@ export const sseHeaders = {
 	"Cache-Control": "no-cache",
 	Connection: "keep-alive",
 	"X-Accel-Buffering": "no",
+	"X-Questpie-Realtime-Protocol": "1",
 };
 
 /**

--- a/packages/questpie/src/server/modules/core/integrated/realtime/service.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/service.ts
@@ -29,6 +29,7 @@ import type {
 	RealtimeChangeEvent,
 	RealtimeChangePayload,
 	RealtimeConfig,
+	RealtimeDualRunComparison,
 	RealtimeErrorListener,
 	RealtimeNotice,
 	RealtimeOperation,
@@ -138,6 +139,10 @@ export class RealtimeService {
 	private adapter?: RealtimeAdapter;
 	private changeBroker?: ChangeBroker;
 	private clientTransport?: ClientTransport;
+	private readonly transportMode: "legacy" | "v2" | "dual";
+	private readonly onDualRunComparison?: (
+		comparison: RealtimeDualRunComparison,
+	) => void;
 	private listeners = new Set<ListenerEntry>();
 	private directCollectionListeners = new Map<string, Set<ListenerEntry>>();
 	private directGlobalListeners = new Map<string, Set<ListenerEntry>>();
@@ -172,8 +177,40 @@ export class RealtimeService {
 		private pgConnectionString?: string,
 		private logger?: Pick<LoggerAdapter, "error" | "warn">,
 	) {
-		this.changeBroker = config.changeBroker;
-		this.clientTransport = config.clientTransport;
+		this.transportMode = config.rollout?.mode ?? "v2";
+		this.onDualRunComparison = config.rollout?.onComparison;
+		if (
+			this.transportMode === "dual" &&
+			(!config.adapter || !config.changeBroker)
+		) {
+			throw new Error(
+				'Realtime rollout mode "dual" requires both adapter and changeBroker',
+			);
+		}
+
+		let compatibleAdapter = config.adapter;
+		if (
+			!compatibleAdapter &&
+			this.pgConnectionString &&
+			(this.transportMode === "legacy" || !config.changeBroker)
+		) {
+			compatibleAdapter = new PgNotifyAdapter({
+				connectionString: this.pgConnectionString,
+				channel: "questpie_realtime",
+			});
+		}
+
+		if (this.transportMode === "legacy") {
+			this.adapter = compatibleAdapter;
+		} else if (this.transportMode === "dual") {
+			this.adapter = config.adapter;
+			this.changeBroker = config.changeBroker;
+			this.clientTransport = config.clientTransport;
+		} else {
+			this.changeBroker = config.changeBroker;
+			this.adapter = this.changeBroker ? undefined : compatibleAdapter;
+			this.clientTransport = config.clientTransport;
+		}
 		this.channelEventLedger = new ChannelEventLedger(
 			this.db,
 			this.changeBroker,
@@ -182,19 +219,6 @@ export class RealtimeService {
 			this.logger,
 			() => this.initialize(),
 		);
-		// Auto-configure adapter if connection string is provided
-		if (config.adapter) {
-			// User provided custom adapter
-			this.adapter = config.adapter;
-		} else if (this.pgConnectionString && !this.changeBroker) {
-			// Create the default publisher at service construction so write-only
-			// instances can broadcast before they ever receive a local subscription.
-			this.adapter = new PgNotifyAdapter({
-				connectionString: this.pgConnectionString,
-				channel: "questpie_realtime",
-			});
-		}
-
 		this.batchSize = config.batchSize ?? 500;
 		this.pollIntervalMs =
 			config.pollIntervalMs ??
@@ -336,6 +360,51 @@ export class RealtimeService {
 	async notify(event: RealtimeChangeEvent): Promise<void> {
 		if (!this.adapter && !this.changeBroker) return;
 		await this.initialize();
+		if (this.transportMode === "dual") {
+			const wake = {
+				kind: "outbox-maybe-advanced" as const,
+				highWaterSeq: event.seq,
+				reason: "publish" as const,
+			};
+			const [legacyResult, v2Result] = await Promise.allSettled([
+				this.adapter!.notify(event),
+				this.changeBroker!.publish(wake),
+			]);
+			const comparison: RealtimeDualRunComparison = {
+				seq: event.seq,
+				legacy: legacyResult.status === "fulfilled" ? "accepted" : "rejected",
+				v2: v2Result.status === "fulfilled" ? "accepted" : "rejected",
+				equivalent: legacyResult.status === v2Result.status,
+				...(legacyResult.status === "rejected"
+					? { legacyError: legacyResult.reason }
+					: {}),
+				...(v2Result.status === "rejected" ? { v2Error: v2Result.reason } : {}),
+			};
+			if (!comparison.equivalent) {
+				this.logger?.warn(
+					"[Realtime] Dual-run invalidation transports diverged",
+					comparison,
+				);
+			}
+			try {
+				this.onDualRunComparison?.(comparison);
+			} catch (error) {
+				this.logger?.warn(
+					"[Realtime] Dual-run comparison observer failed",
+					error,
+				);
+			}
+			if (
+				legacyResult.status === "rejected" &&
+				v2Result.status === "rejected"
+			) {
+				throw new AggregateError(
+					[legacyResult.reason, v2Result.reason],
+					"Both realtime dual-run invalidation transports failed",
+				);
+			}
+			return;
+		}
 		await Promise.all([
 			this.adapter?.notify(event),
 			this.changeBroker?.publish({

--- a/packages/questpie/src/server/modules/core/integrated/realtime/types.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/types.ts
@@ -49,6 +49,30 @@ export type RealtimeNotice = Pick<
 	"seq" | "resourceType" | "resource" | "operation"
 >;
 
+export type RealtimeTransportMode = "legacy" | "v2" | "dual";
+
+export type RealtimeDualRunComparison = {
+	/** Durable outbox sequence published through both invalidation paths. */
+	seq: number;
+	legacy: "accepted" | "rejected";
+	v2: "accepted" | "rejected";
+	/** Whether both transports returned the same acceptance result. */
+	equivalent: boolean;
+	legacyError?: unknown;
+	v2Error?: unknown;
+};
+
+export type RealtimeRolloutConfig = {
+	/**
+	 * `legacy` is the rollback path, `v2` selects the new seams, and `dual`
+	 * shadows invalidation through both paths without duplicating client frames.
+	 * @default "v2"
+	 */
+	mode?: RealtimeTransportMode;
+	/** Observes one comparison per dual-run outbox publish. */
+	onComparison?: (comparison: RealtimeDualRunComparison) => void;
+};
+
 /**
  * Topics for realtime subscriptions.
  * Supports hierarchical filtering via WHERE clause and automatic dependency tracking.
@@ -88,6 +112,8 @@ export type RealtimeSubscriptionContext = {
 };
 
 export interface RealtimeConfig {
+	/** Compatibility, canary, and rollback selection. */
+	rollout?: RealtimeRolloutConfig;
 	/** Realtime edge-session admission limits. */
 	admission?: Partial<import("./admission.js").RealtimeAdmissionConfig>;
 	/** Optional maximum random delay before accepting a new edge session. */

--- a/packages/questpie/test/types/runtime-config.test-d.ts
+++ b/packages/questpie/test/types/runtime-config.test-d.ts
@@ -1,4 +1,5 @@
 import type { RealtimeConfig } from "#questpie/server/modules/core/integrated/realtime/types.js";
+
 import { runtimeConfig } from "../../src/server/config/create-app.js";
 import type { Equal, Expect } from "./type-test-utils.js";
 
@@ -11,3 +12,27 @@ type _realtimeTrueResolvesToConfig = Expect<
 	Equal<typeof realtimeEnabled.realtime, RealtimeConfig>
 >;
 
+runtimeConfig({
+	db: { url: "postgres://localhost/test" },
+	realtime: {
+		rollout: {
+			mode: "dual",
+			onComparison(result) {
+				const seq: number = result.seq;
+				const legacy: "accepted" | "rejected" = result.legacy;
+				const equivalent: boolean = result.equivalent;
+				void [seq, legacy, equivalent];
+			},
+		},
+	},
+});
+
+runtimeConfig({
+	db: { url: "postgres://localhost/test" },
+	realtime: {
+		rollout: {
+			// @ts-expect-error rollout mode is a closed compatibility contract
+			mode: "canary",
+		},
+	},
+});

--- a/packages/questpie/test/units/realtime-rollout.test.ts
+++ b/packages/questpie/test/units/realtime-rollout.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, it } from "bun:test";
+
+import { sseHeaders } from "../../src/server/adapters/utils/response.js";
+import type { RealtimeAdapter } from "../../src/server/modules/core/integrated/realtime/adapter.js";
+import { RealtimeService } from "../../src/server/modules/core/integrated/realtime/service.js";
+import type {
+	ChangeBroker,
+	ChangeWake,
+	ClientSink,
+	ClientTransportConfig,
+	EdgeSessionInput,
+	LocalSessionClientTransport,
+} from "../../src/server/modules/core/integrated/realtime/transport.js";
+import type {
+	RealtimeChangeEvent,
+	RealtimeDualRunComparison,
+	RealtimeNotice,
+} from "../../src/server/modules/core/integrated/realtime/types.js";
+
+const change: RealtimeChangeEvent = {
+	seq: 7,
+	resourceType: "collection",
+	resource: "posts",
+	operation: "update",
+	recordId: "post-1",
+	locale: null,
+	payload: {},
+	createdAt: new Date("2026-07-14T00:00:00.000Z"),
+};
+
+class EmptyRealtimeDb {
+	select() {
+		const query = {
+			from: () => query,
+			where: () => query,
+			orderBy: () => query,
+			limit: async () => [],
+		};
+		return query;
+	}
+}
+
+class RecordingAdapter implements RealtimeAdapter {
+	publisherStarts = 0;
+	starts = 0;
+	stops = 0;
+	notifications: RealtimeChangeEvent[] = [];
+	failNotify = false;
+
+	async startPublisher(): Promise<void> {
+		this.publisherStarts += 1;
+	}
+
+	async start(): Promise<void> {
+		this.starts += 1;
+	}
+
+	async stop(): Promise<void> {
+		this.stops += 1;
+	}
+
+	async notify(event: RealtimeChangeEvent): Promise<void> {
+		this.notifications.push(event);
+		if (this.failNotify) throw new Error("legacy unavailable");
+	}
+
+	subscribe(_handler: (notice: RealtimeNotice) => void): () => void {
+		return () => {};
+	}
+}
+
+class RecordingBroker implements ChangeBroker {
+	starts = 0;
+	stops = 0;
+	wakes: ChangeWake[] = [];
+	failPublish = false;
+
+	async start(): Promise<void> {
+		this.starts += 1;
+	}
+
+	async publish(wake: ChangeWake): Promise<void> {
+		this.wakes.push(wake);
+		if (this.failPublish) throw new Error("v2 unavailable");
+	}
+
+	async stop(): Promise<void> {
+		this.stops += 1;
+	}
+}
+
+class RecordingClientTransport implements LocalSessionClientTransport {
+	readonly channelDeliveryScope = "local-sessions" as const;
+	starts = 0;
+	stops = 0;
+
+	async start(): Promise<void> {
+		this.starts += 1;
+	}
+
+	async openSession(_input: EdgeSessionInput): Promise<ClientSink> {
+		throw new Error("not used by rollout tests");
+	}
+
+	async getClientConfig(): Promise<ClientTransportConfig> {
+		return { transport: "sse" };
+	}
+
+	async stop(): Promise<void> {
+		this.stops += 1;
+	}
+}
+
+function createService(
+	config: ConstructorParameters<typeof RealtimeService>[1],
+) {
+	return new RealtimeService(new EmptyRealtimeDb() as never, {
+		pollIntervalMs: 0,
+		retentionDays: 0,
+		...config,
+	});
+}
+
+describe("realtime compatibility rollout", () => {
+	it("keeps adapter-only config working as the v2 compatibility fallback", async () => {
+		const adapter = new RecordingAdapter();
+		const realtime = createService({ adapter });
+		try {
+			await realtime.notify(change);
+			expect(adapter.publisherStarts).toBe(1);
+			expect(adapter.notifications).toEqual([change]);
+			expect(await realtime.getClientTransportConfig({})).toEqual({
+				transport: "sse",
+			});
+		} finally {
+			await realtime.destroy();
+		}
+	});
+
+	it("legacy rollback starts only the adapter and preserves SSE protocol v1", async () => {
+		const adapter = new RecordingAdapter();
+		const broker = new RecordingBroker();
+		const clientTransport = new RecordingClientTransport();
+		const realtime = createService({
+			adapter,
+			changeBroker: broker,
+			clientTransport,
+			rollout: { mode: "legacy" },
+		});
+		try {
+			await realtime.notify(change);
+			expect(adapter.notifications).toEqual([change]);
+			expect(broker.starts).toBe(0);
+			expect(broker.wakes).toEqual([]);
+			expect(clientTransport.starts).toBe(0);
+			expect(await realtime.getClientTransportConfig({})).toEqual({
+				transport: "sse",
+			});
+			expect(sseHeaders["X-Questpie-Realtime-Protocol"]).toBe("1");
+		} finally {
+			await realtime.destroy();
+		}
+	});
+
+	it("v2 mode selects the new seams when legacy and v2 transports coexist", async () => {
+		const adapter = new RecordingAdapter();
+		const broker = new RecordingBroker();
+		const clientTransport = new RecordingClientTransport();
+		const realtime = createService({
+			adapter,
+			changeBroker: broker,
+			clientTransport,
+			rollout: { mode: "v2" },
+		});
+		try {
+			await realtime.notify(change);
+			expect(adapter.publisherStarts).toBe(0);
+			expect(adapter.notifications).toEqual([]);
+			expect(broker.wakes).toEqual([
+				{
+					kind: "outbox-maybe-advanced",
+					highWaterSeq: 7,
+					reason: "publish",
+				},
+			]);
+			expect(clientTransport.starts).toBe(1);
+		} finally {
+			await realtime.destroy();
+		}
+	});
+
+	it("dual mode compares both publish paths without failing over a one-sided canary error", async () => {
+		const adapter = new RecordingAdapter();
+		adapter.failNotify = true;
+		const broker = new RecordingBroker();
+		const comparisons: RealtimeDualRunComparison[] = [];
+		const realtime = createService({
+			adapter,
+			changeBroker: broker,
+			rollout: {
+				mode: "dual",
+				onComparison: (comparison) => comparisons.push(comparison),
+			},
+		});
+		try {
+			await expect(realtime.notify(change)).resolves.toBeUndefined();
+			expect(adapter.notifications).toEqual([change]);
+			expect(broker.wakes).toHaveLength(1);
+			expect(comparisons).toHaveLength(1);
+			expect(comparisons[0]).toMatchObject({
+				seq: 7,
+				legacy: "rejected",
+				v2: "accepted",
+				equivalent: false,
+			});
+		} finally {
+			await realtime.destroy();
+		}
+	});
+
+	it("rejects dual mode unless both comparable paths are explicit", () => {
+		expect(() =>
+			createService({
+				adapter: new RecordingAdapter(),
+				rollout: { mode: "dual" },
+			}),
+		).toThrow(/dual.*adapter.*changeBroker/i);
+	});
+});


### PR DESCRIPTION
## Summary
- preserve existing `RealtimeConfig.adapter` and SSE protocol v1 while adding explicit `legacy`, `v2`, and `dual` rollout modes
- canary legacy and v2 invalidation publishes without duplicating client delivery, with typed comparison telemetry and config-only rollback
- document the bulk-event consolidation breaking behavior and migration/rollback procedure

## Verification
- `cd packages/questpie && bun test test/ --test-name-pattern realtime` (89 pass, 2 gated Soketi skips, 0 fail)
- `cd packages/questpie && bunx tsc --noEmit -p tsconfig.json`
- `cd packages/questpie && bun run build`
- `cd apps/docs && bun run types:check`
- `bunx oxlint` on changed TypeScript files
- root `questpie:check-types` including `tsconfig.fullapp.json` passed; the wider monorepo command remains red only in pre-existing `examples/tanstack-barbershop` errors

Board: RT4.0