### PR TITLE
test(realtime): cover existing consumers

### DIFF
--- a/.changeset/preserve-app-agnostic-channel-client.md
+++ b/.changeset/preserve-app-agnostic-channel-client.md
@@ -1,0 +1,5 @@
+---
+"questpie": patch
+---
+
+Keep concrete generated clients assignable to app-agnostic `QuestpieClient<any>` consumers after adding typed channels.

--- a/apps/autopilot/src/questpie/server/__tests__/chat-realtime-workflow.test.ts
+++ b/apps/autopilot/src/questpie/server/__tests__/chat-realtime-workflow.test.ts
@@ -10,10 +10,10 @@ import {
 } from "../../../../../../packages/questpie/test/utils/mocks/mock-app-builder";
 import { runTestDbMigrations } from "../../../../../../packages/questpie/test/utils/test-db";
 import { activity } from "../collections/activity";
+import assets from "../collections/assets";
 import { chatMessages } from "../collections/chat-messages";
 import { chatSessions } from "../collections/chat-sessions";
 import { environments } from "../collections/environments";
-import assets from "../collections/assets";
 import { models } from "../collections/models";
 import { projects } from "../collections/projects";
 import { providers } from "../collections/providers";
@@ -345,6 +345,48 @@ describe("chat realtime workflow contract", () => {
 			await expect(stream.readEvent(150)).rejects.toThrow(
 				/Timed out waiting for SSE event/,
 			);
+		} finally {
+			await stream.close();
+		}
+	});
+
+	it("refreshes an active run through the framework direct-subscribe seam", async () => {
+		const app = setup!.app;
+		await app.collections.run_links.create({
+			id: "active-run-realtime",
+			status: "running",
+			runtime: "codex",
+			initiatedBy: "chat",
+			instructions: "Observe this run",
+		} as any);
+
+		const response = await call("/api/run-stream?runId=active-run-realtime", {
+			method: "GET",
+		});
+		const stream = createSSEReader(response);
+		try {
+			await realtimeAdapter.waitForSubscribers();
+			const initial = await stream.readUntil((events) =>
+				events.some(
+					(event) =>
+						event.event === "run" && event.data.run.status === "running",
+				),
+			);
+			expect(initial.some((event) => event.event === "run")).toBe(true);
+
+			await app.collections.run_links.updateById({
+				id: "active-run-realtime",
+				data: { status: "completed", endedAt: new Date() },
+			});
+			const updated = await stream.readUntil((events) =>
+				events.some(
+					(event) =>
+						event.event === "run" && event.data.run.status === "completed",
+				),
+			);
+			expect(
+				updated.find((event) => event.event === "run")?.data.run.status,
+			).toBe("completed");
 		} finally {
 			await stream.close();
 		}

--- a/packages/admin/src/client/hooks/realtime-subscription.ts
+++ b/packages/admin/src/client/hooks/realtime-subscription.ts
@@ -1,0 +1,13 @@
+/** @internal Shared direct-subscribe seam used by admin cache invalidation. */
+export function subscribeAdminCollectionRealtime(input: {
+	client: any;
+	collection: string | undefined;
+	topic: unknown;
+	enabled: boolean | undefined;
+	onChange: () => void;
+}): (() => void) | undefined {
+	if (!input.collection || !input.enabled || !input.topic) return;
+	const realtimeApi = input.client?.realtime;
+	if (!realtimeApi?.subscribe) return;
+	return realtimeApi.subscribe(input.topic, input.onChange);
+}

--- a/packages/admin/src/client/hooks/use-collection.ts
+++ b/packages/admin/src/client/hooks/use-collection.ts
@@ -14,6 +14,7 @@ import type {
 	RegisteredCMS,
 	RegisteredCollectionNames,
 } from "../builder/registry";
+import { subscribeAdminCollectionRealtime } from "./realtime-subscription";
 import { useQuestpieQueryOptions } from "./use-questpie-query-options";
 
 type CollectionRealtimeOptions = {
@@ -38,16 +39,17 @@ function useCollectionRealtimeInvalidation({
 	);
 
 	useEffect(() => {
-		if (!collection || !realtime) return;
-		const realtimeApi = client?.realtime;
-		if (!realtimeApi?.subscribe) return;
 		const topic = JSON.parse(topicSignature);
-		if (!topic) return;
-
-		return realtimeApi.subscribe(topic, () => {
-			void queryClient.invalidateQueries({
-				queryKey: ["questpie", "collections", "collections", collection],
-			});
+		return subscribeAdminCollectionRealtime({
+			client,
+			collection,
+			topic,
+			enabled: realtime,
+			onChange: () => {
+				void queryClient.invalidateQueries({
+					queryKey: ["questpie", "collections", "collections", collection],
+				});
+			},
 		});
 	}, [client, collection, queryClient, realtime, topicSignature]);
 }

--- a/packages/admin/test/client/realtime-consumers.test.ts
+++ b/packages/admin/test/client/realtime-consumers.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, test } from "bun:test";
+
+import { QueryClient } from "@tanstack/react-query";
+import type { QuestpieApp, QuestpieClient } from "questpie/client";
+
+import { createQuestpieQueryOptions } from "@questpie/tanstack-query";
+
+import { subscribeAdminCollectionRealtime } from "../../src/client/hooks/realtime-subscription.js";
+
+async function runQuery(options: {
+	queryFn?: unknown;
+	queryKey: readonly unknown[];
+}) {
+	const controller = new AbortController();
+	return (options.queryFn as (input: unknown) => Promise<unknown>)({
+		client: new QueryClient(),
+		queryKey: options.queryKey,
+		signal: controller.signal,
+	});
+}
+
+describe("admin realtime consumer regression", () => {
+	test("list, table, dashboard, locks, and globals consume SSE snapshots", async () => {
+		const topics: unknown[] = [];
+		let restCalls = 0;
+		const snapshots = new Map([
+			["collection:posts:find", { docs: [{ id: "post-1" }], totalDocs: 1 }],
+			["collection:posts:count", 1],
+			[
+				"collection:admin_locks:find",
+				{ docs: [{ id: "lock-1", resourceId: "post-1" }], totalDocs: 1 },
+			],
+			["global:siteSettings:get", { title: "Realtime" }],
+		]);
+		const client = {
+			collections: new Proxy(
+				{},
+				{
+					get: () => ({
+						find: async () => {
+							restCalls += 1;
+						},
+						count: async () => {
+							restCalls += 1;
+						},
+					}),
+				},
+			),
+			globals: new Proxy(
+				{},
+				{
+					get: () => ({
+						get: async () => {
+							restCalls += 1;
+						},
+					}),
+				},
+			),
+			routes: {},
+			realtime: {
+				subscribe: () => () => {},
+				stream: async function* (topic: {
+					resourceType: "collection" | "global";
+					resource: string;
+					operation?: "find" | "count" | "get";
+				}) {
+					topics.push(topic);
+					const operation =
+						topic.operation ??
+						(topic.resourceType === "global" ? "get" : "find");
+					yield snapshots.get(
+						`${topic.resourceType}:${topic.resource}:${operation}`,
+					);
+				},
+				destroy: () => {},
+				topicCount: 0,
+				subscriberCount: 0,
+			},
+		} as unknown as QuestpieClient<QuestpieApp>;
+		const queries = createQuestpieQueryOptions(client);
+
+		const list = await runQuery(
+			queries.collections.posts.find({}, { realtime: true }),
+		);
+		const dashboardCount = await runQuery(
+			queries.collections.posts.count({}, { realtime: true }),
+		);
+		const locks = await runQuery(
+			queries.collections.admin_locks.find({}, { realtime: true }),
+		);
+		const global = await runQuery(
+			queries.globals.siteSettings.get({}, { realtime: true }),
+		);
+
+		expect(list).toEqual({ docs: [{ id: "post-1" }], totalDocs: 1 });
+		expect(dashboardCount).toBe(1);
+		expect(locks).toEqual({
+			docs: [{ id: "lock-1", resourceId: "post-1" }],
+			totalDocs: 1,
+		});
+		expect(global).toEqual({ title: "Realtime" });
+		expect(restCalls).toBe(0);
+		expect(topics).toEqual([
+			{ resourceType: "collection", resource: "posts", operation: "find" },
+			{ resourceType: "collection", resource: "posts", operation: "count" },
+			{
+				resourceType: "collection",
+				resource: "admin_locks",
+				operation: "find",
+			},
+			{ resourceType: "global", resource: "siteSettings", operation: "get" },
+		]);
+	});
+
+	test("direct invalidation treats one bulk event as one cache wake", () => {
+		let listener: (() => void) | undefined;
+		let unsubscribed = 0;
+		let invalidations = 0;
+		const unsubscribe = subscribeAdminCollectionRealtime({
+			client: {
+				realtime: {
+					subscribe: (_topic: unknown, callback: () => void) => {
+						listener = callback;
+						return () => {
+							unsubscribed += 1;
+						};
+					},
+				},
+			},
+			collection: "posts",
+			topic: { resourceType: "collection", resource: "posts" },
+			enabled: true,
+			onChange: () => {
+				invalidations += 1;
+			},
+		});
+
+		listener?.();
+		expect(invalidations).toBe(1);
+		unsubscribe?.();
+		expect(unsubscribed).toBe(1);
+	});
+});

--- a/packages/questpie/src/client/index.ts
+++ b/packages/questpie/src/client/index.ts
@@ -135,8 +135,9 @@ export interface QuestpieApp {
 	auth?: any;
 }
 
-type AppChannelDefinitions<TApp extends QuestpieApp> =
-	NonNullable<TApp["channels"]> extends ChannelDefinitions
+type AppChannelDefinitions<TApp extends QuestpieApp> = 0 extends 1 & TApp
+	? {}
+	: NonNullable<TApp["channels"]> extends ChannelDefinitions
 		? NonNullable<TApp["channels"]>
 		: {};
 

--- a/packages/questpie/test/types/channel-client.test-d.ts
+++ b/packages/questpie/test/types/channel-client.test-d.ts
@@ -25,6 +25,11 @@ type App = {
 
 declare const client: QuestpieClient<App>;
 
+// App-agnostic consumers can accept a concrete client without widening the
+// channel map into an index signature that conflicts with lifecycle methods.
+const appAgnosticClient: QuestpieClient<any> = client;
+appAgnosticClient.channels.destroy();
+
 client.channels.news.subscribe((message) => {
 	if (message.event === "metric") {
 		type _outputWasInferred = Expect<Equal<typeof message.data.value, number>>;


### PR DESCRIPTION
## Summary
- cover admin list/table/dashboard/locks/global realtime snapshots and N-to-1 bulk invalidation semantics
- verify the Autopilot run stream through the framework direct-subscribe seam
- preserve concrete generated client assignability to app-agnostic admin consumers after typed channels

## Verification
- packages/admin: tsc, 348 tests, build
- packages/questpie: check-types including full-app DB precision fixture, build
- realtime/integration gate: 130 pass, 5 service-dependent skips, 0 fail
- core live/liveIter: 13 pass
- TanStack realtime/channel: 5 pass, tsc, build
- Autopilot run-stream workflow: 3 pass
- changed-file format and lint: 0 errors

Stacked on #160.