### PR TITLE
test(realtime): add cross-driver matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,42 @@ jobs:
         env:
           QUESTPIE_MIGRATIONS_SILENT: "1"
 
+  realtime-matrix:
+    name: Realtime driver matrix
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.13"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Start Postgres, Redis, and Soketi
+        run: docker compose -f packages/questpie/test/fixtures/soketi/compose.yml up -d --wait
+
+      - name: Run realtime driver and security matrix
+        working-directory: packages/questpie
+        run: bun test test/ --test-name-pattern "matrix|storm|dos|channel"
+        env:
+          QUESTPIE_MIGRATIONS_SILENT: "1"
+          QUESTPIE_REALTIME_DRIVER_INTEGRATION: "1"
+          QUESTPIE_SOKETI_INTEGRATION: "1"
+          QUESTPIE_REALTIME_POSTGRES_URL: postgresql://questpie:questpie@127.0.0.1:54329/questpie_realtime
+          QUESTPIE_REALTIME_REDIS_URL: redis://127.0.0.1:6379
+
+      - name: Dump realtime service logs
+        if: failure()
+        run: docker compose -f packages/questpie/test/fixtures/soketi/compose.yml logs --no-color
+
+      - name: Stop realtime services
+        if: always()
+        run: docker compose -f packages/questpie/test/fixtures/soketi/compose.yml down -v
+
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/bun.lock
+++ b/bun.lock
@@ -519,6 +519,7 @@
         "pg-boss": "^12.5.4",
         "pusher": "^5.3.4",
         "pusher-js": "^8.5.0",
+        "redis": "^4.7.0",
         "tsdown": "^0.18.3",
       },
       "peerDependencies": {

--- a/packages/questpie/package.json
+++ b/packages/questpie/package.json
@@ -160,6 +160,7 @@
 		"pg-boss": "^12.5.4",
 		"pusher": "^5.3.4",
 		"pusher-js": "^8.5.0",
+		"redis": "^4.7.0",
 		"tsdown": "^0.18.3"
 	},
 	"peerDependencies": {

--- a/packages/questpie/test/adapters/redis-streams.test.ts
+++ b/packages/questpie/test/adapters/redis-streams.test.ts
@@ -78,7 +78,7 @@ const change: RealtimeChangeEvent = {
 	createdAt: new Date(),
 };
 
-describe("redis streams adapter", () => {
+describe("redis streams realtime matrix adapter", () => {
 	const adapters: RedisStreamsAdapter[] = [];
 
 	afterEach(async () => {

--- a/packages/questpie/test/fixtures/soketi/compose.yml
+++ b/packages/questpie/test/fixtures/soketi/compose.yml
@@ -1,4 +1,28 @@
 services:
+  postgres:
+    image: postgres:17-alpine
+    ports:
+      - "54329:5432"
+    environment:
+      POSTGRES_DB: questpie_realtime
+      POSTGRES_USER: questpie
+      POSTGRES_PASSWORD: questpie
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U questpie -d questpie_realtime"]
+      interval: 2s
+      timeout: 2s
+      retries: 20
+
+  redis:
+    image: redis:7.4-alpine
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 2s
+      timeout: 2s
+      retries: 20
+
   soketi:
     image: quay.io/soketi/soketi:1.6-16-debian
     ports:
@@ -10,3 +34,12 @@ services:
       # Deliberately provider-wide for the hostile raw-client security test.
       SOKETI_DEFAULT_APP_ENABLE_CLIENT_MESSAGES: "true"
       SOKETI_DEBUG: "1"
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          'node -e "require(''http'').get(''http://127.0.0.1:6001/'', () => process.exit(0)).on(''error'', () => process.exit(1))"',
+        ]
+      interval: 2s
+      timeout: 2s
+      retries: 30

--- a/packages/questpie/test/integration/REALTIME_MATRIX.md
+++ b/packages/questpie/test/integration/REALTIME_MATRIX.md
@@ -1,0 +1,45 @@
+# Realtime v2 verification matrix
+
+The CI `realtime-matrix` job starts Postgres, Redis, and Soketi from
+`test/fixtures/soketi/compose.yml`. Gated integration tests use those real
+services; deterministic failure tests stay in-process so drops, retries, clocks,
+and backpressure are reproducible.
+
+## Driver and QoS evidence
+
+| Contract                     | Evidence                                                                                                                                                           |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| SSE + pg-notify broadcast    | `realtime-driver-services.test.ts` sends collection and global wakes to two real LISTEN connections.                                                               |
+| SSE + Redis broadcast        | `realtime-driver-services.test.ts` sends the same wakes through two independent real XREAD cursors.                                                                |
+| Soketi wake broadcast        | `realtime-soketi.test.ts` requires both application subscribers to receive one notice-only wake.                                                                   |
+| Soketi channels and presence | `realtime-soketi.test.ts` observes a presence join and two server-mediated events in order.                                                                        |
+| Latest-snapshot QoS          | `realtime-sse-transport.test.ts` proves latest-wins replacement and a hard byte cap.                                                                               |
+| Ordered-event QoS            | `ordered-channel-ledger.test.ts` proves locked ordering, replay, dedupe, gap close, and slow-consumer close.                                                       |
+| Deploy herd                  | `realtime-refresh-scheduler.test.ts` resumes 500 equivalent clients at the current sequence with zero snapshots, then computes once for all 500.                   |
+| Wake loss and crash window   | `realtime-reconciliation.test.ts` proves poll healing; `realtime-transactional-capture.test.ts` proves same-transaction capture and post-commit wake independence. |
+| Bulk and live count          | `realtime-transactional-capture.test.ts` proves one event per bulk mutation; `realtime.test.ts` proves count uses `count` and transfers one scalar.                |
+| DoS and backpressure         | `realtime-admission.test.ts`, `realtime.test.ts`, and `realtime-sse-transport.test.ts` cover connection/topic/query/depth/snapshot/buffer limits.                  |
+
+## Channel security evidence
+
+The IDs below are the normative checklist in `TRANSPORT.md`. SDK client-event
+allowlists are intentionally not counted as authorization.
+
+| ID     | Automated evidence                                                                                                                                                             |
+| ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| SEC-01 | `channel-routes.test.ts`: subscribe and publish policies are evaluated independently and fallback behavior is explicit.                                                        |
+| SEC-02 | `channel-routes.test.ts`: public/default channels can subscribe but cannot anonymously publish.                                                                                |
+| SEC-03 | `channel-routes.test.ts`: thrown/timed-out/collision denials cause zero provider calls; `realtime.test.ts` rejects before sink allocation.                                     |
+| SEC-04 | `channel-routes.test.ts`: schema and size failures occur before a ledger event id is returned.                                                                                 |
+| SEC-05 | `realtime-soketi.test.ts`: hostile raw client-events require provider-wide enablement and a direct client trigger.                                                             |
+| SEC-06 | `realtime-soketi.test.ts`: hostile client payload delivery proves the provider allowlist is membership-only, unvalidated, non-replayable, and distinct from framework publish. |
+| SEC-07 | `realtime-pusher-transport.test.ts`: final private/presence channel alphabet and 164-character boundary.                                                                       |
+| SEC-08 | `channel-security.test.ts` and `channel-routes.test.ts`: cross-pattern and ambiguous-param collisions fail before authorization/provider work.                                 |
+| SEC-09 | `channel-security.test.ts` and `channel-routes.test.ts`: missing, malformed, and untrusted cookie origins fail.                                                                |
+| SEC-10 | `channel-routes.test.ts`: exact credentialed CORS reflection, `Vary: Origin`, and no wildcard.                                                                                 |
+| SEC-11 | `channel-routes.test.ts`: session/principal token buckets return 429 and recover under a fake clock.                                                                           |
+| SEC-12 | `channel-security.test.ts` and `channel-routes.test.ts`: serialized 10,000 bytes pass and 10,001 bytes fail without allocation.                                                |
+| SEC-13 | `realtime-pusher-transport.test.ts` and `channel-routes.test.ts`: bounded presence identity/info/member count and resolver-only exposure.                                      |
+| SEC-14 | `realtime-pusher-routes.test.ts` and `channel-routes.test.ts`: socket/channel-bound auth, `no-store`, and secret-free config.                                                  |
+| SEC-15 | `realtime-pusher-transport.test.ts`: provider termination plus denial until principal restoration.                                                                             |
+| SEC-16 | `channel-routes.test.ts`: hostile params, payload, wire name, and socket values never enter observations; reasons are from the bounded enum.                                   |

--- a/packages/questpie/test/integration/channel-routes.test.ts
+++ b/packages/questpie/test/integration/channel-routes.test.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 import { createFetchHandler } from "../../src/server/adapters/http.js";
 import { channel } from "../../src/server/channels/channel-builder.js";
 import { ChannelTokenBucketLimiter } from "../../src/server/channels/security.js";
+import type { RealtimeObservation } from "../../src/server/modules/core/integrated/realtime/observer.js";
 import type { PusherProvider } from "../../src/server/modules/core/integrated/realtime/pusher-transport.js";
 import { PusherClientTransport } from "../../src/server/modules/core/integrated/realtime/pusher-transport.js";
 import { setChannelPublishLimiterForTests } from "../../src/server/modules/core/routes/channels/_shared.js";
@@ -14,7 +15,11 @@ import { runTestDbMigrations } from "../utils/test-db.js";
 function channelRequest(
 	path: string,
 	body: Record<string, unknown>,
-	options: { origin?: string; cookie?: boolean } = {},
+	options: {
+		origin?: string;
+		cookie?: boolean;
+		headers?: Record<string, string>;
+	} = {},
 ): Request {
 	return new Request(`https://app.example.com/${path}`, {
 		method: "POST",
@@ -22,6 +27,7 @@ function channelRequest(
 			"Content-Type": "application/json",
 			...(options.origin ? { Origin: options.origin } : {}),
 			...(options.cookie ? { Cookie: "session=test" } : {}),
+			...options.headers,
 		},
 		body: JSON.stringify(body),
 	});
@@ -331,6 +337,35 @@ describe("channel module routes", () => {
 		expect((await publish(rateBody)).status).toBe(429);
 		now = 100;
 		expect((await publish(rateBody)).status).toBe(200);
+
+		now = 0;
+		setChannelPublishLimiterForTests(
+			setup.app,
+			new ChannelTokenBucketLimiter({
+				ratePerSecond: 10,
+				burst: 2,
+				now: () => now,
+			}),
+		);
+		const authenticatedHandler = createFetchHandler(setup.app, {
+			getSession: async (request) => ({
+				user: { id: "shared-user" },
+				session: { id: request.headers.get("x-test-session") },
+			}),
+		});
+		const publishFromTab = (session: string) =>
+			authenticatedHandler(
+				channelRequest("channels/publish", rateBody, {
+					origin: "https://app.example.com",
+					cookie: true,
+					headers: { "x-test-session": session },
+				}),
+			);
+		expect((await publishFromTab("tab-1")).status).toBe(200);
+		expect((await publishFromTab("tab-2")).status).toBe(200);
+		expect((await publishFromTab("tab-3")).status).toBe(429);
+		now = 100;
+		expect((await publishFromTab("tab-3")).status).toBe(200);
 	});
 
 	test("uses one strict origin and credentialed CORS policy for auth and publish", async () => {
@@ -465,5 +500,83 @@ describe("channel module routes", () => {
 		expect(response.status).toBe(409);
 		expect(authorizationCalls).toBe(0);
 		expect(providerCalls).toBe(0);
+	});
+
+	test("SEC-16 channel matrix observations never expose request secrets", async () => {
+		const observations: RealtimeObservation[] = [];
+		const setup = await buildMockApp(
+			{
+				channels: {
+					room: channel("room-[id]")
+						.events({ message: z.object({ text: z.string() }) })
+						.authorize({ subscribe: true, publish: true }),
+				},
+			},
+			{
+				app: { url: "https://app.example.com" },
+				realtime: {
+					retentionDays: 0,
+					observer: { record: (event) => observations.push(event) },
+				},
+			},
+		);
+		cleanup = setup.cleanup;
+		await runTestDbMigrations(setup.app);
+		const handler = createFetchHandler(setup.app);
+		const parameterSecret = "private-parameter-7cb0f3";
+		const socketSecret = "private-socket-7cb0f3";
+		const payloadSecret = "private-payload-7cb0f3";
+
+		const auth = await handler(
+			channelRequest(
+				"channels/auth",
+				{
+					socket_id: socketSecret,
+					channel_name: "private-wire-name-7cb0f3",
+					channel: "room",
+					params: { id: parameterSecret },
+				},
+				{ origin: "https://app.example.com", cookie: true },
+			),
+		);
+		expect(auth.status).toBe(403);
+		const publish = await handler(
+			channelRequest(
+				"channels/publish",
+				{
+					channel: "room",
+					params: { id: parameterSecret },
+					event: "message",
+					data: { text: 42, secret: payloadSecret },
+				},
+				{ origin: "https://app.example.com", cookie: true },
+			),
+		);
+		expect(publish.status).toBe(422);
+
+		const serialized = JSON.stringify(observations);
+		expect(observations.length).toBeGreaterThanOrEqual(2);
+		for (const secret of [parameterSecret, socketSecret, payloadSecret]) {
+			expect(serialized).not.toContain(secret);
+		}
+		expect(
+			observations.every(
+				(event) =>
+					event.type !== "channel.security" ||
+					[
+						"allowed",
+						"access_denied",
+						"origin_denied",
+						"name_invalid",
+						"rate_limited",
+						"payload_invalid",
+						"presence_invalid",
+						"transport_unavailable",
+						"request_invalid",
+						"revoked",
+						"unknown",
+					].includes(event.reason),
+			),
+		).toBe(true);
 	});
 });

--- a/packages/questpie/test/integration/realtime-driver-services.test.ts
+++ b/packages/questpie/test/integration/realtime-driver-services.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { createClient, type RedisClientType } from "redis";
+
+import type { RealtimeAdapter } from "../../src/server/modules/core/integrated/realtime/adapter.js";
+import { PgNotifyAdapter } from "../../src/server/modules/core/integrated/realtime/adapters/pg-notify.js";
+import {
+	RedisStreamsAdapter,
+	type RedisStreamsClient,
+} from "../../src/server/modules/core/integrated/realtime/adapters/redis-streams.js";
+import type {
+	RealtimeChangeEvent,
+	RealtimeNotice,
+} from "../../src/server/modules/core/integrated/realtime/types.js";
+
+const runDrivers = process.env.QUESTPIE_REALTIME_DRIVER_INTEGRATION === "1";
+const postgresUrl =
+	process.env.QUESTPIE_REALTIME_POSTGRES_URL ??
+	"postgresql://questpie:questpie@127.0.0.1:54329/questpie_realtime";
+const redisUrl =
+	process.env.QUESTPIE_REALTIME_REDIS_URL ?? "redis://127.0.0.1:6379";
+
+const changes: RealtimeChangeEvent[] = [
+	{
+		seq: 41,
+		resourceType: "collection",
+		resource: "posts",
+		operation: "update",
+		createdAt: new Date(),
+	},
+	{
+		seq: 42,
+		resourceType: "global",
+		resource: "siteSettings",
+		operation: "update",
+		createdAt: new Date(),
+	},
+];
+const expectedNotices = changes.map(
+	({ seq, resourceType, resource, operation }) => ({
+		seq,
+		resourceType,
+		resource,
+		operation,
+	}),
+);
+
+function timeout<T>(promise: Promise<T>, message: string): Promise<T> {
+	return Promise.race([
+		promise,
+		new Promise<never>((_, reject) =>
+			setTimeout(() => reject(new Error(message)), 10_000),
+		),
+	]);
+}
+
+function receive(
+	adapter: RealtimeAdapter,
+	count: number,
+): Promise<RealtimeNotice[]> {
+	return new Promise((resolve) => {
+		const notices: RealtimeNotice[] = [];
+		const unsubscribe = adapter.subscribe((notice) => {
+			notices.push(notice);
+			if (notices.length !== count) return;
+			unsubscribe();
+			resolve(notices);
+		});
+	});
+}
+
+describe.skipIf(!runDrivers)("realtime driver matrix services", () => {
+	const adapters: RealtimeAdapter[] = [];
+	const redisClients: RedisClientType[] = [];
+
+	afterEach(async () => {
+		await Promise.allSettled(
+			adapters.splice(0).map((adapter) => adapter.stop()),
+		);
+		await Promise.allSettled(
+			redisClients.splice(0).map(async (client) => {
+				if (client.isOpen) await client.quit();
+			}),
+		);
+	});
+
+	test("SSE/pg-notify broadcasts collection and global wakes to every instance", async () => {
+		const channel = `questpie_rt_${crypto.randomUUID().replaceAll("-", "")}`;
+		const first = new PgNotifyAdapter({
+			connectionString: postgresUrl,
+			channel,
+		});
+		const second = new PgNotifyAdapter({
+			connectionString: postgresUrl,
+			channel,
+		});
+		adapters.push(first, second);
+		const received = [
+			receive(first, changes.length),
+			receive(second, changes.length),
+		];
+
+		await Promise.all([first.start(), second.start()]);
+		await Promise.all([first.startPublisher(), second.startPublisher()]);
+		for (const change of changes) await first.notify(change);
+
+		const notices = await timeout(
+			Promise.all(received),
+			"pg-notify matrix delivery timed out",
+		);
+		expect(notices).toEqual([expectedNotices, expectedNotices]);
+	});
+
+	test("SSE/redis streams broadcasts collection and global wakes to every instance", async () => {
+		const stream = `questpie:realtime:${crypto.randomUUID()}`;
+		const clients = [
+			createClient({ url: redisUrl }),
+			createClient({ url: redisUrl }),
+		];
+		redisClients.push(...clients);
+		for (const client of clients) {
+			client.on("error", () => {});
+			await client.connect();
+		}
+		const first = new RedisStreamsAdapter({
+			client: clients[0] as unknown as RedisStreamsClient,
+			stream,
+			blockMs: 100,
+		});
+		const second = new RedisStreamsAdapter({
+			client: clients[1] as unknown as RedisStreamsClient,
+			stream,
+			blockMs: 100,
+		});
+		adapters.push(first, second);
+		const received = [
+			receive(first, changes.length),
+			receive(second, changes.length),
+		];
+
+		await Promise.all([first.start(), second.start()]);
+		await new Promise((resolve) => setTimeout(resolve, 150));
+		for (const change of changes) await first.notify(change);
+
+		const notices = await timeout(
+			Promise.all(received),
+			"Redis matrix delivery timed out",
+		);
+		expect(notices).toEqual([expectedNotices, expectedNotices]);
+	});
+});

--- a/packages/questpie/test/integration/realtime-pusher-routes.test.ts
+++ b/packages/questpie/test/integration/realtime-pusher-routes.test.ts
@@ -22,7 +22,7 @@ const provider: PusherProvider = {
 	getPresenceMemberCount: async () => 0,
 };
 
-describe("pusher transport module routes", () => {
+describe("pusher channel matrix module routes", () => {
 	let setup: Awaited<ReturnType<typeof buildMockApp>>;
 
 	afterEach(async () => {

--- a/packages/questpie/test/integration/realtime-reconciliation.test.ts
+++ b/packages/questpie/test/integration/realtime-reconciliation.test.ts
@@ -195,7 +195,7 @@ async function flushMicrotasks(): Promise<void> {
 	}
 }
 
-describe("realtime reconciliation", () => {
+describe("realtime matrix reconciliation", () => {
 	let cleanup: (() => Promise<void>) | undefined;
 
 	afterEach(async () => {

--- a/packages/questpie/test/integration/realtime-soketi.test.ts
+++ b/packages/questpie/test/integration/realtime-soketi.test.ts
@@ -29,11 +29,17 @@ function timeout<T>(promise: Promise<T>, message: string): Promise<T> {
 	]);
 }
 
-function rawClient(server: Pusher): PusherJs {
+function rawClient(server: Pusher, presenceId?: string): PusherJs {
 	const authorize: ChannelAuthorizationHandler = (params, callback) => {
 		callback(
 			null,
-			server.authorizeChannel(params.socketId, params.channelName),
+			server.authorizeChannel(
+				params.socketId,
+				params.channelName,
+				params.channelName.startsWith("presence-")
+					? { user_id: presenceId ?? crypto.randomUUID() }
+					: undefined,
+			),
 		);
 	};
 	return new PusherJsConstructor(credentials.key, {
@@ -56,32 +62,87 @@ function subscribed(channel: Channel): Promise<void> {
 	);
 }
 
-describe.skipIf(!runSoketi)("soketi pusher transport conformance", () => {
-	test("delivers a notice wake between application instances", async () => {
-		const receiver = pusherRealtime(credentials).changeBroker;
+describe.skipIf(!runSoketi)("soketi channel matrix conformance", () => {
+	test("delivers a notice wake to every application instance", async () => {
+		const receivers = [
+			pusherRealtime(credentials).changeBroker,
+			pusherRealtime(credentials).changeBroker,
+		];
 		const publisher = pusherRealtime(credentials).changeBroker;
-		const received = timeout(
-			new Promise<void>((resolve) => {
-				void receiver.start({
-					onWake: (wake) => {
-						if (wake.reason === "publish" && wake.highWaterSeq === 42)
-							resolve();
-					},
-					onError: () => {},
-				});
-			}),
-			"Soketi notice delivery timed out",
-		);
-		await publisher.start({ onWake: () => {}, onError: () => {} });
-		await new Promise((resolve) => setTimeout(resolve, 100));
-		await publisher.publish({
-			kind: "outbox-maybe-advanced",
-			highWaterSeq: 42,
-			reason: "publish",
-		});
+		try {
+			const received = receivers.map((receiver) =>
+				timeout(
+					new Promise<void>((resolve) => {
+						void receiver.start({
+							onWake: (wake) => {
+								if (wake.reason === "publish" && wake.highWaterSeq === 42)
+									resolve();
+							},
+							onError: () => {},
+						});
+					}),
+					"Soketi notice delivery timed out",
+				),
+			);
+			await publisher.start({ onWake: () => {}, onError: () => {} });
+			await new Promise((resolve) => setTimeout(resolve, 100));
+			await publisher.publish({
+				kind: "outbox-maybe-advanced",
+				highWaterSeq: 42,
+				reason: "publish",
+			});
 
-		await received;
-		await Promise.all([receiver.stop(), publisher.stop()]);
+			await Promise.all(received);
+		} finally {
+			await Promise.allSettled([
+				...receivers.map((receiver) => receiver.stop()),
+				publisher.stop(),
+			]);
+		}
+	});
+
+	test("delivers ordered channel events and presence membership", async () => {
+		const server = new Pusher({
+			appId: credentials.appId,
+			key: credentials.key,
+			secret: credentials.secret,
+			host: credentials.host,
+			port: String(credentials.port),
+			useTLS: false,
+		});
+		const first = rawClient(server, "matrix-member-1");
+		const second = rawClient(server, "matrix-member-2");
+		try {
+			const channelName = "presence-questpie-matrix";
+			const firstChannel = first.subscribe(channelName);
+			await subscribed(firstChannel);
+			const memberAdded = timeout(
+				new Promise<{ id: string }>((resolve) => {
+					firstChannel.bind("pusher:member_added", resolve);
+				}),
+				"Soketi presence member was not observed",
+			);
+			const secondChannel = second.subscribe(channelName);
+			await subscribed(secondChannel);
+			expect(await memberAdded).toMatchObject({ id: "matrix-member-2" });
+
+			const events: Array<{ eventId: string }> = [];
+			const ordered = timeout(
+				new Promise<Array<{ eventId: string }>>((resolve) => {
+					firstChannel.bind("message", (data: { eventId: string }) => {
+						events.push(data);
+						if (events.length === 2) resolve(events);
+					});
+				}),
+				"Soketi ordered channel events timed out",
+			);
+			await server.trigger(channelName, "message", { eventId: "1" });
+			await server.trigger(channelName, "message", { eventId: "2" });
+			expect(await ordered).toEqual([{ eventId: "1" }, { eventId: "2" }]);
+		} finally {
+			first.disconnect();
+			second.disconnect();
+		}
 	});
 
 	test("raw hostile client proves SDK channel allowlists are not authorization", async () => {
@@ -95,26 +156,28 @@ describe.skipIf(!runSoketi)("soketi pusher transport conformance", () => {
 		});
 		const hostile = rawClient(server);
 		const receiver = rawClient(server);
-		const channelName = "private-not-in-framework-allowlist";
-		const hostileChannel = hostile.subscribe(channelName);
-		const receiverChannel = receiver.subscribe(channelName);
-		const event = timeout(
-			new Promise<{ attack: boolean }>((resolve) => {
-				receiverChannel.bind("client-hostile", resolve);
-			}),
-			"Hostile client event was not delivered",
-		);
+		try {
+			const channelName = "private-not-in-framework-allowlist";
+			const hostileChannel = hostile.subscribe(channelName);
+			const receiverChannel = receiver.subscribe(channelName);
+			const event = timeout(
+				new Promise<{ attack: boolean }>((resolve) => {
+					receiverChannel.bind("client-hostile", resolve);
+				}),
+				"Hostile client event was not delivered",
+			);
 
-		await Promise.all([
-			subscribed(hostileChannel),
-			subscribed(receiverChannel),
-		]);
-		expect(hostileChannel.trigger("client-hostile", { attack: true })).toBe(
-			true,
-		);
-		expect(await event).toEqual({ attack: true });
-
-		hostile.disconnect();
-		receiver.disconnect();
+			await Promise.all([
+				subscribed(hostileChannel),
+				subscribed(receiverChannel),
+			]);
+			expect(hostileChannel.trigger("client-hostile", { attack: true })).toBe(
+				true,
+			);
+			expect(await event).toEqual({ attack: true });
+		} finally {
+			hostile.disconnect();
+			receiver.disconnect();
+		}
 	});
 });

--- a/packages/questpie/test/integration/realtime-transactional-capture.test.ts
+++ b/packages/questpie/test/integration/realtime-transactional-capture.test.ts
@@ -36,7 +36,7 @@ async function flushEventLoopTurns(turns = 10): Promise<void> {
 	}
 }
 
-describe("realtime transactional change capture", () => {
+describe("realtime matrix transactional change capture", () => {
 	let setup: Awaited<ReturnType<typeof buildMockApp>>;
 	let ctx: ReturnType<typeof createTestContext>;
 	let observeCollectionHook:

--- a/packages/questpie/test/integration/realtime.test.ts
+++ b/packages/questpie/test/integration/realtime.test.ts
@@ -211,7 +211,7 @@ const createSSEReader = (stream: ReadableStream<Uint8Array>) => {
 // Test Suite
 // ============================================================================
 
-describe("realtime", () => {
+describe("realtime matrix", () => {
 	let setup: Awaited<ReturnType<typeof buildMockApp>>;
 
 	afterEach(async () => {

--- a/packages/questpie/test/units/realtime-admission.test.ts
+++ b/packages/questpie/test/units/realtime-admission.test.ts
@@ -88,4 +88,37 @@ describe("realtime admission", () => {
 			initialSnapshotConcurrency: 4,
 		});
 	});
+
+	it("DoS matrix bounds connection, limit, and relation-depth floods", () => {
+		const registry = new RealtimeAdmissionRegistry(5);
+		const releases = Array.from({ length: 500 }, () =>
+			registry.acquire("one-principal"),
+		);
+		expect(releases.filter(Boolean)).toHaveLength(5);
+		expect(
+			admitRealtimeTopic(
+				{
+					id: "unbounded",
+					resourceType: "collection",
+					resource: "posts",
+					limit: 1_000_000,
+				},
+				DEFAULT_REALTIME_ADMISSION,
+			),
+		).toMatchObject({ accepted: false });
+		expect(
+			admitRealtimeTopic(
+				{
+					id: "deep",
+					resourceType: "collection",
+					resource: "posts",
+					with: {
+						a: { with: { b: { with: { c: { with: { d: true } } } } } },
+					},
+				},
+				DEFAULT_REALTIME_ADMISSION,
+			),
+		).toMatchObject({ accepted: false });
+		for (const release of releases) release?.();
+	});
 });

--- a/packages/questpie/test/units/realtime-observability.test.ts
+++ b/packages/questpie/test/units/realtime-observability.test.ts
@@ -12,7 +12,7 @@ import type { RealtimeChangeEvent } from "../../src/server/modules/core/integrat
 
 const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
 
-describe("realtime observability", () => {
+describe("realtime matrix observability", () => {
 	test("isolates observer and logger failures while exposing bounded metrics", () => {
 		const events: RealtimeObservation[] = [];
 		const observability = new RealtimeObservability({

--- a/packages/questpie/test/units/realtime-pusher-transport.test.ts
+++ b/packages/questpie/test/units/realtime-pusher-transport.test.ts
@@ -101,7 +101,7 @@ class RealtimeReadDb {
 	}
 }
 
-describe("pusher transport change broker", () => {
+describe("pusher channel matrix change broker", () => {
 	test("coalesces notice-only wakes and emits a reconcile wake after reconnect", async () => {
 		const { provider, triggers } = createProvider();
 		let onMessage: ((value: unknown) => void) | undefined;
@@ -278,7 +278,7 @@ describe("pusher transport change broker", () => {
 	});
 });
 
-describe("pusher transport client delivery", () => {
+describe("pusher channel matrix client delivery", () => {
 	test("validates final provider names at the 164-character boundary", () => {
 		expect(() => assertPusherChannelName("a".repeat(164))).not.toThrow();
 		expect(() => assertPusherChannelName("a".repeat(165))).toThrow("1-164");

--- a/packages/questpie/test/units/realtime-refresh-scheduler.test.ts
+++ b/packages/questpie/test/units/realtime-refresh-scheduler.test.ts
@@ -67,6 +67,45 @@ describe("realtime scheduler", () => {
 		expect(realtime.listeners.size).toBe(0);
 	});
 
+	it("deploy storm resumes 500 equivalent clients without a snapshot herd", async () => {
+		const realtime = new FakeRealtimeSource();
+		const observations: Array<{ type: string; subscribers?: number }> = [];
+		const scheduler = new RealtimeRefreshScheduler(realtime, 10, {
+			record: (event) => observations.push(event),
+		});
+		let computes = 0;
+		const frames = Array.from({ length: 500 }, () => 0);
+		const unsubscribers = frames.map((_, index) =>
+			scheduler.subscribe({
+				key: "posts:shared-principal",
+				topicId: "posts",
+				sinceSeq: 4,
+				topics: { resourceType: "collection", resource: "posts" },
+				compute: async () => ({ docs: [], run: ++computes }),
+				onFrame: () => {
+					frames[index] += 1;
+				},
+				onError: () => {},
+			}),
+		);
+
+		await tick();
+		expect(computes).toBe(0);
+		expect(frames.every((count) => count === 0)).toBe(true);
+		expect(realtime.listeners.size).toBe(1);
+
+		realtime.emit(5);
+		await tick();
+		expect(computes).toBe(1);
+		expect(frames.every((count) => count === 1)).toBe(true);
+		expect(observations).toContainEqual(
+			expect.objectContaining({ type: "refresh.completed", subscribers: 500 }),
+		);
+
+		for (const unsubscribe of unsubscribers) unsubscribe();
+		expect(realtime.listeners.size).toBe(0);
+	});
+
 	it("does not share row, field, or afterRead output across access keys", async () => {
 		for (const variant of [
 			"row access",

--- a/packages/questpie/test/units/realtime-sse-transport.test.ts
+++ b/packages/questpie/test/units/realtime-sse-transport.test.ts
@@ -9,7 +9,7 @@ import {
 } from "../../src/server/modules/core/integrated/realtime/sse-client-transport.js";
 import { SharedSseKeepAliveTicker } from "../../src/server/modules/core/integrated/realtime/sse-keep-alive.js";
 
-describe("SseClientTransport", () => {
+describe("realtime matrix SseClientTransport", () => {
 	it("delivers serialized frames through a local-session sink", async () => {
 		const frames: Uint8Array[] = [];
 		let closeCalls = 0;
@@ -147,7 +147,7 @@ describe("SseClientTransport", () => {
 	});
 });
 
-describe("SharedSseKeepAliveTicker", () => {
+describe("realtime matrix SharedSseKeepAliveTicker", () => {
 	it("uses one timer for all registered sessions and emits comment frames", () => {
 		const scheduled: Array<() => void> = [];
 		let cleared = 0;


### PR DESCRIPTION
## Summary
- add a dedicated CI matrix backed by Dockerized Postgres, Redis, and Soketi
- prove real pg-notify and Redis broadcast to two instances for collection and global wakes
- prove Soketi multi-instance wakes, ordered channel events, presence, and the hostile direct-client-event boundary
- exercise a 500-client reconnect storm, QoS/backpressure, DoS caps, poll healing, transactional capture, bulk behavior, and O(1) live count
- audit and map SEC-01 through SEC-16, including bounded sensitive-label observations

## Verification
- real-service matrix: 158 pass, 0 fail (`matrix|storm|dos|channel`)
- `cd packages/questpie && bun run check-types` (includes full-app DB type gate)
- `cd packages/questpie && bun run build`
- changed-file oxlint/oxfmt, `git diff --check`, Docker Compose config, and frozen install

Board: `rt4-1-cross-driver-test-matrix-sse-pg-sse-redis-soketi-storm-backpressure-dos-cap-tests`