### PR TITLE
feat(channels): add typed client subscriptions

### DIFF
--- a/.changeset/add-typed-channel-client.md
+++ b/.changeset/add-typed-channel-client.md
@@ -1,0 +1,6 @@
+---
+"questpie": patch
+"@questpie/tanstack-query": patch
+---
+
+Add typed framework-channel subscribe, publish, presence, and async iteration clients for SSE and managed Pusher transports, plus TanStack Query subscription option factories.

--- a/packages/questpie/src/client/channels/index.ts
+++ b/packages/questpie/src/client/channels/index.ts
@@ -1,0 +1,296 @@
+import type { ChannelDefinitions } from "#questpie/server/channels/channel-builder.js";
+
+import type { GetAuthHeaders } from "../auth.js";
+import type { PusherRealtimeConfig } from "../realtime/pusher.js";
+import { PusherChannelTransport } from "./pusher.js";
+import { SseChannelTransport } from "./sse.js";
+import {
+	resolveChannelClientName,
+	type ChannelClientDescriptor,
+	type ChannelClientTransport,
+	type ChannelClientTransportConfig,
+	type ChannelConnectionInput,
+	type ChannelPublishReceipt,
+	type ChannelsClient,
+	type ChannelSubscribeOptions,
+	type ChannelTransportMessage,
+} from "./types.js";
+
+export type {
+	ChannelClient,
+	ChannelClientDescriptor,
+	ChannelMessage,
+	ChannelPublishInput,
+	ChannelPublishReceipt,
+	ChannelsClient,
+	ChannelSubscribeOptions,
+} from "./types.js";
+
+function normalizedError(error: unknown): Error {
+	return error instanceof Error ? error : new Error(String(error));
+}
+
+async function* channelIterator<TMessage>(
+	subscribe: (
+		callback: (message: TMessage) => void,
+		onError: (error: Error) => void,
+	) => Promise<() => void>,
+	signal?: AbortSignal,
+): AsyncGenerator<TMessage, void, unknown> {
+	if (signal?.aborted) return;
+	const queue: TMessage[] = [];
+	let resolveNext: (() => void) | undefined;
+	let rejectNext: ((error: Error) => void) | undefined;
+	let closed = false;
+	const stop = await subscribe(
+		(message) => {
+			queue.push(message);
+			resolveNext?.();
+		},
+		(error) => rejectNext?.(error),
+	);
+	const abort = () => {
+		closed = true;
+		resolveNext?.();
+	};
+	signal?.addEventListener("abort", abort, { once: true });
+	try {
+		while (true) {
+			if (closed || signal?.aborted) break;
+			while (queue.length) yield queue.shift()!;
+			if (closed || signal?.aborted) break;
+			await new Promise<void>((resolve, reject) => {
+				resolveNext = resolve;
+				rejectNext = reject;
+			});
+			resolveNext = undefined;
+			rejectNext = undefined;
+		}
+	} finally {
+		signal?.removeEventListener("abort", abort);
+		stop();
+	}
+}
+
+/** Build the typed framework-channel surface attached to the main client. */
+export function createChannelsAPI<
+	TChannels extends ChannelDefinitions,
+>(options: {
+	baseUrl: string;
+	withCredentials: boolean;
+	fetcher: typeof fetch;
+	getAuthHeaders?: GetAuthHeaders;
+}): ChannelsClient<TChannels> {
+	let transport: ChannelClientTransport | null = null;
+	let config: ChannelClientTransportConfig | null = null;
+	let transportPromise: Promise<ChannelClientTransport> | null = null;
+	let generation = 0;
+	const handles = new Map<string, object>();
+	const pending = new Set<object>();
+
+	const getTransport = async (): Promise<ChannelClientTransport> => {
+		if (transport) return transport;
+		if (!transportPromise) {
+			const selectedGeneration = generation;
+			transportPromise = (async () => {
+				const authHeaders = await options.getAuthHeaders?.();
+				const response = await options.fetcher(
+					`${options.baseUrl}/channels/config`,
+					{
+						headers: authHeaders,
+						credentials: options.withCredentials ? "include" : "omit",
+					},
+				);
+				if (!response.ok) {
+					throw new Error(`Channel config failed: ${response.status}`);
+				}
+				const selected =
+					(await response.json()) as ChannelClientTransportConfig;
+				if (!selected.channels || typeof selected.channels !== "object") {
+					throw new Error("Invalid channel client config");
+				}
+				config = selected;
+				if (
+					selected.transport === "shared-provider" &&
+					selected.config.provider === "pusher" &&
+					typeof selected.config.key === "string"
+				) {
+					return new PusherChannelTransport({
+						baseUrl: options.baseUrl,
+						fetcher: options.fetcher,
+						getAuthHeaders: options.getAuthHeaders,
+						config: selected.config as PusherRealtimeConfig,
+					});
+				}
+				if (selected.transport !== "sse") {
+					throw new Error("Unsupported channel client transport");
+				}
+				return new SseChannelTransport(options);
+			})()
+				.then((selected) => {
+					if (selectedGeneration !== generation) selected.destroy();
+					else transport = selected;
+					return selected;
+				})
+				.catch((error) => {
+					if (selectedGeneration === generation) {
+						transportPromise = null;
+						config = null;
+					}
+					throw error;
+				});
+		}
+		return transportPromise;
+	};
+
+	const connectionInput = (
+		registryKey: string,
+		descriptor: ChannelClientDescriptor,
+		params: Record<string, string>,
+	): ChannelConnectionInput => ({
+		registryKey,
+		params,
+		resolvedName: resolveChannelClientName(descriptor, params),
+		visibility: descriptor.visibility,
+	});
+
+	const descriptorFor = (registryKey: string): ChannelClientDescriptor => {
+		const descriptor = config?.channels[registryKey];
+		if (!descriptor) throw new Error(`Unknown channel "${registryKey}"`);
+		return descriptor;
+	};
+
+	const getHandle = (registryKey: string) => {
+		let handle = handles.get(registryKey);
+		if (handle) return handle;
+		handle = {
+			subscribe: (...args: unknown[]) => {
+				const hasParams = typeof args[0] !== "function";
+				const params = (hasParams ? args[0] : {}) as Record<string, string>;
+				const callback = (hasParams ? args[1] : args[0]) as (
+					message: ChannelTransportMessage,
+				) => void;
+				const subscribeOptions = (hasParams ? args[2] : args[1]) as
+					| ChannelSubscribeOptions
+					| undefined;
+				const marker = {};
+				const subscriptionGeneration = generation;
+				pending.add(marker);
+				let stopped = false;
+				let stopInner: (() => void) | undefined;
+				void getTransport()
+					.then((selected) => {
+						pending.delete(marker);
+						if (stopped || subscriptionGeneration !== generation) return;
+						const descriptor = descriptorFor(registryKey);
+						stopInner = selected.subscribe(
+							connectionInput(registryKey, descriptor, params),
+							callback,
+							subscribeOptions,
+						);
+					})
+					.catch((error) => {
+						pending.delete(marker);
+						subscribeOptions?.onError?.(normalizedError(error));
+					});
+				return () => {
+					stopped = true;
+					pending.delete(marker);
+					stopInner?.();
+				};
+			},
+			publish: async (input: Record<string, unknown>) => {
+				await getTransport();
+				descriptorFor(registryKey);
+				const authHeaders = await options.getAuthHeaders?.();
+				const response = await options.fetcher(
+					`${options.baseUrl}/channels/publish`,
+					{
+						method: "POST",
+						headers: { "Content-Type": "application/json", ...authHeaders },
+						body: JSON.stringify({
+							channel: registryKey,
+							params: input.params ?? {},
+							event: input.event,
+							data: input.data,
+						}),
+						credentials: options.withCredentials ? "include" : "omit",
+					},
+				);
+				if (!response.ok) {
+					throw new Error(`Channel publish failed: ${response.status}`);
+				}
+				const receipt =
+					(await response.json()) as Partial<ChannelPublishReceipt>;
+				if (typeof receipt.eventId !== "string") {
+					throw new Error("Invalid channel publish receipt");
+				}
+				return { eventId: receipt.eventId };
+			},
+			iter: (...args: unknown[]) => {
+				const last = args.at(-1) as ChannelSubscribeOptions | undefined;
+				const signal =
+					last?.signal && typeof last.signal.addEventListener === "function"
+						? last.signal
+						: undefined;
+				return channelIterator<ChannelTransportMessage>(
+					async (callback, onError) => {
+						await getTransport();
+						const hasParams = descriptorFor(registryKey).pattern.includes("[");
+						const params = (hasParams ? args[0] : {}) as Record<string, string>;
+						const iterOptions = (hasParams ? args[1] : args[0]) as
+							| ChannelSubscribeOptions
+							| undefined;
+						return (
+							handle as { subscribe: (...args: unknown[]) => () => void }
+						).subscribe(...(hasParams ? [params] : []), callback, {
+							...iterOptions,
+							onError,
+						});
+					},
+					signal,
+				);
+			},
+			presence: async (...args: unknown[]) => {
+				const selected = await getTransport();
+				const descriptor = descriptorFor(registryKey);
+				const hasParams = descriptor.pattern.includes("[");
+				const params = (hasParams ? args[0] : {}) as Record<string, string>;
+				const presenceOptions = (hasParams ? args[1] : args[0]) as
+					| ChannelSubscribeOptions
+					| undefined;
+				return selected.presence(
+					connectionInput(registryKey, descriptor, params),
+					presenceOptions,
+				);
+			},
+		};
+		handles.set(registryKey, handle);
+		return handle;
+	};
+
+	const control = {
+		destroy() {
+			generation += 1;
+			pending.clear();
+			transport?.destroy();
+			transport = null;
+			transportPromise = null;
+			config = null;
+		},
+		get channelCount() {
+			return transport?.channelCount ?? pending.size;
+		},
+		get subscriberCount() {
+			return transport?.subscriberCount ?? pending.size;
+		},
+	};
+
+	return new Proxy(control, {
+		get(target, property, receiver) {
+			if (property in target) return Reflect.get(target, property, receiver);
+			if (typeof property !== "string") return undefined;
+			return getHandle(property);
+		},
+	}) as ChannelsClient<TChannels>;
+}

--- a/packages/questpie/src/client/channels/pusher.ts
+++ b/packages/questpie/src/client/channels/pusher.ts
@@ -1,0 +1,327 @@
+import type { GetAuthHeaders } from "../auth.js";
+import type { PusherModule, PusherRealtimeConfig } from "../realtime/pusher.js";
+import type {
+	ChannelClientTransport,
+	ChannelConnectionInput,
+	ChannelSubscribeOptions,
+	ChannelTransportMessage,
+} from "./types.js";
+
+type ProviderChannel = {
+	bind(event: string, callback: (data: unknown) => void): ProviderChannel;
+	unbind(): ProviderChannel;
+	members?: {
+		each(callback: (member: { info?: unknown }) => void): void;
+	};
+};
+
+type Entry = {
+	input: ChannelConnectionInput;
+	channel: ProviderChannel | null;
+	subscribers: Set<(message: ChannelTransportMessage) => void>;
+	errorCallbacks: Set<(error: Error) => void>;
+	presence?: readonly unknown[];
+	presenceWaiters: Set<{
+		resolve: (members: readonly unknown[]) => void;
+		reject: (error: Error) => void;
+	}>;
+};
+
+type AuthResponse = {
+	auth: string;
+	channel_data?: string;
+	shared_secret?: string;
+};
+
+function normalizedError(error: unknown): Error {
+	return error instanceof Error ? error : new Error(String(error));
+}
+
+function collectMembers(value: unknown, channel: ProviderChannel): unknown[] {
+	const members: unknown[] = [];
+	const source =
+		value && typeof value === "object" && "each" in value
+			? (value as ProviderChannel["members"])
+			: channel.members;
+	source?.each((member) => members.push(member.info ?? member));
+	return members;
+}
+
+/** Native ordered framework-channel subscriptions over managed Pusher/Soketi. */
+export class PusherChannelTransport implements ChannelClientTransport {
+	private readonly entries = new Map<string, Entry>();
+	private pusher: InstanceType<PusherModule["default"]> | null = null;
+	private pusherPromise: Promise<InstanceType<PusherModule["default"]>> | null =
+		null;
+	private destroyed = false;
+
+	constructor(
+		private readonly options: {
+			baseUrl: string;
+			fetcher: typeof fetch;
+			getAuthHeaders?: GetAuthHeaders;
+			config: PusherRealtimeConfig;
+			loadPusher?: () => Promise<PusherModule>;
+		},
+	) {}
+
+	subscribe(
+		input: ChannelConnectionInput,
+		callback: (message: ChannelTransportMessage) => void,
+		options: ChannelSubscribeOptions = {},
+	): () => void {
+		let entry = this.entries.get(input.resolvedName);
+		if (!entry) {
+			entry = {
+				input,
+				channel: null,
+				subscribers: new Set(),
+				errorCallbacks: new Set(),
+				presenceWaiters: new Set(),
+			};
+			this.entries.set(input.resolvedName, entry);
+			void this.mount(entry);
+		}
+		entry.subscribers.add(callback);
+		if (options.onError) entry.errorCallbacks.add(options.onError);
+
+		let stopped = false;
+		const stop = () => {
+			if (stopped) return;
+			stopped = true;
+			options.signal?.removeEventListener("abort", stop);
+			const current = this.entries.get(input.resolvedName);
+			if (!current) return;
+			current.subscribers.delete(callback);
+			if (options.onError) current.errorCallbacks.delete(options.onError);
+			if (current.subscribers.size > 0 || current.presenceWaiters.size > 0)
+				return;
+			this.unmount(input.resolvedName, current);
+		};
+		options.signal?.addEventListener("abort", stop, { once: true });
+		if (options.signal?.aborted) stop();
+		return stop;
+	}
+
+	async presence(
+		input: ChannelConnectionInput,
+		options: ChannelSubscribeOptions = {},
+	): Promise<readonly unknown[]> {
+		if (options.signal?.aborted) {
+			throw new Error("Channel presence aborted");
+		}
+		if (input.visibility !== "presence") {
+			throw new Error("Channel does not expose presence");
+		}
+		const stop = this.subscribe(input, () => {}, options);
+		const entry = this.entries.get(input.resolvedName)!;
+		if (entry.presence) {
+			stop();
+			return entry.presence;
+		}
+		return new Promise<readonly unknown[]>((resolve, reject) => {
+			const abort = () => waiter.reject(new Error("Channel presence aborted"));
+			const waiter = {
+				resolve: (members: readonly unknown[]) => {
+					options.signal?.removeEventListener("abort", abort);
+					stop();
+					resolve(members);
+				},
+				reject: (error: Error) => {
+					options.signal?.removeEventListener("abort", abort);
+					stop();
+					reject(error);
+				},
+			};
+			entry.presenceWaiters.add(waiter);
+			options.signal?.addEventListener("abort", abort, { once: true });
+		});
+	}
+
+	private async getPusher(): Promise<InstanceType<PusherModule["default"]>> {
+		if (this.pusher) return this.pusher;
+		if (!this.pusherPromise) {
+			this.pusherPromise = (async () => {
+				const module = await (this.options.loadPusher?.() ??
+					import("pusher-js"));
+				if (this.destroyed) throw new Error("Channel transport is destroyed");
+				const config = this.options.config;
+				const pusher = new module.default(config.key, {
+					cluster: config.cluster ?? "mt1",
+					...(config.wsHost ? { wsHost: config.wsHost } : {}),
+					...(config.wsPort ? { wsPort: config.wsPort } : {}),
+					...(config.wssPort ? { wssPort: config.wssPort } : {}),
+					forceTLS: config.forceTLS ?? true,
+					channelAuthorization: {
+						customHandler: (request, callback) => {
+							void this.authorize(request.socketId, request.channelName)
+								.then((auth) => callback(null, auth))
+								.catch((error) => callback(normalizedError(error), null));
+						},
+					},
+				});
+				this.pusher = pusher;
+				return pusher;
+			})().catch((error) => {
+				this.pusherPromise = null;
+				throw error;
+			});
+		}
+		return this.pusherPromise;
+	}
+
+	private async authorize(
+		socketId: string,
+		channelName: string,
+	): Promise<AuthResponse> {
+		const entry = this.entries.get(channelName);
+		if (!entry) throw new Error("Unknown framework channel authorization");
+		const authHeaders = await this.options.getAuthHeaders?.();
+		const response = await this.options.fetcher(
+			`${this.options.baseUrl}/channels/auth`,
+			{
+				method: "POST",
+				headers: { "Content-Type": "application/json", ...authHeaders },
+				body: JSON.stringify({
+					socketId,
+					channelName,
+					channel: entry.input.registryKey,
+					params: entry.input.params,
+				}),
+				credentials: "include",
+			},
+		);
+		if (!response.ok)
+			throw new Error(`Channel auth failed: ${response.status}`);
+		const auth = (await response.json()) as Partial<AuthResponse>;
+		if (typeof auth.auth !== "string") {
+			throw new Error("Invalid channel auth response");
+		}
+		return {
+			auth: auth.auth,
+			...(typeof auth.channel_data === "string"
+				? { channel_data: auth.channel_data }
+				: {}),
+			...(typeof auth.shared_secret === "string"
+				? { shared_secret: auth.shared_secret }
+				: {}),
+		};
+	}
+
+	private async mount(entry: Entry): Promise<void> {
+		try {
+			const pusher = await this.getPusher();
+			if (
+				this.destroyed ||
+				this.entries.get(entry.input.resolvedName) !== entry
+			) {
+				if (this.entries.size === 0) {
+					pusher.disconnect();
+					this.pusher = null;
+					this.pusherPromise = null;
+				}
+				return;
+			}
+			const channel = pusher.subscribe(
+				entry.input.resolvedName,
+			) as ProviderChannel;
+			entry.channel = channel;
+			channel.bind("questpie:channel", (payload) =>
+				this.handleMessage(entry, payload),
+			);
+			channel.bind("pusher:subscription_error", (error) =>
+				this.notify(entry, normalizedError(error)),
+			);
+			channel.bind("pusher:subscription_succeeded", (members) => {
+				if (entry.input.visibility !== "presence") return;
+				this.setPresence(entry, collectMembers(members, channel));
+			});
+			const refreshPresence = () => {
+				if (entry.input.visibility === "presence") {
+					this.setPresence(entry, collectMembers(undefined, channel));
+				}
+			};
+			channel.bind("pusher:member_added", refreshPresence);
+			channel.bind("pusher:member_removed", refreshPresence);
+		} catch (error) {
+			this.notify(entry, normalizedError(error));
+		}
+	}
+
+	private handleMessage(entry: Entry, payload: unknown): void {
+		try {
+			if (!payload || typeof payload !== "object") {
+				throw new Error("Invalid channel provider payload");
+			}
+			const envelope = payload as { eventId?: unknown; data?: unknown };
+			const decoded =
+				typeof envelope.data === "string"
+					? (JSON.parse(envelope.data) as { event?: unknown; data?: unknown })
+					: (envelope.data as { event?: unknown; data?: unknown });
+			if (
+				typeof envelope.eventId !== "string" ||
+				!decoded ||
+				typeof decoded.event !== "string"
+			) {
+				throw new Error("Invalid channel provider payload");
+			}
+			for (const callback of entry.subscribers) {
+				callback({
+					event: decoded.event,
+					eventId: envelope.eventId,
+					data: decoded.data,
+				});
+			}
+		} catch (error) {
+			this.notify(entry, normalizedError(error));
+		}
+	}
+
+	private setPresence(entry: Entry, members: readonly unknown[]): void {
+		entry.presence = members;
+		const waiters = [...entry.presenceWaiters];
+		entry.presenceWaiters.clear();
+		for (const waiter of waiters) waiter.resolve(members);
+	}
+
+	private notify(entry: Entry, error: Error): void {
+		for (const callback of entry.errorCallbacks) callback(error);
+		const waiters = [...entry.presenceWaiters];
+		entry.presenceWaiters.clear();
+		for (const waiter of waiters) waiter.reject(error);
+	}
+
+	private unmount(name: string, entry: Entry): void {
+		entry.channel?.unbind();
+		this.pusher?.unsubscribe(name);
+		this.entries.delete(name);
+		if (this.entries.size === 0) {
+			this.pusher?.disconnect();
+			this.pusher = null;
+			this.pusherPromise = null;
+		}
+	}
+
+	destroy(): void {
+		if (this.destroyed) return;
+		this.destroyed = true;
+		for (const entry of this.entries.values()) {
+			entry.channel?.unbind();
+			this.notify(entry, new Error("Channel transport destroyed"));
+		}
+		this.entries.clear();
+		this.pusher?.disconnect();
+		this.pusher = null;
+		this.pusherPromise = null;
+	}
+
+	get channelCount(): number {
+		return this.entries.size;
+	}
+
+	get subscriberCount(): number {
+		let count = 0;
+		for (const entry of this.entries.values()) count += entry.subscribers.size;
+		return count;
+	}
+}

--- a/packages/questpie/src/client/channels/sse.ts
+++ b/packages/questpie/src/client/channels/sse.ts
@@ -1,0 +1,378 @@
+import type { GetAuthHeaders } from "../auth.js";
+import type {
+	ChannelClientTransport,
+	ChannelConnectionInput,
+	ChannelSubscribeOptions,
+	ChannelTransportMessage,
+} from "./types.js";
+
+type Entry = {
+	id: string;
+	input: ChannelConnectionInput;
+	subscribers: Set<(message: ChannelTransportMessage) => void>;
+	errorCallbacks: Set<(error: Error) => void>;
+	lastEventId?: string;
+	presence?: readonly unknown[];
+	presenceWaiters: Set<{
+		resolve: (members: readonly unknown[]) => void;
+		reject: (error: Error) => void;
+	}>;
+};
+
+type ControlFrame =
+	| {
+			type: "subscribe_channel";
+			subscriptionId: string;
+			channel: string;
+			params: Record<string, string>;
+			lastEventId?: string;
+	  }
+	| { type: "unsubscribe_channel"; subscriptionId: string };
+
+type SseEvent = { type: string; data: string };
+
+function channelId(input: ChannelConnectionInput): string {
+	return `channel:${input.resolvedName}`;
+}
+
+/** Multiplexed ordered-channel SSE client with durable last-event resume. */
+export class SseChannelTransport implements ChannelClientTransport {
+	private readonly entries = new Map<string, Entry>();
+	private abortController: AbortController | null = null;
+	private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+	private connecting = false;
+	private destroyed = false;
+	private reconnectPending = false;
+	private retryAttempt = 0;
+	private controlSession: { sessionId: string; token: string } | null = null;
+	private controlOperation: Promise<void> = Promise.resolve();
+
+	constructor(
+		private readonly options: {
+			baseUrl: string;
+			fetcher: typeof fetch;
+			getAuthHeaders?: GetAuthHeaders;
+			withCredentials: boolean;
+		},
+	) {}
+
+	subscribe(
+		input: ChannelConnectionInput,
+		callback: (message: ChannelTransportMessage) => void,
+		options: ChannelSubscribeOptions = {},
+	): () => void {
+		const id = channelId(input);
+		let entry = this.entries.get(input.resolvedName);
+		if (!entry) {
+			entry = {
+				id,
+				input,
+				subscribers: new Set(),
+				errorCallbacks: new Set(),
+				presenceWaiters: new Set(),
+			};
+			this.entries.set(input.resolvedName, entry);
+			this.applyTopology({
+				type: "subscribe_channel",
+				subscriptionId: id,
+				channel: input.registryKey,
+				params: input.params,
+			});
+		}
+		entry.subscribers.add(callback);
+		if (options.onError) entry.errorCallbacks.add(options.onError);
+
+		let stopped = false;
+		const stop = () => {
+			if (stopped) return;
+			stopped = true;
+			options.signal?.removeEventListener("abort", stop);
+			const current = this.entries.get(input.resolvedName);
+			if (!current) return;
+			current.subscribers.delete(callback);
+			if (options.onError) current.errorCallbacks.delete(options.onError);
+			if (current.subscribers.size > 0 || current.presenceWaiters.size > 0)
+				return;
+			this.entries.delete(input.resolvedName);
+			this.applyTopology({
+				type: "unsubscribe_channel",
+				subscriptionId: current.id,
+			});
+			if (this.entries.size === 0) this.abortController?.abort();
+		};
+		options.signal?.addEventListener("abort", stop, { once: true });
+		if (options.signal?.aborted) stop();
+		return stop;
+	}
+
+	async presence(
+		input: ChannelConnectionInput,
+		options: ChannelSubscribeOptions = {},
+	): Promise<readonly unknown[]> {
+		if (options.signal?.aborted) {
+			throw new Error("Channel presence aborted");
+		}
+		if (input.visibility !== "presence") {
+			throw new Error("Channel does not expose presence");
+		}
+		const noop = () => {};
+		const stop = this.subscribe(input, noop, options);
+		const entry = this.entries.get(input.resolvedName)!;
+		if (entry.presence) {
+			stop();
+			return entry.presence;
+		}
+		return new Promise<readonly unknown[]>((resolve, reject) => {
+			const abort = () => waiter.reject(new Error("Channel presence aborted"));
+			const waiter = {
+				resolve: (members: readonly unknown[]) => {
+					options.signal?.removeEventListener("abort", abort);
+					stop();
+					resolve(members);
+				},
+				reject: (error: Error) => {
+					options.signal?.removeEventListener("abort", abort);
+					stop();
+					reject(error);
+				},
+			};
+			entry.presenceWaiters.add(waiter);
+			options.signal?.addEventListener("abort", abort, { once: true });
+		});
+	}
+
+	private applyTopology(frame: ControlFrame): void {
+		if (this.destroyed) return;
+		if (this.controlSession) {
+			void this.sendControl([frame]);
+			return;
+		}
+		if (this.connecting) {
+			this.reconnectPending = true;
+			this.abortController?.abort();
+			return;
+		}
+		this.scheduleConnect(0);
+	}
+
+	private scheduleConnect(delayMs: number): void {
+		if (this.destroyed || this.entries.size === 0) return;
+		if (this.reconnectTimer) clearTimeout(this.reconnectTimer);
+		this.reconnectTimer = setTimeout(() => void this.connect(), delayMs);
+	}
+
+	private async connect(): Promise<void> {
+		if (this.destroyed || this.connecting || this.entries.size === 0) return;
+		this.reconnectTimer = null;
+		this.connecting = true;
+		this.controlSession = null;
+		this.abortController = new AbortController();
+		try {
+			const authHeaders = await this.options.getAuthHeaders?.();
+			const response = await this.options.fetcher(
+				`${this.options.baseUrl}/realtime`,
+				{
+					method: "POST",
+					headers: { "Content-Type": "application/json", ...authHeaders },
+					body: JSON.stringify({
+						channels: [...this.entries.values()].map((entry) => ({
+							id: entry.id,
+							channel: entry.input.registryKey,
+							params: entry.input.params,
+							...(entry.lastEventId ? { lastEventId: entry.lastEventId } : {}),
+						})),
+					}),
+					credentials: this.options.withCredentials ? "include" : "omit",
+					signal: this.abortController.signal,
+				},
+			);
+			if (!response.ok || !response.body) {
+				throw new Error(`Channel SSE connection failed: ${response.status}`);
+			}
+			await this.readStream(response.body);
+			throw new Error("Channel SSE stream closed");
+		} catch (error) {
+			if (this.destroyed || this.entries.size === 0) return;
+			if ((error as Error).name !== "AbortError") {
+				const normalized =
+					error instanceof Error ? error : new Error(String(error));
+				if (![...this.entries.values()].some((entry) => entry.lastEventId)) {
+					this.notifyAll(normalized);
+				}
+				const delay = Math.min(1000 * 2 ** this.retryAttempt++, 30_000);
+				this.scheduleConnect(delay * (0.5 + Math.random()));
+			}
+		} finally {
+			this.connecting = false;
+			this.controlSession = null;
+			if (this.reconnectPending) {
+				this.reconnectPending = false;
+				this.scheduleConnect(0);
+			}
+		}
+	}
+
+	private async sendControl(frames: ControlFrame[]): Promise<void> {
+		const session = this.controlSession;
+		if (!session || frames.length === 0) return;
+		this.controlOperation = this.controlOperation
+			.catch(() => {})
+			.then(async () => {
+				const authHeaders = await this.options.getAuthHeaders?.();
+				const response = await this.options.fetcher(
+					`${this.options.baseUrl}/realtime`,
+					{
+						method: "POST",
+						headers: { "Content-Type": "application/json", ...authHeaders },
+						body: JSON.stringify({
+							sessionId: session.sessionId,
+							token: session.token,
+							frames,
+						}),
+						credentials: this.options.withCredentials ? "include" : "omit",
+					},
+				);
+				if (!response.ok) {
+					throw new Error(`Channel SSE control failed: ${response.status}`);
+				}
+			});
+		try {
+			await this.controlOperation;
+		} catch (error) {
+			this.notifyAll(error instanceof Error ? error : new Error(String(error)));
+			this.reconnectPending = true;
+			this.abortController?.abort();
+		}
+	}
+
+	private async readStream(body: ReadableStream<Uint8Array>): Promise<void> {
+		const reader = body.getReader();
+		const decoder = new TextDecoder();
+		let buffer = "";
+		try {
+			while (true) {
+				const { done, value } = await reader.read();
+				if (done) break;
+				buffer += decoder.decode(value, { stream: true });
+				const blocks = buffer.split("\n\n");
+				buffer = blocks.pop() ?? "";
+				for (const block of blocks) {
+					const event = this.parseEvent(block);
+					if (event) this.handleEvent(event);
+				}
+			}
+		} finally {
+			reader.releaseLock();
+		}
+	}
+
+	private parseEvent(block: string): SseEvent | null {
+		let type = "";
+		let data = "";
+		for (const line of block.split("\n")) {
+			if (line.startsWith("event: ")) type = line.slice(7);
+			else if (line.startsWith("data: ")) data = line.slice(6);
+			else if (line.startsWith(":")) return { type: "ping", data: "" };
+		}
+		return type && data ? { type, data } : null;
+	}
+
+	private handleEvent(event: SseEvent): void {
+		if (event.type === "session") {
+			try {
+				const session = JSON.parse(event.data) as {
+					sessionId?: unknown;
+					token?: unknown;
+				};
+				if (
+					typeof session.sessionId === "string" &&
+					typeof session.token === "string"
+				) {
+					this.controlSession = {
+						sessionId: session.sessionId,
+						token: session.token,
+					};
+				}
+			} catch {}
+			return;
+		}
+		if (event.type === "ping") {
+			this.retryAttempt = 0;
+			return;
+		}
+		try {
+			const frame = JSON.parse(event.data) as Record<string, unknown>;
+			if (event.type === "channel_event") {
+				const entry = this.entryForFrame(frame);
+				if (!entry || typeof frame.event !== "string") return;
+				if (typeof frame.eventId === "string")
+					entry.lastEventId = frame.eventId;
+				this.retryAttempt = 0;
+				for (const callback of entry.subscribers) {
+					callback({
+						event: frame.event,
+						eventId: String(frame.eventId ?? ""),
+						data: frame.data,
+					});
+				}
+			} else if (event.type === "channel_presence") {
+				const entry = this.entryForFrame(frame);
+				if (!entry || !Array.isArray(frame.members)) return;
+				entry.presence = frame.members;
+				const waiters = [...entry.presenceWaiters];
+				entry.presenceWaiters.clear();
+				for (const waiter of waiters) waiter.resolve(frame.members);
+			} else if (event.type === "channel_gap") {
+				const entry = this.entryForFrame(frame);
+				if (entry)
+					this.notifyEntry(entry, new Error("Channel event replay gap"));
+			} else if (event.type === "error") {
+				const id = frame.channelSubscriptionId;
+				const entry = [...this.entries.values()].find((item) => item.id === id);
+				if (entry) {
+					this.notifyEntry(
+						entry,
+						new Error(String(frame.message ?? "Channel error")),
+					);
+				}
+			}
+		} catch {}
+	}
+
+	private entryForFrame(frame: Record<string, unknown>): Entry | undefined {
+		return typeof frame.channel === "string"
+			? this.entries.get(frame.channel)
+			: undefined;
+	}
+
+	private notifyEntry(entry: Entry, error: Error): void {
+		for (const callback of entry.errorCallbacks) callback(error);
+		const waiters = [...entry.presenceWaiters];
+		entry.presenceWaiters.clear();
+		for (const waiter of waiters) waiter.reject(error);
+	}
+
+	private notifyAll(error: Error): void {
+		for (const entry of this.entries.values()) this.notifyEntry(entry, error);
+	}
+
+	destroy(): void {
+		if (this.destroyed) return;
+		this.destroyed = true;
+		this.abortController?.abort();
+		if (this.reconnectTimer) clearTimeout(this.reconnectTimer);
+		this.notifyAll(new Error("Channel transport destroyed"));
+		this.entries.clear();
+		this.controlSession = null;
+	}
+
+	get channelCount(): number {
+		return this.entries.size;
+	}
+
+	get subscriberCount(): number {
+		let count = 0;
+		for (const entry of this.entries.values()) count += entry.subscribers.size;
+		return count;
+	}
+}

--- a/packages/questpie/src/client/channels/types.ts
+++ b/packages/questpie/src/client/channels/types.ts
@@ -1,0 +1,181 @@
+import type { z } from "zod";
+
+import type {
+	AnyChannelDefinition,
+	ChannelDefinitions,
+	ChannelEventsOf,
+	ChannelParamsOf,
+	ChannelPresenceOf,
+	ChannelVisibility,
+} from "#questpie/server/channels/channel-builder.js";
+
+type EventOutput<TDefinition extends AnyChannelDefinition> = {
+	[TEvent in keyof ChannelEventsOf<TDefinition> & string]: {
+		event: TEvent;
+		eventId: string;
+		data: z.output<ChannelEventsOf<TDefinition>[TEvent]>;
+	};
+}[keyof ChannelEventsOf<TDefinition> & string];
+
+type EventInput<TDefinition extends AnyChannelDefinition> = {
+	[TEvent in keyof ChannelEventsOf<TDefinition> & string]: {
+		event: TEvent;
+		data: z.input<ChannelEventsOf<TDefinition>[TEvent]>;
+	};
+}[keyof ChannelEventsOf<TDefinition> & string];
+
+type ParamsInput<TDefinition extends AnyChannelDefinition> =
+	keyof ChannelParamsOf<TDefinition> extends never
+		? { params?: never }
+		: { params: ChannelParamsOf<TDefinition> };
+
+export type ChannelMessage<TDefinition extends AnyChannelDefinition> =
+	EventOutput<TDefinition>;
+
+export type ChannelPublishInput<TDefinition extends AnyChannelDefinition> =
+	EventInput<TDefinition> & ParamsInput<TDefinition>;
+
+export type ChannelPublishReceipt = Readonly<{ eventId: string }>;
+
+export type ChannelSubscribeOptions = {
+	signal?: AbortSignal;
+	onError?: (error: Error) => void;
+};
+
+type SubscribeMethod<TDefinition extends AnyChannelDefinition> =
+	keyof ChannelParamsOf<TDefinition> extends never
+		? (
+				callback: (message: ChannelMessage<TDefinition>) => void,
+				options?: ChannelSubscribeOptions,
+			) => () => void
+		: (
+				params: ChannelParamsOf<TDefinition>,
+				callback: (message: ChannelMessage<TDefinition>) => void,
+				options?: ChannelSubscribeOptions,
+			) => () => void;
+
+type IterMethod<TDefinition extends AnyChannelDefinition> =
+	keyof ChannelParamsOf<TDefinition> extends never
+		? (
+				options?: ChannelSubscribeOptions,
+			) => AsyncGenerator<ChannelMessage<TDefinition>, void, unknown>
+		: (
+				params: ChannelParamsOf<TDefinition>,
+				options?: ChannelSubscribeOptions,
+			) => AsyncGenerator<ChannelMessage<TDefinition>, void, unknown>;
+
+type PresenceMethod<TDefinition extends AnyChannelDefinition> = [
+	ChannelPresenceOf<TDefinition>,
+] extends [never]
+	? never
+	: keyof ChannelParamsOf<TDefinition> extends never
+		? (
+				options?: ChannelSubscribeOptions,
+			) => Promise<readonly ChannelPresenceOf<TDefinition>[]>
+		: (
+				params: ChannelParamsOf<TDefinition>,
+				options?: ChannelSubscribeOptions,
+			) => Promise<readonly ChannelPresenceOf<TDefinition>[]>;
+
+export type ChannelClient<TDefinition extends AnyChannelDefinition> = {
+	subscribe: SubscribeMethod<TDefinition>;
+	publish: (
+		input: ChannelPublishInput<TDefinition>,
+	) => Promise<ChannelPublishReceipt>;
+	iter: IterMethod<TDefinition>;
+	presence: PresenceMethod<TDefinition>;
+};
+
+export type ChannelsClient<TChannels extends ChannelDefinitions> = {
+	[TChannel in keyof TChannels]: ChannelClient<TChannels[TChannel]>;
+} & {
+	destroy(): void;
+	readonly channelCount: number;
+	readonly subscriberCount: number;
+};
+
+export type ChannelClientDescriptor = Readonly<{
+	pattern: string;
+	visibility: ChannelVisibility;
+}>;
+
+export type ChannelClientTransportConfig =
+	| {
+			transport: "sse";
+			channels: Record<string, ChannelClientDescriptor>;
+	  }
+	| {
+			transport: "shared-provider";
+			config: Record<string, unknown> & { provider?: unknown; key?: unknown };
+			channels: Record<string, ChannelClientDescriptor>;
+	  };
+
+export type ChannelConnectionInput = Readonly<{
+	registryKey: string;
+	params: Record<string, string>;
+	resolvedName: string;
+	visibility: ChannelVisibility;
+}>;
+
+export type ChannelTransportMessage = Readonly<{
+	event: string;
+	eventId: string;
+	data: unknown;
+}>;
+
+export interface ChannelClientTransport {
+	subscribe(
+		input: ChannelConnectionInput,
+		callback: (message: ChannelTransportMessage) => void,
+		options?: ChannelSubscribeOptions,
+	): () => void;
+	presence(
+		input: ChannelConnectionInput,
+		options?: ChannelSubscribeOptions,
+	): Promise<readonly unknown[]>;
+	destroy(): void;
+	readonly channelCount: number;
+	readonly subscriberCount: number;
+}
+
+const CHANNEL_NAME_PATTERN = /^[A-Za-z0-9_\-=@,.;]+$/;
+
+export function resolveChannelClientName(
+	descriptor: ChannelClientDescriptor,
+	params: Record<string, string>,
+): string {
+	const expected = [...descriptor.pattern.matchAll(/\[([^\]]+)\]/g)].map(
+		(match) => match[1] as string,
+	);
+	if (
+		expected.length !== Object.keys(params).length ||
+		expected.some((key) => !Object.hasOwn(params, key))
+	) {
+		throw new Error("Channel params do not match the wire pattern");
+	}
+	const applicationName = descriptor.pattern.replace(
+		/\[([^\]]+)\]/g,
+		(_match, key: string) => {
+			const value = params[key];
+			if (!value || !CHANNEL_NAME_PATTERN.test(value)) {
+				throw new Error(`Invalid channel param "${key}"`);
+			}
+			return value;
+		},
+	);
+	const prefix =
+		descriptor.visibility === "private"
+			? "private-"
+			: descriptor.visibility === "presence"
+				? "presence-"
+				: "";
+	const resolved = `${prefix}${applicationName}`;
+	if (
+		resolved.length === 0 ||
+		resolved.length > 164 ||
+		!CHANNEL_NAME_PATTERN.test(resolved)
+	) {
+		throw new Error("Resolved channel name is not transport-safe");
+	}
+	return resolved;
+}

--- a/packages/questpie/src/client/index.ts
+++ b/packages/questpie/src/client/index.ts
@@ -23,6 +23,7 @@ import type {
 	ResolveRelationsDeep,
 } from "#questpie/shared/type-utils.js";
 
+import type { ChannelDefinitions } from "../server/channels/channel-builder.js";
 import type {
 	ApplyQuery,
 	CollectionSelect as CollectionSelectFromApp,
@@ -38,6 +39,7 @@ import type {
 } from "../server/collection/crud/types.js";
 import type { GlobalUpdateInput } from "../server/global/crud/types.js";
 import type { GetAuthHeaders } from "./auth.js";
+import { createChannelsAPI, type ChannelsClient } from "./channels/index.js";
 import {
 	buildCollectionTopic,
 	buildGlobalTopic,
@@ -127,10 +129,16 @@ import type { AnyGlobal, GetGlobal } from "#questpie/shared/type-utils.js";
  */
 export interface QuestpieApp {
 	collections: Record<string, AnyCollectionOrBuilder>;
+	channels?: ChannelDefinitions;
 	globals?: Record<string, any>;
 	routes?: Record<string, any>;
 	auth?: any;
 }
+
+type AppChannelDefinitions<TApp extends QuestpieApp> =
+	NonNullable<TApp["channels"]> extends ChannelDefinitions
+		? NonNullable<TApp["channels"]>
+		: {};
 
 /**
  * Type-safe client error with support for ApiErrorShape
@@ -971,6 +979,7 @@ type RouteCallOptions = Omit<RequestInit, "method"> & {
  */
 export type QuestpieClient<TApp extends QuestpieApp> = {
 	collections: CollectionsAPI<TApp>;
+	channels: ChannelsClient<AppChannelDefinitions<TApp>>;
 	globals: GlobalsAPI<TApp>;
 	routes: RoutesClient<TApp["routes"]>;
 	search: SearchAPI;
@@ -1159,6 +1168,12 @@ export function createClient<TApp extends QuestpieApp>(
 				`${apiBasePath}/globals/${topic.resource}${queryString ? `?${queryString}` : ""}`,
 			);
 		},
+	});
+	const channelsApi = createChannelsAPI<AppChannelDefinitions<TApp>>({
+		baseUrl: `${config.baseURL}${apiBasePath}`,
+		withCredentials: true,
+		fetcher,
+		getAuthHeaders: config.getAuthHeaders,
 	});
 
 	/**
@@ -1865,6 +1880,7 @@ export function createClient<TApp extends QuestpieApp>(
 
 	return {
 		collections,
+		channels: channelsApi,
 		globals,
 		routes: routesProxy,
 		search,
@@ -1927,6 +1943,14 @@ export type { GlobalMeta } from "#questpie/shared/global-meta.js";
 // Re-export realtime types and helpers
 export type { RealtimeAPI, TopicConfig, TopicInput } from "./realtime/index.js";
 export { buildCollectionTopic, buildGlobalTopic } from "./realtime/index.js";
+export type {
+	ChannelClient,
+	ChannelMessage,
+	ChannelPublishInput,
+	ChannelPublishReceipt,
+	ChannelsClient,
+	ChannelSubscribeOptions,
+} from "./channels/index.js";
 // Re-export the query-surface types the client's own method signatures are
 // built from, so consumers (e.g. @questpie/tanstack-query) can derive
 // per-call generics without reaching into server internals.

--- a/packages/questpie/src/server/adapters/routes/realtime.ts
+++ b/packages/questpie/src/server/adapters/routes/realtime.ts
@@ -5,6 +5,7 @@
  * Accepts multiple topics via POST and streams updates for all of them.
  */
 
+import { ChannelsService } from "../../channels/service.js";
 import { executeAccessRule } from "../../collection/crud/shared/access-control.js";
 import type { Questpie } from "../../config/questpie.js";
 import type { QuestpieConfig } from "../../config/types.js";
@@ -21,6 +22,7 @@ import {
 	resolveRealtimeAccessKey,
 } from "../../modules/core/integrated/realtime/refresh-scheduler.js";
 import { computeRealtimeSnapshot } from "../../modules/core/integrated/realtime/snapshot.js";
+import { getSseChannelPresenceRegistry } from "../../modules/core/integrated/realtime/sse-channel-presence.js";
 import {
 	encodeSseEvent,
 	RealtimeSnapshotBufferOverflowError,
@@ -93,6 +95,22 @@ type ValidatedTopic =
 			ValidatedTopicMetadata & { type: "collection" })
 	| (Extract<NormalizedTopicInput, { resourceType: "global" }> &
 			ValidatedTopicMetadata & { type: "global" });
+
+type ChannelSubscriptionInput = {
+	id?: string;
+	channel?: string;
+	params?: Record<string, string>;
+	lastEventId?: string;
+};
+
+type ValidatedChannelSubscription = {
+	id: string;
+	channel: string;
+	params: Record<string, string>;
+	resolvedName: string;
+	lastEventId?: string;
+	presence?: Record<string, unknown>;
+};
 
 function normalizeTopicOperation(topic: TopicInput): NormalizedTopicInput {
 	if (topic.resourceType !== "collection" && topic.resourceType !== "global") {
@@ -306,6 +324,59 @@ async function resolveIncrementalTopic(
 	throw new Error("Invalid resource type");
 }
 
+async function resolveChannelSubscription(
+	app: Questpie<any>,
+	input: ChannelSubscriptionInput,
+	context: any,
+): Promise<ValidatedChannelSubscription> {
+	if (!input.id || typeof input.id !== "string") {
+		throw new Error("Channel subscription id is required");
+	}
+	if (!input.channel || typeof input.channel !== "string") {
+		throw new Error("Channel registry key is required");
+	}
+	if (
+		input.lastEventId !== undefined &&
+		typeof input.lastEventId !== "string"
+	) {
+		throw new Error("Channel lastEventId must be a string");
+	}
+	const params = input.params ?? {};
+	if (
+		!params ||
+		typeof params !== "object" ||
+		Array.isArray(params) ||
+		Object.values(params).some((value) => typeof value !== "string")
+	) {
+		throw new Error("Channel params must be a string record");
+	}
+	const channels = new ChannelsService(
+		app.config.channels ?? {},
+		app.realtime,
+		{ ...context, accessMode: "user" },
+		app.config.realtime?.channelSecurity,
+	);
+	const definition = channels.getDefinition(input.channel);
+	const resolvedName = channels.resolveName(input.channel, params);
+	let presence: Record<string, unknown> | undefined;
+	if (definition.visibility === "presence") {
+		const value = await channels.resolvePresence(input.channel, params);
+		if (value && typeof value === "object") {
+			presence = value as Record<string, unknown>;
+		}
+	} else if (!(await channels.authorize(input.channel, params, "subscribe"))) {
+		throw new Error("Channel subscription is denied");
+	}
+	return {
+		id: input.id,
+		channel: input.channel,
+		params,
+		resolvedName,
+		...(input.lastEventId ? { lastEventId: input.lastEventId } : {}),
+		...(presence ? { presence } : {}),
+	};
+}
+
 // ============================================================================
 // Standalone Handler
 // ============================================================================
@@ -362,6 +433,7 @@ export async function realtimeSubscribe(
 	// Parse request body
 	let body: {
 		topics?: TopicInput[];
+		channels?: ChannelSubscriptionInput[];
 		transport?: "shared-provider";
 		sessionId?: string;
 		token?: string;
@@ -381,7 +453,7 @@ export async function realtimeSubscribe(
 		);
 	}
 
-	const { topics } = body;
+	const { channels: channelInputs, topics } = body;
 	const admission = resolveRealtimeAdmissionConfig(
 		app.config?.realtime?.admission,
 	);
@@ -419,11 +491,15 @@ export async function realtimeSubscribe(
 		}
 	}
 
-	// Validate topics
-	if (!Array.isArray(topics) || topics.length === 0) {
+	// Initial sessions may carry live-query topics, framework channels, or both.
+	if (
+		(topics !== undefined && !Array.isArray(topics)) ||
+		(channelInputs !== undefined && !Array.isArray(channelInputs)) ||
+		((topics?.length ?? 0) === 0 && (channelInputs?.length ?? 0) === 0)
+	) {
 		return errorResponse(
 			ApiError.badRequest(
-				"Topics array is required and must not be empty",
+				"At least one realtime topic or channel is required",
 				undefined,
 				"realtime.topicsRequired",
 			),
@@ -442,7 +518,7 @@ export async function realtimeSubscribe(
 	const collectionDefinitions = app.getCollections() as Record<string, any>;
 	const globalDefinitions = app.getGlobals() as Record<string, any>;
 
-	for (const [topicIndex, rawTopic] of topics.entries()) {
+	for (const [topicIndex, rawTopic] of (topics ?? []).entries()) {
 		if (!rawTopic || typeof rawTopic !== "object" || Array.isArray(rawTopic)) {
 			topicErrors.push({ id: "unknown", message: "Topic must be an object" });
 			continue;
@@ -557,19 +633,33 @@ export async function realtimeSubscribe(
 		}
 	}
 
-	// If no valid topics, return error
-	if (validatedTopics.length === 0) {
-		const errors = topicErrors.map((e) => `${e.id}: ${e.message}`).join("; ");
-		return errorResponse(
-			ApiError.badRequest(
-				`No valid topics provided. Errors: ${errors}`,
-				undefined,
-				"realtime.noValidTopics",
-				{ errors },
-			),
-			request,
-			resolved.appContext.locale,
-		);
+	const validatedChannelsById = new Map<string, ValidatedChannelSubscription>();
+	const channelErrors: Array<{ id: string; message: string }> = [];
+	for (const [index, input] of (channelInputs ?? []).entries()) {
+		const id = input?.id ?? "unknown";
+		if (index + validatedTopics.length >= admission.maxTopicsPerConnection) {
+			channelErrors.push({
+				id,
+				message: `Connection accepts at most ${admission.maxTopicsPerConnection} subscriptions`,
+			});
+			continue;
+		}
+		try {
+			const channel = await resolveChannelSubscription(
+				app,
+				input,
+				resolved.appContext,
+			);
+			if (validatedChannelsById.has(channel.id)) {
+				throw new Error("Channel subscription id is already used");
+			}
+			validatedChannelsById.set(channel.id, channel);
+		} catch (error) {
+			channelErrors.push({
+				id,
+				message: error instanceof Error ? error.message : "Channel rejected",
+			});
+		}
 	}
 
 	const accessValidatedTopics: ValidatedTopic[] = [];
@@ -590,8 +680,8 @@ export async function realtimeSubscribe(
 		}
 	}
 
-	if (accessValidatedTopics.length === 0) {
-		const errors = topicErrors
+	if (accessValidatedTopics.length === 0 && validatedChannelsById.size === 0) {
+		const errors = [...topicErrors, ...channelErrors]
 			.map((error) => `${error.id}: ${error.message}`)
 			.join("; ");
 		return errorResponse(
@@ -640,6 +730,16 @@ export async function realtimeSubscribe(
 	}
 
 	if (body.transport === "shared-provider") {
+		if (validatedChannelsById.size > 0 || validatedTopicsById.size === 0) {
+			releaseConnection();
+			return errorResponse(
+				ApiError.badRequest(
+					"Shared-provider session bootstrap only accepts live-query topics",
+				),
+				request,
+				resolved.appContext.locale,
+			);
+		}
 		const transportConfig = await app.realtime.getClientTransportConfig({
 			request,
 		});
@@ -823,6 +923,7 @@ export async function realtimeSubscribe(
 			let transport: SseClientTransport | null = null;
 			try {
 				const topicUnsubscribers = new Map<string, () => void>();
+				const channelUnsubscribers = new Map<string, () => void>();
 				let closed = false;
 				let closeRequested = false;
 
@@ -867,6 +968,10 @@ export async function realtimeSubscribe(
 						unsub();
 					}
 					topicUnsubscribers.clear();
+					for (const unsub of channelUnsubscribers.values()) {
+						unsub();
+					}
+					channelUnsubscribers.clear();
 					void transport?.stop().catch(() => {});
 				};
 				closeStream = close;
@@ -886,6 +991,17 @@ export async function realtimeSubscribe(
 				const sendTopicError = (topicId: string, message: string) => {
 					return send("error", { topicId, message });
 				};
+				const sendChannelError = (subscriptionId: string, message: string) =>
+					send("error", { channelSubscriptionId: subscriptionId, message });
+
+				const closeIfEmpty = () => {
+					if (
+						topicUnsubscribers.size === 0 &&
+						channelUnsubscribers.size === 0
+					) {
+						requestClose();
+					}
+				};
 
 				const teardownTopic = (topicId: string) => {
 					const unsubscribe = topicUnsubscribers.get(topicId);
@@ -893,7 +1009,57 @@ export async function realtimeSubscribe(
 
 					topicUnsubscribers.delete(topicId);
 					unsubscribe();
-					if (topicUnsubscribers.size === 0) requestClose();
+					closeIfEmpty();
+				};
+
+				const teardownChannel = (subscriptionId: string) => {
+					const unsubscribe = channelUnsubscribers.get(subscriptionId);
+					if (!unsubscribe) return;
+					channelUnsubscribers.delete(subscriptionId);
+					unsubscribe();
+					closeIfEmpty();
+				};
+
+				const subscribeChannel = async (
+					channel: ValidatedChannelSubscription,
+				) => {
+					if (closed) return;
+					if (channelUnsubscribers.has(channel.id)) {
+						await sendChannelError(
+							channel.id,
+							"Channel subscription id is already used",
+						);
+						return;
+					}
+					let unsubscribeLedger: (() => void) | undefined;
+					let unsubscribePresence: (() => void) | undefined;
+					try {
+						unsubscribeLedger = await app.realtime!.subscribeChannel({
+							subscriptionId: `${edgeSessionId}:${channel.id}`,
+							channel: channel.resolvedName,
+							sink,
+							lastEventId: channel.lastEventId,
+							encodeFrame: (frame) => transport!.encodeChannelFrame(frame),
+						});
+						if (channel.presence) {
+							unsubscribePresence = await getSseChannelPresenceRegistry(
+								app,
+							).register({
+								channel: channel.resolvedName,
+								subscriptionId: `${edgeSessionId}:${channel.id}`,
+								sink,
+								data: channel.presence,
+							});
+						}
+						channelUnsubscribers.set(channel.id, () => {
+							unsubscribePresence?.();
+							unsubscribeLedger?.();
+						});
+					} catch (error) {
+						unsubscribePresence?.();
+						unsubscribeLedger?.();
+						throw error;
+					}
 				};
 
 				const subscribeTopic = async (
@@ -988,6 +1154,41 @@ export async function realtimeSubscribe(
 						}
 
 						for (const frame of frames) {
+							if (frame.type === "unsubscribe_channel") {
+								teardownChannel(frame.subscriptionId);
+								continue;
+							}
+							if (frame.type === "subscribe_channel") {
+								if (
+									topicUnsubscribers.size + channelUnsubscribers.size >=
+									admission.maxTopicsPerConnection
+								) {
+									await sendChannelError(
+										frame.subscriptionId,
+										`Connection accepts at most ${admission.maxTopicsPerConnection} subscriptions`,
+									);
+									continue;
+								}
+								try {
+									const channel = await resolveChannelSubscription(
+										app,
+										{
+											id: frame.subscriptionId,
+											channel: frame.channel,
+											params: frame.params,
+											lastEventId: frame.lastEventId,
+										},
+										controlContext,
+									);
+									await subscribeChannel(channel);
+								} catch (error) {
+									await sendChannelError(
+										frame.subscriptionId,
+										error instanceof Error ? error.message : "Channel rejected",
+									);
+								}
+								continue;
+							}
 							if (frame.type === "remove_topic") {
 								teardownTopic(frame.topicId);
 								continue;
@@ -995,7 +1196,10 @@ export async function realtimeSubscribe(
 							if (frame.type !== "add_topic") {
 								throw new Error("Unknown realtime control frame");
 							}
-							if (topicUnsubscribers.size >= admission.maxTopicsPerConnection) {
+							if (
+								topicUnsubscribers.size + channelUnsubscribers.size >=
+								admission.maxTopicsPerConnection
+							) {
 								await sendTopicError(
 									frame.topicId,
 									`Connection accepts at most ${admission.maxTopicsPerConnection} topics`,
@@ -1041,10 +1245,23 @@ export async function realtimeSubscribe(
 				for (const topic of validatedTopicsById.values()) {
 					await subscribeTopic(topic, resolved.appContext);
 				}
+				for (const channel of validatedChannelsById.values()) {
+					try {
+						await subscribeChannel(channel);
+					} catch (error) {
+						await sendChannelError(
+							channel.id,
+							error instanceof Error ? error.message : "Channel rejected",
+						);
+					}
+				}
 
 				// Send initial errors for invalid topics
 				for (const error of topicErrors) {
 					await sendTopicError(error.id, error.message);
+				}
+				for (const error of channelErrors) {
+					await sendChannelError(error.id, error.message);
 				}
 				if (closed) return;
 

--- a/packages/questpie/src/server/modules/core/integrated/realtime/channel-event-ledger.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/channel-event-ledger.ts
@@ -68,6 +68,9 @@ export type LocalChannelSubscriptionInput = {
 	channel: string;
 	sink: ClientSink;
 	lastEventId?: string | null;
+	encodeFrame?: (
+		frame: OrderedChannelEventFrame | ChannelGapFrame,
+	) => Uint8Array;
 };
 
 type ChannelEventRow = typeof questpieChannelEventTable.$inferSelect;
@@ -85,6 +88,7 @@ type LocalSubscription = {
 	drainPending: boolean;
 	closed: boolean;
 	retryTimer: ReturnType<typeof setTimeout> | null;
+	encodeFrame?: LocalChannelSubscriptionInput["encodeFrame"];
 };
 
 export function hashResolvedChannel(channel: string): string {
@@ -290,6 +294,7 @@ export class ChannelEventLedger {
 			drainPending: false,
 			closed: false,
 			retryTimer: null,
+			encodeFrame: input.encodeFrame,
 		};
 		this.localSubscriptions.set(subscription.id, subscription);
 		const channelSubscriptions =
@@ -386,7 +391,7 @@ export class ChannelEventLedger {
 			oldestEventId,
 		};
 		await input.sink.write(
-			this.encodeLocalFrame(frame),
+			this.encodeLocalFrame(frame, input.encodeFrame),
 			"ordered-channel-event",
 		);
 	}
@@ -479,7 +484,10 @@ export class ChannelEventLedger {
 		subscription: LocalSubscription,
 		row: ChannelEventRow,
 	): boolean {
-		const frameBytes = this.encodeLocalFrame(this.toLocalFrame(row)).byteLength;
+		const frameBytes = this.encodeLocalFrame(
+			this.toLocalFrame(row),
+			subscription.encodeFrame,
+		).byteLength;
 		if (
 			subscription.pending.length + 1 > this.config.maxBufferedEvents ||
 			subscription.pendingBytes + frameBytes > this.config.maxBufferedBytes
@@ -497,7 +505,10 @@ export class ChannelEventLedger {
 	): Promise<boolean> {
 		while (!subscription.closed && subscription.pending.length > 0) {
 			const row = subscription.pending[0];
-			const encodedFrame = this.encodeLocalFrame(this.toLocalFrame(row));
+			const encodedFrame = this.encodeLocalFrame(
+				this.toLocalFrame(row),
+				subscription.encodeFrame,
+			);
 			const result = await subscription.sink.write(
 				encodedFrame,
 				"ordered-channel-event",
@@ -540,7 +551,9 @@ export class ChannelEventLedger {
 
 	private encodeLocalFrame(
 		frame: OrderedChannelEventFrame | ChannelGapFrame,
+		encodeFrame?: LocalChannelSubscriptionInput["encodeFrame"],
 	): Uint8Array {
+		if (encodeFrame) return encodeFrame(frame);
 		if (this.clientTransport?.channelDeliveryScope === "local-sessions") {
 			const encoded = this.clientTransport.encodeChannelFrame?.(frame);
 			if (encoded) return encoded;

--- a/packages/questpie/src/server/modules/core/integrated/realtime/sse-channel-presence.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/sse-channel-presence.ts
@@ -1,0 +1,65 @@
+import { encodeSseEvent } from "./sse-client-transport.js";
+import type { ClientSink } from "./transport.js";
+
+type PresenceMember = {
+	subscriptionId: string;
+	sink: ClientSink;
+	data: Record<string, unknown>;
+};
+
+/** App-instance-local coarse presence for the zero-infrastructure SSE tier. */
+export class SseChannelPresenceRegistry {
+	private readonly channels = new Map<string, Map<string, PresenceMember>>();
+
+	async register(input: {
+		channel: string;
+		subscriptionId: string;
+		sink: ClientSink;
+		data: Record<string, unknown>;
+	}): Promise<() => void> {
+		const members = this.channels.get(input.channel) ?? new Map();
+		members.set(input.subscriptionId, input);
+		this.channels.set(input.channel, members);
+		await this.broadcast(input.channel);
+		let removed = false;
+		return () => {
+			if (removed) return;
+			removed = true;
+			const current = this.channels.get(input.channel);
+			current?.delete(input.subscriptionId);
+			if (current?.size === 0) this.channels.delete(input.channel);
+			void this.broadcast(input.channel);
+		};
+	}
+
+	private async broadcast(channel: string): Promise<void> {
+		const members = [...(this.channels.get(channel)?.values() ?? [])];
+		const frame = encodeSseEvent("channel_presence", {
+			type: "channel_presence",
+			channel,
+			members: members.map((member) => member.data),
+		});
+		await Promise.all(
+			members.map(async (member) => {
+				try {
+					await member.sink.write(frame, "latest-snapshot");
+				} catch {
+					this.channels.get(channel)?.delete(member.subscriptionId);
+				}
+			}),
+		);
+	}
+}
+
+const registries = new WeakMap<object, SseChannelPresenceRegistry>();
+
+export function getSseChannelPresenceRegistry(
+	owner: object,
+): SseChannelPresenceRegistry {
+	let registry = registries.get(owner);
+	if (!registry) {
+		registry = new SseChannelPresenceRegistry();
+		registries.set(owner, registry);
+	}
+	return registry;
+}

--- a/packages/questpie/src/server/modules/core/integrated/realtime/sse-control.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/sse-control.ts
@@ -10,9 +10,24 @@ export type RealtimeRemoveTopicFrame = {
 	topicId: string;
 };
 
+export type RealtimeSubscribeChannelFrame = {
+	type: "subscribe_channel";
+	subscriptionId: string;
+	channel: string;
+	params: Record<string, string>;
+	lastEventId?: string;
+};
+
+export type RealtimeUnsubscribeChannelFrame = {
+	type: "unsubscribe_channel";
+	subscriptionId: string;
+};
+
 export type RealtimeControlFrame =
 	| RealtimeAddTopicFrame
-	| RealtimeRemoveTopicFrame;
+	| RealtimeRemoveTopicFrame
+	| RealtimeSubscribeChannelFrame
+	| RealtimeUnsubscribeChannelFrame;
 
 type ControlSession<TContext> = {
 	token: string;

--- a/packages/questpie/src/server/modules/core/routes/channels/config.ts
+++ b/packages/questpie/src/server/modules/core/routes/channels/config.ts
@@ -16,10 +16,24 @@ export default route()
 		let origin: string | null = null;
 		try {
 			origin = validateChannelRouteOrigin(ctx, false);
-			const config = await routeApp(ctx).realtime?.getClientTransportConfig({
+			const app = routeApp(ctx);
+			const config = await app.realtime?.getClientTransportConfig({
 				request: ctx.request,
 			});
-			return channelRouteResponse(config ?? { transport: "sse" }, 200, origin);
+			const channels = Object.fromEntries(
+				Object.entries(app.config.channels ?? {}).map(([key, definition]) => [
+					key,
+					{
+						pattern: definition.pattern,
+						visibility: definition.visibility,
+					},
+				]),
+			);
+			return channelRouteResponse(
+				{ ...(config ?? { transport: "sse" }), channels },
+				200,
+				origin,
+			);
 		} catch (error) {
 			return channelRouteError(error, origin);
 		}

--- a/packages/questpie/test/client/client-channels.test.ts
+++ b/packages/questpie/test/client/client-channels.test.ts
@@ -1,0 +1,288 @@
+import { describe, expect, mock, test } from "bun:test";
+
+type FakePusherOptions = {
+	channelAuthorization: {
+		customHandler: (
+			input: { socketId: string; channelName: string },
+			callback: (error: Error | null, auth: unknown) => void,
+		) => void;
+	};
+};
+
+class FakeChannel {
+	private readonly listeners = new Map<string, Set<(data: unknown) => void>>();
+	readonly members = {
+		each: (callback: (member: { info: unknown }) => void) => {
+			callback({ info: { id: "member-1", roomId: "one" } });
+		},
+	};
+
+	bind(event: string, callback: (data: unknown) => void): this {
+		const listeners = this.listeners.get(event) ?? new Set();
+		listeners.add(callback);
+		this.listeners.set(event, listeners);
+		return this;
+	}
+
+	unbind(): this {
+		this.listeners.clear();
+		return this;
+	}
+
+	emit(event: string, data: unknown): void {
+		for (const callback of this.listeners.get(event) ?? []) callback(data);
+	}
+}
+
+class FakePusher {
+	static instances: FakePusher[] = [];
+	readonly channel = new FakeChannel();
+	disconnected = false;
+
+	constructor(
+		readonly key: string,
+		readonly options: FakePusherOptions,
+	) {
+		FakePusher.instances.push(this);
+	}
+
+	subscribe(channelName: string): FakeChannel {
+		if (
+			channelName.startsWith("private-") ||
+			channelName.startsWith("presence-")
+		) {
+			this.options.channelAuthorization.customHandler(
+				{ socketId: "123.456", channelName },
+				(error) => {
+					if (error) throw error;
+				},
+			);
+		}
+		return this.channel;
+	}
+
+	unsubscribe(): void {}
+
+	disconnect(): void {
+		this.disconnected = true;
+	}
+}
+
+mock.module("pusher-js", () => ({ default: FakePusher }));
+
+import { createClient } from "../../src/client/index.js";
+
+async function waitFor(
+	assertion: () => boolean,
+	timeoutMs = 3000,
+): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (assertion()) return;
+		await new Promise((resolve) => setTimeout(resolve, 10));
+	}
+	throw new Error("Timed out waiting for assertion");
+}
+
+describe("channels client", () => {
+	test("subscribes and publishes through the SSE transport with fresh auth", async () => {
+		const requests: Array<{ url: string; init?: RequestInit }> = [];
+		let streamController:
+			| ReadableStreamDefaultController<Uint8Array>
+			| undefined;
+		let authVersion = 0;
+		const encoder = new TextEncoder();
+		const fetcher: typeof fetch = async (input, init) => {
+			const url = String(input);
+			requests.push({ url, init });
+			expect(new Headers(init?.headers).get("Authorization")).toMatch(
+				/^Bearer channel-/,
+			);
+			if (url.endsWith("/channels/config")) {
+				return Response.json({
+					transport: "sse",
+					channels: {
+						news: { pattern: "news", visibility: "public" },
+					},
+				});
+			}
+			if (url.endsWith("/realtime")) {
+				const stream = new ReadableStream<Uint8Array>({
+					start(controller) {
+						streamController = controller;
+						controller.enqueue(
+							encoder.encode(
+								`event: session\ndata: ${JSON.stringify({ sessionId: "s1", token: "t1" })}\n\n`,
+							),
+						);
+					},
+				});
+				return new Response(stream, {
+					headers: { "Content-Type": "text/event-stream" },
+				});
+			}
+			if (url.endsWith("/channels/publish")) {
+				return Response.json({ eventId: "event-1" });
+			}
+			throw new Error(`Unexpected request: ${url}`);
+		};
+		const client = createClient<any>({
+			baseURL: "http://localhost:3000",
+			fetch: fetcher,
+			getAuthHeaders: () => ({
+				Authorization: `Bearer channel-${++authVersion}`,
+			}),
+		});
+		const messages: unknown[] = [];
+		const errors: Error[] = [];
+		const stop = client.channels.news.subscribe(
+			(message: unknown) => messages.push(message),
+			{ onError: (error: Error) => errors.push(error) },
+		);
+
+		await waitFor(() => !!streamController);
+		streamController!.enqueue(
+			encoder.encode(
+				`event: channel_event\ndata: ${JSON.stringify({ type: "channel_event", channel: "news", event: "updated", eventId: "event-1", data: { title: "Hello" } })}\n\n`,
+			),
+		);
+		await waitFor(() => messages.length === 1);
+		expect(messages[0]).toEqual({
+			event: "updated",
+			eventId: "event-1",
+			data: { title: "Hello" },
+		});
+		expect(errors).toHaveLength(0);
+
+		await expect(
+			client.channels.news.publish({
+				event: "updated",
+				data: { title: "Published" },
+			}),
+		).resolves.toEqual({ eventId: "event-1" });
+		const publishRequest = requests.find(({ url }) =>
+			url.endsWith("/channels/publish"),
+		);
+		expect(JSON.parse(String(publishRequest?.init?.body))).toEqual({
+			channel: "news",
+			params: {},
+			event: "updated",
+			data: { title: "Published" },
+		});
+
+		stop();
+		client.channels.destroy();
+	});
+
+	test("subscribes to typed provider channels and exposes native presence", async () => {
+		FakePusher.instances = [];
+		const requests: Array<{ url: string; init?: RequestInit }> = [];
+		let token = 0;
+		const fetcher: typeof fetch = async (input, init) => {
+			const url = String(input);
+			requests.push({ url, init });
+			expect(new Headers(init?.headers).get("Authorization")).toMatch(
+				/^Bearer provider-/,
+			);
+			if (url.endsWith("/channels/config")) {
+				return Response.json({
+					transport: "shared-provider",
+					config: { provider: "pusher", key: "public-key", cluster: "eu" },
+					channels: {
+						room: {
+							pattern: "room-[roomId]",
+							visibility: "presence",
+						},
+						signalRoom: {
+							pattern: "signal-room-[signal]",
+							visibility: "presence",
+						},
+					},
+				});
+			}
+			if (url.endsWith("/channels/auth")) {
+				return Response.json({ auth: "signed", channel_data: "{}" });
+			}
+			throw new Error(`Unexpected request: ${url}`);
+		};
+		const client = createClient<any>({
+			baseURL: "http://localhost:3000",
+			fetch: fetcher,
+			getAuthHeaders: () => ({
+				Authorization: `Bearer provider-${++token}`,
+			}),
+		});
+		const messages: unknown[] = [];
+		const stop = client.channels.room.subscribe(
+			{ roomId: "one" },
+			(message: unknown) => messages.push(message),
+		);
+
+		await waitFor(() => FakePusher.instances.length === 1);
+		const provider = FakePusher.instances[0];
+		expect(provider.key).toBe("public-key");
+		provider.channel.emit("questpie:channel", {
+			eventId: "event-2",
+			data: JSON.stringify({ event: "message", data: { text: "hello" } }),
+		});
+		await waitFor(() => messages.length === 1);
+		expect(messages[0]).toEqual({
+			event: "message",
+			eventId: "event-2",
+			data: { text: "hello" },
+		});
+		provider.channel.emit(
+			"pusher:subscription_succeeded",
+			provider.channel.members,
+		);
+		await expect(
+			client.channels.room.presence({ roomId: "one" }),
+		).resolves.toEqual([{ id: "member-1", roomId: "one" }]);
+		const signalPresence = client.channels.signalRoom.presence({
+			signal: "two",
+		});
+		await waitFor(() =>
+			requests
+				.filter(({ url }) => url.endsWith("/channels/auth"))
+				.map(({ init }) => JSON.parse(String(init?.body)))
+				.some(({ channel }) => channel === "signalRoom"),
+		);
+		provider.channel.emit(
+			"pusher:subscription_succeeded",
+			provider.channel.members,
+		);
+		await expect(signalPresence).resolves.toEqual([
+			{ id: "member-1", roomId: "one" },
+		]);
+		await waitFor(() =>
+			requests.some(({ url }) => url.endsWith("/channels/auth")),
+		);
+		expect(
+			JSON.parse(
+				String(
+					requests.find(({ url }) => url.endsWith("/channels/auth"))?.init
+						?.body,
+				),
+			),
+		).toEqual({
+			socketId: "123.456",
+			channelName: "presence-room-one",
+			channel: "room",
+			params: { roomId: "one" },
+		});
+		expect(
+			requests
+				.filter(({ url }) => url.endsWith("/channels/auth"))
+				.map(({ init }) => JSON.parse(String(init?.body))),
+		).toContainEqual({
+			socketId: "123.456",
+			channelName: "presence-signal-room-two",
+			channel: "signalRoom",
+			params: { signal: "two" },
+		});
+
+		stop();
+		client.channels.destroy();
+		expect(provider.disconnected).toBe(true);
+	});
+});

--- a/packages/questpie/test/integration/channel-routes.test.ts
+++ b/packages/questpie/test/integration/channel-routes.test.ts
@@ -27,12 +27,121 @@ function channelRequest(
 	});
 }
 
+async function readSseEvent(
+	reader: ReadableStreamDefaultReader<Uint8Array>,
+	state: { buffer: string },
+	eventType: string,
+): Promise<Record<string, unknown>> {
+	const decoder = new TextDecoder();
+	for (;;) {
+		const blocks = state.buffer.split("\n\n");
+		state.buffer = blocks.pop() ?? "";
+		for (const block of blocks) {
+			const type = block
+				.split("\n")
+				.find((line) => line.startsWith("event: "))
+				?.slice(7);
+			const data = block
+				.split("\n")
+				.find((line) => line.startsWith("data: "))
+				?.slice(6);
+			if (type === eventType && data) return JSON.parse(data);
+		}
+		const next = await reader.read();
+		if (next.done) throw new Error(`SSE ended before ${eventType}`);
+		state.buffer += decoder.decode(next.value, { stream: true });
+	}
+}
+
 describe("channel module routes", () => {
 	let cleanup: (() => Promise<void>) | undefined;
 
 	afterEach(async () => {
 		await cleanup?.();
 		cleanup = undefined;
+	});
+
+	test("streams authorized ordered channels and coarse presence over SSE", async () => {
+		const setup = await buildMockApp(
+			{
+				channels: {
+					room: channel("room-[roomId]")
+						.events({ message: z.object({ text: z.string() }) })
+						.authorize({ subscribe: true, publish: true })
+						.presence(({ params }) => ({
+							id: "member-1",
+							roomId: params.roomId,
+						})),
+				},
+			},
+			{
+				app: { url: "https://app.example.com" },
+				realtime: { retentionDays: 0 },
+			},
+		);
+		cleanup = setup.cleanup;
+		await runTestDbMigrations(setup.app);
+		const handler = createFetchHandler(setup.app);
+
+		const configResponse = await handler(
+			new Request("https://app.example.com/channels/config"),
+		);
+		expect(await configResponse.json()).toMatchObject({
+			transport: "sse",
+			channels: {
+				room: { pattern: "room-[roomId]", visibility: "presence" },
+			},
+		});
+
+		const streamResponse = await handler(
+			new Request("https://app.example.com/realtime", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({
+					channels: [
+						{
+							id: "room-subscription",
+							channel: "room",
+							params: { roomId: "one" },
+						},
+					],
+				}),
+			}),
+		);
+		expect(streamResponse.status).toBe(200);
+		const reader = streamResponse.body!.getReader();
+		const state = { buffer: "" };
+		expect(await readSseEvent(reader, state, "session")).toMatchObject({
+			sessionId: expect.any(String),
+			token: expect.any(String),
+		});
+		expect(await readSseEvent(reader, state, "channel_presence")).toEqual({
+			type: "channel_presence",
+			channel: "presence-room-one",
+			members: [{ id: "member-1", roomId: "one" }],
+		});
+
+		const publishResponse = await handler(
+			channelRequest(
+				"channels/publish",
+				{
+					channel: "room",
+					params: { roomId: "one" },
+					event: "message",
+					data: { text: "hello" },
+				},
+				{ origin: "https://app.example.com", cookie: true },
+			),
+		);
+		expect(publishResponse.status).toBe(200);
+		expect(await readSseEvent(reader, state, "channel_event")).toMatchObject({
+			type: "channel_event",
+			channel: "presence-room-one",
+			event: "message",
+			eventId: expect.any(String),
+			data: { text: "hello" },
+		});
+		await reader.cancel();
 	});
 
 	test("authorizes subscribe independently and never trusts the supplied wire name", async () => {
@@ -289,7 +398,12 @@ describe("channel module routes", () => {
 				headers: { Cookie: "session=test" },
 			}),
 		);
-		expect(await sseConfig.json()).toEqual({ transport: "sse" });
+		expect(await sseConfig.json()).toEqual({
+			transport: "sse",
+			channels: {
+				publicNews: { pattern: "news", visibility: "public" },
+			},
+		});
 
 		const rejectedPreflight = await handler(
 			new Request("https://app.example.com/channels/publish", {

--- a/packages/questpie/test/types/channel-client.test-d.ts
+++ b/packages/questpie/test/types/channel-client.test-d.ts
@@ -1,0 +1,84 @@
+import { z } from "zod";
+
+import type { ChannelMessage, QuestpieClient } from "#questpie/client/index.js";
+import { channel } from "#questpie/server/channels/channel-builder.js";
+
+import type { Equal, Expect } from "./type-test-utils.js";
+
+const news = channel("news").events({
+	metric: z.object({ value: z.string().transform(Number) }),
+});
+const room = channel("room-[roomId]")
+	.events({
+		message: z.object({ text: z.string() }),
+		typing: z.object({ active: z.boolean() }),
+	})
+	.authorize({ subscribe: true })
+	.presence(({ params }) => ({ id: "user-1", roomId: params.roomId }));
+
+type App = {
+	collections: {};
+	channels: { news: typeof news; room: typeof room };
+	globals: {};
+	routes: {};
+};
+
+declare const client: QuestpieClient<App>;
+
+client.channels.news.subscribe((message) => {
+	if (message.event === "metric") {
+		type _outputWasInferred = Expect<Equal<typeof message.data.value, number>>;
+	}
+});
+client.channels.room.subscribe({ roomId: "one" }, (message) => {
+	if (message.event === "message") {
+		type _messagePayload = Expect<Equal<typeof message.data, { text: string }>>;
+	} else {
+		type _typingPayload = Expect<
+			Equal<typeof message.data, { active: boolean }>
+		>;
+	}
+});
+
+client.channels.news.publish({
+	event: "metric",
+	data: { value: "42" },
+});
+client.channels.room.publish({
+	params: { roomId: "one" },
+	event: "message",
+	data: { text: "hello" },
+});
+
+const roomMessages = client.channels.room.iter({ roomId: "one" });
+type _iterMessage = Expect<
+	Equal<
+		Awaited<ReturnType<typeof roomMessages.next>>["value"],
+		ChannelMessage<typeof room> | void
+	>
+>;
+const presence = client.channels.room.presence({ roomId: "one" });
+type _presence = Expect<
+	Equal<Awaited<typeof presence>, readonly { id: string; roomId: string }[]>
+>;
+
+// @ts-expect-error parameterized subscriptions require their pattern params
+client.channels.room.subscribe(() => {});
+// @ts-expect-error public no-param channels do not accept params
+client.channels.news.subscribe({}, () => {});
+// @ts-expect-error parameterized publish requires params
+client.channels.room.publish({ event: "message", data: { text: "hello" } });
+client.channels.room.publish({
+	// @ts-expect-error wrong param key
+	params: { id: "one" },
+	event: "message",
+	data: { text: "hello" },
+});
+client.channels.room.publish({
+	params: { roomId: "one" },
+	event: "typing",
+	// @ts-expect-error event payload is schema-typed
+	data: { active: "yes" },
+});
+// @ts-expect-error only presence channels expose presence()
+client.channels.news.presence();

--- a/packages/tanstack-query/src/channel-query-options.test.ts
+++ b/packages/tanstack-query/src/channel-query-options.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test";
+
+import { QueryClient } from "@tanstack/react-query";
+import { channel } from "questpie/channels";
+import type { QuestpieClient } from "questpie/client";
+import { z } from "zod";
+
+import { createQuestpieQueryOptions } from "./index.js";
+
+const news = channel("news").events({
+	updated: z.object({ title: z.string() }),
+});
+const room = channel("room-[roomId]")
+	.events({ message: z.object({ text: z.string() }) })
+	.authorize({ subscribe: true });
+
+type App = {
+	collections: {};
+	channels: { news: typeof news; room: typeof room };
+	globals: {};
+	routes: {};
+};
+
+describe("channel query options", () => {
+	test("accumulates typed channel messages through streamedQuery", async () => {
+		let receivedSignal: AbortSignal | undefined;
+		const client = {
+			collections: {},
+			channels: {
+				news: {
+					iter: async function* (options?: { signal?: AbortSignal }) {
+						receivedSignal = options?.signal;
+						yield {
+							event: "updated" as const,
+							eventId: "one",
+							data: { title: "One" },
+						};
+						yield {
+							event: "updated" as const,
+							eventId: "two",
+							data: { title: "Two" },
+						};
+					},
+				},
+			},
+			globals: {},
+			routes: {},
+		} as unknown as QuestpieClient<App>;
+		const queryClient = new QueryClient();
+		const abortController = new AbortController();
+		const options =
+			createQuestpieQueryOptions(client).channels.news.subscription();
+		const value = await (options.queryFn as any)({
+			client: queryClient,
+			queryKey: options.queryKey,
+			signal: abortController.signal,
+		});
+
+		expect(receivedSignal).toBe(abortController.signal);
+		expect(value).toEqual([
+			{ event: "updated", eventId: "one", data: { title: "One" } },
+			{ event: "updated", eventId: "two", data: { title: "Two" } },
+		]);
+	});
+
+	test("preserves generated channel params in the option factory", () => {
+		expect(typeof declareClientTypes).toBe("function");
+	});
+});
+
+function declareClientTypes(client: QuestpieClient<App>): void {
+	const q = createQuestpieQueryOptions(client);
+	q.channels.news.subscription();
+	q.channels.room.subscription({ roomId: "one" });
+	// @ts-expect-error parametric channel requires params
+	q.channels.room.subscription();
+	// @ts-expect-error unknown channel key
+	q.channels.missing.subscription();
+}

--- a/packages/tanstack-query/src/index.ts
+++ b/packages/tanstack-query/src/index.ts
@@ -7,6 +7,7 @@ import {
 	type UseMutationOptions,
 	type UseQueryOptions,
 } from "@tanstack/react-query";
+import type { AnyChannelDefinition, ChannelParamsOf } from "questpie/channels";
 import type {
 	ApplyQuery,
 	CollectionRelations,
@@ -140,6 +141,49 @@ type GlobalKeys<TApp extends QuestpieApp> = Extract<
 	keyof QuestpieClient<TApp>["globals"],
 	string
 >;
+
+/** Extract generated channel registry keys without client control properties. */
+type ChannelKeys<TApp extends QuestpieApp> = Extract<
+	keyof NonNullable<TApp["channels"]>,
+	string
+>;
+
+type ChannelIter<
+	TApp extends QuestpieApp,
+	K extends ChannelKeys<TApp>,
+> = QuestpieClient<TApp>["channels"][K] extends { iter: infer TIter }
+	? TIter extends (...args: any[]) => AsyncGenerator<any, void, unknown>
+		? TIter
+		: never
+	: never;
+
+type ChannelIterMessage<TIter> = TIter extends (
+	...args: any[]
+) => AsyncGenerator<infer TMessage, void, unknown>
+	? TMessage
+	: never;
+
+type ChannelDefinition<
+	TApp extends QuestpieApp,
+	K extends ChannelKeys<TApp>,
+> = NonNullable<TApp["channels"]>[K] extends AnyChannelDefinition
+	? NonNullable<TApp["channels"]>[K]
+	: never;
+
+type ChannelSubscriptionOptionsAPI<
+	TApp extends QuestpieApp,
+	K extends ChannelKeys<TApp>,
+> = keyof ChannelParamsOf<ChannelDefinition<TApp, K>> extends never
+	? {
+			subscription: () => UseQueryOptions<
+				readonly ChannelIterMessage<ChannelIter<TApp, K>>[]
+			>;
+		}
+	: {
+			subscription: (
+				params: ChannelParamsOf<ChannelDefinition<TApp, K>>,
+			) => UseQueryOptions<readonly ChannelIterMessage<ChannelIter<TApp, K>>[]>;
+		};
 
 // Per-collection select/relations — the same derivation the client's own
 // method signatures use, so per-call generics below produce results identical
@@ -387,6 +431,9 @@ export type QuestpieQueryOptionsProxy<TApp extends QuestpieApp = QuestpieApp> =
 		};
 		globals: {
 			[K in GlobalKeys<TApp>]: GlobalQueryOptionsAPI<TApp, K>;
+		};
+		channels: {
+			[K in ChannelKeys<TApp>]: ChannelSubscriptionOptionsAPI<TApp, K>;
 		};
 		routes: RoutesQueryOptionsAPI<QuestpieClient<TApp>["routes"]>;
 		custom: {
@@ -942,6 +989,40 @@ export function createQuestpieQueryOptions<
 		},
 	});
 
+	const channels = new Proxy(
+		{} as QuestpieQueryOptionsProxy<TApp>["channels"],
+		{
+			get: (_target, channelName) => {
+				if (typeof channelName !== "string") return undefined;
+				const channel = client.channels[
+					channelName as ChannelKeys<TApp>
+				] as any;
+				return {
+					subscription: (...args: any[]) => {
+						const queryKey = buildKey(keyPrefix, [
+							"channels",
+							channelName,
+							"subscription",
+							normalizeQueryKeyOptions(args),
+						]);
+						return queryOptions({
+							queryKey,
+							queryFn: streamedQuery({
+								streamFn: ({ signal }) => channel.iter(...args, { signal }),
+								reducer: (messages: readonly unknown[], message: unknown) => [
+									...messages,
+									message,
+								],
+								initialValue: [] as readonly unknown[],
+								refetchMode: "reset",
+							}),
+						});
+					},
+				};
+			},
+		},
+	);
+
 	/**
 	 * Resolve a nested route caller from the client by traversing dot segments.
 	 */
@@ -1034,6 +1115,7 @@ export function createQuestpieQueryOptions<
 	return {
 		collections,
 		globals,
+		channels,
 		routes: routesProxy,
 		custom: {
 			query: (customConfig) =>


### PR DESCRIPTION
## Summary
- add typed `client.channels.<key>` subscribe, publish, presence, and async iteration APIs
- deliver ordered channels over multiplexed SSE or lazy managed Pusher with dynamic auth headers
- add `q.channels.<key>.subscription()` TanStack streamed-query factories
- expose secret-free channel registry metadata and coarse local SSE presence

## Verification
- `cd packages/questpie && bun test test/ --test-name-pattern "channel|client"` (94 pass, 2 gated Soketi skips, 0 fail)
- `cd packages/questpie && bun run check-types` (includes full-app DB NoAny gate)
- `cd packages/tanstack-query && bunx tsc --noEmit -p tsconfig.json`
- both package builds
- changed-file oxlint and oxfmt checks