### PR TITLE
feat(realtime): add operation-aware topics

### DIFF
--- a/.changeset/realtime-operation-topics.md
+++ b/.changeset/realtime-operation-topics.md
@@ -1,0 +1,6 @@
+---
+"questpie": patch
+"@questpie/tanstack-query": patch
+---
+
+Add operation-aware realtime topics for collection `find`, `count`, and `get` queries. Live counts now execute the database count operation and stream a scalar value instead of materializing and transferring the matching records.

--- a/packages/questpie/src/client/realtime/multiplexer.ts
+++ b/packages/questpie/src/client/realtime/multiplexer.ts
@@ -9,24 +9,42 @@
 // Types
 // ============================================================================
 
-export type TopicConfig = {
-	/** Resource type */
-	resourceType: "collection" | "global";
-	/** Resource name (collection or global name) */
+type TopicCommon = {
+	/** Resource name (collection or global name). */
 	resource: string;
-	/** Optional WHERE filters */
-	where?: Record<string, unknown>;
-	/** Optional relations to include */
-	with?: Record<string, unknown>;
-	/** Pagination limit */
-	limit?: number;
-	/** Pagination offset */
-	offset?: number;
-	/** Order by configuration */
-	orderBy?: Record<string, "asc" | "desc">;
-	/** Content locale */
+	/** Content locale. */
 	locale?: string;
 };
+
+export type TopicConfig =
+	| (TopicCommon & {
+			resourceType: "collection";
+			/** Omitted by legacy callers and normalized to `find` by the server. */
+			operation?: "find";
+			where?: Record<string, unknown>;
+			with?: Record<string, unknown>;
+			limit?: number;
+			offset?: number;
+			orderBy?: Record<string, "asc" | "desc">;
+	  })
+	| (TopicCommon & {
+			resourceType: "collection";
+			operation: "count";
+			where?: Record<string, unknown>;
+	  })
+	| (TopicCommon & {
+			resourceType: "collection";
+			operation: "get";
+			id: string;
+			with?: Record<string, unknown>;
+	  })
+	| (TopicCommon & {
+			resourceType: "global";
+			/** Omitted by legacy callers and normalized to `get` by the server. */
+			operation?: "get";
+			where?: Record<string, unknown>;
+			with?: Record<string, unknown>;
+	  });
 
 export type TopicInput = TopicConfig & {
 	/** Optional custom topic ID. If not provided, one will be generated. */
@@ -340,10 +358,15 @@ export class RealtimeMultiplexer {
 		this.watchdogTriggered = false;
 
 		const getTopicsPayload = () =>
-			Array.from(this.topics.entries()).map(([id, config]) => ({
-				id,
+			Array.from(this.topics.entries()).map(([topicId, config]) => ({
 				...config,
-				...(this.lastSeq.has(id) ? { sinceSeq: this.lastSeq.get(id) } : {}),
+				...(config.resourceType === "collection" && config.operation === "get"
+					? { recordId: config.id }
+					: {}),
+				id: topicId,
+				...(this.lastSeq.has(topicId)
+					? { sinceSeq: this.lastSeq.get(topicId) }
+					: {}),
 			}));
 
 		try {

--- a/packages/questpie/src/client/realtime/stream.ts
+++ b/packages/questpie/src/client/realtime/stream.ts
@@ -140,26 +140,80 @@ export async function* sseSnapshotStream<TData>(options: {
 /**
  * Build a topic config for a collection query.
  */
+type CollectionFindTopicOptions = {
+	where?: Record<string, unknown>;
+	with?: Record<string, unknown>;
+	limit?: number;
+	offset?: number;
+	orderBy?: Record<string, "asc" | "desc">;
+	locale?: string;
+};
+
+type CollectionCountTopicOptions = Pick<
+	CollectionFindTopicOptions,
+	"where" | "locale"
+>;
+
+type CollectionGetTopicOptions = Pick<
+	CollectionFindTopicOptions,
+	"with" | "locale"
+> & { id: string };
+
 export function buildCollectionTopic(
 	collectionName: string,
-	options?: {
-		where?: Record<string, unknown>;
-		with?: Record<string, unknown>;
-		limit?: number;
-		offset?: number;
-		orderBy?: Record<string, "asc" | "desc">;
-		locale?: string;
-	},
+	options?: CollectionFindTopicOptions,
+	operation?: "find",
+): Extract<TopicConfig, { resourceType: "collection"; operation?: "find" }>;
+export function buildCollectionTopic(
+	collectionName: string,
+	options: CollectionCountTopicOptions | undefined,
+	operation: "count",
+): Extract<TopicConfig, { resourceType: "collection"; operation: "count" }>;
+export function buildCollectionTopic(
+	collectionName: string,
+	options: CollectionGetTopicOptions,
+	operation: "get",
+): Extract<TopicConfig, { resourceType: "collection"; operation: "get" }>;
+export function buildCollectionTopic(
+	collectionName: string,
+	options?:
+		| CollectionFindTopicOptions
+		| CollectionCountTopicOptions
+		| CollectionGetTopicOptions,
+	operation: "find" | "count" | "get" = "find",
 ): TopicConfig {
+	if (operation === "get") {
+		const getOptions = options as CollectionGetTopicOptions;
+		return {
+			resourceType: "collection",
+			resource: collectionName,
+			operation: "get",
+			id: getOptions.id,
+			...(getOptions.with && { with: getOptions.with }),
+			...(getOptions.locale && { locale: getOptions.locale }),
+		};
+	}
+	if (operation === "count") {
+		const countOptions = options as CollectionCountTopicOptions | undefined;
+		return {
+			resourceType: "collection",
+			resource: collectionName,
+			operation: "count",
+			...(countOptions?.where && { where: countOptions.where }),
+			...(countOptions?.locale && { locale: countOptions.locale }),
+		};
+	}
+	const findOptions = options as CollectionFindTopicOptions | undefined;
 	return {
 		resourceType: "collection",
 		resource: collectionName,
-		...(options?.where && { where: options.where }),
-		...(options?.with && { with: options.with }),
-		...(options?.limit !== undefined && { limit: options.limit }),
-		...(options?.offset !== undefined && { offset: options.offset }),
-		...(options?.orderBy && { orderBy: options.orderBy }),
-		...(options?.locale && { locale: options.locale }),
+		operation: "find",
+		...(findOptions?.where && { where: findOptions.where }),
+		...(findOptions?.with && { with: findOptions.with }),
+		...(findOptions?.limit !== undefined && { limit: findOptions.limit }),
+		...(findOptions?.offset !== undefined && { offset: findOptions.offset }),
+		...(findOptions?.orderBy && { orderBy: findOptions.orderBy }),
+		...(findOptions?.locale && { locale: findOptions.locale }),
 	};
 }
 
@@ -177,6 +231,7 @@ export function buildGlobalTopic(
 	return {
 		resourceType: "global",
 		resource: globalName,
+		operation: "get",
 		...(options?.where && { where: options.where }),
 		...(options?.with && { with: options.with }),
 		...(options?.locale && { locale: options.locale }),

--- a/packages/questpie/src/server/adapters/routes/realtime.ts
+++ b/packages/questpie/src/server/adapters/routes/realtime.ts
@@ -47,6 +47,10 @@ type TopicInput = {
 	resourceType: "collection" | "global";
 	/** Resource name */
 	resource: string;
+	/** Query operation; omitted legacy topics are normalized by resource type. */
+	operation?: "find" | "count" | "get";
+	/** Record id for a collection `get` topic. */
+	recordId?: string;
 	/** WHERE filters */
 	where?: Record<string, unknown>;
 	/** Relations to include */
@@ -63,8 +67,17 @@ type TopicInput = {
 	sinceSeq?: number;
 };
 
-type ValidatedTopic = TopicInput & {
-	type: "collection" | "global";
+type NormalizedTopicInput =
+	| (TopicInput & { resourceType: "collection"; operation: "find" })
+	| (TopicInput & { resourceType: "collection"; operation: "count" })
+	| (TopicInput & {
+			resourceType: "collection";
+			operation: "get";
+			recordId: string;
+	  })
+	| (TopicInput & { resourceType: "global"; operation: "get" });
+
+type ValidatedTopicMetadata = {
 	crud: any;
 	definition: any;
 	accessWhere?: true | Record<string, unknown>;
@@ -73,6 +86,63 @@ type ValidatedTopic = TopicInput & {
 		context: any,
 	) => string | null | undefined | Promise<string | null | undefined>;
 };
+
+type ValidatedTopic =
+	| (Extract<NormalizedTopicInput, { resourceType: "collection" }> &
+			ValidatedTopicMetadata & { type: "collection" })
+	| (Extract<NormalizedTopicInput, { resourceType: "global" }> &
+			ValidatedTopicMetadata & { type: "global" });
+
+function normalizeTopicOperation(topic: TopicInput): NormalizedTopicInput {
+	if (topic.resourceType !== "collection" && topic.resourceType !== "global") {
+		throw new Error("Invalid realtime resource type");
+	}
+	const operation =
+		topic.operation ?? (topic.resourceType === "global" ? "get" : "find");
+	if (operation !== "find" && operation !== "count" && operation !== "get") {
+		throw new Error("Invalid realtime topic operation");
+	}
+	if (topic.resourceType === "global") {
+		if (operation !== "get") {
+			throw new Error("Global realtime topics only support the get operation");
+		}
+		return { ...topic, resourceType: "global", operation: "get" };
+	}
+	if (operation === "get") {
+		if (!topic.recordId || typeof topic.recordId !== "string") {
+			throw new Error("Collection get topics require a record id");
+		}
+		if (
+			topic.where ||
+			topic.limit !== undefined ||
+			topic.offset !== undefined ||
+			topic.orderBy
+		) {
+			throw new Error(
+				"Collection get topics accept only recordId, with, and locale",
+			);
+		}
+		return {
+			...topic,
+			resourceType: "collection",
+			operation: "get",
+			recordId: topic.recordId,
+		};
+	}
+	if (operation === "count") {
+		if (
+			topic.with ||
+			topic.limit !== undefined ||
+			topic.offset !== undefined ||
+			topic.orderBy ||
+			topic.recordId
+		) {
+			throw new Error("Collection count topics accept only where and locale");
+		}
+		return { ...topic, resourceType: "collection", operation: "count" };
+	}
+	return { ...topic, resourceType: "collection", operation: "find" };
+}
 
 function mergeAccessWhere(
 	where: Record<string, unknown> | undefined,
@@ -187,7 +257,8 @@ async function resolveIncrementalTopic(
 	) {
 		throw new Error("Topic sinceSeq must be a non-negative safe integer");
 	}
-	const topicAdmission = admitRealtimeTopic(rawTopic, admission);
+	const normalizedTopic = normalizeTopicOperation(rawTopic);
+	const topicAdmission = admitRealtimeTopic(normalizedTopic, admission);
 	if (!topicAdmission.accepted) throw new Error(topicAdmission.message);
 	const topic = topicAdmission.topic;
 
@@ -374,17 +445,17 @@ export async function realtimeSubscribe(
 			topicErrors.push({ id: "unknown", message: "Topic must be an object" });
 			continue;
 		}
-		let topic = rawTopic;
+		let topic: NormalizedTopicInput;
 		if (topicIndex >= admission.maxTopicsPerConnection) {
 			topicErrors.push({
-				id: topic.id ?? "unknown",
+				id: rawTopic.id ?? "unknown",
 				message: `Connection accepts at most ${admission.maxTopicsPerConnection} topics`,
 			});
 			continue;
 		}
-		if (!topic.id || typeof topic.id !== "string") {
+		if (!rawTopic.id || typeof rawTopic.id !== "string") {
 			topicErrors.push({
-				id: topic.id ?? "unknown",
+				id: rawTopic.id ?? "unknown",
 				message: app.t(
 					"realtime.topicIdRequired",
 					undefined,
@@ -394,9 +465,9 @@ export async function realtimeSubscribe(
 			continue;
 		}
 
-		if (!topic.resourceType || !topic.resource) {
+		if (!rawTopic.resourceType || !rawTopic.resource) {
 			topicErrors.push({
-				id: topic.id,
+				id: rawTopic.id,
 				message: app.t(
 					"realtime.resourceRequired",
 					undefined,
@@ -406,12 +477,21 @@ export async function realtimeSubscribe(
 			continue;
 		}
 		if (
-			topic.sinceSeq !== undefined &&
-			(!Number.isSafeInteger(topic.sinceSeq) || topic.sinceSeq < 0)
+			rawTopic.sinceSeq !== undefined &&
+			(!Number.isSafeInteger(rawTopic.sinceSeq) || rawTopic.sinceSeq < 0)
 		) {
 			topicErrors.push({
-				id: topic.id,
+				id: rawTopic.id,
 				message: "Topic sinceSeq must be a non-negative safe integer",
+			});
+			continue;
+		}
+		try {
+			topic = normalizeTopicOperation(rawTopic);
+		} catch (error) {
+			topicErrors.push({
+				id: rawTopic.id,
+				message: error instanceof Error ? error.message : "Invalid operation",
 			});
 			continue;
 		}
@@ -472,15 +552,6 @@ export async function realtimeSubscribe(
 					),
 				});
 			}
-		} else {
-			topicErrors.push({
-				id: topic.id,
-				message: app.t(
-					"realtime.invalidResourceType",
-					{ resourceType: topic.resourceType },
-					resolved.appContext.locale,
-				),
-			});
 		}
 	}
 
@@ -674,6 +745,7 @@ export async function realtimeSubscribe(
 						topics: {
 							resourceType: topic.resourceType,
 							resource: topic.resource,
+							operation: topic.operation,
 							where: topic.where,
 							with: topic.with,
 						},
@@ -758,6 +830,10 @@ export async function realtimeSubscribe(
 							try {
 								const rawTopic = {
 									...frame.topic,
+									...(frame.topic.resourceType === "collection" &&
+									frame.topic.operation === "get"
+										? { recordId: frame.topic.id }
+										: {}),
 									id: frame.topicId,
 									sinceSeq: frame.sinceSeq,
 								} as TopicInput;

--- a/packages/questpie/src/server/modules/core/integrated/realtime/admission.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/admission.ts
@@ -60,12 +60,13 @@ type AdmissionTopic = {
 	id: string;
 	resourceType: "collection" | "global";
 	resource: string;
+	operation?: "find" | "count" | "get";
 	limit?: number;
 	with?: Record<string, unknown>;
 } & Record<string, unknown>;
 
 export type TopicAdmissionResult<TTopic extends AdmissionTopic> =
-	| { accepted: true; topic: TTopic & { limit: number } }
+	| { accepted: true; topic: TTopic & { limit?: number } }
 	| { accepted: false; message: string };
 
 function withDepth(withConfig: Record<string, unknown> | undefined): number {
@@ -92,6 +93,9 @@ export function admitRealtimeTopic<TTopic extends AdmissionTopic>(
 			accepted: false,
 			message: `Topic exceeds maximum relation depth of ${config.maxWithDepth}`,
 		};
+	}
+	if ((topic.operation ?? "find") !== "find") {
+		return { accepted: true, topic: { ...topic } };
 	}
 
 	const limit = topic.limit ?? config.maxFindLimit;

--- a/packages/questpie/src/server/modules/core/integrated/realtime/snapshot.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/snapshot.ts
@@ -1,7 +1,15 @@
 import { PRECHECKED_READ_ACCESS } from "#questpie/server/collection/crud/shared/access-control.js";
 
-type CollectionSnapshotCrud = {
+type CollectionFindSnapshotCrud = {
 	find(options: Record<string, unknown>, context: unknown): Promise<unknown>;
+};
+
+type CollectionCountSnapshotCrud = {
+	count(options: Record<string, unknown>, context: unknown): Promise<number>;
+};
+
+type CollectionGetSnapshotCrud = {
+	findOne(options: Record<string, unknown>, context: unknown): Promise<unknown>;
 };
 
 type GlobalSnapshotCrud = {
@@ -19,8 +27,27 @@ type SnapshotQuery = {
 };
 
 export type RealtimeSnapshotTopic =
-	| (SnapshotQuery & { type: "collection"; crud: CollectionSnapshotCrud })
-	| (SnapshotQuery & { type: "global"; crud: GlobalSnapshotCrud });
+	| (SnapshotQuery & {
+			type: "collection";
+			operation: "find";
+			crud: CollectionFindSnapshotCrud;
+	  })
+	| (Pick<SnapshotQuery, "accessWhere" | "where" | "locale"> & {
+			type: "collection";
+			operation: "count";
+			crud: CollectionCountSnapshotCrud;
+	  })
+	| (Pick<SnapshotQuery, "accessWhere" | "with" | "locale"> & {
+			type: "collection";
+			operation: "get";
+			recordId: string;
+			crud: CollectionGetSnapshotCrud;
+	  })
+	| (SnapshotQuery & {
+			type: "global";
+			operation: "get";
+			crud: GlobalSnapshotCrud;
+	  });
 
 /** Compute one authorized snapshot without knowing how its bytes are delivered. */
 export function computeRealtimeSnapshot(
@@ -28,6 +55,29 @@ export function computeRealtimeSnapshot(
 	context: unknown,
 ): Promise<unknown> {
 	if (topic.type === "collection") {
+		if (topic.operation === "count") {
+			return topic.crud.count(
+				{
+					[PRECHECKED_READ_ACCESS]: topic.accessWhere,
+					where: topic.where,
+					locale: topic.locale,
+				},
+				context,
+			);
+		}
+
+		if (topic.operation === "get") {
+			return topic.crud.findOne(
+				{
+					[PRECHECKED_READ_ACCESS]: topic.accessWhere,
+					where: { id: topic.recordId },
+					with: topic.with,
+					locale: topic.locale,
+				},
+				context,
+			);
+		}
+
 		return topic.crud.find(
 			{
 				[PRECHECKED_READ_ACCESS]: topic.accessWhere,

--- a/packages/questpie/src/server/modules/core/integrated/realtime/types.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/types.ts
@@ -80,6 +80,8 @@ export type RealtimeRolloutConfig = {
 export type RealtimeTopics = {
 	resourceType: RealtimeResourceType;
 	resource: string;
+	/** Query shape used to compute the latest snapshot. */
+	operation?: "find" | "count" | "get";
 	/**
 	 * WHERE clause for filtering events.
 	 * Simple equality filters are extracted for topic routing.

--- a/packages/questpie/test/client/client-live.test.ts
+++ b/packages/questpie/test/client/client-live.test.ts
@@ -22,6 +22,8 @@ type SSEConnection = {
 		id: string;
 		resourceType: string;
 		resource: string;
+		operation?: "find" | "count" | "get";
+		recordId?: string;
 		where?: Record<string, unknown>;
 		with?: Record<string, unknown>;
 		limit?: number;
@@ -154,6 +156,7 @@ describe("client live queries", () => {
 		expect(connection.topics).toHaveLength(1);
 		expect(connection.topics[0].resourceType).toBe("collection");
 		expect(connection.topics[0].resource).toBe("posts");
+		expect(connection.topics[0].operation).toBe("find");
 		expect(connection.topics[0].where).toEqual({ status: "published" });
 		expect(connection.topics[0].limit).toBe(10);
 
@@ -187,6 +190,35 @@ describe("client live queries", () => {
 		connection.sendSnapshot(topicId, 3, { docs: [], totalDocs: 0 });
 		await new Promise((resolve) => setTimeout(resolve, 50));
 		expect(snapshots).toHaveLength(2);
+	});
+
+	it("keeps collection get record ids separate from subscription ids", async () => {
+		const multiplexer = new RealtimeMultiplexer(
+			"http://localhost:3000",
+			true,
+			0,
+		);
+		multiplexer.subscribe(
+			{
+				resourceType: "collection",
+				resource: "posts",
+				operation: "get",
+				id: "post-1",
+			},
+			() => {},
+			undefined,
+			"topic-post-1",
+		);
+
+		await waitFor(() => connections.length === 1);
+		expect(connections[0].topics[0]).toMatchObject({
+			id: "topic-post-1",
+			resourceType: "collection",
+			resource: "posts",
+			operation: "get",
+			recordId: "post-1",
+		});
+		multiplexer.destroy();
 	});
 
 	it("adds one mounted topic with one control frame and no reconnect", async () => {

--- a/packages/questpie/test/integration/realtime.test.ts
+++ b/packages/questpie/test/integration/realtime.test.ts
@@ -87,6 +87,8 @@ type TopicInput = {
 	id: string;
 	resourceType: "collection" | "global";
 	resource: string;
+	operation?: "find" | "count" | "get";
+	recordId?: string;
 	where?: Record<string, unknown>;
 	with?: Record<string, unknown>;
 	limit?: number;
@@ -217,6 +219,84 @@ describe("realtime", () => {
 			await setup.cleanup();
 			// setup = null;
 		}
+	});
+
+	// ==========================================================================
+	// Operation-aware topic tests
+	// ==========================================================================
+
+	describe("operation-aware topics", () => {
+		it("streams live count as an O(1) scalar without running find", async () => {
+			const adapter = new MockRealtimeAdapter();
+			const posts = collection("posts")
+				.fields(({ f }) => ({
+					title: f.textarea().required(),
+				}))
+				.access({ read: true });
+			setup = await buildMockApp(
+				{ collections: { posts } },
+				{ realtime: { adapter } },
+			);
+			await runTestDbMigrations(setup.app);
+			const context = createTestContext();
+			for (let index = 0; index < 32; index += 1) {
+				await setup.app.collections.posts.create(
+					{ title: `Post ${index}` },
+					context,
+				);
+			}
+
+			const routes = createAdapterRoutes(setup.app, { accessMode: "user" });
+			const response = await routes.realtime.subscribe(
+				createRealtimeRequest([
+					collectionTopic("posts", { operation: "count" }),
+				]),
+				{},
+				undefined,
+			);
+			expect(response.status).toBe(200);
+			const reader = createSSEReader(response.body!);
+
+			const initial = await reader.readSnapshot();
+			expect(initial.data.data).toBe(32);
+			expect(JSON.stringify(initial.data.data).length).toBeLessThan(16);
+
+			await setup.app.collections.posts.create({ title: "Post 32" }, context);
+			const updated = await reader.readSnapshot();
+			expect(updated.data.data).toBe(33);
+			expect(JSON.stringify(updated.data.data).length).toBeLessThan(16);
+			await reader.close();
+		});
+
+		it("rejects invalid operation and query-shape combinations", async () => {
+			const posts = collection("posts")
+				.fields(({ f }) => ({ title: f.textarea().required() }))
+				.access({ read: true });
+			setup = await buildMockApp(
+				{ collections: { posts } },
+				{ realtime: true },
+			);
+			await runTestDbMigrations(setup.app);
+			const routes = createAdapterRoutes(setup.app, { accessMode: "user" });
+
+			const countWithFindLimit = await routes.realtime.subscribe(
+				createRealtimeRequest([
+					collectionTopic("posts", { operation: "count", limit: 1 }),
+				]),
+				{},
+				undefined,
+			);
+			expect(countWithFindLimit.status).toBe(400);
+
+			const unknownOperation = await routes.realtime.subscribe(
+				createRealtimeRequest([
+					collectionTopic("posts", { operation: "delete" as any }),
+				]),
+				{},
+				undefined,
+			);
+			expect(unknownOperation.status).toBe(400);
+		});
 	});
 
 	// ==========================================================================

--- a/packages/questpie/test/units/realtime-admission.test.ts
+++ b/packages/questpie/test/units/realtime-admission.test.ts
@@ -41,6 +41,25 @@ describe("realtime admission", () => {
 				DEFAULT_REALTIME_ADMISSION,
 			),
 		).toMatchObject({ accepted: false });
+		expect(
+			admitRealtimeTopic(
+				{
+					id: "posts-count",
+					resourceType: "collection",
+					resource: "posts",
+					operation: "count",
+				},
+				DEFAULT_REALTIME_ADMISSION,
+			),
+		).toEqual({
+			accepted: true,
+			topic: {
+				id: "posts-count",
+				resourceType: "collection",
+				resource: "posts",
+				operation: "count",
+			},
+		});
 	});
 
 	it("releases per-principal counters idempotently", () => {

--- a/packages/questpie/test/units/realtime-snapshot.test.ts
+++ b/packages/questpie/test/units/realtime-snapshot.test.ts
@@ -12,6 +12,7 @@ describe("computeRealtimeSnapshot", () => {
 			computeRealtimeSnapshot(
 				{
 					type: "collection",
+					operation: "find",
 					crud: {
 						find: async (...args: unknown[]) => {
 							calls.push(args);
@@ -43,6 +44,90 @@ describe("computeRealtimeSnapshot", () => {
 		]);
 	});
 
+	it("runs collection counts without materializing matching rows", async () => {
+		let findCalls = 0;
+		const countCalls: unknown[] = [];
+		const context = { locale: "en" };
+		const smallCrud = {
+			find: async () => {
+				findCalls += 1;
+				return { docs: Array.from({ length: 10_000 }) };
+			},
+			count: async (...args: unknown[]) => {
+				countCalls.push(args);
+				return 1;
+			},
+		};
+		const largeCrud = {
+			find: async () => {
+				findCalls += 1;
+				return { docs: Array.from({ length: 10_000 }) };
+			},
+			count: async () => 10_000,
+		};
+
+		const small = await computeRealtimeSnapshot(
+			{
+				type: "collection",
+				operation: "count",
+				crud: smallCrud,
+				where: { published: true },
+				locale: "en",
+			},
+			context,
+		);
+		const large = await computeRealtimeSnapshot(
+			{
+				type: "collection",
+				operation: "count",
+				crud: largeCrud,
+			},
+			context,
+		);
+
+		expect(findCalls).toBe(0);
+		expect(countCalls).toHaveLength(1);
+		expect(small).toBe(1);
+		expect(large).toBe(10_000);
+		expect(JSON.stringify(large).length).toBeLessThan(16);
+	});
+
+	it("runs collection gets through findOne", async () => {
+		const calls: unknown[] = [];
+		const context = { locale: "sk" };
+		const result = { id: "post-1", title: "One" };
+		const crud = {
+			findOne: async (...args: unknown[]) => {
+				calls.push(args);
+				return result;
+			},
+		};
+
+		await expect(
+			computeRealtimeSnapshot(
+				{
+					type: "collection",
+					operation: "get",
+					recordId: "post-1",
+					crud,
+					with: { author: true },
+					locale: "sk",
+				},
+				context,
+			),
+		).resolves.toBe(result);
+		expect(calls).toEqual([
+			[
+				{
+					where: { id: "post-1" },
+					with: { author: true },
+					locale: "sk",
+				},
+				context,
+			],
+		]);
+	});
+
 	it("runs global gets without rebuilding CRUD", async () => {
 		let getCalls = 0;
 		const context = { locale: "sk" };
@@ -52,6 +137,7 @@ describe("computeRealtimeSnapshot", () => {
 			computeRealtimeSnapshot(
 				{
 					type: "global",
+					operation: "get",
 					crud: {
 						get: async () => {
 							getCalls += 1;

--- a/packages/tanstack-query/src/index.ts
+++ b/packages/tanstack-query/src/index.ts
@@ -468,7 +468,7 @@ async function* streamRealtimeQuery<TInitialData>(options: {
 	topic: TopicConfig;
 	signal?: AbortSignal;
 	errorMap: QuestpieQueryErrorMap;
-}): AsyncGenerator<unknown, void, unknown> {
+}): AsyncGenerator<TInitialData, void, unknown> {
 	const { realtime, topic, signal, errorMap } = options;
 	try {
 		for await (const snapshot of realtime.stream<TInitialData>(topic, signal)) {
@@ -542,7 +542,7 @@ export function createQuestpieQueryOptions<
 								queryKey: qKey,
 								queryFn: streamedQuery({
 									streamFn: ({ signal }) =>
-										streamRealtimeQuery({
+										streamRealtimeQuery<any>({
 											realtime: client.realtime,
 											topic,
 											signal,
@@ -570,22 +570,22 @@ export function createQuestpieQueryOptions<
 						]);
 
 						if (queryConfig?.realtime && client.realtime) {
-							const topic = buildCollectionTopic(collectionName, options);
-							// For count, we extract totalDocs from the snapshot
+							const topic = buildCollectionTopic(
+								collectionName,
+								options,
+								"count",
+							);
 							return queryOptions({
 								queryKey: qKey,
 								queryFn: streamedQuery({
 									streamFn: ({ signal }) =>
-										streamRealtimeQuery({
+										streamRealtimeQuery<number>({
 											realtime: client.realtime,
 											topic,
 											signal,
 											errorMap,
 										}),
-									reducer: (_: any, chunk: any) =>
-										typeof chunk?.totalDocs === "number"
-											? chunk.totalDocs
-											: chunk,
+									reducer: (_: any, chunk: number) => chunk,
 									initialValue: undefined,
 									refetchMode: "append",
 								}),

--- a/packages/tanstack-query/src/realtime-query-options.test.ts
+++ b/packages/tanstack-query/src/realtime-query-options.test.ts
@@ -97,4 +97,46 @@ describe("realtime query options", () => {
 		const reject = () => q.collections.posts.findOne({}, { realtime: true });
 		expect(typeof reject).toBe("function");
 	});
+
+	it("subscribes live counts with a count topic and consumes the scalar payload", async () => {
+		let subscribedTopic: unknown;
+		const client = {
+			collections: {
+				posts: {
+					count: async () => 999,
+				},
+			},
+			globals: {},
+			routes: {},
+			realtime: {
+				subscribe: () => () => {},
+				stream: async function* (topic: unknown) {
+					subscribedTopic = topic;
+					yield 10_000;
+				},
+				destroy: () => {},
+				topicCount: 0,
+				subscriberCount: 0,
+			},
+		} as unknown as QuestpieClient<QuestpieApp>;
+		const queryClient = new QueryClient();
+		const abortController = new AbortController();
+		const options = createQuestpieQueryOptions(client).collections.posts.count(
+			{},
+			{ realtime: true },
+		);
+
+		const value = await (options.queryFn as any)({
+			client: queryClient,
+			queryKey: options.queryKey,
+			signal: abortController.signal,
+		});
+
+		expect(subscribedTopic).toEqual({
+			resourceType: "collection",
+			resource: "posts",
+			operation: "count",
+		});
+		expect(value).toBe(10_000);
+	});
 });


### PR DESCRIPTION
## Summary
- add discriminated `find`, `count`, and `get` realtime topics while normalizing legacy collection/global topics
- execute count snapshots through CRUD `count` and collection get snapshots through `findOne`, with invalid query shapes rejected before scheduling
- make TanStack live counts consume scalar count frames and keep collection record ids separate from subscription ids

## Verification
- `cd packages/questpie && bun test test/ --test-name-pattern "realtime|count"` (118 pass, 2 gated Soketi skips, 0 fail)
- `cd packages/questpie && bun run check-types` (includes `tsconfig.fullapp.json`)
- `cd packages/questpie && bun run build`
- `cd packages/tanstack-query && bun test` (6 pass)
- `cd packages/tanstack-query && bun run check-types && bun run build`
- focused operation-aware integration: 2 pass

Board: RT1.6