### PR TITLE
feat(channels): secure auth and publish routes

### DIFF
--- a/.changeset/channel-security-routes.md
+++ b/.changeset/channel-security-routes.md
@@ -1,0 +1,5 @@
+---
+"questpie": minor
+---
+
+Add generated-key channel auth, client transport config, and schema-validated server publish routes with strict origin/CORS checks, resolved-name collision proof, payload limits, and per-session plus per-principal rate limiting.

--- a/packages/questpie/src/server/channels/security.ts
+++ b/packages/questpie/src/server/channels/security.ts
@@ -1,0 +1,363 @@
+import type {
+	AnyChannelDefinition,
+	ChannelDefinitions,
+} from "./channel-builder.js";
+import { resolveChannelName } from "./channel-builder.js";
+
+const CHANNEL_NAME_PATTERN = /^[A-Za-z0-9_\-=@,.;]+$/;
+const CHANNEL_MAX_LENGTH = 164;
+export const CHANNEL_MAX_PAYLOAD_BYTES = 10_000;
+
+export type ChannelSecurityConfig = Readonly<{
+	/** Additional exact browser origins allowed to call authority-bearing routes. */
+	trustedOrigins?: readonly string[];
+	/** Authorization rule deadline. @default 5000 */
+	authorizationTimeoutMs?: number;
+	/** Refill rate for each session and principal publish bucket. @default 10 */
+	publishRatePerSecond?: number;
+	/** Maximum tokens in each publish bucket. @default 20 */
+	publishBurst?: number;
+}>;
+
+export class ChannelSecurityError extends Error {
+	constructor(
+		readonly code:
+			| "channel_origin_denied"
+			| "channel_name_collision"
+			| "channel_payload_too_large"
+			| "channel_payload_invalid",
+		message: string,
+	) {
+		super(message);
+		this.name = "ChannelSecurityError";
+	}
+}
+
+function exactOrigin(value: string, allowAppPath = false): string {
+	if (value === "*" || value === "null") {
+		throw new Error(`Invalid trusted channel origin "${value}"`);
+	}
+	let url: URL;
+	try {
+		url = new URL(value);
+	} catch {
+		throw new Error(`Invalid trusted channel origin "${value}"`);
+	}
+	if (url.username || url.password || url.origin === "null") {
+		throw new Error(`Invalid trusted channel origin "${value}"`);
+	}
+	if (
+		!allowAppPath &&
+		(url.pathname !== "/" || url.search !== "" || url.hash !== "")
+	) {
+		throw new Error(`Trusted channel origins cannot contain a path`);
+	}
+	const localHttp =
+		url.protocol === "http:" &&
+		(url.hostname === "localhost" ||
+			url.hostname === "127.0.0.1" ||
+			url.hostname === "[::1]");
+	if (url.protocol !== "https:" && !localHttp) {
+		throw new Error(`Trusted channel origins must use HTTPS`);
+	}
+	return url.origin;
+}
+
+export type ChannelOriginOptions = Readonly<{
+	appUrl: string;
+	trustedOrigins?: readonly string[];
+	/** Public GETs can validate a supplied origin without requiring one for cookies. */
+	requireOriginForCookies?: boolean;
+}>;
+
+export function trustedChannelOrigins(
+	options: ChannelOriginOptions,
+): ReadonlySet<string> {
+	return new Set([
+		exactOrigin(options.appUrl, true),
+		...(options.trustedOrigins ?? []).map((origin) => exactOrigin(origin)),
+	]);
+}
+
+/** Validate CSRF origin policy and return the exact origin to reflect for CORS. */
+export function resolveChannelRequestOrigin(
+	request: Request,
+	options: ChannelOriginOptions,
+): string | null {
+	const trusted = trustedChannelOrigins(options);
+	const supplied = request.headers.get("origin");
+	const cookieAuthenticated =
+		(options.requireOriginForCookies ?? true) && request.headers.has("cookie");
+	if (!supplied) {
+		if (!cookieAuthenticated) return null;
+		throw new ChannelSecurityError(
+			"channel_origin_denied",
+			"Cookie-authenticated channel requests require a trusted Origin",
+		);
+	}
+	if (supplied === "null") {
+		throw new ChannelSecurityError(
+			"channel_origin_denied",
+			"Channel requests require a trusted Origin",
+		);
+	}
+	let parsed: URL;
+	try {
+		parsed = new URL(supplied);
+	} catch {
+		throw new ChannelSecurityError(
+			"channel_origin_denied",
+			"Channel requests require a trusted Origin",
+		);
+	}
+	if (supplied !== parsed.origin || !trusted.has(parsed.origin)) {
+		throw new ChannelSecurityError(
+			"channel_origin_denied",
+			"Channel requests require a trusted Origin",
+		);
+	}
+	return parsed.origin;
+}
+
+export function channelCorsHeaders(
+	origin: string | null,
+	allowedHeaders = "Authorization, Content-Type, X-API-Key",
+): Headers {
+	const headers = new Headers({
+		"Access-Control-Allow-Credentials": "true",
+		"Access-Control-Allow-Headers": allowedHeaders,
+		"Access-Control-Allow-Methods": "POST, OPTIONS",
+		"Cache-Control": "no-store",
+		Vary: "Origin",
+	});
+	if (origin) headers.set("Access-Control-Allow-Origin", origin);
+	return headers;
+}
+
+type PatternToken =
+	| { kind: "literal"; value: string }
+	| { kind: "param"; value: string };
+
+function patternTokens(pattern: string): PatternToken[] {
+	const tokens: PatternToken[] = [];
+	let cursor = 0;
+	for (const match of pattern.matchAll(/\[([^\]]+)\]/g)) {
+		const index = match.index ?? 0;
+		if (index > cursor) {
+			tokens.push({ kind: "literal", value: pattern.slice(cursor, index) });
+		}
+		tokens.push({ kind: "param", value: match[1] as string });
+		cursor = index + match[0].length;
+	}
+	if (cursor < pattern.length) {
+		tokens.push({ kind: "literal", value: pattern.slice(cursor) });
+	}
+	return tokens;
+}
+
+function visibilityPrefix(definition: AnyChannelDefinition): string {
+	if (definition.visibility === "private") return "private-";
+	if (definition.visibility === "presence") return "presence-";
+	return "";
+}
+
+function matchingParams(
+	definition: AnyChannelDefinition,
+	resolvedName: string,
+): Record<string, string>[] {
+	const prefix = visibilityPrefix(definition);
+	if (!resolvedName.startsWith(prefix)) return [];
+	const applicationName = resolvedName.slice(prefix.length);
+	const tokens = patternTokens(definition.pattern);
+	const matches: Record<string, string>[] = [];
+	const maxMatches = 2;
+
+	function visit(
+		tokenIndex: number,
+		nameIndex: number,
+		params: Record<string, string>,
+	): void {
+		if (matches.length >= maxMatches) return;
+		if (tokenIndex === tokens.length) {
+			if (nameIndex === applicationName.length) matches.push(params);
+			return;
+		}
+		const token = tokens[tokenIndex] as PatternToken;
+		if (token.kind === "literal") {
+			if (applicationName.startsWith(token.value, nameIndex)) {
+				visit(tokenIndex + 1, nameIndex + token.value.length, params);
+			}
+			return;
+		}
+
+		const next = tokens[tokenIndex + 1];
+		const remainingParams = tokens
+			.slice(tokenIndex + 1)
+			.filter((candidate) => candidate.kind === "param").length;
+		const latestEnd = applicationName.length - remainingParams;
+		const possibleEnds: number[] = [];
+		if (next?.kind === "literal") {
+			let found = applicationName.indexOf(next.value, nameIndex + 1);
+			while (found !== -1 && found <= latestEnd) {
+				possibleEnds.push(found);
+				found = applicationName.indexOf(next.value, found + 1);
+			}
+		} else {
+			for (let end = nameIndex + 1; end <= latestEnd; end++) {
+				possibleEnds.push(end);
+			}
+		}
+		for (const end of possibleEnds) {
+			const value = applicationName.slice(nameIndex, end);
+			if (!CHANNEL_NAME_PATTERN.test(value)) continue;
+			visit(tokenIndex + 1, end, { ...params, [token.value]: value });
+		}
+	}
+
+	visit(0, 0, {});
+	return matches;
+}
+
+/**
+ * Render a client-claimed key/params pair, then prove it is the sole canonical
+ * identity for that final provider name across the generated registry.
+ */
+export function assertUniqueResolvedChannelName(
+	definitions: ChannelDefinitions,
+	channel: string,
+	params: Record<string, string>,
+): string {
+	const definition = definitions[channel];
+	if (!definition) throw new Error(`Unknown channel "${channel}"`);
+	const resolved = resolveChannelName(definition, params);
+	if (
+		resolved.length > CHANNEL_MAX_LENGTH ||
+		!CHANNEL_NAME_PATTERN.test(resolved)
+	) {
+		throw new ChannelSecurityError(
+			"channel_name_collision",
+			"Resolved channel name is invalid",
+		);
+	}
+	const candidates: Array<{ channel: string; params: Record<string, string> }> =
+		[];
+	for (const [candidateChannel, candidateDefinition] of Object.entries(
+		definitions,
+	)) {
+		for (const candidateParams of matchingParams(
+			candidateDefinition,
+			resolved,
+		)) {
+			candidates.push({ channel: candidateChannel, params: candidateParams });
+			if (candidates.length > 1) break;
+		}
+		if (candidates.length > 1) break;
+	}
+	const sole = candidates[0];
+	const canonicalParams = Object.fromEntries(
+		Object.entries(params).sort(([left], [right]) => left.localeCompare(right)),
+	);
+	const soleParams = sole
+		? Object.fromEntries(
+				Object.entries(sole.params).sort(([left], [right]) =>
+					left.localeCompare(right),
+				),
+			)
+		: null;
+	if (
+		candidates.length !== 1 ||
+		sole?.channel !== channel ||
+		JSON.stringify(soleParams) !== JSON.stringify(canonicalParams)
+	) {
+		throw new ChannelSecurityError(
+			"channel_name_collision",
+			"Resolved channel name collision",
+		);
+	}
+	return resolved;
+}
+
+/** Return the exact JSON string whose UTF-8 bytes enter the ledger/provider. */
+export function assertChannelPayloadSize(data: unknown): string {
+	let serialized: string | undefined;
+	try {
+		serialized = JSON.stringify(data);
+	} catch {
+		throw new ChannelSecurityError(
+			"channel_payload_invalid",
+			"Channel event data must be JSON serializable",
+		);
+	}
+	if (serialized === undefined) {
+		throw new ChannelSecurityError(
+			"channel_payload_invalid",
+			"Channel event data must be JSON serializable",
+		);
+	}
+	if (
+		new TextEncoder().encode(serialized).byteLength > CHANNEL_MAX_PAYLOAD_BYTES
+	) {
+		throw new ChannelSecurityError(
+			"channel_payload_too_large",
+			"Channel event data exceeds the 10,000-byte limit",
+		);
+	}
+	return serialized;
+}
+
+type Bucket = { tokens: number; updatedAt: number };
+
+export class ChannelTokenBucketLimiter {
+	private readonly buckets = new Map<string, Bucket>();
+	private readonly ratePerMillisecond: number;
+
+	constructor(
+		private readonly options: {
+			ratePerSecond: number;
+			burst: number;
+			now?: () => number;
+		},
+	) {
+		this.ratePerMillisecond = options.ratePerSecond / 1000;
+	}
+
+	private bucket(key: string): Bucket {
+		const now = (this.options.now ?? Date.now)();
+		const current = this.buckets.get(key) ?? {
+			tokens: this.options.burst,
+			updatedAt: now,
+		};
+		current.tokens = Math.min(
+			this.options.burst,
+			current.tokens +
+				Math.max(0, now - current.updatedAt) * this.ratePerMillisecond,
+		);
+		current.updatedAt = now;
+		this.buckets.set(key, current);
+		return current;
+	}
+
+	consume(key: string): boolean {
+		return this.consumeAll([key]);
+	}
+
+	/** Atomically consume one token from every independent bucket. */
+	consumeAll(keys: readonly string[]): boolean {
+		const buckets = [...new Set(keys)].map((key) => this.bucket(key));
+		if (buckets.some((bucket) => bucket.tokens < 1)) return false;
+		for (const bucket of buckets) bucket.tokens -= 1;
+		return true;
+	}
+
+	retryAfterMs(keys: readonly string[]): number {
+		if (this.ratePerMillisecond <= 0) return 60_000;
+		const delay = Math.max(
+			...[...new Set(keys)].map((key) =>
+				Math.ceil(
+					Math.max(0, 1 - this.bucket(key).tokens) / this.ratePerMillisecond,
+				),
+			),
+		);
+		return Math.min(60_000, Math.max(1, delay));
+	}
+}

--- a/packages/questpie/src/server/channels/service.ts
+++ b/packages/questpie/src/server/channels/service.ts
@@ -15,8 +15,12 @@ import {
 	type ChannelEventsOf,
 	type ChannelParamsOf,
 	type ChannelPresenceOf,
-	resolveChannelName,
 } from "./channel-builder.js";
+import {
+	assertChannelPayloadSize,
+	assertUniqueResolvedChannelName,
+	type ChannelSecurityConfig,
+} from "./security.js";
 
 export type ChannelRuntimeErrorCode =
 	| "channel_not_found"
@@ -80,6 +84,8 @@ export type ChannelPublishReceipt = Readonly<{
 	eventId: string;
 }>;
 
+export type PreparedChannelPublish = Readonly<AppendChannelEventInput>;
+
 function isSystemContext(context: StoredChannelServiceContext): boolean {
 	if (context.accessMode === "system") return true;
 	if (context.accessMode === "user") return false;
@@ -95,6 +101,7 @@ export class ChannelsService<
 		private readonly definitions: TChannels,
 		private readonly publisher: ChannelPublisher,
 		context: ChannelServiceContext,
+		private readonly security: ChannelSecurityConfig = {},
 	) {
 		this.context = context as unknown as StoredChannelServiceContext;
 	}
@@ -118,7 +125,12 @@ export class ChannelsService<
 		channel: TChannel,
 		params: ChannelParamsOf<TChannels[TChannel]>,
 	): string {
-		return resolveChannelName(this.getDefinition(channel), params);
+		this.getDefinition(channel);
+		return assertUniqueResolvedChannelName(
+			this.definitions,
+			channel,
+			params as Record<string, string>,
+		);
 	}
 
 	async authorize<TChannel extends keyof TChannels & string>(
@@ -127,7 +139,11 @@ export class ChannelsService<
 		verb: "subscribe" | "publish",
 	): Promise<boolean> {
 		const definition = this.getDefinition(channel);
-		resolveChannelName(definition, params);
+		assertUniqueResolvedChannelName(
+			this.definitions,
+			channel,
+			params as Record<string, string>,
+		);
 
 		if (verb === "publish" && isSystemContext(this.context)) return true;
 		const authorization = definition.authorization;
@@ -173,10 +189,23 @@ export class ChannelsService<
 		channel: TChannel,
 		input: ChannelPublishInput<TChannels[TChannel]>,
 	): Promise<ChannelPublishReceipt> {
+		const prepared = await this.preparePublish(channel, input);
+		return this.publishPrepared(prepared);
+	}
+
+	/** Validate a client publish completely without allocating a ledger event id. */
+	async preparePublish<TChannel extends keyof TChannels & string>(
+		channel: TChannel,
+		input: ChannelPublishInput<TChannels[TChannel]>,
+	): Promise<PreparedChannelPublish> {
 		const definition = this.getDefinition(channel);
 		const params = ((input as { params?: Record<string, string> }).params ??
 			{}) as ChannelParamsOf<TChannels[TChannel]>;
-		const resolvedName = resolveChannelName(definition, params);
+		const resolvedName = assertUniqueResolvedChannelName(
+			this.definitions,
+			channel,
+			params as Record<string, string>,
+		);
 		if (!(await this.authorize(channel, params, "publish"))) {
 			throw new ChannelRuntimeError(
 				"channel_publish_denied",
@@ -202,16 +231,23 @@ export class ChannelsService<
 				{ cause: parsed.error },
 			);
 		}
+		assertChannelPayloadSize(parsed.data);
 
-		return this.publisher.appendChannelEvent(
-			{
-				channel: resolvedName,
-				event,
-				schemaIdentity: `${String(channel)}:${event}`,
-				data: parsed.data,
-			},
-			{ db: this.context.db as AppendChannelEventOptions["db"] },
-		);
+		return {
+			channel: resolvedName,
+			event,
+			schemaIdentity: `${String(channel)}:${event}`,
+			data: parsed.data,
+		};
+	}
+
+	/** Append a previously validated publish after route-level admission checks. */
+	publishPrepared(
+		prepared: PreparedChannelPublish,
+	): Promise<ChannelPublishReceipt> {
+		return this.publisher.appendChannelEvent(prepared, {
+			db: this.context.db as AppendChannelEventOptions["db"],
+		});
 	}
 
 	async publishBatch(
@@ -231,10 +267,20 @@ export class ChannelsService<
 		params: Record<string, string>,
 	): Promise<boolean> {
 		if (typeof rule === "boolean") return rule;
+		const timeoutMs = this.security.authorizationTimeoutMs ?? 5_000;
+		let timer: ReturnType<typeof setTimeout> | undefined;
 		try {
-			return (await rule({ ...this.context, params } as any)) === true;
+			const result = await Promise.race([
+				Promise.resolve(rule({ ...this.context, params } as any)),
+				new Promise<false>((resolve) => {
+					timer = setTimeout(() => resolve(false), timeoutMs);
+				}),
+			]);
+			return result === true;
 		} catch {
 			return false;
+		} finally {
+			if (timer) clearTimeout(timer);
 		}
 	}
 }

--- a/packages/questpie/src/server/modules/core/.generated/module.ts
+++ b/packages/questpie/src/server/modules/core/.generated/module.ts
@@ -29,6 +29,11 @@ import _route_collection_updateBatch from "../routes/[collection]/update-batch";
 import _route_collection_upload from "../routes/[collection]/upload";
 import _route_auth_spread_path_GET from "../routes/auth/[...path].get";
 import _route_auth_spread_path_POST from "../routes/auth/[...path].post";
+import _route_channels_auth_OPTIONS from "../routes/channels/auth.options";
+import _route_channels_auth_POST from "../routes/channels/auth.post";
+import _route_channels_config from "../routes/channels/config";
+import _route_channels_publish_OPTIONS from "../routes/channels/publish.options";
+import _route_channels_publish_POST from "../routes/channels/publish.post";
 import _route_globals_name from "../routes/globals/[name]";
 import _route_globals_name_PATCH from "../routes/globals/[name].patch";
 import _route_globals_name_audit from "../routes/globals/[name]/audit";
@@ -121,6 +126,11 @@ export type CoreRoutes = {
 	"[collection]/upload": typeof _route_collection_upload extends { __brand: "route" } ? RouteDefinition<unknown, unknown, RouteParamsFromKey<"[collection]/upload">> : typeof _route_collection_upload;
 	"auth/[...path]:GET": typeof _route_auth_spread_path_GET extends { __brand: "route" } ? RouteDefinition<unknown, unknown, RouteParamsFromKey<"auth/[...path]:GET">> : typeof _route_auth_spread_path_GET;
 	"auth/[...path]:POST": typeof _route_auth_spread_path_POST extends { __brand: "route" } ? RouteDefinition<unknown, unknown, RouteParamsFromKey<"auth/[...path]:POST">> : typeof _route_auth_spread_path_POST;
+	"channels/auth:OPTIONS": typeof _route_channels_auth_OPTIONS extends { __brand: "route" } ? RouteDefinition<unknown, unknown, RouteParamsFromKey<"channels/auth:OPTIONS">> : typeof _route_channels_auth_OPTIONS;
+	"channels/auth:POST": typeof _route_channels_auth_POST extends { __brand: "route" } ? RouteDefinition<unknown, unknown, RouteParamsFromKey<"channels/auth:POST">> : typeof _route_channels_auth_POST;
+	"channels/config": typeof _route_channels_config extends { __brand: "route" } ? RouteDefinition<unknown, unknown, RouteParamsFromKey<"channels/config">> : typeof _route_channels_config;
+	"channels/publish:OPTIONS": typeof _route_channels_publish_OPTIONS extends { __brand: "route" } ? RouteDefinition<unknown, unknown, RouteParamsFromKey<"channels/publish:OPTIONS">> : typeof _route_channels_publish_OPTIONS;
+	"channels/publish:POST": typeof _route_channels_publish_POST extends { __brand: "route" } ? RouteDefinition<unknown, unknown, RouteParamsFromKey<"channels/publish:POST">> : typeof _route_channels_publish_POST;
 	"globals/[name]": typeof _route_globals_name extends { __brand: "route" } ? RouteDefinition<unknown, unknown, RouteParamsFromKey<"globals/[name]">> : typeof _route_globals_name;
 	"globals/[name]:PATCH": typeof _route_globals_name_PATCH extends { __brand: "route" } ? RouteDefinition<unknown, unknown, RouteParamsFromKey<"globals/[name]:PATCH">> : typeof _route_globals_name_PATCH;
 	"globals/[name]/audit": typeof _route_globals_name_audit extends { __brand: "route" } ? RouteDefinition<unknown, unknown, RouteParamsFromKey<"globals/[name]/audit">> : typeof _route_globals_name_audit;
@@ -224,6 +234,11 @@ const _module: CoreModule = {
 		"[collection]/upload": _route_collection_upload,
 		"auth/[...path]:GET": _route_auth_spread_path_GET,
 		"auth/[...path]:POST": _route_auth_spread_path_POST,
+		"channels/auth:OPTIONS": _route_channels_auth_OPTIONS,
+		"channels/auth:POST": _route_channels_auth_POST,
+		"channels/config": _route_channels_config,
+		"channels/publish:OPTIONS": _route_channels_publish_OPTIONS,
+		"channels/publish:POST": _route_channels_publish_POST,
 		"globals/[name]": _route_globals_name,
 		"globals/[name]:PATCH": _route_globals_name_PATCH,
 		"globals/[name]/audit": _route_globals_name_audit,

--- a/packages/questpie/src/server/modules/core/integrated/realtime/pusher-transport.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/pusher-transport.ts
@@ -418,9 +418,30 @@ export class PusherClientTransport implements SharedProviderClientTransport {
 		socketId: string;
 		channel: string;
 		principal: Principal | null;
+		scope?: "session" | "channel";
+		presence?: { user_info?: Record<string, unknown> };
 	}): Promise<PusherAuthResponse> {
 		assertSocketId(input.socketId);
 		assertPusherChannelName(input.channel);
+		if (input.scope === "channel") {
+			if (input.channel.startsWith("presence-")) {
+				if (!input.principal) {
+					throw new Error(
+						"Presence channel authorization requires a principal",
+					);
+				}
+				return this.generatePresenceAuth({
+					socketId: input.socketId,
+					channel: input.channel,
+					principal: input.principal,
+					member: input.presence,
+				});
+			}
+			return this.options.provider.authorizeChannel(
+				input.socketId,
+				input.channel,
+			);
+		}
 		const session = this.sessions.get(input.channel);
 		if (!session) throw new Error("Realtime session is not authorized");
 		const currentPrincipal = await session.resolvePrincipal();

--- a/packages/questpie/src/server/modules/core/integrated/realtime/transport.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/transport.ts
@@ -66,6 +66,10 @@ export type ClientAuthInput = {
 	socketId: string;
 	channel: string;
 	principal: Principal | null;
+	/** Framework channel routes have already proved subscribe authorization. */
+	scope?: "session" | "channel";
+	/** Presence data classified as visible to every channel member. */
+	presence?: { user_info?: Record<string, unknown> };
 };
 
 export type ClientAuthResponse = {

--- a/packages/questpie/src/server/modules/core/integrated/realtime/types.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/types.ts
@@ -132,6 +132,8 @@ export interface RealtimeConfig {
 	channelEvents?: Partial<
 		import("./channel-event-ledger.js").ChannelEventLedgerConfig
 	>;
+	/** Security policy shared by channel auth and server-mediated publish routes. */
+	channelSecurity?: import("#questpie/server/channels/security.js").ChannelSecurityConfig;
 
 	/**
 	 * Reconciliation poll interval in ms. Polling runs alongside adapters so a

--- a/packages/questpie/src/server/modules/core/routes/channels/_shared.ts
+++ b/packages/questpie/src/server/modules/core/routes/channels/_shared.ts
@@ -1,0 +1,288 @@
+import { z } from "zod";
+
+import {
+	channelCorsHeaders,
+	ChannelSecurityError,
+	ChannelTokenBucketLimiter,
+	resolveChannelRequestOrigin,
+} from "#questpie/server/channels/security.js";
+import { ChannelsService } from "#questpie/server/channels/service.js";
+import type { Principal } from "#questpie/server/config/context.js";
+import { routeApp } from "#questpie/server/routes/route-app.js";
+
+type ChannelRouteContext = object & {
+	db?: unknown;
+	session?: {
+		user?: { id?: string };
+		session?: { id?: string };
+	} | null;
+	principal?: Principal;
+};
+
+export type ChannelRouteInput = {
+	channel: string;
+	params: Record<string, string>;
+};
+
+export type ChannelAuthRouteInput = ChannelRouteInput & {
+	socketId: string;
+	channelName: string;
+};
+
+function securityOptions(ctx: ChannelRouteContext) {
+	const app = routeApp(ctx);
+	return {
+		appUrl: app.config.app.url,
+		trustedOrigins: app.config.realtime?.channelSecurity?.trustedOrigins,
+	};
+}
+
+export function validateChannelRouteOrigin(
+	ctx: ChannelRouteContext,
+	requireOriginForCookies = true,
+): string | null {
+	const request = (ctx as { request: Request }).request;
+	return resolveChannelRequestOrigin(request, {
+		...securityOptions(ctx),
+		requireOriginForCookies,
+	});
+}
+
+export function validateChannelPreflight(request: Request): void {
+	const method = request.headers.get("access-control-request-method");
+	if (method && method.toUpperCase() !== "POST") {
+		throw new Error("Unsupported channel preflight method");
+	}
+	const requestedHeaders = request.headers
+		.get("access-control-request-headers")
+		?.split(",")
+		.map((header) => header.trim().toLowerCase())
+		.filter(Boolean);
+	const allowedHeaders = new Set([
+		"authorization",
+		"content-type",
+		"x-api-key",
+	]);
+	if (requestedHeaders?.some((header) => !allowedHeaders.has(header))) {
+		throw new Error("Unsupported channel preflight header");
+	}
+}
+
+export function channelRouteHeaders(origin: string | null): Headers {
+	return channelCorsHeaders(origin);
+}
+
+export function channelRouteResponse(
+	body: unknown,
+	status: number,
+	origin: string | null,
+): Response {
+	return Response.json(body, {
+		status,
+		headers: channelRouteHeaders(origin),
+	});
+}
+
+export function channelRouteError(
+	error: unknown,
+	origin: string | null,
+): Response {
+	if (error instanceof ChannelSecurityError) {
+		const status =
+			error.code === "channel_payload_too_large"
+				? 413
+				: error.code === "channel_name_collision"
+					? 409
+					: 403;
+		return channelRouteResponse({ error: error.code }, status, origin);
+	}
+	if (error instanceof Error && "code" in error) {
+		const code = String((error as { code: unknown }).code);
+		const status =
+			code === "channel_not_found"
+				? 404
+				: code === "channel_event_not_found"
+					? 404
+					: code === "channel_event_invalid"
+						? 422
+						: 403;
+		return channelRouteResponse({ error: code }, status, origin);
+	}
+	return channelRouteResponse({ error: "channel_request_denied" }, 403, origin);
+}
+
+function parseParams(value: unknown): Record<string, string> {
+	if (typeof value === "string") {
+		try {
+			value = JSON.parse(value);
+		} catch {
+			throw new Error("Invalid channel params");
+		}
+	}
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		throw new Error("Invalid channel params");
+	}
+	const params: Record<string, string> = {};
+	for (const [key, param] of Object.entries(value)) {
+		if (typeof param !== "string") throw new Error("Invalid channel params");
+		params[key] = param;
+	}
+	return params;
+}
+
+function requireString(value: unknown): string {
+	if (typeof value !== "string" || value.length === 0) {
+		throw new Error("Missing channel request field");
+	}
+	return value;
+}
+
+export async function parseChannelAuthRequest(
+	request: Request,
+): Promise<ChannelAuthRouteInput> {
+	const mediaType = (request.headers.get("content-type") ?? "")
+		.split(";", 1)[0]
+		?.trim()
+		.toLowerCase();
+	let body: Record<string, unknown>;
+	if (mediaType === "application/json") {
+		try {
+			body = (await request.json()) as Record<string, unknown>;
+		} catch {
+			throw Object.assign(new Error("Invalid channel auth body"), {
+				status: 400,
+			});
+		}
+	} else if (mediaType === "application/x-www-form-urlencoded") {
+		const form = new URLSearchParams(await request.text());
+		body = Object.fromEntries(form.entries());
+	} else {
+		throw Object.assign(new Error("Unsupported channel auth content type"), {
+			status: 415,
+		});
+	}
+	return {
+		socketId: requireString(body.socket_id ?? body.socketId),
+		channelName: requireString(body.channel_name ?? body.channelName),
+		channel: requireString(body.channel),
+		params: parseParams(body.params ?? {}),
+	};
+}
+
+export async function parseChannelPublishRequest(request: Request): Promise<
+	ChannelRouteInput & {
+		event: string;
+		data: unknown;
+	}
+> {
+	const mediaType = (request.headers.get("content-type") ?? "")
+		.split(";", 1)[0]
+		?.trim()
+		.toLowerCase();
+	if (mediaType !== "application/json") {
+		throw Object.assign(new Error("Unsupported channel publish content type"), {
+			status: 415,
+		});
+	}
+	let json: unknown;
+	try {
+		json = await request.json();
+	} catch {
+		throw Object.assign(new Error("Invalid channel publish body"), {
+			status: 400,
+		});
+	}
+	const parsed = await z
+		.object({
+			channel: z.string().min(1),
+			params: z.record(z.string(), z.string()).default({}),
+			event: z.string().min(1),
+			data: z.unknown(),
+		})
+		.strict()
+		.safeParseAsync(json);
+	if (!parsed.success) {
+		throw Object.assign(new Error("Invalid channel publish body"), {
+			status: 400,
+		});
+	}
+	return parsed.data;
+}
+
+export function requestChannels(
+	ctx: ChannelRouteContext,
+): ChannelsService<any> {
+	const app = routeApp(ctx);
+	return new ChannelsService(
+		app.config.channels ?? {},
+		app.realtime,
+		{ ...ctx, accessMode: "user" } as any,
+		app.config.realtime?.channelSecurity,
+	);
+}
+
+const publishLimiters = new WeakMap<object, ChannelTokenBucketLimiter>();
+
+/** @internal Deterministic route-test seam; not exported from the package API. */
+export function setChannelPublishLimiterForTests(
+	app: object,
+	limiter: ChannelTokenBucketLimiter,
+): void {
+	publishLimiters.set(app, limiter);
+}
+
+function publishLimiter(ctx: ChannelRouteContext): ChannelTokenBucketLimiter {
+	const app = routeApp(ctx);
+	let limiter = publishLimiters.get(app);
+	if (!limiter) {
+		const config = app.config.realtime?.channelSecurity;
+		limiter = new ChannelTokenBucketLimiter({
+			ratePerSecond: config?.publishRatePerSecond ?? 10,
+			burst: config?.publishBurst ?? 20,
+		});
+		publishLimiters.set(app, limiter);
+	}
+	return limiter;
+}
+
+function anonymousEdgeKey(request: Request): string {
+	const forwarded = request.headers
+		.get("x-forwarded-for")
+		?.split(",", 1)[0]
+		?.trim();
+	return forwarded || request.headers.get("x-real-ip") || "anonymous";
+}
+
+export function consumeChannelPublishQuota(
+	ctx: ChannelRouteContext,
+	request: Request,
+): { allowed: boolean; retryAfterMs: number } {
+	const sessionId =
+		ctx.session?.session?.id ??
+		(ctx.principal?.kind === "user" ? ctx.principal.session.id : undefined);
+	const edge = anonymousEdgeKey(request);
+	const sessionKey = `session:${sessionId ?? edge}`;
+	let principalKey: string;
+	if (ctx.principal?.kind === "oauth") {
+		principalKey = `principal:oauth:${ctx.principal.tokenId}`;
+	} else if (ctx.principal?.kind === "user") {
+		principalKey = `principal:user:${ctx.principal.user.id}`;
+	} else if (ctx.principal?.kind === "system") {
+		principalKey = "principal:system";
+	} else if (ctx.session?.user?.id) {
+		principalKey = `principal:user:${ctx.session.user.id}`;
+	} else {
+		principalKey = `principal:anonymous:${edge}`;
+	}
+	const limiter = publishLimiter(ctx);
+	const keys = [sessionKey, principalKey];
+	const allowed = limiter.consumeAll(keys);
+	return {
+		allowed,
+		retryAfterMs: allowed ? 0 : limiter.retryAfterMs(keys),
+	};
+}
+
+export function principalOf(ctx: ChannelRouteContext): Principal | null {
+	return ctx.principal ?? null;
+}

--- a/packages/questpie/src/server/modules/core/routes/channels/auth.options.ts
+++ b/packages/questpie/src/server/modules/core/routes/channels/auth.options.ts
@@ -1,0 +1,29 @@
+import { route } from "#questpie/server/routes/define-route.js";
+
+import {
+	channelRouteHeaders,
+	channelRouteResponse,
+	validateChannelPreflight,
+	validateChannelRouteOrigin,
+} from "./_shared.js";
+
+export default route()
+	.options()
+	.access(true)
+	.raw()
+	.handler((ctx) => {
+		try {
+			const origin = validateChannelRouteOrigin(ctx);
+			validateChannelPreflight(ctx.request);
+			return new Response(null, {
+				status: 204,
+				headers: channelRouteHeaders(origin),
+			});
+		} catch {
+			return channelRouteResponse(
+				{ error: "channel_origin_denied" },
+				403,
+				null,
+			);
+		}
+	});

--- a/packages/questpie/src/server/modules/core/routes/channels/auth.post.ts
+++ b/packages/questpie/src/server/modules/core/routes/channels/auth.post.ts
@@ -1,0 +1,79 @@
+import { route } from "#questpie/server/routes/define-route.js";
+import { routeApp } from "#questpie/server/routes/route-app.js";
+
+import {
+	channelRouteError,
+	channelRouteResponse,
+	parseChannelAuthRequest,
+	principalOf,
+	requestChannels,
+	validateChannelRouteOrigin,
+} from "./_shared.js";
+
+/** Authorize a generated channel key/params identity for one provider socket. */
+export default route()
+	.post()
+	.access(true)
+	.raw()
+	.handler(async (ctx) => {
+		let origin: string | null = null;
+		try {
+			origin = validateChannelRouteOrigin(ctx);
+			const input = await parseChannelAuthRequest(ctx.request);
+			const channels = requestChannels(ctx);
+			const resolvedName = channels.resolveName(input.channel, input.params);
+			if (resolvedName !== input.channelName) {
+				throw new Error("Channel name does not match generated identity");
+			}
+			const definition = channels.getDefinition(input.channel);
+			let presence: { user_info?: Record<string, unknown> } | undefined;
+			if (definition.visibility === "presence") {
+				const resolved = await channels.resolvePresence(
+					input.channel,
+					input.params,
+				);
+				if (resolved && typeof resolved === "object") {
+					presence = { user_info: resolved as Record<string, unknown> };
+				}
+			} else if (
+				!(await channels.authorize(input.channel, input.params, "subscribe"))
+			) {
+				return channelRouteResponse(
+					{ error: "channel_subscribe_denied" },
+					403,
+					origin,
+				);
+			}
+			const realtime = routeApp(ctx).realtime;
+			if (!realtime) {
+				return channelRouteResponse(
+					{ error: "channel_transport_unavailable" },
+					404,
+					origin,
+				);
+			}
+			const auth = await realtime.generateClientAuth({
+				socketId: input.socketId,
+				channel: resolvedName,
+				principal: principalOf(ctx),
+				scope: "channel",
+				presence,
+			});
+			return channelRouteResponse(auth, 200, origin);
+		} catch (error) {
+			if (error instanceof Error && "status" in error) {
+				const status = Number((error as { status: unknown }).status);
+				return channelRouteResponse(
+					{
+						error:
+							status === 415
+								? "channel_content_type_invalid"
+								: "channel_request_invalid",
+					},
+					status,
+					origin,
+				);
+			}
+			return channelRouteError(error, origin);
+		}
+	});

--- a/packages/questpie/src/server/modules/core/routes/channels/config.ts
+++ b/packages/questpie/src/server/modules/core/routes/channels/config.ts
@@ -1,0 +1,26 @@
+import { route } from "#questpie/server/routes/define-route.js";
+import { routeApp } from "#questpie/server/routes/route-app.js";
+
+import {
+	channelRouteError,
+	channelRouteResponse,
+	validateChannelRouteOrigin,
+} from "./_shared.js";
+
+/** Public client transport metadata. Provider secrets never enter this shape. */
+export default route()
+	.get()
+	.access(true)
+	.raw()
+	.handler(async (ctx) => {
+		let origin: string | null = null;
+		try {
+			origin = validateChannelRouteOrigin(ctx, false);
+			const config = await routeApp(ctx).realtime?.getClientTransportConfig({
+				request: ctx.request,
+			});
+			return channelRouteResponse(config ?? { transport: "sse" }, 200, origin);
+		} catch (error) {
+			return channelRouteError(error, origin);
+		}
+	});

--- a/packages/questpie/src/server/modules/core/routes/channels/publish.options.ts
+++ b/packages/questpie/src/server/modules/core/routes/channels/publish.options.ts
@@ -1,0 +1,29 @@
+import { route } from "#questpie/server/routes/define-route.js";
+
+import {
+	channelRouteHeaders,
+	channelRouteResponse,
+	validateChannelPreflight,
+	validateChannelRouteOrigin,
+} from "./_shared.js";
+
+export default route()
+	.options()
+	.access(true)
+	.raw()
+	.handler((ctx) => {
+		try {
+			const origin = validateChannelRouteOrigin(ctx);
+			validateChannelPreflight(ctx.request);
+			return new Response(null, {
+				status: 204,
+				headers: channelRouteHeaders(origin),
+			});
+		} catch {
+			return channelRouteResponse(
+				{ error: "channel_origin_denied" },
+				403,
+				null,
+			);
+		}
+	});

--- a/packages/questpie/src/server/modules/core/routes/channels/publish.post.ts
+++ b/packages/questpie/src/server/modules/core/routes/channels/publish.post.ts
@@ -1,0 +1,62 @@
+import { route } from "#questpie/server/routes/define-route.js";
+
+import {
+	channelRouteError,
+	channelRouteResponse,
+	consumeChannelPublishQuota,
+	parseChannelPublishRequest,
+	requestChannels,
+	validateChannelRouteOrigin,
+} from "./_shared.js";
+
+/** Server-mediated, schema-validated client publish path for every preset. */
+export default route()
+	.post()
+	.access(true)
+	.raw()
+	.handler(async (ctx) => {
+		let origin: string | null = null;
+		try {
+			origin = validateChannelRouteOrigin(ctx);
+			const input = await parseChannelPublishRequest(ctx.request);
+			const channels = requestChannels(ctx);
+			const prepared = await channels.preparePublish(input.channel, {
+				params: input.params,
+				event: input.event,
+				data: input.data,
+			} as any);
+			const quota = consumeChannelPublishQuota(ctx, ctx.request);
+			if (!quota.allowed) {
+				const response = channelRouteResponse(
+					{
+						error: "channel_publish_rate_limited",
+						retryAfterMs: quota.retryAfterMs,
+					},
+					429,
+					origin,
+				);
+				response.headers.set(
+					"Retry-After",
+					String(Math.max(1, Math.ceil(quota.retryAfterMs / 1000))),
+				);
+				return response;
+			}
+			const receipt = await channels.publishPrepared(prepared);
+			return channelRouteResponse(receipt, 200, origin);
+		} catch (error) {
+			if (error instanceof Error && "status" in error) {
+				const status = Number((error as { status: unknown }).status);
+				return channelRouteResponse(
+					{
+						error:
+							status === 415
+								? "channel_content_type_invalid"
+								: "channel_request_invalid",
+					},
+					status,
+					origin,
+				);
+			}
+			return channelRouteError(error, origin);
+		}
+	});

--- a/packages/questpie/src/server/modules/core/services/channels.ts
+++ b/packages/questpie/src/server/modules/core/services/channels.ts
@@ -14,6 +14,7 @@ export default service({
 			app.config.channels ?? {},
 			app.realtime,
 			ctx as ChannelServiceContext,
+			app.config.realtime?.channelSecurity,
 		);
 	},
 });

--- a/packages/questpie/test/integration/channel-routes.test.ts
+++ b/packages/questpie/test/integration/channel-routes.test.ts
@@ -1,0 +1,355 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { z } from "zod";
+
+import { createFetchHandler } from "../../src/server/adapters/http.js";
+import { channel } from "../../src/server/channels/channel-builder.js";
+import { ChannelTokenBucketLimiter } from "../../src/server/channels/security.js";
+import type { PusherProvider } from "../../src/server/modules/core/integrated/realtime/pusher-transport.js";
+import { PusherClientTransport } from "../../src/server/modules/core/integrated/realtime/pusher-transport.js";
+import { setChannelPublishLimiterForTests } from "../../src/server/modules/core/routes/channels/_shared.js";
+import { buildMockApp } from "../utils/mocks/mock-app-builder.js";
+import { runTestDbMigrations } from "../utils/test-db.js";
+
+function channelRequest(
+	path: string,
+	body: Record<string, unknown>,
+	options: { origin?: string; cookie?: boolean } = {},
+): Request {
+	return new Request(`https://app.example.com/${path}`, {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
+			...(options.origin ? { Origin: options.origin } : {}),
+			...(options.cookie ? { Cookie: "session=test" } : {}),
+		},
+		body: JSON.stringify(body),
+	});
+}
+
+describe("channel module routes", () => {
+	let cleanup: (() => Promise<void>) | undefined;
+
+	afterEach(async () => {
+		await cleanup?.();
+		cleanup = undefined;
+	});
+
+	test("authorizes subscribe independently and never trusts the supplied wire name", async () => {
+		const providerCalls: string[] = [];
+		const provider: PusherProvider = {
+			trigger: async () => {},
+			authorizeChannel: (_socket, channelName) => {
+				providerCalls.push(channelName);
+				return { auth: `signed:${channelName}` };
+			},
+			authenticateUser: () => ({ auth: "user", user_data: "{}" }),
+			terminateUserConnections: async () => {},
+			getPresenceMemberCount: async () => 0,
+		};
+		const transport = new PusherClientTransport({
+			provider,
+			key: "public-key",
+			identityKey: "provider-secret",
+		});
+		const setup = await buildMockApp(
+			{
+				channels: {
+					readOnly: channel("room-[id]")
+						.events({ message: z.object({ text: z.string() }) })
+						.authorize({ subscribe: true, publish: false }),
+					fallback: channel("fallback-[id]")
+						.events({ message: z.object({ text: z.string() }) })
+						.authorize({ subscribe: true }),
+					publicNews: channel("news"),
+					throws: channel("throws").authorize(() => {
+						throw new Error("never expose this");
+					}),
+					timesOut: channel("slow").authorize(
+						() => new Promise(() => undefined),
+					),
+				},
+			},
+			{
+				app: { url: "https://app.example.com" },
+				realtime: {
+					clientTransport: transport,
+					retentionDays: 0,
+					channelSecurity: { authorizationTimeoutMs: 5 },
+				},
+			},
+		);
+		cleanup = setup.cleanup;
+		await runTestDbMigrations(setup.app);
+		const handler = createFetchHandler(setup.app);
+		const auth = (channelKey: string, channelName: string, params = {}) =>
+			handler(
+				channelRequest(
+					"channels/auth",
+					{
+						socket_id: "123.456",
+						channel_name: channelName,
+						channel: channelKey,
+						params,
+					},
+					{ origin: "https://app.example.com", cookie: true },
+				),
+			);
+
+		const allowed = await auth("readOnly", "private-room-one", { id: "one" });
+		expect(allowed.status).toBe(200);
+		expect(allowed.headers.get("cache-control")).toBe("no-store");
+		expect(allowed.headers.get("access-control-allow-origin")).toBe(
+			"https://app.example.com",
+		);
+		expect(await allowed.json()).toEqual({ auth: "signed:private-room-one" });
+
+		expect((await auth("publicNews", "news")).status).toBe(200);
+		expect((await auth("missing", "missing")).status).toBe(404);
+		expect((await auth("throws", "private-throws")).status).toBe(403);
+		expect((await auth("timesOut", "private-slow")).status).toBe(403);
+		expect(
+			(await auth("readOnly", "private-room-other", { id: "one" })).status,
+		).toBe(403);
+		expect(providerCalls).toEqual(["private-room-one", "news"]);
+
+		const configResponse = await handler(
+			new Request("https://app.example.com/channels/config", {
+				headers: { Origin: "https://app.example.com" },
+			}),
+		);
+		const configText = JSON.stringify(await configResponse.json());
+		expect(configResponse.status).toBe(200);
+		expect(configText).toContain("public-key");
+		expect(configText).not.toContain("provider-secret");
+	});
+
+	test("enforces publish authorization, schema, payload, and rate before ledger allocation", async () => {
+		const setup = await buildMockApp(
+			{
+				channels: {
+					fallback: channel("fallback-[id]")
+						.events({ message: z.string() })
+						.authorize({ subscribe: true }),
+					readOnly: channel("readonly")
+						.events({ message: z.string() })
+						.authorize({ subscribe: true, publish: false }),
+					publicNews: channel("news").events({ message: z.string() }),
+				},
+			},
+			{
+				app: { url: "https://app.example.com" },
+				realtime: { retentionDays: 0 },
+			},
+		);
+		cleanup = setup.cleanup;
+		await runTestDbMigrations(setup.app);
+		const handler = createFetchHandler(setup.app);
+		const publish = (body: Record<string, unknown>) =>
+			handler(
+				channelRequest("channels/publish", body, {
+					origin: "https://app.example.com",
+					cookie: true,
+				}),
+			);
+
+		expect(
+			(
+				await publish({
+					channel: "readOnly",
+					params: {},
+					event: "message",
+					data: "denied",
+				})
+			).status,
+		).toBe(403);
+		expect(
+			(
+				await publish({
+					channel: "publicNews",
+					params: {},
+					event: "message",
+					data: "denied",
+				})
+			).status,
+		).toBe(403);
+		expect(
+			(
+				await publish({
+					channel: "fallback",
+					params: { id: "one" },
+					event: "message",
+					data: 42,
+				})
+			).status,
+		).toBe(422);
+
+		const accepted = await publish({
+			channel: "fallback",
+			params: { id: "one" },
+			event: "message",
+			data: "x".repeat(9_998),
+		});
+		expect(accepted.status).toBe(200);
+		expect(await accepted.json()).toEqual({ eventId: expect.any(String) });
+		expect(
+			(
+				await publish({
+					channel: "fallback",
+					params: { id: "one" },
+					event: "message",
+					data: "x".repeat(9_999),
+				})
+			).status,
+		).toBe(413);
+
+		let now = 0;
+		setChannelPublishLimiterForTests(
+			setup.app,
+			new ChannelTokenBucketLimiter({
+				ratePerSecond: 10,
+				burst: 1,
+				now: () => now,
+			}),
+		);
+		const rateBody = {
+			channel: "fallback",
+			params: { id: "rate" },
+			event: "message",
+			data: "ok",
+		};
+		expect((await publish(rateBody)).status).toBe(200);
+		expect((await publish(rateBody)).status).toBe(429);
+		now = 100;
+		expect((await publish(rateBody)).status).toBe(200);
+	});
+
+	test("uses one strict origin and credentialed CORS policy for auth and publish", async () => {
+		const setup = await buildMockApp(
+			{ channels: { publicNews: channel("news") } },
+			{
+				app: { url: "https://app.example.com" },
+				realtime: {
+					retentionDays: 0,
+					channelSecurity: {
+						trustedOrigins: ["https://admin.example.com"],
+					},
+				},
+			},
+		);
+		cleanup = setup.cleanup;
+		const handler = createFetchHandler(setup.app);
+		for (const path of ["channels/auth", "channels/publish"]) {
+			const missing = await handler(channelRequest(path, {}, { cookie: true }));
+			expect(missing.status).toBe(403);
+			const untrusted = await handler(
+				channelRequest(
+					path,
+					{},
+					{
+						cookie: true,
+						origin: "https://evil.example.com",
+					},
+				),
+			);
+			expect(untrusted.status).toBe(403);
+			const preflight = await handler(
+				new Request(`https://app.example.com/${path}`, {
+					method: "OPTIONS",
+					headers: { Origin: "https://admin.example.com" },
+				}),
+			);
+			expect(preflight.status).toBe(204);
+			expect(preflight.headers.get("access-control-allow-origin")).toBe(
+				"https://admin.example.com",
+			);
+			expect(preflight.headers.get("access-control-allow-credentials")).toBe(
+				"true",
+			);
+			expect(preflight.headers.get("vary")).toContain("Origin");
+			expect(preflight.headers.get("access-control-allow-origin")).not.toBe(
+				"*",
+			);
+		}
+
+		const simpleSubmission = await handler(
+			new Request("https://app.example.com/channels/publish", {
+				method: "POST",
+				headers: {
+					"Content-Type": "text/plain",
+					Origin: "https://app.example.com",
+				},
+				body: "{}",
+			}),
+		);
+		expect(simpleSubmission.status).toBe(415);
+
+		const sseConfig = await handler(
+			new Request("https://app.example.com/channels/config", {
+				headers: { Cookie: "session=test" },
+			}),
+		);
+		expect(await sseConfig.json()).toEqual({ transport: "sse" });
+
+		const rejectedPreflight = await handler(
+			new Request("https://app.example.com/channels/publish", {
+				method: "OPTIONS",
+				headers: {
+					Origin: "https://app.example.com",
+					"Access-Control-Request-Method": "POST",
+					"Access-Control-Request-Headers": "Content-Type, X-Unsafe",
+				},
+			}),
+		);
+		expect(rejectedPreflight.status).toBe(403);
+	});
+
+	test("rejects resolved-name collisions before authorization or provider contact", async () => {
+		let authorizationCalls = 0;
+		let providerCalls = 0;
+		const provider: PusherProvider = {
+			trigger: async () => {},
+			authorizeChannel: () => {
+				providerCalls += 1;
+				return { auth: "unexpected" };
+			},
+			authenticateUser: () => ({ auth: "user", user_data: "{}" }),
+			terminateUserConnections: async () => {},
+			getPresenceMemberCount: async () => 0,
+		};
+		const setup = await buildMockApp(
+			{
+				channels: {
+					first: channel("room-[id]").authorize(() => {
+						authorizationCalls += 1;
+						return true;
+					}),
+					second: channel("room-[slug]").authorize(true),
+				},
+			},
+			{
+				app: { url: "https://app.example.com" },
+				realtime: {
+					retentionDays: 0,
+					clientTransport: new PusherClientTransport({
+						provider,
+						key: "public",
+						identityKey: "secret",
+					}),
+				},
+			},
+		);
+		cleanup = setup.cleanup;
+		const response = await createFetchHandler(setup.app)(
+			channelRequest("channels/auth", {
+				socket_id: "123.456",
+				channel_name: "private-room-one",
+				channel: "first",
+				params: { id: "one" },
+			}),
+		);
+		expect(response.status).toBe(409);
+		expect(authorizationCalls).toBe(0);
+		expect(providerCalls).toBe(0);
+	});
+});

--- a/packages/questpie/test/units/channel-security.test.ts
+++ b/packages/questpie/test/units/channel-security.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test } from "bun:test";
+
+import { channel } from "../../src/server/channels/channel-builder.js";
+import {
+	assertChannelPayloadSize,
+	assertUniqueResolvedChannelName,
+	ChannelTokenBucketLimiter,
+	resolveChannelRequestOrigin,
+} from "../../src/server/channels/security.js";
+
+describe("channel security", () => {
+	test("requires an exact trusted origin for cookie requests", () => {
+		const trusted = { appUrl: "https://app.example.com" };
+		expect(
+			resolveChannelRequestOrigin(
+				new Request("https://app.example.com/channels/auth", {
+					headers: {
+						cookie: "session=one",
+						origin: "https://app.example.com",
+					},
+				}),
+				trusted,
+			),
+		).toBe("https://app.example.com");
+		expect(() =>
+			resolveChannelRequestOrigin(
+				new Request("https://app.example.com/channels/auth", {
+					headers: { cookie: "session=one" },
+				}),
+				trusted,
+			),
+		).toThrow("trusted Origin");
+		expect(() =>
+			resolveChannelRequestOrigin(
+				new Request("https://app.example.com/channels/auth", {
+					headers: { origin: "https://evil.example.com" },
+				}),
+				trusted,
+			),
+		).toThrow("trusted Origin");
+		expect(
+			resolveChannelRequestOrigin(
+				new Request("https://app.example.com/channels/publish", {
+					headers: { authorization: "Bearer token" },
+				}),
+				trusted,
+			),
+		).toBeNull();
+	});
+
+	test("rejects unsafe trusted-origin configuration", () => {
+		for (const origin of [
+			"*",
+			"null",
+			"https://example.com/path",
+			"http://example.com",
+			"https://user@example.com",
+		]) {
+			expect(() =>
+				resolveChannelRequestOrigin(new Request("https://app.example.com"), {
+					appUrl: "https://app.example.com",
+					trustedOrigins: [origin],
+				}),
+			).toThrow();
+		}
+	});
+
+	test("proves one canonical resolved-name identity", () => {
+		const unique = {
+			room: channel("room-[id]").authorize(true),
+			news: channel("news-[slug]"),
+		};
+		expect(assertUniqueResolvedChannelName(unique, "room", { id: "one" })).toBe(
+			"private-room-one",
+		);
+
+		const crossPattern = {
+			first: channel("room-[id]").authorize(true),
+			second: channel("room-[slug]").authorize(true),
+		};
+		expect(() =>
+			assertUniqueResolvedChannelName(crossPattern, "first", { id: "one" }),
+		).toThrow("collision");
+
+		const ambiguous = {
+			pair: channel("[left][right]").authorize(true),
+		};
+		expect(() =>
+			assertUniqueResolvedChannelName(ambiguous, "pair", {
+				left: "a",
+				right: "bc",
+			}),
+		).toThrow("collision");
+	});
+
+	test("enforces exact serialized 10,000-byte payload boundary", () => {
+		const accepted = "x".repeat(9_998);
+		const rejected = "x".repeat(9_999);
+		expect(assertChannelPayloadSize(accepted)).toBe(`"${accepted}"`);
+		expect(() => assertChannelPayloadSize(rejected)).toThrow("10,000");
+	});
+
+	test("recovers publish tokens with a fake clock", () => {
+		let now = 0;
+		const limiter = new ChannelTokenBucketLimiter({
+			ratePerSecond: 10,
+			burst: 20,
+			now: () => now,
+		});
+		for (let index = 0; index < 20; index++) {
+			expect(limiter.consume("session-1")).toBe(true);
+		}
+		expect(limiter.consume("session-1")).toBe(false);
+		expect(limiter.retryAfterMs(["session-1"])).toBe(100);
+		now = 100;
+		expect(limiter.consume("session-1")).toBe(true);
+		expect(limiter.consume("session-1")).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary
- add generated-key `channels/auth`, `channels/config`, and server-mediated `channels/publish` core routes
- enforce shared exact-origin/CORS policy, authorization deadlines, collision proof, Zod + 10,000-byte validation, and two-dimensional token buckets
- keep Pusher auth socket/channel-bound while exposing secret-free config, with SSE config parity

## Verification
- `cd packages/questpie && bun test test/ --test-name-pattern "channel"` (38 pass, 2 env-gated Soketi skips)
- `cd packages/questpie && bunx tsc --noEmit -p tsconfig.json`
- `bunx tsc --noEmit -p packages/questpie/tsconfig.fullapp.json`
- `cd packages/questpie && bun run build`
- focused oxlint: 0 warnings/errors

Board: RT3.3