### PR TITLE
feat(realtime): select managed client transport

### DIFF
--- a/.changeset/fresh-auth-headers.md
+++ b/.changeset/fresh-auth-headers.md
@@ -1,0 +1,5 @@
+---
+"questpie": patch
+---
+
+Add a dynamic authentication-header resolver shared by data, upload, and realtime client requests.

--- a/.changeset/select-pusher-realtime-client.md
+++ b/.changeset/select-pusher-realtime-client.md
@@ -1,0 +1,5 @@
+---
+"questpie": patch
+---
+
+Select the configured realtime client transport at runtime and lazily use PusherJS for private invalidation-driven live-query refetches without changing the typed client API.

--- a/packages/questpie/src/client/auth.ts
+++ b/packages/questpie/src/client/auth.ts
@@ -1,0 +1,3 @@
+export type AuthHeaders = Record<string, string>;
+
+export type GetAuthHeaders = () => AuthHeaders | Promise<AuthHeaders>;

--- a/packages/questpie/src/client/index.ts
+++ b/packages/questpie/src/client/index.ts
@@ -37,12 +37,15 @@ import type {
 	With,
 } from "../server/collection/crud/types.js";
 import type { GlobalUpdateInput } from "../server/global/crud/types.js";
+import type { GetAuthHeaders } from "./auth.js";
 import {
 	buildCollectionTopic,
 	buildGlobalTopic,
 	createRealtimeAPI,
 	type RealtimeAPI,
 } from "./realtime/index.js";
+
+export type { AuthHeaders, GetAuthHeaders } from "./auth.js";
 
 // ============================================================================
 // Upload Types
@@ -237,6 +240,16 @@ export type QuestpieClientConfig = {
 	 * Default headers to include in all requests
 	 */
 	headers?: Record<string, string>;
+
+	/**
+	 * Resolve authentication headers for every request.
+	 *
+	 * The resolver runs immediately before data, upload, and realtime requests,
+	 * so rotated bearer tokens do not require recreating the client. Resolved
+	 * headers override matching static `headers`. Cookie credentials remain
+	 * enabled when this hook is omitted or used.
+	 */
+	getAuthHeaders?: GetAuthHeaders;
 
 	/**
 	 * Enable SuperJSON serialization for enhanced type support (Date, Map, Set, BigInt)
@@ -1014,10 +1027,12 @@ export function createClient<TApp extends QuestpieApp>(
 			? "application/superjson+json"
 			: "application/json";
 
+		const authHeaders = await config.getAuthHeaders?.();
 		const headers: Record<string, string> = {
 			"Content-Type": contentType,
 			...defaultHeaders,
 			...(options.headers as Record<string, string>),
+			...authHeaders,
 		};
 
 		if (useSuperJSON) {
@@ -1098,6 +1113,7 @@ export function createClient<TApp extends QuestpieApp>(
 		baseUrl: `${config.baseURL}${apiBasePath}`,
 		withCredentials: true,
 		debounceMs: 50,
+		getAuthHeaders: config.getAuthHeaders,
 	});
 
 	/**
@@ -1443,10 +1459,29 @@ export function createClient<TApp extends QuestpieApp>(
 							formData.append("path", options.path);
 						}
 
-						// Send request with credentials (cookies)
+						const send = (authHeaders?: Record<string, string>) => {
+							for (const [name, value] of Object.entries(authHeaders ?? {})) {
+								xhr.setRequestHeader(name, value);
+							}
+							xhr.send(formData);
+						};
+
+						// Keep cookie credentials enabled while allowing dynamic bearer auth.
 						xhr.open("POST", url);
 						xhr.withCredentials = true;
-						xhr.send(formData);
+						if (config.getAuthHeaders) {
+							try {
+								Promise.resolve(config.getAuthHeaders()).then(send, (error) => {
+									cleanup();
+									reject(error);
+								});
+							} catch (error) {
+								cleanup();
+								reject(error);
+							}
+						} else {
+							send();
+						}
 					});
 				},
 

--- a/packages/questpie/src/client/index.ts
+++ b/packages/questpie/src/client/index.ts
@@ -1114,6 +1114,51 @@ export function createClient<TApp extends QuestpieApp>(
 		withCredentials: true,
 		debounceMs: 50,
 		getAuthHeaders: config.getAuthHeaders,
+		fetcher,
+		refetchTopic: async (topic) => {
+			if (topic.resourceType === "collection") {
+				if (topic.operation === "count") {
+					const queryString = qs.stringify(
+						{ where: topic.where, locale: topic.locale },
+						{ skipNulls: true, arrayFormat: "brackets" },
+					);
+					const result = await request(
+						`${apiBasePath}/${topic.resource}/count${queryString ? `?${queryString}` : ""}`,
+					);
+					return result.count;
+				}
+				if (topic.operation === "get") {
+					const queryString = qs.stringify(
+						{ with: topic.with, locale: topic.locale },
+						{ skipNulls: true, arrayFormat: "brackets" },
+					);
+					return request(
+						`${apiBasePath}/${topic.resource}/${topic.id}${queryString ? `?${queryString}` : ""}`,
+					);
+				}
+				const queryString = qs.stringify(
+					{
+						where: topic.where,
+						with: topic.with,
+						limit: topic.limit,
+						offset: topic.offset,
+						orderBy: topic.orderBy,
+						locale: topic.locale,
+					},
+					{ skipNulls: true, arrayFormat: "brackets" },
+				);
+				return request(
+					`${apiBasePath}/${topic.resource}${queryString ? `?${queryString}` : ""}`,
+				);
+			}
+			const queryString = qs.stringify(
+				{ where: topic.where, with: topic.with, locale: topic.locale },
+				{ skipNulls: true, arrayFormat: "brackets" },
+			);
+			return request(
+				`${apiBasePath}/globals/${topic.resource}${queryString ? `?${queryString}` : ""}`,
+			);
+		},
 	});
 
 	/**

--- a/packages/questpie/src/client/realtime/index.ts
+++ b/packages/questpie/src/client/realtime/index.ts
@@ -10,3 +10,8 @@ export {
 	type RealtimeAPI,
 	sseSnapshotStream,
 } from "./stream.js";
+export {
+	PusherRealtimeTransport,
+	type PusherRealtimeConfig,
+} from "./pusher.js";
+export type { RealtimeClientTransport } from "./transport.js";

--- a/packages/questpie/src/client/realtime/multiplexer.ts
+++ b/packages/questpie/src/client/realtime/multiplexer.ts
@@ -6,6 +6,7 @@
  */
 
 import type { GetAuthHeaders } from "../auth.js";
+import type { RealtimeClientTransport } from "./transport.js";
 
 // ============================================================================
 // Types
@@ -102,11 +103,25 @@ export function stableStringify(x: unknown): string {
 	return `{${keys.map((k) => JSON.stringify(k) + ":" + stableStringify((x as Record<string, unknown>)[k])).join(",")}}`;
 }
 
+export function realtimeTopicId(topic: TopicConfig): string {
+	const normalized = stableStringify(topic);
+	if (typeof Buffer !== "undefined") {
+		return Buffer.from(normalized, "utf8").toString("base64url");
+	}
+	const bytes = new TextEncoder().encode(normalized);
+	let binary = "";
+	for (const byte of bytes) binary += String.fromCharCode(byte);
+	return btoa(binary)
+		.replace(/\+/g, "-")
+		.replace(/\//g, "_")
+		.replace(/=+$/, "");
+}
+
 // ============================================================================
 // Multiplexer
 // ============================================================================
 
-export class RealtimeMultiplexer {
+export class RealtimeMultiplexer implements RealtimeClientTransport {
 	private abortController: AbortController | null = null;
 	private subscribers = new Map<string, Set<Subscriber>>();
 	private errorCallbacks = new Map<string, Set<ErrorCallback>>();
@@ -134,6 +149,7 @@ export class RealtimeMultiplexer {
 		private debounceMs = 50,
 		runtime: RealtimeMultiplexerRuntime = {},
 		private getAuthHeaders?: GetAuthHeaders,
+		private fetcher: typeof fetch = globalThis.fetch,
 	) {
 		this.retryBaseMs = runtime.retryBaseMs ?? 1000;
 		this.maxRetryMs = runtime.maxRetryMs ?? 30_000;
@@ -223,19 +239,7 @@ export class RealtimeMultiplexer {
 	 * construction, and unicode-safe.
 	 */
 	private hashTopic(topic: TopicConfig): string {
-		const normalized = stableStringify(topic);
-		if (typeof Buffer !== "undefined") {
-			return Buffer.from(normalized, "utf8").toString("base64url");
-		}
-		// Browser: utf-8 encode before base64 — btoa() is Latin1-only and throws
-		// on unicode (e.g. accented `where` values).
-		const bytes = new TextEncoder().encode(normalized);
-		let binary = "";
-		for (const byte of bytes) binary += String.fromCharCode(byte);
-		return btoa(binary)
-			.replace(/\+/g, "-")
-			.replace(/\//g, "_")
-			.replace(/=+$/, "");
+		return realtimeTopicId(topic);
 	}
 
 	private applyTopologyChange(frame: ControlFrame): void {
@@ -259,7 +263,7 @@ export class RealtimeMultiplexer {
 		this.controlOperation = this.controlOperation
 			.then(async () => {
 				const authHeaders = await this.getAuthHeaders?.();
-				const response = await fetch(`${this.baseUrl}/realtime`, {
+				const response = await this.fetcher(`${this.baseUrl}/realtime`, {
 					method: "POST",
 					headers: { "Content-Type": "application/json", ...authHeaders },
 					body: JSON.stringify({
@@ -375,7 +379,7 @@ export class RealtimeMultiplexer {
 
 		try {
 			const authHeaders = await this.getAuthHeaders?.();
-			const response = await fetch(`${this.baseUrl}/realtime`, {
+			const response = await this.fetcher(`${this.baseUrl}/realtime`, {
 				method: "POST",
 				headers: { "Content-Type": "application/json", ...authHeaders },
 				body: JSON.stringify({ topics: getTopicsPayload() }),

--- a/packages/questpie/src/client/realtime/multiplexer.ts
+++ b/packages/questpie/src/client/realtime/multiplexer.ts
@@ -5,6 +5,8 @@
  * Solves the HTTP/1.1 connection limit problem (6 connections per domain).
  */
 
+import type { GetAuthHeaders } from "../auth.js";
+
 // ============================================================================
 // Types
 // ============================================================================
@@ -131,6 +133,7 @@ export class RealtimeMultiplexer {
 		private withCredentials = true,
 		private debounceMs = 50,
 		runtime: RealtimeMultiplexerRuntime = {},
+		private getAuthHeaders?: GetAuthHeaders,
 	) {
 		this.retryBaseMs = runtime.retryBaseMs ?? 1000;
 		this.maxRetryMs = runtime.maxRetryMs ?? 30_000;
@@ -255,9 +258,10 @@ export class RealtimeMultiplexer {
 		const frames = this.pendingControlFrames.splice(0);
 		this.controlOperation = this.controlOperation
 			.then(async () => {
+				const authHeaders = await this.getAuthHeaders?.();
 				const response = await fetch(`${this.baseUrl}/realtime`, {
 					method: "POST",
-					headers: { "Content-Type": "application/json" },
+					headers: { "Content-Type": "application/json", ...authHeaders },
 					body: JSON.stringify({
 						sessionId: session.sessionId,
 						token: session.token,
@@ -370,9 +374,10 @@ export class RealtimeMultiplexer {
 			}));
 
 		try {
+			const authHeaders = await this.getAuthHeaders?.();
 			const response = await fetch(`${this.baseUrl}/realtime`, {
 				method: "POST",
-				headers: { "Content-Type": "application/json" },
+				headers: { "Content-Type": "application/json", ...authHeaders },
 				body: JSON.stringify({ topics: getTopicsPayload() }),
 				credentials: this.withCredentials ? "include" : "omit",
 				signal: this.abortController.signal,

--- a/packages/questpie/src/client/realtime/pusher.ts
+++ b/packages/questpie/src/client/realtime/pusher.ts
@@ -1,0 +1,389 @@
+import type { GetAuthHeaders } from "../auth.js";
+import { realtimeTopicId, type TopicConfig } from "./multiplexer.js";
+import type {
+	RealtimeClientTransport,
+	RealtimeErrorCallback,
+	RealtimeSubscriber,
+} from "./transport.js";
+
+export type PusherRealtimeConfig = {
+	provider: "pusher";
+	key: string;
+	cluster?: string;
+	wsHost?: string;
+	wsPort?: number;
+	wssPort?: number;
+	forceTLS?: boolean;
+	authEndpoint?: string;
+};
+
+export type PusherModule = typeof import("pusher-js");
+
+type TopicEntry = {
+	topic: TopicConfig;
+	subscribers: Set<RealtimeSubscriber>;
+	errorCallbacks: Set<RealtimeErrorCallback>;
+	registered: boolean;
+	lastSnapshot?: unknown;
+};
+
+type SessionResponse = {
+	transport: "shared-provider";
+	sessionId: string;
+	token: string;
+	channel: string;
+	errors?: Array<{ id: string; message: string }>;
+};
+
+function errorFrom(value: unknown): Error {
+	return value instanceof Error ? value : new Error(String(value));
+}
+
+function endpoint(baseUrl: string, path: string): string {
+	if (/^https?:\/\//.test(path)) return path;
+	return `${baseUrl.replace(/\/$/, "")}/${path.replace(/^\//, "")}`;
+}
+
+function topicPayload(topicId: string, topic: TopicConfig) {
+	return {
+		...topic,
+		...(topic.resourceType === "collection" && topic.operation === "get"
+			? { recordId: topic.id }
+			: {}),
+		id: topicId,
+	};
+}
+
+/** Lazy managed-Pusher driver. Provider frames are private refetch hints only. */
+export class PusherRealtimeTransport implements RealtimeClientTransport {
+	private readonly topics = new Map<string, TopicEntry>();
+	private session: SessionResponse | null = null;
+	private pusher: InstanceType<PusherModule["default"]> | null = null;
+	private channel: ReturnType<
+		InstanceType<PusherModule["default"]>["subscribe"]
+	> | null = null;
+	private sessionPromise: Promise<void> | null = null;
+	private controlOperation: Promise<void> = Promise.resolve();
+	private refreshPromise: Promise<void> | null = null;
+	private refreshPending = false;
+	private destroyed = false;
+
+	constructor(
+		private readonly options: {
+			baseUrl: string;
+			fetcher: typeof fetch;
+			getAuthHeaders?: GetAuthHeaders;
+			config: PusherRealtimeConfig;
+			refetchTopic: (topic: TopicConfig) => Promise<unknown>;
+			loadPusher?: () => Promise<PusherModule>;
+		},
+	) {}
+
+	subscribe(
+		topic: TopicConfig,
+		callback: RealtimeSubscriber,
+		signal?: AbortSignal,
+		customId?: string,
+		onError?: RealtimeErrorCallback,
+	): () => void {
+		const topicId = customId ?? realtimeTopicId(topic);
+		let entry = this.topics.get(topicId);
+		if (!entry) {
+			entry = {
+				topic,
+				subscribers: new Set(),
+				errorCallbacks: new Set(),
+				registered: false,
+			};
+			this.topics.set(topicId, entry);
+		} else if (entry.lastSnapshot !== undefined) {
+			queueMicrotask(() => callback(entry!.lastSnapshot));
+		}
+		entry.subscribers.add(callback);
+		if (onError) entry.errorCallbacks.add(onError);
+		if (!entry.registered && entry.subscribers.size === 1) {
+			void this.mountTopic(topicId, entry);
+		}
+
+		let stopped = false;
+		const stop = () => {
+			if (stopped) return;
+			stopped = true;
+			signal?.removeEventListener("abort", stop);
+			const current = this.topics.get(topicId);
+			if (!current) return;
+			current.subscribers.delete(callback);
+			if (onError) current.errorCallbacks.delete(onError);
+			if (current.subscribers.size > 0) return;
+			this.topics.delete(topicId);
+			if (current.registered) {
+				void this.sendControl([{ type: "remove_topic", topicId }]).finally(
+					() => {
+						if (this.topics.size === 0) this.disconnect();
+					},
+				);
+			} else if (this.topics.size === 0 && !this.sessionPromise) {
+				this.disconnect();
+			}
+		};
+		signal?.addEventListener("abort", stop, { once: true });
+		return stop;
+	}
+
+	private async mountTopic(topicId: string, entry: TopicEntry): Promise<void> {
+		try {
+			await this.ensureSession();
+			if (this.destroyed || this.topics.get(topicId) !== entry) return;
+			if (!entry.registered) {
+				await this.sendControl([
+					{ type: "add_topic", topicId, topic: entry.topic },
+				]);
+				entry.registered = true;
+			}
+			await this.refetchEntry(entry);
+		} catch (error) {
+			this.notifyError(entry, errorFrom(error));
+		}
+	}
+
+	private async ensureSession(): Promise<void> {
+		if (this.session || this.destroyed) return;
+		if (this.sessionPromise) return this.sessionPromise;
+		this.sessionPromise = this.openSession().finally(() => {
+			this.sessionPromise = null;
+		});
+		return this.sessionPromise;
+	}
+
+	private async openSession(): Promise<void> {
+		const initial = [...this.topics.entries()];
+		if (initial.length === 0 || this.destroyed) return;
+		const authHeaders = await this.options.getAuthHeaders?.();
+		const response = await this.options.fetcher(
+			`${this.options.baseUrl}/realtime`,
+			{
+				method: "POST",
+				headers: { "Content-Type": "application/json", ...authHeaders },
+				body: JSON.stringify({
+					transport: "shared-provider",
+					topics: initial.map(([topicId, entry]) =>
+						topicPayload(topicId, entry.topic),
+					),
+				}),
+				credentials: "include",
+			},
+		);
+		if (!response.ok) {
+			throw new Error(`Realtime session failed: ${response.status}`);
+		}
+		const session = (await response.json()) as SessionResponse;
+		if (
+			session.transport !== "shared-provider" ||
+			!session.sessionId ||
+			!session.token ||
+			!session.channel
+		) {
+			throw new Error("Invalid shared-provider realtime session");
+		}
+		this.session = session;
+		if (this.destroyed) {
+			await this.sendControl(
+				initial.map(([topicId]) => ({ type: "remove_topic", topicId })),
+			).catch(() => {});
+			this.disconnect();
+			return;
+		}
+		for (const [topicId, entry] of initial) {
+			if (this.topics.get(topicId) === entry) entry.registered = true;
+		}
+		for (const error of session.errors ?? []) {
+			const entry = this.topics.get(error.id);
+			if (entry) this.notifyError(entry, new Error(error.message));
+		}
+
+		const module = await (this.options.loadPusher?.() ?? import("pusher-js"));
+		if (this.destroyed) return;
+		const config = this.options.config;
+		const authEndpoint = endpoint(
+			this.options.baseUrl,
+			config.authEndpoint ?? "realtime/auth",
+		);
+		this.pusher = new module.default(config.key, {
+			cluster: config.cluster ?? "mt1",
+			...(config.wsHost ? { wsHost: config.wsHost } : {}),
+			...(config.wsPort ? { wsPort: config.wsPort } : {}),
+			...(config.wssPort ? { wssPort: config.wssPort } : {}),
+			forceTLS: config.forceTLS ?? true,
+			channelAuthorization: {
+				customHandler: (input, callback) => {
+					void this.authorize(authEndpoint, input.socketId, input.channelName)
+						.then((auth) => callback(null, auth))
+						.catch((error) => callback(errorFrom(error), null));
+				},
+			},
+		});
+		this.channel = this.pusher.subscribe(session.channel);
+		this.channel.bind("questpie:invalidate", () => this.scheduleRefresh());
+		this.channel.bind("pusher:subscription_succeeded", () =>
+			this.scheduleRefresh(),
+		);
+		this.channel.bind("pusher:subscription_error", (error: unknown) => {
+			this.notifyAll(errorFrom(error));
+		});
+
+		const removed = initial
+			.filter(([topicId, entry]) => this.topics.get(topicId) !== entry)
+			.map(([topicId]) => ({ type: "remove_topic" as const, topicId }));
+		const added = [...this.topics.entries()]
+			.filter(([, entry]) => !entry.registered)
+			.map(([topicId, entry]) => ({
+				type: "add_topic" as const,
+				topicId,
+				topic: entry.topic,
+			}));
+		if (removed.length || added.length)
+			await this.sendControl([...removed, ...added]);
+		for (const frame of added) {
+			const entry = this.topics.get(frame.topicId);
+			if (entry) entry.registered = true;
+		}
+	}
+
+	private async authorize(
+		authEndpoint: string,
+		socketId: string,
+		channelName: string,
+	): Promise<{
+		auth: string;
+		channel_data?: string;
+		shared_secret?: string;
+	}> {
+		const authHeaders = await this.options.getAuthHeaders?.();
+		const response = await this.options.fetcher(authEndpoint, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/x-www-form-urlencoded",
+				...authHeaders,
+			},
+			body: new URLSearchParams({
+				socket_id: socketId,
+				channel_name: channelName,
+			}),
+			credentials: "include",
+		});
+		if (!response.ok)
+			throw new Error(`Realtime auth failed: ${response.status}`);
+		const auth = (await response.json()) as {
+			auth?: unknown;
+			channel_data?: unknown;
+			shared_secret?: unknown;
+		};
+		if (typeof auth.auth !== "string") {
+			throw new Error("Invalid realtime auth response");
+		}
+		return {
+			auth: auth.auth,
+			...(typeof auth.channel_data === "string"
+				? { channel_data: auth.channel_data }
+				: {}),
+			...(typeof auth.shared_secret === "string"
+				? { shared_secret: auth.shared_secret }
+				: {}),
+		};
+	}
+
+	private sendControl(frames: Array<Record<string, unknown>>): Promise<void> {
+		const session = this.session;
+		if (!session || frames.length === 0) return Promise.resolve();
+		this.controlOperation = this.controlOperation
+			.catch(() => {})
+			.then(async () => {
+				const authHeaders = await this.options.getAuthHeaders?.();
+				const response = await this.options.fetcher(
+					`${this.options.baseUrl}/realtime`,
+					{
+						method: "POST",
+						headers: { "Content-Type": "application/json", ...authHeaders },
+						body: JSON.stringify({
+							sessionId: session.sessionId,
+							token: session.token,
+							frames,
+						}),
+						credentials: "include",
+					},
+				);
+				if (!response.ok) {
+					throw new Error(`Realtime control failed: ${response.status}`);
+				}
+			});
+		return this.controlOperation;
+	}
+
+	private scheduleRefresh(): void {
+		if (this.refreshPromise) {
+			this.refreshPending = true;
+			return;
+		}
+		this.refreshPromise = (async () => {
+			do {
+				this.refreshPending = false;
+				await Promise.all(
+					[...this.topics.values()].map((entry) => this.refetchEntry(entry)),
+				);
+			} while (this.refreshPending && !this.destroyed);
+		})().finally(() => {
+			this.refreshPromise = null;
+		});
+	}
+
+	private async refetchEntry(entry: TopicEntry): Promise<void> {
+		try {
+			const snapshot = await this.options.refetchTopic(entry.topic);
+			if (this.destroyed) return;
+			entry.lastSnapshot = snapshot;
+			for (const subscriber of entry.subscribers) subscriber(snapshot);
+		} catch (error) {
+			this.notifyError(entry, errorFrom(error));
+		}
+	}
+
+	private notifyError(entry: TopicEntry, error: Error): void {
+		for (const callback of entry.errorCallbacks) callback(error);
+	}
+
+	private notifyAll(error: Error): void {
+		for (const entry of this.topics.values()) this.notifyError(entry, error);
+	}
+
+	private disconnect(): void {
+		if (this.channel && this.session) {
+			this.channel.unbind();
+			this.pusher?.unsubscribe(this.session.channel);
+		}
+		this.pusher?.disconnect();
+		this.pusher = null;
+		this.channel = null;
+		this.session = null;
+	}
+
+	destroy(): void {
+		if (this.destroyed) return;
+		this.destroyed = true;
+		const frames = [...this.topics.entries()]
+			.filter(([, entry]) => entry.registered)
+			.map(([topicId]) => ({ type: "remove_topic", topicId }));
+		if (frames.length) void this.sendControl(frames).catch(() => {});
+		this.topics.clear();
+		this.disconnect();
+	}
+
+	get topicCount(): number {
+		return this.topics.size;
+	}
+
+	get subscriberCount(): number {
+		let count = 0;
+		for (const entry of this.topics.values()) count += entry.subscribers.size;
+		return count;
+	}
+}

--- a/packages/questpie/src/client/realtime/stream.ts
+++ b/packages/questpie/src/client/realtime/stream.ts
@@ -7,6 +7,11 @@
 
 import type { GetAuthHeaders } from "../auth.js";
 import { RealtimeMultiplexer, type TopicConfig } from "./multiplexer.js";
+import {
+	PusherRealtimeTransport,
+	type PusherRealtimeConfig,
+} from "./pusher.js";
+import type { RealtimeClientTransport } from "./transport.js";
 
 // ============================================================================
 // Types
@@ -65,7 +70,7 @@ export type RealtimeAPI = {
  * ```
  */
 export async function* sseSnapshotStream<TData>(options: {
-	multiplexer: RealtimeMultiplexer;
+	multiplexer: RealtimeClientTransport;
 	topic: TopicConfig;
 	signal?: AbortSignal;
 	customId?: string;
@@ -251,20 +256,69 @@ export function createRealtimeAPI(opts: {
 	withCredentials: boolean;
 	debounceMs: number;
 	getAuthHeaders?: GetAuthHeaders;
+	fetcher?: typeof fetch;
+	refetchTopic?: (topic: TopicConfig) => Promise<unknown>;
 }): RealtimeAPI {
-	let multiplexer: RealtimeMultiplexer | null = null;
+	let transport: RealtimeClientTransport | null = null;
+	let transportPromise: Promise<RealtimeClientTransport> | null = null;
+	let generation = 0;
+	const pending = new Set<object>();
+	const fetcher = opts.fetcher ?? globalThis.fetch;
 
-	const getOrCreate = () => {
-		if (!multiplexer) {
-			multiplexer = new RealtimeMultiplexer(
-				opts.baseUrl,
-				opts.withCredentials,
-				opts.debounceMs,
-				{},
-				opts.getAuthHeaders,
-			);
+	const createSse = () =>
+		new RealtimeMultiplexer(
+			opts.baseUrl,
+			opts.withCredentials,
+			opts.debounceMs,
+			{},
+			opts.getAuthHeaders,
+			fetcher,
+		);
+
+	const getOrCreate = async (): Promise<RealtimeClientTransport> => {
+		if (transport) return transport;
+		if (!transportPromise) {
+			const selectedGeneration = generation;
+			transportPromise = (async () => {
+				try {
+					const authHeaders = await opts.getAuthHeaders?.();
+					const response = await fetcher(`${opts.baseUrl}/realtime/config`, {
+						headers: authHeaders,
+						credentials: opts.withCredentials ? "include" : "omit",
+					});
+					if (
+						response.ok &&
+						response.headers.get("content-type")?.includes("application/json")
+					) {
+						const selected = (await response.json()) as
+							| { transport: "sse" }
+							| { transport: "shared-provider"; config: PusherRealtimeConfig };
+						if (
+							selected.transport === "shared-provider" &&
+							selected.config?.provider === "pusher" &&
+							typeof selected.config.key === "string" &&
+							opts.refetchTopic
+						) {
+							return new PusherRealtimeTransport({
+								baseUrl: opts.baseUrl,
+								fetcher,
+								getAuthHeaders: opts.getAuthHeaders,
+								config: selected.config,
+								refetchTopic: opts.refetchTopic,
+							});
+						}
+					}
+				} catch {
+					// Backward compatibility with servers predating realtime/config.
+				}
+				return createSse();
+			})().then((selected) => {
+				if (selectedGeneration !== generation) selected.destroy();
+				else transport = selected;
+				return selected;
+			});
 		}
-		return multiplexer;
+		return transportPromise;
 	};
 
 	return {
@@ -275,31 +329,63 @@ export function createRealtimeAPI(opts: {
 			customId?: string,
 			onError?: (error: Error) => void,
 		) {
-			return getOrCreate().subscribe(
-				topic,
-				callback as (data: unknown) => void,
-				signal,
-				customId,
-				onError,
-			);
+			const subscriptionGeneration = generation;
+			const marker = {};
+			pending.add(marker);
+			let stopped = false;
+			let stopInner: (() => void) | undefined;
+			void getOrCreate()
+				.then((selected) => {
+					pending.delete(marker);
+					if (stopped || subscriptionGeneration !== generation) return;
+					stopInner = selected.subscribe(
+						topic,
+						callback as (data: unknown) => void,
+						signal,
+						customId,
+						onError,
+					);
+				})
+				.catch((error) => {
+					pending.delete(marker);
+					onError?.(error instanceof Error ? error : new Error(String(error)));
+				});
+			return () => {
+				stopped = true;
+				pending.delete(marker);
+				stopInner?.();
+			};
 		},
 		stream<TData>(topic: TopicConfig, signal?: AbortSignal, customId?: string) {
+			const facade: RealtimeClientTransport = {
+				subscribe: (...args) => this.subscribe(...args),
+				destroy: () => this.destroy(),
+				get topicCount() {
+					return transport?.topicCount ?? pending.size;
+				},
+				get subscriberCount() {
+					return transport?.subscriberCount ?? pending.size;
+				},
+			};
 			return sseSnapshotStream<TData>({
-				multiplexer: getOrCreate(),
+				multiplexer: facade,
 				topic,
 				signal,
 				customId,
 			});
 		},
 		destroy() {
-			multiplexer?.destroy();
-			multiplexer = null;
+			generation += 1;
+			pending.clear();
+			transport?.destroy();
+			transport = null;
+			transportPromise = null;
 		},
 		get topicCount() {
-			return multiplexer?.topicCount ?? 0;
+			return transport?.topicCount ?? pending.size;
 		},
 		get subscriberCount() {
-			return multiplexer?.subscriberCount ?? 0;
+			return transport?.subscriberCount ?? pending.size;
 		},
 	};
 }

--- a/packages/questpie/src/client/realtime/stream.ts
+++ b/packages/questpie/src/client/realtime/stream.ts
@@ -5,6 +5,7 @@
  * for the realtime SSE multiplexer.
  */
 
+import type { GetAuthHeaders } from "../auth.js";
 import { RealtimeMultiplexer, type TopicConfig } from "./multiplexer.js";
 
 // ============================================================================
@@ -249,6 +250,7 @@ export function createRealtimeAPI(opts: {
 	baseUrl: string;
 	withCredentials: boolean;
 	debounceMs: number;
+	getAuthHeaders?: GetAuthHeaders;
 }): RealtimeAPI {
 	let multiplexer: RealtimeMultiplexer | null = null;
 
@@ -258,6 +260,8 @@ export function createRealtimeAPI(opts: {
 				opts.baseUrl,
 				opts.withCredentials,
 				opts.debounceMs,
+				{},
+				opts.getAuthHeaders,
 			);
 		}
 		return multiplexer;

--- a/packages/questpie/src/client/realtime/transport.ts
+++ b/packages/questpie/src/client/realtime/transport.ts
@@ -1,0 +1,18 @@
+import type { TopicConfig } from "./multiplexer.js";
+
+export type RealtimeSubscriber = (data: unknown) => void;
+export type RealtimeErrorCallback = (error: Error) => void;
+
+/** Client-side delivery seam shared by SSE and managed-Pusher live queries. */
+export interface RealtimeClientTransport {
+	subscribe(
+		topic: TopicConfig,
+		callback: RealtimeSubscriber,
+		signal?: AbortSignal,
+		customId?: string,
+		onError?: RealtimeErrorCallback,
+	): () => void;
+	destroy(): void;
+	readonly topicCount: number;
+	readonly subscriberCount: number;
+}

--- a/packages/questpie/src/server/adapters/routes/realtime.ts
+++ b/packages/questpie/src/server/adapters/routes/realtime.ts
@@ -32,6 +32,7 @@ import {
 	type RealtimeControlFrame,
 } from "../../modules/core/integrated/realtime/sse-control.js";
 import { sharedSseKeepAliveTicker } from "../../modules/core/integrated/realtime/sse-keep-alive.js";
+import type { ClientSink } from "../../modules/core/integrated/realtime/transport.js";
 import type { AdapterConfig, AdapterContext } from "../types.js";
 import { resolveContext } from "../utils/context.js";
 import { handleError, sseHeaders } from "../utils/response.js";
@@ -361,6 +362,7 @@ export async function realtimeSubscribe(
 	// Parse request body
 	let body: {
 		topics?: TopicInput[];
+		transport?: "shared-provider";
 		sessionId?: string;
 		token?: string;
 		frames?: RealtimeControlFrame[];
@@ -635,6 +637,179 @@ export async function realtimeSubscribe(
 			request,
 			resolved.appContext.locale,
 		);
+	}
+
+	if (body.transport === "shared-provider") {
+		const transportConfig = await app.realtime.getClientTransportConfig({
+			request,
+		});
+		if (transportConfig.transport !== "shared-provider") {
+			releaseConnection();
+			return errorResponse(
+				ApiError.badRequest("Shared-provider realtime is not configured"),
+				request,
+				resolved.appContext.locale,
+			);
+		}
+
+		const edgeSessionId = globalThis.crypto.randomUUID();
+		const controlToken = globalThis.crypto.randomUUID();
+		const topicUnsubscribers = new Map<string, () => void>();
+		let unregisterControl = () => {};
+		let sink: ClientSink | null = null;
+		let closed = false;
+		try {
+			sink = await app.realtime.openClientSession({
+				sessionId: edgeSessionId,
+				principal: resolved.appContext.principal ?? null,
+				resolvePrincipal: async () => resolved.appContext.principal ?? null,
+			});
+			if (!sink.clientChannel) {
+				throw new Error(
+					"Shared-provider session did not expose a client channel",
+				);
+			}
+			const activeSink = sink;
+			const refreshScheduler = getRealtimeRefreshScheduler(app, app.realtime);
+			const limitSnapshotConcurrency = createConcurrencyLimiter(
+				admission.initialSnapshotConcurrency,
+			);
+			const close = () => {
+				if (closed) return;
+				closed = true;
+				releaseConnection();
+				unregisterControl();
+				for (const unsubscribe of topicUnsubscribers.values()) unsubscribe();
+				topicUnsubscribers.clear();
+				void activeSink.close("normal").catch(() => {});
+			};
+			const teardownTopic = (topicId: string) => {
+				const unsubscribe = topicUnsubscribers.get(topicId);
+				if (!unsubscribe) return;
+				topicUnsubscribers.delete(topicId);
+				unsubscribe();
+				if (topicUnsubscribers.size === 0) close();
+			};
+			const subscribeTopic = async (
+				topic: ValidatedTopic,
+				baseContext: any,
+			) => {
+				if (closed) throw new Error("Realtime session is closed");
+				if (topicUnsubscribers.has(topic.id)) {
+					throw new Error("Topic id is already subscribed");
+				}
+				const topicContext =
+					topic.locale && topic.locale !== baseContext.locale
+						? { ...baseContext, locale: topic.locale }
+						: baseContext;
+				const accessKey = await resolveRealtimeAccessKey(
+					edgeSessionId,
+					topicContext,
+					topic.accessCacheKey,
+				);
+				const unsubscribe = refreshScheduler.subscribe({
+					key: schedulerKey(topic, accessKey),
+					topicId: topic.id,
+					topics: {
+						resourceType: topic.resourceType,
+						resource: topic.resource,
+						operation: topic.operation,
+						where: topic.where,
+						with: topic.with,
+					},
+					sinceSeq: topic.sinceSeq,
+					compute: () =>
+						limitSnapshotConcurrency(async () => {
+							const admitted = await evaluateTopicAccess(
+								app,
+								topic,
+								topicContext,
+							);
+							return computeRealtimeSnapshot(admitted, topicContext);
+						}),
+					onFrame: async (frame) => {
+						if (frame.byteLength > admission.maxBufferedSnapshotBytes) {
+							teardownTopic(topic.id);
+							return;
+						}
+						await activeSink.write(frame, "latest-snapshot");
+					},
+					onError: (error) => {
+						if (
+							isPermanentAccessError(error) ||
+							error instanceof RealtimeSnapshotBufferOverflowError
+						) {
+							teardownTopic(topic.id);
+						}
+					},
+					onTransportError: close,
+				});
+				topicUnsubscribers.set(topic.id, unsubscribe);
+			};
+
+			const originalIdentity = realtimeControlIdentity(resolved.appContext);
+			unregisterControl = getRealtimeSseControlRegistry<any>(app).register(
+				edgeSessionId,
+				controlToken,
+				async (frames, controlContext) => {
+					if (closed) throw new Error("Realtime session is closed");
+					if (realtimeControlIdentity(controlContext) !== originalIdentity) {
+						close();
+						throw new Error("Realtime session identity changed");
+					}
+					for (const frame of frames) {
+						if (frame.type === "remove_topic") {
+							teardownTopic(frame.topicId);
+							continue;
+						}
+						if (frame.type !== "add_topic") {
+							throw new Error("Unknown realtime control frame");
+						}
+						if (topicUnsubscribers.size >= admission.maxTopicsPerConnection) {
+							throw new Error(
+								`Connection accepts at most ${admission.maxTopicsPerConnection} topics`,
+							);
+						}
+						const rawTopic = {
+							...frame.topic,
+							...(frame.topic.resourceType === "collection" &&
+							frame.topic.operation === "get"
+								? { recordId: frame.topic.id }
+								: {}),
+							id: frame.topicId,
+							sinceSeq: frame.sinceSeq,
+						} as TopicInput;
+						const topic = await resolveIncrementalTopic(
+							app,
+							rawTopic,
+							controlContext,
+							admission,
+						);
+						await subscribeTopic(topic, controlContext);
+					}
+				},
+			);
+			for (const topic of validatedTopicsById.values()) {
+				await subscribeTopic(topic, resolved.appContext);
+			}
+
+			return Response.json(
+				{
+					transport: "shared-provider",
+					sessionId: edgeSessionId,
+					token: controlToken,
+					channel: activeSink.clientChannel,
+					...(topicErrors.length ? { errors: topicErrors } : {}),
+				},
+				{ headers: { "Cache-Control": "no-store" } },
+			);
+		} catch (error) {
+			if (!closed) releaseConnection();
+			unregisterControl();
+			for (const unsubscribe of topicUnsubscribers.values()) unsubscribe();
+			if (sink) void sink.close("transport_error").catch(() => {});
+			return errorResponse(error, request, resolved.appContext.locale);
+		}
 	}
 
 	// Create SSE stream

--- a/packages/questpie/src/server/modules/core/integrated/realtime/pusher-transport.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/pusher-transport.ts
@@ -279,7 +279,7 @@ class PusherSessionSink implements ClientSink {
 
 	constructor(
 		readonly sessionId: string,
-		private readonly channel: string,
+		readonly clientChannel: string,
 		private readonly provider: PusherProvider,
 		private readonly onError: (error: unknown) => void,
 		private readonly onClose: () => void,
@@ -299,7 +299,7 @@ class PusherSessionSink implements ClientSink {
 				this.queued = false;
 				if (this.closed) return;
 				void this.provider
-					.trigger(this.channel, "questpie:invalidate", {
+					.trigger(this.clientChannel, "questpie:invalidate", {
 						sessionId: this.sessionId,
 					})
 					.catch(this.onError);

--- a/packages/questpie/src/server/modules/core/integrated/realtime/transport.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/transport.ts
@@ -48,6 +48,8 @@ export type ClientCloseReason =
 
 export interface ClientSink {
 	readonly sessionId: string;
+	/** Provider-private channel returned only for managed client transports. */
+	readonly clientChannel?: string;
 	write(frame: Uint8Array, delivery: DeliveryClass): Promise<SinkWriteResult>;
 	close(reason: ClientCloseReason): Promise<void>;
 }

--- a/packages/questpie/test/client/client-auth-headers.test.ts
+++ b/packages/questpie/test/client/client-auth-headers.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, describe, expect, it } from "bun:test";
+
+import { createClient } from "../../src/client/index.js";
+
+async function waitFor(assertion: () => boolean, timeoutMs = 3000) {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (assertion()) return;
+		await new Promise((resolve) => setTimeout(resolve, 10));
+	}
+	throw new Error("Timed out waiting for assertion");
+}
+
+describe("client dynamic auth headers", () => {
+	const originalFetch = globalThis.fetch;
+	const originalXMLHttpRequest = globalThis.XMLHttpRequest;
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+		globalThis.XMLHttpRequest = originalXMLHttpRequest;
+	});
+
+	it("resolves fresh auth headers for every data request", async () => {
+		const authorizationHeaders: Array<string | null> = [];
+		let token = 0;
+		const client = createClient<any>({
+			baseURL: "http://localhost:3000",
+			headers: { Authorization: "Bearer static" },
+			getAuthHeaders: async () => ({
+				Authorization: `Bearer data-${++token}`,
+			}),
+			fetch: async (_input, init) => {
+				authorizationHeaders.push(
+					new Headers(init?.headers).get("Authorization"),
+				);
+				return Response.json({ docs: [], totalDocs: 0 });
+			},
+		});
+
+		await client.collections.posts.find();
+		await client.collections.posts.find();
+
+		expect(authorizationHeaders).toEqual(["Bearer data-1", "Bearer data-2"]);
+	});
+
+	it("resolves fresh auth headers for every upload while retaining cookies", async () => {
+		const requests: Array<{
+			headers: Record<string, string>;
+			withCredentials: boolean;
+		}> = [];
+
+		class FakeXMLHttpRequest extends EventTarget {
+			upload = new EventTarget();
+			status = 200;
+			responseText = JSON.stringify({ ok: true });
+			withCredentials = false;
+			private headers: Record<string, string> = {};
+
+			open() {}
+
+			setRequestHeader(name: string, value: string) {
+				this.headers[name] = value;
+			}
+
+			send() {
+				requests.push({
+					headers: { ...this.headers },
+					withCredentials: this.withCredentials,
+				});
+				queueMicrotask(() => this.dispatchEvent(new Event("load")));
+			}
+
+			abort() {
+				this.dispatchEvent(new Event("abort"));
+			}
+		}
+
+		globalThis.XMLHttpRequest =
+			FakeXMLHttpRequest as unknown as typeof XMLHttpRequest;
+
+		const file = new File(["image"], "photo.jpg", { type: "image/jpeg" });
+		const cookieClient = createClient<any>({
+			baseURL: "http://localhost:3000",
+		});
+		await cookieClient.collections.assets.upload(file);
+
+		let token = 0;
+		const client = createClient<any>({
+			baseURL: "http://localhost:3000",
+			getAuthHeaders: () => ({
+				Authorization: `Bearer upload-${++token}`,
+			}),
+		});
+		await client.collections.assets.upload(file);
+		await client.collections.assets.upload(file);
+
+		expect(requests).toEqual([
+			{
+				headers: {},
+				withCredentials: true,
+			},
+			{
+				headers: { Authorization: "Bearer upload-1" },
+				withCredentials: true,
+			},
+			{
+				headers: { Authorization: "Bearer upload-2" },
+				withCredentials: true,
+			},
+		]);
+	});
+
+	it("resolves fresh auth headers for every realtime connection", async () => {
+		const requests: Array<{
+			authorization: string | null;
+			credentials: RequestCredentials | undefined;
+		}> = [];
+
+		globalThis.fetch = (async (_input, init) => {
+			let controller!: ReadableStreamDefaultController<Uint8Array>;
+			const body = new ReadableStream<Uint8Array>({
+				start(streamController) {
+					controller = streamController;
+				},
+			});
+			init?.signal?.addEventListener("abort", () => controller.close());
+			requests.push({
+				authorization: new Headers(init?.headers).get("Authorization"),
+				credentials: init?.credentials,
+			});
+			return new Response(body, {
+				status: 200,
+				headers: { "Content-Type": "text/event-stream" },
+			});
+		}) as typeof fetch;
+
+		let token = 0;
+		const client = createClient<any>({
+			baseURL: "http://localhost:3000",
+			getAuthHeaders: () => ({
+				Authorization: `Bearer realtime-${++token}`,
+			}),
+		});
+
+		const stopFirst = client.collections.posts.live({}, () => {});
+		await waitFor(() => requests.length === 1);
+		stopFirst();
+		await waitFor(() => client.realtime.topicCount === 0);
+
+		const stopSecond = client.collections.posts.live({}, () => {});
+		await waitFor(() => requests.length === 2);
+		stopSecond();
+		client.realtime.destroy();
+
+		expect(requests).toEqual([
+			{
+				authorization: "Bearer realtime-1",
+				credentials: "include",
+			},
+			{
+				authorization: "Bearer realtime-2",
+				credentials: "include",
+			},
+		]);
+	});
+});

--- a/packages/questpie/test/client/client-auth-headers.test.ts
+++ b/packages/questpie/test/client/client-auth-headers.test.ts
@@ -110,7 +110,7 @@ describe("client dynamic auth headers", () => {
 		]);
 	});
 
-	it("resolves fresh auth headers for every realtime connection", async () => {
+	it("resolves fresh auth headers for realtime discovery and every connection", async () => {
 		const requests: Array<{
 			authorization: string | null;
 			credentials: RequestCredentials | undefined;
@@ -143,12 +143,13 @@ describe("client dynamic auth headers", () => {
 		});
 
 		const stopFirst = client.collections.posts.live({}, () => {});
-		await waitFor(() => requests.length === 1);
+		await waitFor(() => requests.length === 2);
 		stopFirst();
 		await waitFor(() => client.realtime.topicCount === 0);
+		client.realtime.destroy();
 
 		const stopSecond = client.collections.posts.live({}, () => {});
-		await waitFor(() => requests.length === 2);
+		await waitFor(() => requests.length === 4);
 		stopSecond();
 		client.realtime.destroy();
 
@@ -159,6 +160,14 @@ describe("client dynamic auth headers", () => {
 			},
 			{
 				authorization: "Bearer realtime-2",
+				credentials: "include",
+			},
+			{
+				authorization: "Bearer realtime-3",
+				credentials: "include",
+			},
+			{
+				authorization: "Bearer realtime-4",
 				credentials: "include",
 			},
 		]);

--- a/packages/questpie/test/client/client-pusher-realtime.test.ts
+++ b/packages/questpie/test/client/client-pusher-realtime.test.ts
@@ -1,0 +1,189 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+type FakePusherOptions = {
+	channelAuthorization: {
+		customHandler: (
+			input: { socketId: string; channelName: string },
+			callback: (error: Error | null, auth: unknown) => void,
+		) => void;
+	};
+};
+
+class FakeChannel {
+	private listeners = new Map<string, Set<(data: unknown) => void>>();
+
+	bind(event: string, callback: (data: unknown) => void): this {
+		const listeners = this.listeners.get(event) ?? new Set();
+		listeners.add(callback);
+		this.listeners.set(event, listeners);
+		return this;
+	}
+
+	unbind(event?: string, callback?: (data: unknown) => void): this {
+		if (!event) this.listeners.clear();
+		else if (!callback) this.listeners.delete(event);
+		else this.listeners.get(event)?.delete(callback);
+		return this;
+	}
+
+	emit(event: string, data: unknown): void {
+		for (const callback of this.listeners.get(event) ?? []) callback(data);
+	}
+}
+
+class FakePusher {
+	static instances: FakePusher[] = [];
+	readonly channel = new FakeChannel();
+	disconnected = false;
+
+	constructor(
+		readonly key: string,
+		readonly options: FakePusherOptions,
+	) {
+		FakePusher.instances.push(this);
+	}
+
+	subscribe(channelName: string): FakeChannel {
+		this.options.channelAuthorization.customHandler(
+			{ socketId: "123.456", channelName },
+			(error) => {
+				if (error) throw error;
+			},
+		);
+		return this.channel;
+	}
+
+	unsubscribe(): void {}
+
+	disconnect(): void {
+		this.disconnected = true;
+	}
+}
+
+mock.module("pusher-js", () => ({ default: FakePusher }));
+
+import { createClient } from "../../src/client/index.js";
+
+async function waitFor(
+	assertion: () => boolean,
+	timeoutMs = 3000,
+): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (assertion()) return;
+		await new Promise((resolve) => setTimeout(resolve, 10));
+	}
+	throw new Error("Timed out waiting for assertion");
+}
+
+describe("Pusher realtime client transport", () => {
+	let requests: Array<{ url: string; init?: RequestInit }>;
+	let snapshotVersion: number;
+	let authVersion: number;
+
+	beforeEach(() => {
+		requests = [];
+		snapshotVersion = 0;
+		authVersion = 0;
+		FakePusher.instances = [];
+	});
+
+	afterEach(() => {
+		mock.restore();
+	});
+
+	test("keeps collections.live transport-agnostic and refetches on private invalidation", async () => {
+		const fetcher: typeof fetch = async (input, init) => {
+			const url = String(input);
+			requests.push({ url, init });
+			expect(new Headers(init?.headers).get("Authorization")).toMatch(
+				/^Bearer token-/,
+			);
+			if (url.endsWith("/realtime/config")) {
+				return Response.json({
+					transport: "shared-provider",
+					config: {
+						provider: "pusher",
+						key: "public-key",
+						cluster: "eu",
+						authEndpoint: "realtime/auth",
+					},
+				});
+			}
+			if (url.endsWith("/realtime/auth")) {
+				expect(init?.headers).toMatchObject({
+					Authorization: expect.stringMatching(/^Bearer token-/),
+					"Content-Type": "application/x-www-form-urlencoded",
+				});
+				return Response.json({ auth: "signed" });
+			}
+			if (url.endsWith("/realtime") && init?.method === "POST") {
+				const body = JSON.parse(String(init.body));
+				if (body.transport === "shared-provider") {
+					return Response.json({
+						transport: "shared-provider",
+						sessionId: "session-1",
+						token: "control-1",
+						channel: "private-questpie-rt-session-1",
+					});
+				}
+				return new Response(null, { status: 204 });
+			}
+			if (url.startsWith("http://localhost:3000/posts")) {
+				snapshotVersion += 1;
+				return Response.json({
+					docs: [{ id: String(snapshotVersion) }],
+					totalDocs: 1,
+				});
+			}
+			throw new Error(`Unexpected request: ${url}`);
+		};
+		const client = createClient<any>({
+			baseURL: "http://localhost:3000",
+			fetch: fetcher,
+			getAuthHeaders: () => ({
+				Authorization: `Bearer token-${++authVersion}`,
+			}),
+		});
+		const snapshots: unknown[] = [];
+		const errors: Error[] = [];
+		const stop = client.collections.posts.live(
+			{ where: { published: true } },
+			(snapshot) => snapshots.push(snapshot),
+			{ onError: (error) => errors.push(error) },
+		);
+
+		await waitFor(
+			() => snapshots.length === 1 && FakePusher.instances.length === 1,
+		);
+		expect(FakePusher.instances[0].key).toBe("public-key");
+		expect(snapshots[0]).toEqual({
+			docs: [{ id: "1" }],
+			totalDocs: 1,
+		});
+		expect(errors).toHaveLength(0);
+
+		FakePusher.instances[0].channel.emit("questpie:invalidate", {
+			sessionId: "session-1",
+		});
+		await waitFor(() => snapshots.length === 2);
+		expect(snapshots[1]).toEqual({
+			docs: [{ id: "2" }],
+			totalDocs: 1,
+		});
+
+		stop();
+		await waitFor(() =>
+			requests.some(({ url, init }) => {
+				if (!url.endsWith("/realtime") || init?.method !== "POST") return false;
+				const body = JSON.parse(String(init.body));
+				return body.frames?.some(
+					(frame: { type: string }) => frame.type === "remove_topic",
+				);
+			}),
+		);
+		client.realtime.destroy();
+		expect(FakePusher.instances[0].disconnected).toBe(true);
+		expect(authVersion).toBeGreaterThanOrEqual(4);
+	});
+});

--- a/packages/questpie/test/integration/realtime-pusher-routes.test.ts
+++ b/packages/questpie/test/integration/realtime-pusher-routes.test.ts
@@ -1,11 +1,13 @@
 import { afterEach, describe, expect, test } from "bun:test";
 
 import { createFetchHandler } from "../../src/server/adapters/http.js";
+import { collection } from "../../src/server/collection/builder/collection-builder.js";
 import {
 	PusherClientTransport,
 	type PusherProvider,
 } from "../../src/server/modules/core/integrated/realtime/pusher-transport.js";
 import { buildMockApp } from "../utils/mocks/mock-app-builder";
+import { runTestDbMigrations } from "../utils/test-db.js";
 
 const provider: PusherProvider = {
 	trigger: async () => {},
@@ -98,5 +100,98 @@ describe("pusher transport module routes", () => {
 
 		expect(response.status).toBe(403);
 		expect(response.headers.get("cache-control")).toBe("no-store");
+	});
+
+	test("bootstraps and tears down a private provider live-query session", async () => {
+		const authorizedChannels: string[] = [];
+		const sessionProvider: PusherProvider = {
+			...provider,
+			authorizeChannel: (socketId, channel) => {
+				authorizedChannels.push(channel);
+				return { auth: `${socketId}:${channel}` };
+			},
+		};
+		const transport = new PusherClientTransport({
+			provider: sessionProvider,
+			key: "public-key",
+			identityKey: "test-secret",
+		});
+		setup = await buildMockApp(
+			{
+				collections: {
+					posts: collection("posts")
+						.fields(({ f }) => ({
+							title: f.text().required(),
+						}))
+						.access({ read: true }),
+				},
+			},
+			{ realtime: { clientTransport: transport, retentionDays: 0 } },
+		);
+		await runTestDbMigrations(setup.app);
+		const handler = createFetchHandler(setup.app);
+		const sessionResponse = await handler(
+			new Request("http://localhost/realtime", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({
+					transport: "shared-provider",
+					topics: [
+						{
+							id: "posts-topic",
+							resourceType: "collection",
+							resource: "posts",
+							operation: "find",
+						},
+					],
+				}),
+			}),
+		);
+		expect(sessionResponse.status).toBe(200);
+		expect(sessionResponse.headers.get("content-type")).toContain(
+			"application/json",
+		);
+		const session = (await sessionResponse.json()) as {
+			sessionId: string;
+			token: string;
+			channel: string;
+		};
+		expect(session.channel).toMatch(/^private-questpie-rt-/);
+
+		const auth = new URLSearchParams({
+			socket_id: "123.456",
+			channel_name: session.channel,
+		});
+		const authResponse = await handler(
+			new Request("http://localhost/realtime/auth", {
+				method: "POST",
+				headers: { "Content-Type": "application/x-www-form-urlencoded" },
+				body: auth,
+			}),
+		);
+		expect(authResponse.status).toBe(200);
+		expect(authorizedChannels).toEqual([session.channel]);
+
+		const removeResponse = await handler(
+			new Request("http://localhost/realtime", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({
+					sessionId: session.sessionId,
+					token: session.token,
+					frames: [{ type: "remove_topic", topicId: "posts-topic" }],
+				}),
+			}),
+		);
+		expect(removeResponse.status).toBe(204);
+
+		const staleAuthResponse = await handler(
+			new Request("http://localhost/realtime/auth", {
+				method: "POST",
+				headers: { "Content-Type": "application/x-www-form-urlencoded" },
+				body: auth,
+			}),
+		);
+		expect(staleAuthResponse.status).toBe(403);
 	});
 });


### PR DESCRIPTION
## Summary
- select SSE or managed Pusher at runtime through the existing typed `createClient` live-query API
- lazy-load `pusher-js`, authenticate private per-session channels with fresh shared auth headers, and heal invalidations/reconnects through authorized CRUD refetches
- bootstrap and tear down provider live-query sessions through the existing realtime route while preserving admission, ACL, refresh sharing, and control frames

This is stacked on #156. It also contains the already-reviewed dynamic-auth dependency from #141 until that stack is merged.

## Verification
- `cd packages/questpie && bun test test/ --test-name-pattern "client|transport"` — 66 pass, 2 gated Soketi skips, 0 fail
- focused Pusher client/server/auth lifecycle — 7 pass, 0 fail
- `cd packages/questpie && bun run check-types` (includes `tsconfig.fullapp.json` DB NoAny gate)
- `cd packages/questpie && bun run build`
- oxlint: 0 errors; oxfmt check: green