### PR TITLE
docs(realtime): document v2 and typed channels

### DIFF
--- a/apps/docs/content/docs/adapters/realtime.mdx
+++ b/apps/docs/content/docs/adapters/realtime.mdx
@@ -1,24 +1,27 @@
 ---
 title: Realtime adapter
-description: The server-side transport that powers live queries, turn on realtime in your config and changes are recorded to an outbox, then fanned out across every app instance over pg_notify, Redis streams, or Cloudflare Durable Objects.
+description: Configure the durable realtime runtime, its notice broker, SSE or Pusher/Soketi edge delivery, reconciliation, admission limits, privacy, and deployment-specific drivers.
 ---
 
-The **realtime adapter** is the server-side transport behind QUESTPIE's live queries. Set `realtime` in your runtime config and every write is recorded to a change **outbox** table; the adapter then signals each app instance to re-run the affected subscriptions and push fresh snapshots over SSE. With no adapter the service polls that outbox on a timer, fine for a single process. Add `pgNotifyAdapter()` or `redisStreamsAdapter({ client })` and changes propagate the instant they happen, across every horizontally-scaled instance.
+The **realtime runtime** powers live queries and typed channels. Set `realtime` in runtime config and each logical mutation writes one change row to the durable **outbox inside the business transaction**. A broker wake tells app instances to drain that state quickly; a reconciliation poll drains it even when the wake is missing. Authorized frames then leave through the default SSE edge transport or an opt-in Pusher/Soketi client transport.
 
 This page covers the **server** side: the `realtime` config, the outbox/poll model, and each transport adapter's options. The client API, `live()`, `liveIter()`, and the TanStack Query `{ realtime: true }` flag, is taught on [Realtime](/docs/client/realtime).
 
 <Callout type="info" title="Prerequisites">
-Read [Configuration](/docs/concepts/configuration) (where adapters are wired in `questpie.config.ts`) and [Realtime](/docs/client/realtime) (the client `live()` API this transport serves).
+	Read [Configuration](/docs/concepts/configuration) (where adapters are wired
+	in `questpie.config.ts`) and [Realtime](/docs/client/realtime) (the client
+	`live()` API this transport serves).
 </Callout>
 
 ## What it does
 
-- **Records every change to an outbox.** Each create/update/delete (and bulk variant) appends a row to the `questpie_realtime_log` table, a durable, ordered change log keyed by an auto-incrementing `seq`.
-- **Fans out across instances.** The adapter broadcasts a tiny *notice* ("seq N on collection posts changed") to every process, which then drains the outbox and pushes snapshots to its own SSE subscribers.
-- **Zero-config default.** Turn `realtime` on with `true` and you get a working transport, polling on a non-Postgres setup, or an auto-wired `pg_notify` listener when a Postgres connection is available.
+- **Records every logical change transactionally.** Each create/update/delete (and bulk variant) appends one row to `questpie_realtime_log` using the mutation's database transaction.
+- **Fans out across instances.** The adapter broadcasts a tiny _notice_ ("seq N on collection posts changed") to every process, which then drains the outbox and pushes snapshots to its own SSE subscribers.
+- **Zero-infrastructure edge default.** `realtime: true` serves multiplexed SSE. It polls on a non-Postgres setup or auto-wires pg_notify when a normal Postgres connection string is available.
 - **Push transports for scale.** `pgNotifyAdapter` rides the database you already run; `redisStreamsAdapter` gives every instance an independent Redis Stream tail; `cloudflareRealtimeAdapter` is backed by a Durable Object.
-- **Privacy-safe by design.** Only a `RealtimeNotice` crosses the wire, never row data. Each subscriber re-runs its own access-controlled query to build its snapshot, so one user's data can't leak through the transport.
-- **Swap with one config line.** The transport is a single `realtime.adapter` value, no app-code change to move from polling to Redis.
+- **Two explicit seams.** `ChangeBroker` carries lossy notice-only wakes between instances. `ClientTransport` carries already-authorized frames to edge sessions. Live snapshots and channel events have different QoS and are not conflated in a driver.
+- **Privacy-safe by design.** Brokers never carry rows or snapshots. Snapshot sharing is per-principal by default; managed WS delivers access-filtered live-query frames on private per-session channels. Shared multicast is reserved for schema-validated, channel-authorized events.
+- **Switch without changing consumers.** Choose SSE or the Pusher/Soketi preset under `realtime`; `live()`, `{ realtime: true }`, and `client.channels.*` remain unchanged.
 
 ## Quick start
 
@@ -30,8 +33,8 @@ import { runtimeConfig } from "questpie/app";
 import env from "./env"; // declared + validated in env.ts, see Environment
 
 export default runtimeConfig({
-  db: { url: env.DATABASE_URL },
-  realtime: true,
+	db: { url: env.DATABASE_URL },
+	realtime: true,
 });
 ```
 
@@ -45,14 +48,14 @@ That's the whole server requirement. Subscribe from the client with `client.coll
 
 The flow, from a write to a pushed snapshot:
 
-| Step | What happens | Source |
-|---|---|---|
-| 1. Write commits | A create/update/delete appends one row to `questpie_realtime_log` (`appendChange`), `{ seq, resourceType, resource, operation, recordId?, locale?, payload }`. | `realtime/service.ts:217`; `realtime/collection.ts:9` |
-| 2. Signal | The adapter `notify(event)` broadcasts a minimal `RealtimeNotice` (`{ seq, resourceType, resource, operation }`) to every instance. | `realtime/adapter.ts:9`; `realtime/service.ts:249` |
-| 3. Drain | Each instance reacts to the notice (or a poll tick) by `drain()`ing new outbox rows past its watermark. | `realtime/service.ts:418-426` |
-| 4. Re-run + push | For each affected subscription, the server re-runs the query **under the subscriber's session** and pushes the fresh snapshot over its `POST /realtime` SSE stream. | `realtime/service.ts` (drain → listeners) |
+| Step                           | What happens                                                                                                                                                        | Source                                             |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
+| 1. Transaction captures change | A create/update/delete appends one row to `questpie_realtime_log` using the mutation-bound `db`; the business row and outbox row commit or roll back together.      | `realtime/service.ts`; transactional capture hooks |
+| 2. Signal                      | The adapter `notify(event)` broadcasts a minimal `RealtimeNotice` (`{ seq, resourceType, resource, operation }`) to every instance.                                 | `realtime/adapter.ts:9`; `realtime/service.ts:249` |
+| 3. Drain                       | Each instance reacts to the notice (or a poll tick) by `drain()`ing new outbox rows past its watermark.                                                             | `realtime/service.ts:418-426`                      |
+| 4. Re-run + push               | For each affected subscription, the server re-runs the query **under the subscriber's session** and pushes the fresh snapshot over its `POST /realtime` SSE stream. | `realtime/service.ts` (drain → listeners)          |
 
-The adapter is only the *signal* layer (steps 2-3). The outbox (step 1) and the access-controlled re-run (step 4) happen regardless of which adapter you pick. This is why the notice carries no payload, the snapshot is always rebuilt server-side per subscriber.
+The broker is only a _latency hint_ (steps 2-3). The outbox (step 1), unconditional reconciliation, and access-controlled re-run (step 4) provide correctness regardless of which driver you pick. Wakes are intentionally unordered, at-most-once, and coalescable.
 
 <Callout type="info" title="The notice is a cue, not the data">
 A `RealtimeNotice` is `Pick<RealtimeChangeEvent, "seq" | "resourceType" | "resource" | "operation">`, just enough to say *something matching changed*. The full event (with `payload`) lives in the outbox; subscribers never receive another user's rows over the transport.
@@ -64,44 +67,95 @@ Use `realtime: true` to turn on the default transport. Use an object when you wa
 
 ```ts
 interface RealtimeConfig {
-  adapter?: RealtimeAdapter;       // transport (pg_notify, redis, …). Omit → poll / auto pg_notify
-  pollIntervalMs?: number;         // default 2000, drain interval when running pollless (no adapter)
-  batchSize?: number;              // default 500, max outbox rows read per drain
-  retentionDays?: number;          // default 3; set 0 to disable time-based cleanup
-  keepAliveIntervalMs?: number;    // default 8000, SSE keep-alive ping interval
+	observer?: RealtimeObserver;
+	rollout?: RealtimeRolloutConfig;
+	admission?: Partial<RealtimeAdmissionConfig>;
+	connectionAcceptPacingMs?: number;
+	adapter?: RealtimeAdapter; // legacy-compatible broker adapter
+	changeBroker?: ChangeBroker; // v2 cross-instance notice seam
+	clientTransport?: ClientTransport; // managed edge transport; omit → SSE
+	channelEvents?: Partial<ChannelEventLedgerConfig>;
+	channelSecurity?: ChannelSecurityConfig;
+	pollIntervalMs?: number; // 15000 with push, 2000 without
+	batchSize?: number; // default 500, max outbox rows read per drain
+	retentionDays?: number; // default 3; set 0 to disable time-based cleanup
+	keepAliveIntervalMs?: number; // default 8000, SSE keep-alive ping interval
 }
 ```
 
-
-
-| Option | Default | What it controls |
-|---|---|---|
-| `adapter` | *(none)* | The transport that broadcasts change notices. Omit it for the poll / auto-`pg_notify` default (below). |
-| `pollIntervalMs` | `2000` | How often the service drains the outbox **when there is no adapter** (defaults to `0` if you omit it while an adapter is set). With an adapter, drains are notice-driven, so this is ignored, the poll timer only runs on the no-adapter path. |
-| `batchSize` | `500` | Max outbox rows pulled per drain. Raise it for very high write volume. |
-| `retentionDays` | `3` | Time horizon for outbox cleanup, including apps with zero subscribers. Set `0` to disable. Cleanup never uses a process-local subscriber watermark, because that could delete rows another instance has not drained yet. |
-| `keepAliveIntervalMs` | `8000` | Interval between `ping` keep-alive events on each `POST /realtime` SSE stream. |
+| Option                     | Default                           | What it controls                                                                                                                                                                                                         |
+| -------------------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `observer`                 | _(none)_                          | Structured lifecycle/admission/transport diagnostics. Observer failures are isolated from delivery.                                                                                                                      |
+| `rollout`                  | v2                                | Compatibility/canary selection (`legacy`, `v2`, or `dual`) used by the migration and rollback path.                                                                                                                      |
+| `admission`                | limits below                      | Edge-session topic, connection, query-shape, concurrency, and buffer caps.                                                                                                                                               |
+| `connectionAcceptPacingMs` | `0`                               | Optional maximum random delay before accepting a new edge session.                                                                                                                                                       |
+| `adapter`                  | _(none)_                          | Existing `RealtimeAdapter` compatibility path, including pg_notify, Redis, and Cloudflare.                                                                                                                               |
+| `changeBroker`             | _(none)_                          | Realtime v2 notice-only broker. If absent, v2 maps an existing `adapter` onto the new runtime.                                                                                                                           |
+| `clientTransport`          | SSE                               | Optional managed edge transport. The Pusher preset supplies both `changeBroker` and `clientTransport`.                                                                                                                   |
+| `channelEvents`            | bounded defaults                  | Ordered-channel replay retention, lease, and slow-consumer buffer tuning.                                                                                                                                                |
+| `channelSecurity`          | secure defaults                   | Trusted origins, payload size, publish rate, and authorization timeout policy.                                                                                                                                           |
+| `pollIntervalMs`           | `15000` with push; `2000` without | Reconciliation interval. It runs **alongside** a broker/adapter so dropped wakes heal; provider failure temporarily tightens it to at most 2s. Set `0` only when deliberately accepting loss of that recovery path.      |
+| `batchSize`                | `500`                             | Max outbox rows pulled per drain. Raise it for very high write volume.                                                                                                                                                   |
+| `retentionDays`            | `3`                               | Time horizon for outbox cleanup, including apps with zero subscribers. Set `0` to disable. Cleanup never uses a process-local subscriber watermark, because that could delete rows another instance has not drained yet. |
+| `keepAliveIntervalMs`      | `8000`                            | Interval between `ping` keep-alive events on each `POST /realtime` SSE stream.                                                                                                                                           |
 
 <Callout type="warn" title="Keep `keepAliveIntervalMs` under your idle timeout">
-The default `8000` ms is deliberately under Bun's default 10s `idleTimeout`, so SSE streams survive on an untuned `Bun.serve`. Behind a proxy with a shorter read timeout (some default to 30-60s, but custom ones can be lower), drop it further so the connection never goes idle long enough to be culled.
+	The default `8000` ms is deliberately under Bun's default 10s `idleTimeout`,
+	so SSE streams survive on an untuned `Bun.serve`. Behind a proxy with a
+	shorter read timeout (some default to 30-60s, but custom ones can be lower),
+	drop it further so the connection never goes idle long enough to be culled.
 </Callout>
+
+### Admission defaults
+
+The SSE edge rejects abusive or accidentally unbounded topics before registering listeners or computing snapshots:
+
+| Limit                                            | Default |
+| ------------------------------------------------ | ------: |
+| Topics per edge connection                       |      20 |
+| Edge connections per authenticated principal     |       5 |
+| Maximum `find` limit (also applied when omitted) |     100 |
+| Maximum nested `with` depth                      |       3 |
+| Concurrent initial snapshots                     |       4 |
+| Buffered snapshot bytes per edge session         |   1 MiB |
+
+Override only the values you have measured:
+
+```ts
+realtime: {
+  admission: {
+    maxTopicsPerConnection: 30,
+    maxFindLimit: 50,
+  },
+}
+```
+
+Equivalent subscriptions compute once and fan out serialized bytes, but the access-equivalence key is session/principal-scoped by default. Row access, field access, and `afterRead` hooks may depend on the current session, so cross-user sharing requires an explicit deterministic opt-in and isolation tests.
 
 ## The default: poll vs auto `pg_notify`
 
-Omitting `adapter` does **not** always mean naive polling. The service resolves the transport lazily on the first subscription (in `ensureStarted()`, triggered from `subscribe()`, not at process boot), like this:
+Omitting `adapter` does **not** always mean naive polling. The runtime selects the compatibility broker like this:
 
 1. **Explicit `adapter` set** → use it.
-2. **No adapter, but a Postgres connection string is available** → the service lazily constructs a `pgNotifyAdapter` on the `questpie_realtime` channel for you. Most Postgres apps get push delivery from `realtime: true` with no extra config.
+2. **No adapter/broker, but a Postgres connection string is available** → construct `pgNotifyAdapter` on `questpie_realtime`. Its publisher starts with the app lifecycle, including write-only workers with no local subscribers.
 3. **No adapter and no Postgres connection** → fall back to polling the outbox every `pollIntervalMs` (default 2s).
 
-
-
-<Callout type="info" title="Polling is real, just laggy">
-The poll path is correct, not a downgrade in behavior, it drains the same outbox and pushes the same access-controlled snapshots, just on a 2s timer instead of on-change. It's a fine default for a single instance and local dev. For multiple processes you want a real adapter (next section) so a write on instance A reaches a subscriber on instance B.
+<Callout type="info" title="Polling is the recovery guarantee">
+	The poll drains the same outbox and pushes the same access-controlled
+	snapshots. Without push it is the 2s primary path; with push it is the slower
+	15s reconciliation path. A notice lowers latency, but missing it does not
+	permanently stall an instance.
 </Callout>
 
-<Callout type="warn" title="One instance, multiple processes need a shared transport">
-The outbox is shared (it's a DB table), but the poll timer and the auto-`pg_notify` listener are **per process**. Polling means each instance independently notices changes on its own timer, workable but laggy and DB-chatty at scale. An explicit `pgNotifyAdapter` / `redisStreamsAdapter` fans a single notice out to all instances the moment a change lands. Reach for one once you run more than one process.
+<Callout
+	type="warn"
+	title="Multi-tier deployments need a broker every writer can reach"
+>
+	The outbox and reconciliation preserve correctness when every tier shares the
+	same database, but latency and DB load degrade when split workers only poll.
+	Ensure API, worker, and subscriber-serving instances use the same explicit
+	pg/Redis/Pusher broker. Do not assume an implicit database URL exists in every
+	process.
 </Callout>
 
 ## `pgNotifyAdapter`, Postgres `LISTEN`/`NOTIFY`
@@ -115,24 +169,24 @@ import { pgNotifyAdapter } from "questpie/adapters/pg-notify";
 import env from "./env";
 
 export default runtimeConfig({
-  db: { url: env.DATABASE_URL },
-  realtime: {
-    adapter: pgNotifyAdapter({
-      connectionString: env.DATABASE_URL,
-      // channel: "questpie_realtime", // default
-    }),
-  },
+	db: { url: env.DATABASE_URL },
+	realtime: {
+		adapter: pgNotifyAdapter({
+			connectionString: env.DATABASE_URL,
+			// channel: "questpie_realtime", // default
+		}),
+	},
 });
 ```
 
 `PgNotifyAdapterOptions` is `{ channel?, client?, connection?, connectionString? }`. You must supply **one** connection source.
 
-| Option | Type | Default | Notes |
-|---|---|---|---|
-| `channel` | `string` | `"questpie_realtime"` | Postgres channel name. Validated against `/^[a-zA-Z0-9_]+$/`, an invalid name throws at construction. |
-| `client` | `pg.Client` | none | An existing `pg` client to reuse. **Not** `.end()`-ed by the adapter on stop (you own its lifecycle). |
-| `connection` | `pg.ClientConfig` | none | A `pg` connection config; the adapter constructs and owns the client. |
-| `connectionString` | `string` | none | A connection URL; the adapter constructs and owns the client. |
+| Option             | Type              | Default               | Notes                                                                                                 |
+| ------------------ | ----------------- | --------------------- | ----------------------------------------------------------------------------------------------------- |
+| `channel`          | `string`          | `"questpie_realtime"` | Postgres channel name. Validated against `/^[a-zA-Z0-9_]+$/`, an invalid name throws at construction. |
+| `client`           | `pg.Client`       | none                  | An existing `pg` client to reuse. **Not** `.end()`-ed by the adapter on stop (you own its lifecycle). |
+| `connection`       | `pg.ClientConfig` | none                  | A `pg` connection config; the adapter constructs and owns the client.                                 |
+| `connectionString` | `string`          | none                  | A connection URL; the adapter constructs and owns the client.                                         |
 
 Behavior:
 
@@ -142,8 +196,49 @@ Behavior:
 - **Uses `LISTEN`/`UNLISTEN` + `pg_notify($1, $2)`.** The notice JSON (`{ seq, resourceType, resource, operation }`) is the channel payload.
 
 <Callout type="info" title="You usually don't need to write this">
-On a Postgres app, `realtime: true` already auto-wires `pg_notify` on the default channel (see [the default](#the-default-poll-vs-auto-pg-notify) above). Configure `pgNotifyAdapter` explicitly only when you want a **non-default channel**, want to **reuse an existing `pg` client**, or are pointing realtime at a **different database** than your main `db`.
+	On a Postgres app, `realtime: true` already auto-wires `pg_notify` on the
+	default channel (see [the default](#the-default-poll-vs-auto-pg-notify)
+	above). Configure `pgNotifyAdapter` explicitly only when you want a
+	**non-default channel**, want to **reuse an existing `pg` client**, or are
+	pointing realtime at a **different database** than your main `db`.
 </Callout>
+
+## Pusher/Soketi preset, managed WebSockets
+
+SSE is the default client delivery path. Select `pusherRealtime()` when you want provider-managed WebSockets, native presence, and shared multicast for framework channel events. The preset supplies both v2 seams: a notice-only `changeBroker` and a `clientTransport`.
+
+```ts title="src/questpie/server/questpie.config.ts"
+import { pusherRealtime } from "questpie/adapters/pusher";
+import { runtimeConfig } from "questpie/app";
+
+const managed = pusherRealtime({
+	appId: env.PUSHER_APP_ID,
+	key: env.PUSHER_KEY,
+	secret: env.PUSHER_SECRET,
+	cluster: env.PUSHER_CLUSTER,
+	// Soketi: host, port, wsHost, wsPort/wssPort, useTLS
+});
+
+export default runtimeConfig({
+	realtime: { ...managed },
+});
+```
+
+The isolated `questpie/adapters/pusher` export is the only entry that loads the optional `pusher` and `pusher-js` peers. Unrelated imports do not load them.
+
+Live-query snapshots remain private per edge session because each snapshot has already passed that principal's row/field access and `afterRead` hooks. The shared provider broker carries only wakes. Framework channel events may use provider multicast after subscribe/publish authorization and Zod validation.
+
+Direct provider client events are **off by default** and are not equivalent to `client.channels.*.publish()`. Enabling them requires:
+
+```ts
+clientEvents: {
+  enabled: true,
+  acknowledgeProviderWideRisk: true,
+  allowedChannels: ["presence-chat-room-one"],
+}
+```
+
+That allowlist only constrains the QUESTPIE SDK. Raw provider clients can bypass it, and their events bypass framework schemas, publish authorization, rate limits, ordered replay, and delivery guarantees.
 
 ## `redisStreamsAdapter`, Redis Streams
 
@@ -160,30 +255,30 @@ const redis = createClient({ url: env.REDIS_URL });
 await redis.connect();
 
 export default runtimeConfig({
-  db: { url: env.DATABASE_URL },
-  realtime: {
-    adapter: redisStreamsAdapter({
-      client: redis,
-      // stream: "questpie:realtime",   // default
-      // blockMs: 5000, batchSize: 100, // defaults
-      // maxLen: 10_000,                // approximate stream cap
-    }),
-  },
+	db: { url: env.DATABASE_URL },
+	realtime: {
+		adapter: redisStreamsAdapter({
+			client: redis,
+			// stream: "questpie:realtime",   // default
+			// blockMs: 5000, batchSize: 100, // defaults
+			// maxLen: 10_000,                // approximate stream cap
+		}),
+	},
 });
 ```
 
 `RedisStreamsAdapterOptions` is `{ client (required), reader?, stream?, blockMs?, batchSize?, maxLen?, retryDelayMs?, onError? }`.
 
-| Option | Type | Default | Notes |
-|---|---|---|---|
-| `client` | `RedisStreamsClient` | none **required** | Publishing client. Must implement `xAdd` + `xRead`; node-redis clients are automatically duplicated for the blocking reader. |
-| `reader` | `RedisStreamsClient` | auto | Optional already-connected blocking-read client for structural clients without `duplicate()`. |
-| `stream` | `string` | `"questpie:realtime"` | The Redis stream key notices are `XADD`-ed to. |
-| `blockMs` | `number` | `5000` | How long `XREAD` blocks waiting for new messages. |
-| `batchSize` | `number` | `100` | `COUNT` per `XREAD` call. |
-| `maxLen` | `number` | `10000` | Approximate `MAXLEN ~` cap applied by every `XADD`. |
-| `retryDelayMs` | `number` | `500` | Backoff after a read-loop failure. |
-| `onError` | `(error) => void` | `console.warn` | Error hook for read/listener failures. |
+| Option         | Type                 | Default               | Notes                                                                                                                        |
+| -------------- | -------------------- | --------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `client`       | `RedisStreamsClient` | none **required**     | Publishing client. Must implement `xAdd` + `xRead`; node-redis clients are automatically duplicated for the blocking reader. |
+| `reader`       | `RedisStreamsClient` | auto                  | Optional already-connected blocking-read client for structural clients without `duplicate()`.                                |
+| `stream`       | `string`             | `"questpie:realtime"` | The Redis stream key notices are `XADD`-ed to.                                                                               |
+| `blockMs`      | `number`             | `5000`                | How long `XREAD` blocks waiting for new messages.                                                                            |
+| `batchSize`    | `number`             | `100`                 | `COUNT` per `XREAD` call.                                                                                                    |
+| `maxLen`       | `number`             | `10000`               | Approximate `MAXLEN ~` cap applied by every `XADD`.                                                                          |
+| `retryDelayMs` | `number`             | `500`                 | Backoff after a read-loop failure.                                                                                           |
+| `onError`      | `(error) => void`    | `console.warn`        | Error hook for read/listener failures.                                                                                       |
 
 Behavior:
 
@@ -219,47 +314,50 @@ import { runtimeConfig } from "questpie/app";
 import { cloudflareRealtimeAdapter } from "questpie/adapters/cloudflare-realtime";
 
 export default runtimeConfig({
-  realtime: {
-    adapter: cloudflareRealtimeAdapter({
-      // A Durable Object namespace binding, or a zero-arg function that
-      // returns one (so you can resolve it lazily from your Worker env).
-      namespace: () => getEnv().QUESTPIE_REALTIME,
-      // objectName: "questpie-realtime",  // default DO instance name
-      // hubPath: "/__questpie/realtime",   // default internal hub path
-    }),
-  },
+	realtime: {
+		adapter: cloudflareRealtimeAdapter({
+			// A Durable Object namespace binding, or a zero-arg function that
+			// returns one (so you can resolve it lazily from your Worker env).
+			namespace: () => getEnv().QUESTPIE_REALTIME,
+			// objectName: "questpie-realtime",  // default shard-name prefix
+			// hubPath: "/__questpie/realtime",   // default internal hub path
+		}),
+	},
 });
 ```
 
-`CloudflareRealtimeAdapterOptions` is `{ namespace (required), objectName?, hubPath? }`. The `namespace` is a Durable Object namespace binding, or a **zero-argument** function that returns one (resolved lazily when the adapter first needs it, so you can defer reading it out of your Worker env).
+`CloudflareRealtimeAdapterOptions` is `{ namespace (required), objectName?, hubPath?, waitUntil?, onError? }`. The `namespace` is a Durable Object namespace binding, or a **zero-argument** function that returns one (resolved lazily when the adapter first needs it, so you can defer reading it out of your Worker env).
 
-| Option | Type | Default | Notes |
-|---|---|---|---|
-| `namespace` | `CloudflareDurableObjectNamespaceInput` | none **required** | The DO namespace binding, or `() => namespace`. |
-| `objectName` | `string` | `"questpie-realtime"` | Name of the DO instance (`idFromName`) all notices route through. |
-| `hubPath` | `string` | `"/__questpie/realtime"` | Internal hub path; the adapter derives `${hubPath}/subscribe` and `${hubPath}/notify`. |
+| Option       | Type                                    | Default                  | Notes                                                                                  |
+| ------------ | --------------------------------------- | ------------------------ | -------------------------------------------------------------------------------------- |
+| `namespace`  | `CloudflareDurableObjectNamespaceInput` | none **required**        | The DO namespace binding, or `() => namespace`.                                        |
+| `objectName` | `string`                                | `"questpie-realtime"`    | Base DO name; the runtime appends resource type and resource name to shard notices.    |
+| `hubPath`    | `string`                                | `"/__questpie/realtime"` | Internal hub path; the adapter derives `${hubPath}/subscribe` and `${hubPath}/notify`. |
+| `waitUntil`  | `(promise) => void`                     | none                     | Keeps the non-blocking notify relay alive for the current Worker event.                |
+| `onError`    | `(error) => void`                       | `console.error`          | Reports background publish and relay failures.                                         |
 
-This adapter carries a `runtime: "cloudflare"` discriminator so the Cloudflare fetch/queue handlers detect it, and it's wired together with the **`createCloudflareRealtimeDurableObjectHandler`** export (from `questpie/adapters/cloudflare`) that implements the DO itself.
+This adapter carries a `runtime: "cloudflare"` discriminator so the Cloudflare fetch/queue handlers detect it, and it's wired together with the **`createCloudflareRealtimeDurableObjectHandler`** export (from `questpie/adapters/cloudflare`) that implements the DO itself. Durable Objects are sharded by `resourceType` and resource; mutation publish is non-blocking, only the minimal notice crosses the DO boundary, and snapshot queries stay in the requesting Worker.
 
 <Callout type="info" title="Cloudflare realtime is a deployment-specific setup">
-Unlike `pg_notify` / Redis, this adapter requires a Durable Object class bound in your `wrangler` config plus the DO handler. It's part of the Cloudflare Workers deployment story rather than a drop-in line. The other two adapters need no Workers-specific wiring.
+	Unlike `pg_notify` / Redis, this adapter requires a Durable Object class bound
+	in your `wrangler` config plus the DO handler. It's part of the Cloudflare
+	Workers deployment story rather than a drop-in line. The other two adapters
+	need no Workers-specific wiring.
 </Callout>
 
 ## The outbox table
 
 The change log lives in one Drizzle table, `questpie_realtime_log`, created by codegen alongside your schema (it's part of the core module). You rarely touch it directly, but it's worth knowing it exists:
 
-| Column | Notes |
-|---|---|
-| `seq` | `bigserial` primary key, the monotonic ordering every subscriber watermarks against. |
-| `resource_type` | `"collection"` or `"global"`. |
-| `resource` | The collection/global name. |
-| `operation` | `create` / `update` / `delete` / `bulk_update` / `bulk_delete`. |
-| `record_id`, `locale` | Nullable; the specific record + locale when applicable. |
-| `payload` | `jsonb` (default `{}`), kept server-side (never broadcast). Single-record changes store shallow scalar `{ before, after }` equality projections; bulk changes store `{ count, recordIds }`. Nested objects, arrays, and hydrated relations are excluded. |
-| `created_at` | Insert timestamp; powers `retentionDays` cleanup. |
-
-
+| Column                | Notes                                                                                                                                                                                                                                                    |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `seq`                 | `bigserial` primary key, the monotonic ordering every subscriber watermarks against.                                                                                                                                                                     |
+| `resource_type`       | `"collection"` or `"global"`.                                                                                                                                                                                                                            |
+| `resource`            | The collection/global name.                                                                                                                                                                                                                              |
+| `operation`           | `create` / `update` / `delete` / `bulk_update` / `bulk_delete`.                                                                                                                                                                                          |
+| `record_id`, `locale` | Nullable; the specific record + locale when applicable.                                                                                                                                                                                                  |
+| `payload`             | `jsonb` (default `{}`), kept server-side (never broadcast). Single-record changes store shallow scalar `{ before, after }` equality projections; bulk changes store `{ count, recordIds }`. Nested objects, arrays, and hydrated relations are excluded. |
+| `created_at`          | Insert timestamp; powers `retentionDays` cleanup.                                                                                                                                                                                                        |
 
 ## TypeScript
 
@@ -267,14 +365,14 @@ The transport contract and config types are exported from `questpie` (and `quest
 
 ```ts
 import type {
-  RealtimeAdapter,        // the transport contract you implement for a custom adapter
-  RealtimeConfig,         // the `realtime` config shape
-  RealtimeChangeEvent,    // a full outbox event
-  RealtimeChangePayload,  // { before, after } or { count, recordIds }
-  RealtimeEqualityProjection, // shallow scalar fields used for equality routing
-  RealtimeNotice,         // the minimal broadcast notice
-  RealtimeOperation,      // "create" | "update" | "delete" | "bulk_update" | "bulk_delete"
-  RealtimeResourceType,   // "collection" | "global"
+	RealtimeAdapter, // the transport contract you implement for a custom adapter
+	RealtimeConfig, // the `realtime` config shape
+	RealtimeChangeEvent, // a full outbox event
+	RealtimeChangePayload, // { before, after } or { count, recordIds }
+	RealtimeEqualityProjection, // shallow scalar fields used for equality routing
+	RealtimeNotice, // the minimal broadcast notice
+	RealtimeOperation, // "create" | "update" | "delete" | "bulk_update" | "bulk_delete"
+	RealtimeResourceType, // "collection" | "global"
 } from "questpie/realtime";
 ```
 
@@ -282,14 +380,16 @@ Each adapter's option type ships from its own entry, `PgNotifyAdapterOptions` fr
 
 ## Build your own transport
 
-`RealtimeAdapter` is a four-method contract, implement it to back realtime on any pub/sub system (NATS, Kafka, a cloud queue):
+`RealtimeAdapter` remains the compatibility contract for an invalidation driver. Realtime v2 internally separates that concern into `ChangeBroker` and keeps edge delivery in `ClientTransport`; new managed presets should implement those independent seams instead of combining broker, auth, and delivery in one object.
+
+The compatibility adapter shape is:
 
 ```ts
 interface RealtimeAdapter {
-  start(): Promise<void>;
-  stop(): Promise<void>;
-  notify(event: RealtimeChangeEvent): Promise<void>;          // broadcast a change
-  subscribe(handler: (notice: RealtimeNotice) => void): () => void; // receive changes; returns unsubscribe
+	start(): Promise<void>;
+	stop(): Promise<void>;
+	notify(event: RealtimeChangeEvent): Promise<void>; // broadcast a change
+	subscribe(handler: (notice: RealtimeNotice) => void): () => void; // receive changes; returns unsubscribe
 }
 ```
 
@@ -298,8 +398,9 @@ interface RealtimeAdapter {
 ## Related
 
 - [Realtime](/docs/client/realtime), the client API this transport powers: `live()`, `liveIter()`, and the TanStack Query `{ realtime: true }` flag.
+- [Channels](/docs/client/channels), typed ordered application events over SSE or Pusher/Soketi.
+- [Realtime v2 migration and rollback](/docs/adapters/realtime-v2-migration), dual-run canaries and the legacy rollback flag.
 - [Configuration](/docs/concepts/configuration), where `realtime` lives in `QuestpieConfig`, alongside the other adapters.
 - [Adapters](/docs/adapters), the hub listing every adapter kind and the swap-the-backend model.
 - [Building a plugin](/docs/extend/build-a-plugin), implement `RealtimeAdapter` (or any adapter contract) yourself.
 - [Multi-tenancy](/docs/extend/multi-tenancy), how access rules re-run per subscriber keep tenant data isolated over realtime.
-- Runnable example: [`examples/tanstack-barbershop`](https://github.com/questpie/questpie/tree/main/examples/tanstack-barbershop), a TanStack Start app using realtime via the typed client and TanStack Query bindings.

--- a/apps/docs/content/docs/client/channels.mdx
+++ b/apps/docs/content/docs/client/channels.mdx
@@ -1,0 +1,211 @@
+---
+title: Channels
+description: Define schema-validated application events with channel(), authorize subscribe and publish separately, then use the generated server, client, presence, and TanStack APIs over SSE or Pusher/Soketi.
+---
+
+Channels are typed application event streams built on the same realtime runtime as live queries. Define each channel once in `channels/`; codegen adds it to request contexts as `channels`, to the generated `AppConfig`, and to `client.channels`. The application API stays the same whether delivery uses the zero-infrastructure SSE path or the managed Pusher/Soketi path.
+
+Use channels for transient events such as chat notifications, progress, typing, or presence. The bounded replay ledger is delivery infrastructure, **not** queryable application history. Persist messages that users must retrieve later in a collection.
+
+## Define a channel
+
+```ts title="src/questpie/server/channels/chat-room.ts"
+import { channel } from "questpie/channels";
+import { z } from "zod";
+
+export default channel("chat-room-[roomId]")
+	.events({
+		message: z.object({ id: z.string(), text: z.string() }),
+		typing: z.object({ active: z.boolean() }),
+	})
+	.authorize({
+		subscribe: async ({ params, session, collections }) => {
+			if (!session?.user) return false;
+			return Boolean(
+				await collections.rooms.findOne({
+					where: { id: params.roomId, members: { contains: session.user.id } },
+				}),
+			);
+		},
+		publish: async ({ params, session, collections }) => {
+			if (!session?.user) return false;
+			return Boolean(
+				await collections.rooms.findOne({
+					where: { id: params.roomId, members: { contains: session.user.id } },
+				}),
+			);
+		},
+	})
+	.presence(({ params, session }) => ({
+		id: session!.user.id,
+		roomId: params.roomId,
+		name: session!.user.name,
+	}));
+```
+
+The registry/API key is `chatRoom`, derived from the default-export filename. The explicit builder string is the stable wire pattern. Renaming the file changes the typed API and causes compile errors at call sites; it does **not** silently rename the wire channel. `[roomId]` becomes a required `{ roomId: string }` parameter everywhere.
+
+Run codegen after adding or renaming a channel:
+
+```bash
+bunx questpie generate
+```
+
+### Visibility and authorization
+
+| Builder state                         | Visibility | Subscribe          | Publish                                    |
+| ------------------------------------- | ---------- | ------------------ | ------------------------------------------ |
+| `channel(...).events(...)`            | public     | allowed by default | client publish denied by default           |
+| `.authorize(rule)`                    | private    | `rule`             | falls back to the same `rule`              |
+| `.authorize({ subscribe, publish })`  | private    | explicit rule      | explicit rule, or `subscribe` when omitted |
+| `.presence(resolver)` after authorize | presence   | authorize first    | authorize first                            |
+
+Authorization receives the generated `AppContext` plus typed `params`. Use `session`, `collections`, `db`, and services directly. A false result, thrown error, or authorization timeout denies the operation. Server/system contexts may publish without a client publish grant; browser publishes still go through the framework route, authorization, rate limits, and Zod parsing.
+
+## Publish on the server
+
+Framework handlers receive a generated, request-bound `channels` service:
+
+```ts title="src/questpie/server/routes/send-message.ts"
+import { route } from "questpie/services";
+import { z } from "zod";
+
+export default route()
+	.post()
+	.schema(z.object({ roomId: z.string(), id: z.string(), text: z.string() }))
+	.handler(async ({ input, channels }) => {
+		return channels.publish("chatRoom", {
+			params: { roomId: input.roomId },
+			event: "message",
+			data: { id: input.id, text: input.text },
+		});
+	});
+```
+
+The event name and input are inferred from the channel's Zod schemas. Zod transforms run before the event enters the ledger. `publish()` resolves to `{ eventId }`, the channel-local ordered id clients use for replay and deduplication.
+
+### Publish from collection or global hooks
+
+Use the hook's injected `{ channels }` argument. It carries the same generated types and the mutation-bound database context:
+
+```ts
+.hooks({
+  afterChange: [async ({ data, channels }) => {
+    await channels.publish("chatRoom", {
+      params: { roomId: data.room },
+      event: "message",
+      data: { id: data.id, text: data.text },
+    });
+  }],
+})
+```
+
+Do not import the generated `app` into a collection/hook file, and do not resolve channels later through ambient `getContext()`. Contextless update/delete calls do not guarantee an ambient scope; the injected hook argument is the reliable and transaction-aware path.
+
+## Subscribe and publish on the client
+
+`createClient<AppConfig>()` exposes one handle per generated channel:
+
+```ts
+const stop = client.channels.chatRoom.subscribe(
+	{ roomId },
+	(message) => {
+		if (message.event === "message") {
+			console.log(message.eventId, message.data.text);
+		} else {
+			console.log(message.data.active);
+		}
+	},
+	{ onError: console.error },
+);
+
+const receipt = await client.channels.chatRoom.publish({
+	params: { roomId },
+	event: "typing",
+	data: { active: true },
+});
+
+stop();
+```
+
+Client publish is server-mediated even on Pusher/Soketi: the request uses the same dynamic auth headers as other client calls, re-evaluates `publish` authorization, validates the event with Zod, enforces payload/origin/rate limits, and only then appends the ordered event.
+
+For async iteration:
+
+```ts
+for await (const message of client.channels.chatRoom.iter(
+	{ roomId },
+	{ signal: controller.signal },
+)) {
+	consume(message);
+}
+```
+
+Call `client.channels.destroy()` only when disposing the whole client-side channel runtime. Normal components should call the subscription's `stop()` function or abort their iterator.
+
+## Presence
+
+Only a channel with `.presence()` has a callable presence API:
+
+```ts
+const members = await client.channels.chatRoom.presence({ roomId });
+// readonly Array<{ id: string; roomId: string; name: string }>
+```
+
+Pusher/Soketi uses native provider presence. The SSE tier provides coarse app-instance-local presence from subscription lifecycle, so it is suitable for lightweight indicators, not a globally exact occupancy counter.
+
+## TanStack Query
+
+The query-options proxy exposes channel subscriptions without adding a separate React provider or bespoke hook:
+
+```tsx
+const { data: messages = [] } = useQuery(
+	q.channels.chatRoom.subscription({ roomId }),
+);
+```
+
+The query starts with `[]` and appends each typed `{ event, eventId, data }` message. Its abort signal closes the underlying iterator. This is an event accumulation query; it is separate from live-query `{ realtime: true }`, whose reducer keeps only the newest collection/global snapshot.
+
+## Transport selection
+
+SSE is the default edge transport. Channel subscribe uses the framework SSE/control routes, publish uses HTTP POST, and presence is coarse/local. No client configuration changes are needed.
+
+To use managed WebSockets and native presence, install the optional Pusher peers and select the preset under `realtime`:
+
+```ts title="src/questpie/server/questpie.config.ts"
+import { pusherRealtime } from "questpie/adapters/pusher";
+import { runtimeConfig } from "questpie/app";
+
+const managed = pusherRealtime({
+	appId: env.PUSHER_APP_ID,
+	key: env.PUSHER_KEY,
+	secret: env.PUSHER_SECRET,
+	cluster: env.PUSHER_CLUSTER,
+	// For Soketi, provide host/wsHost/ports instead.
+});
+
+export default runtimeConfig({
+	realtime: { ...managed },
+});
+```
+
+The client discovers the selected transport from `/channels/config`; `client.channels.*` call sites do not change.
+
+<Callout type="warn" title="Direct Pusher client events are a separate unsafe capability">
+Provider client events bypass QUESTPIE's publish route, per-verb authorization, Zod schemas, ordered ledger, replay, and rate limits. They are off by default. Enabling `clientEvents` requires `acknowledgeProviderWideRisk: true`; its `allowedChannels` list is only an SDK affordance and a raw provider client can bypass it. Prefer `client.channels.<name>.publish()`.
+</Callout>
+
+## Delivery and security contracts
+
+- Framework events are ordered per resolved channel and are never coalesced. Reconnect may replay an event id; clients deduplicate it.
+- Falling behind the bounded replay horizon produces an explicit channel gap rather than invented state. Recover from a persisted collection or subscribe from now.
+- A slow SSE consumer is disconnected after bounded event/byte queues fill; ordered events are not silently dropped.
+- Payloads must be JSON-serializable and at most 10,000 UTF-8 bytes.
+- Cookie-authenticated authority routes require an exact trusted `Origin`. Additional origins belong in `realtime.channelSecurity.trustedOrigins`.
+- Client publishes use independent per-session and per-principal token buckets (defaults: 10/s, burst 20).
+
+## Related
+
+- [Realtime](/docs/client/realtime), live collection/global snapshots.
+- [Realtime adapter](/docs/adapters/realtime), SSE versus Pusher/Soketi selection, reconciliation, admission, and privacy.
+- [TanStack Query](/docs/client/tanstack-query), the complete option-builder surface.

--- a/apps/docs/content/docs/client/index.mdx
+++ b/apps/docs/content/docs/client/index.mdx
@@ -7,11 +7,12 @@ The client layer consumes the API that codegen derives from your server files. C
 
 ## Pages
 
-| Page | What it covers |
-|---|---|
-| **[Client SDK](/docs/client/sdk)** | `createClient<AppConfig>()`, collection/global CRUD, routes, uploads, search, errors, and adapter-specific mounts. |
-| **[TanStack Query](/docs/client/tanstack-query)** | Query and mutation option builders for collections, globals, routes, and realtime-backed reads. |
-| **[Realtime](/docs/client/realtime)** | Live collection and global queries over one multiplexed connection. |
+| Page                                              | What it covers                                                                                                     |
+| ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| **[Client SDK](/docs/client/sdk)**                | `createClient<AppConfig>()`, collection/global CRUD, routes, uploads, search, errors, and adapter-specific mounts. |
+| **[TanStack Query](/docs/client/tanstack-query)** | Query and mutation option builders for collections, globals, routes, and realtime-backed reads.                    |
+| **[Realtime](/docs/client/realtime)**             | Live collection and global queries over one multiplexed connection.                                                |
+| **[Channels](/docs/client/channels)**             | Typed application events, authorization, presence, client subscriptions, and TanStack channel streams.             |
 
 ## Related
 

--- a/apps/docs/content/docs/client/meta.json
+++ b/apps/docs/content/docs/client/meta.json
@@ -1,4 +1,4 @@
 {
 	"title": "Client",
-	"pages": ["index", "sdk", "tanstack-query", "realtime"]
+	"pages": ["index", "sdk", "tanstack-query", "realtime", "channels"]
 }

--- a/apps/docs/content/docs/client/realtime.mdx
+++ b/apps/docs/content/docs/client/realtime.mdx
@@ -1,18 +1,18 @@
 ---
 title: Realtime
-description: Subscribe to a live query and get a fresh, access-controlled snapshot every time a matching record changes, typed exactly like find(), pushed over one multiplexed SSE connection, with one server-side adapter to wire.
+description: Subscribe to typed, access-controlled collection and global snapshots over the server-selected SSE or Pusher/Soketi transport, with durable reconciliation behind every push hint.
 ---
 
-**Realtime** turns any read into a live subscription. Call `client.collections.posts.live({ where: { published: true } }, onSnapshot)` and your callback fires with the full `find()` result immediately, then again whenever a matching post is created, updated, or deleted. The snapshot is the exact same shape and type as `find()`, relations, pagination envelope, and all, re-run server-side through the collection's access rules. Many subscriptions share **one** SSE connection, and you turn the whole thing on with a single `realtime` adapter in your config.
+**Realtime** turns a collection or global read into a live subscription. Call `client.collections.posts.live({ where: { published: true } }, onSnapshot)` and your callback fires with the full `find()` result immediately, then again whenever a relevant change lands. The snapshot has the same shape and type as `find()`, relations and pagination envelope included, and is re-run server-side through the subscriber's access rules. The default client multiplexes topics over SSE; a server can select Pusher/Soketi without changing this API.
 
 ## What it does
 
 - **Live queries, fully typed.** `live()` / `liveIter()` push `find()`-shaped snapshots; the snapshot type is inferred from your query options, so `snapshot.docs[0].title` is type-checked end to end.
 - **One snapshot now, then on every change.** The first snapshot arrives immediately on connect (no separate initial fetch); later snapshots arrive whenever a record matching your `where`/`with`/`orderBy` changes.
 - **Access-controlled at the source.** Each snapshot is the result of re-running your query server-side under the subscriber's session, realtime never leaks rows the user can't read.
-- **One connection for many topics.** A single multiplexer holds one `POST /realtime` SSE stream and fans out to every active subscription, sidestepping the browser's 6-connections-per-domain limit.
+- **One client runtime for many topics.** The default multiplexer holds one `POST /realtime` SSE stream; managed Pusher/Soketi uses one provider connection and private per-session delivery.
 - **`{ realtime: true }` on TanStack Query.** Opt a `find` / `count` / `get` query into live mode with one flag and the hook streams instead of one-shot fetching.
-- **Pluggable transport.** Default polling needs zero setup; add `pgNotifyAdapter()` or `redisStreamsAdapter({ client })` for push-based, horizontally-scalable delivery.
+- **Push for latency, reconciliation for correctness.** A transaction-bound outbox is durable truth. pg_notify, Redis, Cloudflare, or Pusher wakes reduce latency; a slow reconciliation poll still heals a missed wake.
 
 ## Quick start
 
@@ -24,8 +24,8 @@ import { runtimeConfig } from "questpie/app";
 import env from "./env"; // declared + validated in env.ts, see Environment
 
 export default runtimeConfig({
-  db: { url: env.DATABASE_URL },
-  realtime: true,
+	db: { url: env.DATABASE_URL },
+	realtime: true,
 });
 ```
 
@@ -36,11 +36,11 @@ import { client } from "@/lib/client.js";
 
 // First snapshot fires immediately; then on every matching change.
 const unsubscribe = client.collections.posts.live(
-  { where: { published: true }, orderBy: { createdAt: "desc" }, limit: 10 },
-  (snapshot) => {
-    // snapshot is the SAME shape & type as client.collections.posts.find(...)
-    console.log(snapshot.totalDocs, snapshot.docs[0]?.title);
-  },
+	{ where: { published: true }, orderBy: { createdAt: "desc" }, limit: 10 },
+	(snapshot) => {
+		// snapshot is the SAME shape & type as client.collections.posts.find(...)
+		console.log(snapshot.totalDocs, snapshot.docs[0]?.title);
+	},
 );
 
 // Later, stop listening (e.g. on unmount):
@@ -50,7 +50,9 @@ unsubscribe();
 That callback now re-fires with a fresh, access-filtered top-10 every time a published post changes.
 
 <Callout type="info" title="The first snapshot is your initial data">
-You do **not** need a separate `find()` before subscribing. `live()` delivers a full snapshot the moment the connection opens, then keeps it fresh. Treat the first callback invocation as "data loaded".
+	You do **not** need a separate `find()` before subscribing. `live()` delivers
+	a full snapshot the moment the connection opens, then keeps it fresh. Treat
+	the first callback invocation as "data loaded".
 </Callout>
 
 ## Example → inferred snapshot
@@ -59,13 +61,13 @@ The snapshot type equals the `find()` result type for the same options, `FindRes
 
 ```ts
 client.collections.posts.live(
-  { where: { published: true }, with: { author: true }, limit: 5 },
-  (snapshot) => {
-    snapshot.docs[0].author.name;
-    //         ^? string, `with: { author: true }` hydrated the relation
-    snapshot.hasNextPage;
-    //         ^? boolean, full PaginatedResult envelope, same as find()
-  },
+	{ where: { published: true }, with: { author: true }, limit: 5 },
+	(snapshot) => {
+		snapshot.docs[0].author.name;
+		//         ^? string, `with: { author: true }` hydrated the relation
+		snapshot.hasNextPage;
+		//         ^? boolean, full PaginatedResult envelope, same as find()
+	},
 );
 ```
 
@@ -77,19 +79,25 @@ A snapshot is a `PaginatedResult<T>` (`{ docs, totalDocs, totalPages, page, hasP
 
 ```ts
 type LiveQueryOptions<TSelect, TRelations> = {
-  where?: Where<TSelect, TRelations>;
-  with?: With<TRelations>;
-  limit?: number;
-  offset?: number;
-  orderBy?: OrderBy<TSelect>;
-  locale?: string;
+	where?: Where<TSelect, TRelations>;
+	with?: With<TRelations>;
+	limit?: number;
+	offset?: number;
+	orderBy?: OrderBy<TSelect>;
+	locale?: string;
 };
 ```
 
-
-
-<Callout type="warn" title="`columns`, `groupBy`, `search`, `includeDeleted`, `stage` are not live options">
-`LiveQueryOptions` intentionally **excludes** `columns`, `groupBy`, `search`, `includeDeleted`, and `stage`. Realtime snapshots are the full query re-run server-side from the topic fields, so column projection / grouping / soft-delete-included / stage-pinned reads aren't expressed over the wire. If you pass them they're simply not part of the subscription. For those, use a one-shot `find()`.
+<Callout
+	type="warn"
+	title="`columns`, `groupBy`, `search`, `includeDeleted`, `stage` are not live options"
+>
+	`LiveQueryOptions` intentionally **excludes** `columns`, `groupBy`, `search`,
+	`includeDeleted`, and `stage`. Realtime snapshots are the full query re-run
+	server-side from the topic fields, so column projection / grouping /
+	soft-delete-included / stage-pinned reads aren't expressed over the wire. If
+	you pass them they're simply not part of the subscription. For those, use a
+	one-shot `find()`.
 </Callout>
 
 ### `LiveSubscribeOptions`, the third argument
@@ -98,20 +106,20 @@ type LiveQueryOptions<TSelect, TRelations> = {
 
 ```ts
 type LiveSubscribeOptions = {
-  signal?: AbortSignal;          // abort → auto-unsubscribe
-  onError?: (error: Error) => void; // SSE connection failed
+	signal?: AbortSignal; // abort → auto-unsubscribe
+	onError?: (error: Error) => void; // SSE connection failed
 };
 ```
 
 ```ts
 const ac = new AbortController();
 client.collections.posts.live(
-  { where: { published: true } },
-  (snapshot) => render(snapshot),
-  {
-    signal: ac.signal,
-    onError: (err) => console.error("realtime dropped:", err),
-  },
+	{ where: { published: true } },
+	(snapshot) => render(snapshot),
+	{
+		signal: ac.signal,
+		onError: (err) => console.error("realtime dropped:", err),
+	},
 );
 // ac.abort() unsubscribes, equivalent to calling the returned function.
 ```
@@ -126,11 +134,11 @@ client.collections.posts.live(
 const ac = new AbortController();
 
 for await (const snapshot of client.collections.posts.liveIter(
-  { where: { published: true }, limit: 10 },
-  { signal: ac.signal },
+	{ where: { published: true }, limit: 10 },
+	{ signal: ac.signal },
 )) {
-  console.log("posts now:", snapshot.totalDocs);
-  // ac.abort() ends the loop.
+	console.log("posts now:", snapshot.totalDocs);
+	// ac.abort() ends the loop.
 }
 ```
 
@@ -142,11 +150,11 @@ Globals are singletons, so their live API mirrors `get()` with a smaller option 
 
 ```ts
 const stop = client.globals.siteSettings.live(
-  { with: { logo: true } },
-  (snapshot) => {
-    // snapshot is the SAME shape & type as client.globals.siteSettings.get(...)
-    document.title = snapshot.title;
-  },
+	{ with: { logo: true } },
+	(snapshot) => {
+		// snapshot is the SAME shape & type as client.globals.siteSettings.get(...)
+		document.title = snapshot.title;
+	},
 );
 ```
 
@@ -162,39 +170,55 @@ import { useQuery } from "@tanstack/react-query";
 import { q } from "@/lib/query.js";
 
 function LivePosts() {
-  const { data } = useQuery(
-    // 1st arg: query options. 2nd arg: { realtime: true }.
-    q.collections.posts.find({ where: { published: true }, limit: 10 }, { realtime: true }),
-  );
+	const { data } = useQuery(
+		// 1st arg: query options. 2nd arg: { realtime: true }.
+		q.collections.posts.find(
+			{ where: { published: true }, limit: 10 },
+			{ realtime: true },
+		),
+	);
 
-  return <p>{data?.totalDocs ?? 0} published posts (live)</p>;
+	return <p>{data?.totalDocs ?? 0} published posts (live)</p>;
 }
 ```
 
-Under the hood the hook uses TanStack's `experimental_streamedQuery` with `refetchMode: "append"`, seeding from `find()` and then replacing the result with each pushed snapshot. The query **key is identical** to the non-realtime version, so the same cache entry is reused.
+Under the hood the hook uses TanStack's `experimental_streamedQuery` with `refetchMode: "append"`. The SSE/managed transport supplies the initial snapshot directly, so enabling realtime does not perform a duplicate one-shot REST read. Each later snapshot replaces the previous value. The query **key is identical** to the non-realtime version, so the same cache entry is reused.
 
-<Callout type="info" title="A live count reads `totalDocs` off the snapshot">
-`q.collections.posts.count(opts, { realtime: true })` streams the full collection snapshot and extracts `totalDocs`, so your count stays live without a dedicated count subscription.
+<Callout type="info" title="A live count transfers one number">
+`q.collections.posts.count(opts, { realtime: true })` uses an operation-aware `count` topic. The server executes count directly and streams the scalar result; it does not fetch or serialize the matching rows.
 </Callout>
 
 <Callout type="warn" title="`{ realtime: true }` only exists on find / count / get">
 `findOne` and every mutation **reject** a `{ realtime: true }` argument at the type level, passing it is a compile error (the tests assert `@ts-expect-error`). There's no live `findOne`; subscribe with `find({ where: { id } })` (or `live()`) and read `docs[0]`.
 </Callout>
 
-<Callout type="warn" title="If the server has no realtime, `{ realtime: true }` falls back to a stuck stream">
-The client always wires `client.realtime`, so the TanStack flag is honored client-side regardless. The real prerequisite is **server-side realtime**: set `realtime` in your config so `POST /realtime` exists. Without it the SSE connect fails, the stream errors out (and `find()`/`get()`/`live()`'s `onError` fires) rather than silently degrading to a poll. Turn `realtime` on in the server config before relying on live queries.
+<Callout
+	type="warn"
+	title="If the server has no realtime, `{ realtime: true }` errors"
+>
+	The client always wires `client.realtime`, so the TanStack flag is honored
+	client-side regardless. The real prerequisite is **server-side realtime**: set
+	`realtime` in your config so `POST /realtime` exists. Without it the SSE
+	connect fails, the stream errors out (and `find()`/`get()`/`live()`'s
+	`onError` fires) rather than silently degrading to a poll. Turn `realtime` on
+	in the server config before relying on live queries.
 </Callout>
 
 The TanStack realtime topic is derived purely from your read `options` via `buildCollectionTopic` / `buildGlobalTopic`, config-level `locale`/`stage` are **not** added to the topic, only `options.locale` is. Two subscriptions that differ only by `where` get distinct live streams.
 
 ## Server-side: turning realtime on
 
-Everything above is the **client** API. None of it works until you turn realtime on in the **server** config, that's the one server requirement, and you've already seen it in [Quick start](#quick-start): set `realtime` in `runtimeConfig` and the app records every change to an outbox and serves the `POST /realtime` SSE stream. With no adapter the service polls that outbox (or auto-wires `pg_notify` on a Postgres app); add `pgNotifyAdapter()` or `redisStreamsAdapter({ client })` to push changes the instant they happen, across every horizontally-scaled instance.
+Everything above is the **client** API. None of it works until you turn realtime on in the **server** config, that's the one server requirement, and you've already seen it in [Quick start](#quick-start). Each mutation appends its outbox row inside the business transaction. With a normal Postgres URL, `realtime: true` auto-wires pg_notify; otherwise the service polls. Every configured broker also keeps a slower reconciliation poll, so a dropped wake cannot stall delivery forever.
 
 The full server surface, `RealtimeConfig` options, the outbox/poll model, every transport adapter (`pgNotifyAdapter`, `redisStreamsAdapter`, `cloudflareRealtimeAdapter`), and building your own, lives on one page: see [Realtime adapter](/docs/adapters/realtime).
 
-<Callout type="info" title="One connection, by design, don't open your own SSE per query">
-On the client side, every `live()` / `liveIter()` call (and the TanStack flag) shares **one** multiplexed `POST /realtime` SSE connection, 50 subscriptions cost one HTTP connection, sidestepping the browser's ~6-per-domain cap over HTTP/1.1. Always subscribe through the typed wrappers (or `client.realtime`) so they share that connection rather than opening your own stream.
+<Callout type="info" title="One client transport, by design">
+	On the default path, `live()` / `liveIter()` calls (and the TanStack flag)
+	share a multiplexed `POST /realtime` SSE connection within the server's
+	admission caps. With Pusher/Soketi selected, the same APIs share the managed
+	provider connection. Always subscribe through the typed wrappers (or
+	`client.realtime`) so the runtime can multiplex, resume, and tear down
+	correctly.
 </Callout>
 
 ## Raw realtime, `client.realtime`
@@ -205,15 +229,18 @@ The typed wrappers are the recommended path. If you need to subscribe to a hand-
 import { buildCollectionTopic } from "questpie/client";
 
 // Typed wrapper (preferred), TData inferred, topic built for you:
-const stop = client.collections.posts.live({ where: { published: true } }, onSnap);
+const stop = client.collections.posts.live(
+	{ where: { published: true } },
+	onSnap,
+);
 
 // Raw equivalent, you build the topic and supply TData yourself:
 const stopRaw = client.realtime.subscribe<MySnapshot>(
-  buildCollectionTopic("posts", { where: { published: true } }),
-  (data) => onSnap(data),
-  /* signal */ undefined,
-  /* customId */ undefined,
-  /* onError */ (err) => console.error(err),
+	buildCollectionTopic("posts", { where: { published: true } }),
+	(data) => onSnap(data),
+	/* signal */ undefined,
+	/* customId */ undefined,
+	/* onError */ (err) => console.error(err),
 );
 ```
 
@@ -226,7 +253,10 @@ const stopRaw = client.realtime.subscribe<MySnapshot>(
 Pass `locale` in the live options to subscribe to a specific localized variant, it becomes part of the topic, so the `en` and `de` views of the same query are independent subscriptions:
 
 ```ts
-client.collections.posts.live({ where: { published: true }, locale: "de" }, onSnap);
+client.collections.posts.live(
+	{ where: { published: true }, locale: "de" },
+	onSnap,
+);
 ```
 
 `setLocale()` on the client mutates request headers for `find`/`create`/etc., but does **not** retarget already-open realtime subscriptions, realtime carries `locale` per topic. To switch a subscription's locale, unsubscribe and re-subscribe with the new `locale`.
@@ -244,11 +274,11 @@ The realtime option and result types come from `questpie/client`:
 
 ```ts
 import type {
-  RealtimeAPI,
-  TopicConfig,
-  TopicInput,
-  FindResult,
-  PaginatedResult,
+	RealtimeAPI,
+	TopicConfig,
+	TopicInput,
+	FindResult,
+	PaginatedResult,
 } from "questpie/client";
 ```
 
@@ -257,9 +287,9 @@ import type {
 ## Related
 
 - [Realtime adapter](/docs/adapters/realtime), the server-side transport this client API rides: `RealtimeConfig`, the outbox/poll model, and the `pg_notify` / Redis / Cloudflare adapters.
+- [Channels](/docs/client/channels), typed ordered application events over the same runtime.
 - [Collections](/docs/concepts/collections), `find()`, the paginated envelope, and access rules that every snapshot is re-run through.
 - [Globals](/docs/concepts/globals), the singleton `get()` whose shape `globals.<name>.live()` mirrors.
 - [Relations](/docs/concepts/relations), `with` hydration, which `live()` carries into the snapshot.
 - [Configuration](/docs/concepts/configuration), where `realtime` lives in `QuestpieConfig`, alongside the other adapters.
 - [Getting started](/docs/getting-started), sets up `client` and the `q` query-options proxy used in the examples above.
-- Runnable example: [`examples/tanstack-barbershop`](https://github.com/questpie/questpie/tree/main/examples/tanstack-barbershop), a TanStack Start app using the typed client and TanStack Query bindings.

--- a/apps/docs/content/docs/client/tanstack-query.mdx
+++ b/apps/docs/content/docs/client/tanstack-query.mdx
@@ -1,6 +1,6 @@
 ---
 title: TanStack Query
-description: One factory turns your typed client into ready-made queryOptions() and mutationOptions() for every collection, global, and route, fully typed, with stable keys, error mapping, and opt-in realtime, that you pass straight into useQuery and useMutation.
+description: One factory turns your typed client into queryOptions() and mutationOptions() for collections, globals, routes, live snapshots, and typed channel subscriptions.
 ---
 
 `@questpie/tanstack-query` wraps your typed [client](/docs/client/sdk) in a single factory, `createQuestpieQueryOptions(client)`, that returns a proxy of **option builders**. Each builder hands you a finished `queryOptions()` or `mutationOptions()` object, query key, fetcher, and error mapping already assembled, so a React component is one line: `useQuery(q.collections.posts.find({ limit: 10 }))`. The types flow from your schema through the client into the hook, so collection names, `where` filters, and result shapes are all inferred. No hooks to write, no keys to invent.
@@ -10,7 +10,8 @@ description: One factory turns your typed client into ready-made queryOptions() 
 - **One builder per operation.** `q.collections.<name>.find()`, `.create()`, `.update()`; `q.globals.<name>.get()`, `.update()`; `q.routes.<path>.query()`, `.mutation()`, each returns a ready `queryOptions()` / `mutationOptions()` object for `useQuery` / `useMutation`.
 - **Typed end to end.** Every builder is derived from the client's own method signatures, so a `find()` here narrows its result exactly like a direct `client.collections.posts.find()` call. Variables, options, and return types are all inferred from your schema.
 - **Stable, structured query keys.** Keys are built and sanitized for you (`['questpie', 'collections', 'posts', 'find', locale, stage, options]`), so React Query's cache, refetch, and invalidation work without you hand-rolling keys.
-- **Opt-in realtime.** Pass `{ realtime: true }` to `find`, `count`, or `get` and, if your client has a realtime adapter, the query becomes a live SSE-backed stream instead of a one-shot fetch. Same builder, same hook.
+- **Opt-in realtime.** Pass `{ realtime: true }` to `find`, `count`, or `get` and the query consumes server-pushed snapshots over the selected SSE or managed-WS transport. Same builder, same hook.
+- **Typed channel streams.** `q.channels.<name>.subscription(params?)` accumulates generated channel messages through the same `useQuery` API.
 - **One error shape.** Every fetcher and mutator is wrapped with an `errorMap`, so thrown non-`Error` values are coerced to `Error` before they reach React Query (override it once, globally).
 - **An escape hatch.** `q.custom.query` / `q.custom.mutation` wrap any async function with the same key-prefixing and error mapping, for anything the proxies don't cover.
 
@@ -45,39 +46,47 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { q } from "@/lib/query.js";
 
 function Posts() {
-  const queryClient = useQueryClient();
+	const queryClient = useQueryClient();
 
-  // Read: q.collections.posts.find(...) returns queryOptions()
-  const { data } = useQuery(
-    q.collections.posts.find({ where: { published: true }, limit: 10 }),
-  );
+	// Read: q.collections.posts.find(...) returns queryOptions()
+	const { data } = useQuery(
+		q.collections.posts.find({ where: { published: true }, limit: 10 }),
+	);
 
-  // Write: q.collections.posts.create() returns mutationOptions()
-  const create = useMutation({
-    ...q.collections.posts.create(),
-    onSuccess: () => {
-      // Invalidate every posts query with the top-level key helper.
-      queryClient.invalidateQueries({ queryKey: q.key(["collections", "posts"]) });
-    },
-  });
+	// Write: q.collections.posts.create() returns mutationOptions()
+	const create = useMutation({
+		...q.collections.posts.create(),
+		onSuccess: () => {
+			// Invalidate every posts query with the top-level key helper.
+			queryClient.invalidateQueries({
+				queryKey: q.key(["collections", "posts"]),
+			});
+		},
+	});
 
-  return (
-    <div>
-      <p>{data?.totalDocs ?? 0} published posts</p>
-      <button
-        onClick={() => create.mutate({ title: "Hello", slug: "hello", published: true })}
-      >
-        Add post
-      </button>
-    </div>
-  );
+	return (
+		<div>
+			<p>{data?.totalDocs ?? 0} published posts</p>
+			<button
+				onClick={() =>
+					create.mutate({ title: "Hello", slug: "hello", published: true })
+				}
+			>
+				Add post
+			</button>
+		</div>
+	);
 }
 ```
 
 `find()` resolves to the same **paginated envelope** the client returns, `{ docs, totalDocs, page, hasNextPage, … }`, so read your rows off `data.docs`. The mutation variables (`{ title, slug, published }`) are the collection's create input, inferred from your schema.
 
 <Callout type="info" title="Build the proxy once, not per render">
-`createQuestpieQueryOptions(client)` is cheap, but the returned proxies are stable identities, create it once at module scope (as the scaffold does) and import `q` everywhere. The builders themselves are pure: calling `q.collections.posts.find(opts)` only *builds* an options object; nothing fetches until you hand it to `useQuery`.
+	`createQuestpieQueryOptions(client)` is cheap, but the returned proxies are
+	stable identities, create it once at module scope (as the scaffold does) and
+	import `q` everywhere. The builders themselves are pure: calling
+	`q.collections.posts.find(opts)` only *builds* an options object; nothing
+	fetches until you hand it to `useQuery`.
 </Callout>
 
 ## Example → inferred types
@@ -85,7 +94,10 @@ function Posts() {
 Each builder mirrors the client method it wraps, so the inferred result is identical to a direct client call, not a widened `{}`:
 
 ```ts
-const opts = q.collections.posts.find({ where: { published: true }, limit: 10 });
+const opts = q.collections.posts.find({
+	where: { published: true },
+	limit: 10,
+});
 //    ^? UseQueryOptions<FindResult<…, { docs: Post[]; totalDocs: number; … }>>
 
 const createOpts = q.collections.posts.create();
@@ -106,10 +118,10 @@ The selection generic is applied **per call**, `find<TQuery>(options?)` narrows 
 ```ts
 // List, paginated envelope. Optional second arg enables realtime (below).
 q.collections.posts.find({
-  where: { published: true },
-  with: { author: true },
-  orderBy: { createdAt: "desc" },
-  limit: 10,
+	where: { published: true },
+	with: { author: true },
+	orderBy: { createdAt: "desc" },
+	limit: 10,
 });
 
 // Count, number (or live total with { realtime: true }).
@@ -122,14 +134,12 @@ q.collections.posts.findOne({ where: { slug: "hello" } });
 q.collections.posts.findVersions({ id: postId, limit: 20 });
 ```
 
-| Builder | Returns (`data`) | Options | Realtime |
-|---|---|---|---|
-| `find(options?, queryConfig?)` | `FindResult`, `{ docs, totalDocs, … }` | `where`, `with`, `orderBy`, `limit`, `offset`, `columns`, `locale`, `stage`, `localeFallback`, `includeDeleted` | yes |
-| `count(options?, queryConfig?)` | `number` | `where`, `includeDeleted` | yes |
-| `findOne(options?)` | row `| null` | same as `find` (single result) | no |
-| `findVersions(params)` | `Array<row & { versionId, versionNumber, … }>` | `{ id, limit?, offset? }`, `id` **required** | no |
-
-
+| Builder                         | Returns (`data`)                               | Options                                                                                                         | Realtime                       |
+| ------------------------------- | ---------------------------------------------- | --------------------------------------------------------------------------------------------------------------- | ------------------------------ | --- |
+| `find(options?, queryConfig?)`  | `FindResult`, `{ docs, totalDocs, … }`         | `where`, `with`, `orderBy`, `limit`, `offset`, `columns`, `locale`, `stage`, `localeFallback`, `includeDeleted` | yes                            |
+| `count(options?, queryConfig?)` | `number`                                       | `where`, `includeDeleted`                                                                                       | yes                            |
+| `findOne(options?)`             | row `                                          | null`                                                                                                           | same as `find` (single result) | no  |
+| `findVersions(params)`          | `Array<row & { versionId, versionNumber, … }>` | `{ id, limit?, offset? }`, `id` **required**                                                                    | no                             |
 
 <Callout type="warn" title="`find()` returns an envelope; `findOne()` can be `null`">
 `find()` always resolves to `{ docs, totalDocs, totalPages, page, hasNextPage, … }`, your rows are on `data.docs`, never `data` directly. `findOne()` resolves to the row **or `null`** when nothing matches, so guard it (`data ?? fallback`). Only `find` and `count` take the realtime `queryConfig` second argument, `findOne` does not (passing `{ realtime: true }` to it is a type error).
@@ -150,18 +160,16 @@ const remove = useMutation(q.collections.posts.delete());
 remove.mutate({ id: postId }); // { id } -> { success: boolean }
 ```
 
-| Builder | `mutate(variables)` shape | Returns (`data`) |
-|---|---|---|
-| `create()` | the create `data` object | the created row |
-| `update()` | `{ id, data }` | the updated row |
-| `delete()` | `{ id }` | `{ success: boolean }` |
-| `restore()` | `{ id }` | the restored row (soft-delete collections) |
-| `revertToVersion()` | `{ id, version }` **or** `{ id, versionId }` | the reverted row (versioning) |
-| `transitionStage()` | `{ id, stage }` | the row at its new stage (workflow) |
-| `updateMany()` | `{ where, data }` | the written rows |
-| `deleteMany()` | `{ where }` | `{ success: boolean; count: number }` |
-
-
+| Builder             | `mutate(variables)` shape                    | Returns (`data`)                           |
+| ------------------- | -------------------------------------------- | ------------------------------------------ |
+| `create()`          | the create `data` object                     | the created row                            |
+| `update()`          | `{ id, data }`                               | the updated row                            |
+| `delete()`          | `{ id }`                                     | `{ success: boolean }`                     |
+| `restore()`         | `{ id }`                                     | the restored row (soft-delete collections) |
+| `revertToVersion()` | `{ id, version }` **or** `{ id, versionId }` | the reverted row (versioning)              |
+| `transitionStage()` | `{ id, stage }`                              | the row at its new stage (workflow)        |
+| `updateMany()`      | `{ where, data }`                            | the written rows                           |
+| `deleteMany()`      | `{ where }`                                  | `{ success: boolean; count: number }`      |
 
 <Callout type="warn" title="`update`/`delete` are by id; use `updateMany`/`deleteMany` for filters">
 `update()` and `delete()` wrap the single-record **by-id** client methods, their variables are `{ id, data }` and `{ id }`, never a `where` clause. For bulk operations use `updateMany({ where, data })` / `deleteMany({ where })`. Two caveats on the bulk pair: their `where`/`data` variables are typed `any` (no schema-level checking of the filter, unlike `find`'s typed `where`), and `updateMany`'s **declared** return type is a single row while the runtime actually returns an array of written rows, the static type is narrower than reality.
@@ -180,15 +188,13 @@ const update = useMutation(q.globals.siteSettings.update());
 update.mutate({ data: { siteName: "QUESTPIE" } });
 ```
 
-| Builder | `mutate(variables)` / options | Returns | Realtime |
-|---|---|---|---|
-| `get(options?, queryConfig?)` | `{ with?, columns?, locale?, localeFallback?, stage? }` | the singleton row (non-nullable) | yes |
-| `update()` | `{ data, options? }` | the updated global | none |
-| `findVersions(options?)` | `{ id?, limit?, offset?, locale?, localeFallback? }` | version array | none |
-| `revertToVersion()` | `{ params, options? }` | the reverted global | none |
-| `transitionStage()` | `{ params, options? }` | the global at its new stage | none |
-
-
+| Builder                       | `mutate(variables)` / options                           | Returns                          | Realtime |
+| ----------------------------- | ------------------------------------------------------- | -------------------------------- | -------- |
+| `get(options?, queryConfig?)` | `{ with?, columns?, locale?, localeFallback?, stage? }` | the singleton row (non-nullable) | yes      |
+| `update()`                    | `{ data, options? }`                                    | the updated global               | none     |
+| `findVersions(options?)`      | `{ id?, limit?, offset?, locale?, localeFallback? }`    | version array                    | none     |
+| `revertToVersion()`           | `{ params, options? }`                                  | the reverted global              | none     |
+| `transitionStage()`           | `{ params, options? }`                                  | the global at its new stage      | none     |
 
 <Callout type="warn" title="Global mutations nest their payload under `data` / `params`">
 This is the one spot that trips people up. `q.globals.siteSettings.update().mutate(...)` takes **`{ data: { … } }`**, *not* the fields directly, `mutate({ data: { siteName: "X" } })`, never `mutate({ siteName: "X" })`. Likewise `revertToVersion` and `transitionStage` take `{ params, options? }` (params nested), whereas the **collection** equivalents take the params object directly.
@@ -204,7 +210,9 @@ A global always exists (it's a singleton with defaults), so `q.globals.<name>.ge
 
 ```ts
 // Read a route as a query.
-const stats = useQuery(q.routes.dashboard.getStats.post.query({ period: "week" }));
+const stats = useQuery(
+	q.routes.dashboard.getStats.post.query({ period: "week" }),
+);
 
 // Call a route as a mutation.
 const send = useMutation(q.routes.notifications.send.post.mutation());
@@ -218,39 +226,64 @@ const key = q.routes.dashboard.getStats.post.key({ period: "week" });
 - **`.mutation()`** → `mutationOptions()`. `mutate(variables)` calls the route with `variables`; if the route takes no arguments, `mutate()` calls it with none.
 - **`.key(input?)`** → the route's **query** key, for `invalidateQueries` / prefetch.
 
-
-
 <Callout type="info" title="`.key()` always builds the query key, there is no mutation-key helper">
 `q.routes.<path>.<method>.key()` returns the same key shape as `.query()` (the `'query'` segment), even when a sibling `.mutation()` exists. Mutation keys are set internally on the mutation options object; there's no helper to construct one. Use `.key()` to invalidate or prefetch a route **query**.
 </Callout>
 
 <Callout type="warn" title="Unknown routes throw at fetch time, not build time">
-The routes proxy is loose, `q.routes.a.b.c.post.query()` *builds* an options object for any dot-path. The path is only resolved against `client.routes` when the query runs; if it doesn't resolve to a function the fetcher throws `Route not found at path: a.b.c.post`. There's no build-time check that the route exists, so a typo'd path surfaces as a runtime query error, not a red squiggle. The same lazy-resolution applies to unknown collection/global names.
+	The routes proxy is loose, `q.routes.a.b.c.post.query()` *builds* an options
+	object for any dot-path. The path is only resolved against `client.routes`
+	when the query runs; if it doesn't resolve to a function the fetcher throws
+	`Route not found at path: a.b.c.post`. There's no build-time check that the
+	route exists, so a typo'd path surfaces as a runtime query error, not a red
+	squiggle. The same lazy-resolution applies to unknown collection/global names.
 </Callout>
 
 ## Realtime
 
-Three reads can become **live** by passing `{ realtime: true }` as their second argument: `collections.<name>.find`, `collections.<name>.count`, and `globals.<name>.get`. The query fetches once for initial data, then the server pushes a full snapshot on every matching change over the multiplexed SSE stream.
+Three reads can become **live** by passing `{ realtime: true }` as their second argument: `collections.<name>.find`, `collections.<name>.count`, and `globals.<name>.get`. The server transport sends the initial result and every later snapshot; enabling realtime does not issue a duplicate one-shot REST read.
 
 ```tsx
 function LivePosts() {
-  // Re-renders whenever a matching post changes, no manual invalidation.
-  const { data } = useQuery(
-    q.collections.posts.find({ where: { published: true } }, { realtime: true }),
-  );
-  return <p>{data?.totalDocs ?? 0} published posts (live)</p>;
+	// Re-renders whenever a matching post changes, no manual invalidation.
+	const { data } = useQuery(
+		q.collections.posts.find(
+			{ where: { published: true } },
+			{ realtime: true },
+		),
+	);
+	return <p>{data?.totalDocs ?? 0} published posts (live)</p>;
 }
 ```
 
-Under the hood a live query uses React Query's `experimental_streamedQuery` with `refetchMode: "append"`; for `count`, the reducer reads `totalDocs` off each snapshot so `data` stays a `number`.
+Under the hood a live query uses React Query's `experimental_streamedQuery` with `refetchMode: "append"` and replaces the cached value with each newest snapshot. `count` uses an operation-aware server topic and streams one scalar number, not the matching rows.
 
-<Callout type="warn" title="Realtime needs a wired client, otherwise the flag is silently ignored">
-Live mode activates only when **both** hold: `queryConfig.realtime` is truthy **and** your client has a realtime adapter (`client.realtime` is present). If the client has no realtime adapter configured, `{ realtime: true }` is **silently ignored** and the query falls back to a one-shot fetch, no error, no warning. `findOne`, `findVersions`, and all mutations never stream.
+<Callout type="warn" title="Realtime must be enabled on the server">
+`createClient()` always exposes `client.realtime`, so `{ realtime: true }` attempts a stream. If server runtime config does not enable realtime, the connection errors; it does not silently fall back to a one-shot read. `findOne`, `findVersions`, and all mutations never stream.
 </Callout>
 
 <Callout type="info" title="Realtime topic ignores some read options">
-The live subscription's topic is derived from your read `options` via `buildCollectionTopic` / `buildGlobalTopic`, which carry only `where` / `with` / `limit` / `offset` / `orderBy` / `locale` (globals: `where` / `with` / `locale`). `columns`, `stage`, `includeDeleted`, and `localeFallback` are **dropped from the topic**, and the config-level `locale`/`stage` are *not* added to it, so live matching ignores those. Both builders are re-exported from the package if you want to subscribe manually via `client.realtime.subscribe`.
+	The live subscription's topic is derived from your read `options` via
+	`buildCollectionTopic` / `buildGlobalTopic`, which carry only `where` / `with`
+	/ `limit` / `offset` / `orderBy` / `locale` (globals: `where` / `with` /
+	`locale`). `columns`, `stage`, `includeDeleted`, and `localeFallback` are
+	**dropped from the topic**, and the config-level `locale`/`stage` are *not*
+	added to it, so live matching ignores those. Both builders are re-exported
+	from the package if you want to subscribe manually via
+	`client.realtime.subscribe`.
 </Callout>
+
+## Channel subscriptions
+
+Generated channels appear beside collections, globals, and routes:
+
+```tsx
+const { data: messages = [] } = useQuery(
+	q.channels.chatRoom.subscription({ roomId }),
+);
+```
+
+No-param channels use `.subscription()` with no argument. Parameterized channels require their exact generated params. The query starts with an empty array and appends each typed `{ event, eventId, data }` message; aborting or unmounting closes the underlying `client.channels.<name>.iter()` stream. See [Channels](/docs/client/channels) for definitions, authorization, publish, presence, and transport behavior.
 
 ## Configuration
 
@@ -258,24 +291,33 @@ The live subscription's topic is derived from your read `options` via `buildColl
 
 ```ts
 export const q = createQuestpieQueryOptions(client, {
-  keyPrefix: ["questpie"],   // QueryKey prepended to every key. Default ['questpie'].
-  errorMap: defaultErrorMap, // (error: unknown) => unknown. Wraps every fetcher/mutator.
-  locale: undefined,         // string, baked into keys AND threaded into every call.
-  stage: undefined,          // string, same: keyed and threaded.
+	keyPrefix: ["questpie"], // QueryKey prepended to every key. Default ['questpie'].
+	errorMap: defaultErrorMap, // (error: unknown) => unknown. Wraps every fetcher/mutator.
+	locale: undefined, // string, baked into keys AND threaded into every call.
+	stage: undefined, // string, same: keyed and threaded.
 });
 ```
 
-| Option | Type | Default | Effect |
-|---|---|---|---|
-| `keyPrefix` | `QueryKey` | `['questpie']` | Prepended to **every** query/mutation key. Pass `[]` to emit keys with no prefix. |
-| `errorMap` | `(error: unknown) => unknown` | `defaultErrorMap` | Runs in the `catch` of every fetcher/mutator; its return value is thrown instead of the raw error. |
-| `locale` | `string` | `undefined` | Pinned read/write locale, see the warning below. |
-| `stage` | `string` | `undefined` | Pinned workflow stage, see the warning below. |
+| Option      | Type                          | Default           | Effect                                                                                             |
+| ----------- | ----------------------------- | ----------------- | -------------------------------------------------------------------------------------------------- |
+| `keyPrefix` | `QueryKey`                    | `['questpie']`    | Prepended to **every** query/mutation key. Pass `[]` to emit keys with no prefix.                  |
+| `errorMap`  | `(error: unknown) => unknown` | `defaultErrorMap` | Runs in the `catch` of every fetcher/mutator; its return value is thrown instead of the raw error. |
+| `locale`    | `string`                      | `undefined`       | Pinned read/write locale, see the warning below.                                                   |
+| `stage`     | `string`                      | `undefined`       | Pinned workflow stage, see the warning below.                                                      |
 
-
-
-<Callout type="warn" title="`locale` and `stage` are global to the proxy and override per-call options for globals">
-A `locale`/`stage` set in `config` is baked into **every** query key and threaded into **every** read and mutation, for collections as the call's options/`LocaleOptions` second argument, for globals **merged into the options object**. Because they're spread *after* the caller's options, they **override** any per-call `locale`/`stage` on `globals.update` / `revertToVersion` / `findVersions`. If you need different locales in different parts of the UI, create a second proxy with its own `config` rather than fighting the override. (One asymmetry: `globals.transitionStage` merges only `locale` from config, not `stage`.
+<Callout
+	type="warn"
+	title="`locale` and `stage` are global to the proxy and override per-call options for globals"
+>
+	A `locale`/`stage` set in `config` is baked into **every** query key and
+	threaded into **every** read and mutation, for collections as the call's
+	options/`LocaleOptions` second argument, for globals **merged into the options
+	object**. Because they're spread *after* the caller's options, they
+	**override** any per-call `locale`/`stage` on `globals.update` /
+	`revertToVersion` / `findVersions`. If you need different locales in different
+	parts of the UI, create a second proxy with its own `config` rather than
+	fighting the override. (One asymmetry: `globals.transitionStage` merges only
+	`locale` from config, not `stage`.
 </Callout>
 
 ### Custom error mapping
@@ -284,10 +326,10 @@ The default `errorMap` coerces non-`Error` throws into `Error` (passes `Error` t
 
 ```ts
 export const q = createQuestpieQueryOptions(client, {
-  errorMap: (error) => {
-    if (error instanceof MyApiError) return error;
-    return new Error("Request failed", { cause: error });
-  },
+	errorMap: (error) => {
+		if (error instanceof MyApiError) return error;
+		return new Error("Request failed", { cause: error });
+	},
 });
 ```
 
@@ -313,19 +355,35 @@ Build keys for invalidation with the top-level **`q.key(parts)`** helper, it pre
 queryClient.invalidateQueries({ queryKey: q.key(["collections", "posts"]) });
 
 // Invalidate one route query exactly.
-queryClient.invalidateQueries({ queryKey: q.routes.dashboard.getStats.post.key({ period: "week" }) });
+queryClient.invalidateQueries({
+	queryKey: q.routes.dashboard.getStats.post.key({ period: "week" }),
+});
 
 // Or read the key straight off any builder result:
 const { queryKey } = q.collections.posts.find({ where: { published: true } });
 queryClient.invalidateQueries({ queryKey });
 ```
 
-<Callout type="warn" title="There is no `.key()` on `q.collections.<name>` or `q.globals.<name>`">
-Only **routes** have a per-leaf `.key()` builder. Collections and globals do **not** expose a `key` method, to invalidate them, use the top-level `q.key([...])` for partial matching, or read `.queryKey` off the options object a builder returns. For an *exact* key match you'd also have to replicate the `[…, locale, stage, options]` tail yourself, so partial-match invalidation via `q.key(["collections", "posts"])` is almost always what you want.
+<Callout
+	type="warn"
+	title="There is no `.key()` on `q.collections.<name>` or `q.globals.<name>`"
+>
+	Only **routes** have a per-leaf `.key()` builder. Collections and globals do
+	**not** expose a `key` method, to invalidate them, use the top-level
+	`q.key([...])` for partial matching, or read `.queryKey` off the options
+	object a builder returns. For an *exact* key match you'd also have to
+	replicate the `[…, locale, stage, options]` tail yourself, so partial-match
+	invalidation via `q.key(["collections", "posts"])` is almost always what you
+	want.
 </Callout>
 
 <Callout type="info" title="Functions in options are stripped from the key">
-Key options are sanitized: function-valued properties are removed and `undefined`-valued keys are dropped (`null` is kept) before they land in the query key, so non-serializable values don't break React Query's structural key equality. The footgun: two `find()` calls that differ **only** by a function argument produce the **same** key and therefore share a cache entry. Don't encode a discriminator as a function in your options.
+	Key options are sanitized: function-valued properties are removed and
+	`undefined`-valued keys are dropped (`null` is kept) before they land in the
+	query key, so non-serializable values don't break React Query's structural key
+	equality. The footgun: two `find()` calls that differ **only** by a function
+	argument produce the **same** key and therefore share a cache entry. Don't
+	encode a discriminator as a function in your options.
 </Callout>
 
 ## Custom queries & mutations
@@ -335,14 +393,14 @@ For anything the proxies don't cover, a third-party endpoint, a composed call, a
 ```ts
 // Query
 const opts = q.custom.query<DashboardData>({
-  key: ["dashboard", "summary"], // suffix only, keyPrefix is prepended for you
-  queryFn: () => fetchDashboard(),
+	key: ["dashboard", "summary"], // suffix only, keyPrefix is prepended for you
+	queryFn: () => fetchDashboard(),
 });
 
 // Mutation
 const mut = q.custom.mutation<{ id: string }, void>({
-  key: ["dashboard", "refresh"],
-  mutationFn: (vars) => refreshDashboard(vars.id),
+	key: ["dashboard", "refresh"],
+	mutationFn: (vars) => refreshDashboard(vars.id),
 });
 ```
 
@@ -354,28 +412,34 @@ The package re-exports the React Query types you'll reference, plus its own:
 
 ```ts
 import type {
-  // Re-exported from @tanstack/react-query for convenience:
-  QueryKey,
-  DefaultError,
-  UseQueryOptions,
-  UseMutationOptions,
-  // This package's types:
-  QuestpieQueryOptionsProxy,  // return type of createQuestpieQueryOptions
-  QuestpieQueryOptionsConfig, // the config argument
-  QuestpieQueryErrorMap,      // (error: unknown) => unknown
-  RealtimeQueryConfig,        // { realtime?: boolean }
-  // Realtime topic helpers (re-exported from questpie/client):
-  TopicConfig,
-  RealtimeAPI,
+	// Re-exported from @tanstack/react-query for convenience:
+	QueryKey,
+	DefaultError,
+	UseQueryOptions,
+	UseMutationOptions,
+	// This package's types:
+	QuestpieQueryOptionsProxy, // return type of createQuestpieQueryOptions
+	QuestpieQueryOptionsConfig, // the config argument
+	QuestpieQueryErrorMap, // (error: unknown) => unknown
+	RealtimeQueryConfig, // { realtime?: boolean }
+	// Realtime topic helpers (re-exported from questpie/client):
+	TopicConfig,
+	RealtimeAPI,
 } from "@questpie/tanstack-query";
 
-import { buildCollectionTopic, buildGlobalTopic } from "@questpie/tanstack-query";
+import {
+	buildCollectionTopic,
+	buildGlobalTopic,
+} from "@questpie/tanstack-query";
 ```
 
 `QuestpieQueryOptionsProxy<TApp>` is the typed shape of `q`; you rarely name it directly because the scaffold exports `typeof q`. `buildCollectionTopic` / `buildGlobalTopic` are runtime values (re-exported from `questpie/client`) for building realtime topics manually.
 
 <Callout type="info" title="The proxies don't enumerate">
-`q.collections`, `q.globals`, and `q.routes` are JS `Proxy` objects with a get-trap only. `Object.keys(q.collections)`, spreading, or `for…in` over them returns nothing useful, access builders by name (`q.collections.posts`). `q.custom` and `q.key` are plain.
+	`q.collections`, `q.globals`, and `q.routes` are JS `Proxy` objects with a
+	get-trap only. `Object.keys(q.collections)`, spreading, or `for…in` over them
+	returns nothing useful, access builders by name (`q.collections.posts`).
+	`q.custom` and `q.key` are plain.
 </Callout>
 
 ## Related
@@ -384,4 +448,5 @@ import { buildCollectionTopic, buildGlobalTopic } from "@questpie/tanstack-query
 - [Collections](/docs/concepts/collections), the CRUD surface (`find`, `create`, `updateMany`, …) these builders wrap, and the `find()` envelope shape.
 - [Globals](/docs/concepts/globals), the singleton counterpart, and why `get()` is non-nullable.
 - [Routes](/docs/concepts/routes), custom server functions exposed as `q.routes.<path>.query()` / `.mutation()`.
+- [Channels](/docs/client/channels), typed application-event subscriptions exposed as `q.channels.<name>.subscription()`.
 - [Relations](/docs/concepts/relations), the `with` hydration and `where` query language available inside `find()` options.

--- a/skills/questpie-admin/AGENTS.md
+++ b/skills/questpie-admin/AGENTS.md
@@ -10,12 +10,12 @@ The QUESTPIE admin panel is a **projection of your server schema**, not the fram
 
 ## Reference Topics
 
-| Topic     | File                      | Covers                                                                                 |
-| --------- | ------------------------- | -------------------------------------------------------------------------------------- |
-| Views     | `references/views.md`     | List views, form views, dashboard, sidebar, filters, bulk actions, visibility, history |
-| Blocks    | `references/blocks.md`    | Block definitions, fields, prefetch, renderers, block picker                           |
+| Topic     | File                      | Covers                                                                                           |
+| --------- | ------------------------- | ------------------------------------------------------------------------------------------------ |
+| Views     | `references/views.md`     | List/form/dashboard views, realtime refresh and locks, sidebar, filters, bulk actions, history   |
+| Blocks    | `references/blocks.md`    | Block definitions, fields, prefetch, renderers, block picker                                     |
 | Custom UI | `references/custom-ui.md` | Declarative `field()`/`view()`/`widget()`/`page()` definitions, component props, reactive fields |
-| Recipes   | `references/recipes.md`   | BE vs FE field, end-to-end custom field, custom admin page (e.g. chat), custom view     |
+| Recipes   | `references/recipes.md`   | BE vs FE field, end-to-end custom field, custom admin page (e.g. chat), custom view              |
 
 ## Full Compiled Document
 
@@ -207,10 +207,10 @@ when overriding (see Custom Theme below).
 
 ### Typography
 
-| Variable      | Value                                                               |
-| ------------- | ------------------------------------------------------------------- |
-| `--font-sans` | `"Geist Variable"`, UI, prose, headings, labels, navigation        |
-| `--font-mono` | `"JetBrains Mono Variable"`, code, file paths, commands, IDs       |
+| Variable      | Value                                                        |
+| ------------- | ------------------------------------------------------------ |
+| `--font-sans` | `"Geist Variable"`, UI, prose, headings, labels, navigation  |
+| `--font-mono` | `"JetBrains Mono Variable"`, code, file paths, commands, IDs |
 
 ### Sidebar Variables
 
@@ -527,7 +527,7 @@ For the framework side (enabling the provider, the token flow, the scope model, 
 
 This skill builds on questpie-admin.
 
-Views control how data appears in the QUESTPIE admin panel. They are configured **server-side** on collections and globals via `.list()` / `.form()`, and the admin client renders them from that introspected config. Custom view *types* (kanban, calendar, …) are declarative `view()` definitions discovered by codegen - see `references/custom-ui.md`.
+Views control how data appears in the QUESTPIE admin panel. They are configured **server-side** on collections and globals via `.list()` / `.form()`, and the admin client renders them from that introspected config. Custom view _types_ (kanban, calendar, …) are declarative `view()` definitions discovered by codegen - see `references/custom-ui.md`.
 
 ```text
 Server Config                     Admin UI
@@ -884,6 +884,14 @@ Users can save filter + sort + column combinations as named views.
 ## Bulk Actions
 
 List views support multi-select. Check rows, then use the floating toolbar. Built-in: **Delete** (with confirmation). Soft-delete collections soft-delete instead of permanent removal.
+
+## Realtime consumers and locks
+
+Admin list, dashboard, lock, and collaboration consumers must use the generated typed client surface. For collection/global state, prefer `client.collections.<name>.live()` or TanStack Query `{ realtime: true }`; the server re-runs access-controlled queries and reconciles missed broker wakes. For ordered collaboration events, define a typed channel and use `client.channels.<name>` or `q.channels.<name>.subscription()`.
+
+Do not create custom CRUD hooks that emit one realtime event per record. The framework writes one transactional outbox row per logical mutation, including bulk operations, and the live-query runtime coalesces snapshot wakes. Code that assumes update-many produces N record events will regress bulk behavior.
+
+Lock indicators are hints, not authorization. Writes must still enforce access and conflict rules on the server. Clean up direct subscriptions on unmount, use the returned stop function or abort signal, and call `client.channels.destroy()` only when disposing the entire client runtime.
 
 ## History & Versions
 

--- a/skills/questpie-admin/SKILL.md
+++ b/skills/questpie-admin/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: questpie-admin
-description: QUESTPIE admin panel, setup, branding, theming, sidebar, dashboard, views, blocks, custom fields, media, localization, live preview, auth, dark mode, CSS variables. Use when building or customizing the QUESTPIE admin UI.
+description: QUESTPIE admin panel, setup, branding, theming, sidebar, dashboard, views, blocks, custom fields, media, localization, realtime refresh and locks, live preview, auth, dark mode, CSS variables. Use when building or customizing the QUESTPIE admin UI.
 license: MIT
 metadata:
   author: questpie
@@ -13,12 +13,12 @@ The QUESTPIE admin panel is a **projection of your server schema**, not the fram
 
 ## Reference Topics
 
-| Topic     | File                      | Covers                                                                                 |
-| --------- | ------------------------- | -------------------------------------------------------------------------------------- |
-| Views     | `references/views.md`     | List views, form views, dashboard, sidebar, filters, bulk actions, visibility, history |
-| Blocks    | `references/blocks.md`    | Block definitions, fields, prefetch, renderers, block picker                           |
+| Topic     | File                      | Covers                                                                                           |
+| --------- | ------------------------- | ------------------------------------------------------------------------------------------------ |
+| Views     | `references/views.md`     | List/form/dashboard views, realtime refresh and locks, sidebar, filters, bulk actions, history   |
+| Blocks    | `references/blocks.md`    | Block definitions, fields, prefetch, renderers, block picker                                     |
 | Custom UI | `references/custom-ui.md` | Declarative `field()`/`view()`/`widget()`/`page()` definitions, component props, reactive fields |
-| Recipes   | `references/recipes.md`   | BE vs FE field, end-to-end custom field, custom admin page (e.g. chat), custom view     |
+| Recipes   | `references/recipes.md`   | BE vs FE field, end-to-end custom field, custom admin page (e.g. chat), custom view              |
 
 ## Full Compiled Document
 
@@ -210,10 +210,10 @@ when overriding (see Custom Theme below).
 
 ### Typography
 
-| Variable      | Value                                                               |
-| ------------- | ------------------------------------------------------------------- |
-| `--font-sans` | `"Geist Variable"`, UI, prose, headings, labels, navigation        |
-| `--font-mono` | `"JetBrains Mono Variable"`, code, file paths, commands, IDs       |
+| Variable      | Value                                                        |
+| ------------- | ------------------------------------------------------------ |
+| `--font-sans` | `"Geist Variable"`, UI, prose, headings, labels, navigation  |
+| `--font-mono` | `"JetBrains Mono Variable"`, code, file paths, commands, IDs |
 
 ### Sidebar Variables
 

--- a/skills/questpie-admin/references/views.md
+++ b/skills/questpie-admin/references/views.md
@@ -7,7 +7,7 @@ description: QUESTPIE admin views list-view table form-view sections sidebar das
 
 This skill builds on questpie-admin.
 
-Views control how data appears in the QUESTPIE admin panel. They are configured **server-side** on collections and globals via `.list()` / `.form()`, and the admin client renders them from that introspected config. Custom view *types* (kanban, calendar, …) are declarative `view()` definitions discovered by codegen - see `references/custom-ui.md`.
+Views control how data appears in the QUESTPIE admin panel. They are configured **server-side** on collections and globals via `.list()` / `.form()`, and the admin client renders them from that introspected config. Custom view _types_ (kanban, calendar, …) are declarative `view()` definitions discovered by codegen - see `references/custom-ui.md`.
 
 ```text
 Server Config                     Admin UI
@@ -364,6 +364,14 @@ Users can save filter + sort + column combinations as named views.
 ## Bulk Actions
 
 List views support multi-select. Check rows, then use the floating toolbar. Built-in: **Delete** (with confirmation). Soft-delete collections soft-delete instead of permanent removal.
+
+## Realtime consumers and locks
+
+Admin list, dashboard, lock, and collaboration consumers must use the generated typed client surface. For collection/global state, prefer `client.collections.<name>.live()` or TanStack Query `{ realtime: true }`; the server re-runs access-controlled queries and reconciles missed broker wakes. For ordered collaboration events, define a typed channel and use `client.channels.<name>` or `q.channels.<name>.subscription()`.
+
+Do not create custom CRUD hooks that emit one realtime event per record. The framework writes one transactional outbox row per logical mutation, including bulk operations, and the live-query runtime coalesces snapshot wakes. Code that assumes update-many produces N record events will regress bulk behavior.
+
+Lock indicators are hints, not authorization. Writes must still enforce access and conflict rules on the server. Clean up direct subscriptions on unmount, use the returned stop function or abort signal, and call `client.channels.destroy()` only when disposing the entire client runtime.
 
 ## History & Versions
 

--- a/skills/questpie/AGENTS.md
+++ b/skills/questpie/AGENTS.md
@@ -12,7 +12,7 @@ Server-first TypeScript application framework. Define your data schema once usin
 
 Reference these guidelines when:
 
-- Creating or modifying collections, globals, routes, jobs, services, emails, blocks
+- Creating or modifying collections, globals, routes, jobs, services, emails, blocks, or channels
 - Working with file conventions or codegen pipeline
 - Configuring adapters (queue, search, storage, realtime, email, KV)
 - Setting up access control, hooks, or validation
@@ -23,25 +23,26 @@ Reference these guidelines when:
 
 ## Import Paths, Critical
 
-| Factory                        | Import From                  | Needs Codegen? |
-| ------------------------------ | ---------------------------- | -------------- |
-| `collection(name)`             | `#questpie/factories`        | Yes            |
-| `global(name)`                 | `#questpie/factories`        | Yes            |
-| `block(name)`                  | `#questpie/factories`        | Yes            |
-| `adminConfig({...})`           | `#questpie/factories`        | Yes            |
-| `route()`                      | `"questpie"`                 | No             |
-| `job({...})`                   | `"questpie"`                 | No             |
-| `service()`                    | `"questpie"`                 | No             |
-| `email({...})`                 | `"questpie"`                 | No             |
-| `migration({...})`             | `"questpie"`                 | No             |
-| `seed({...})` / `seed.steps({...})` | `"questpie"`            | No             |
-| `runtimeConfig({...})`         | `"questpie/app"`             | No             |
-| `appConfig({...})`             | `"questpie/app"`             | No             |
-| `authConfig({...})`            | `"questpie/app"`             | No             |
-| `env({...})`                   | `"questpie/env"`             | No             |
-| `clientEnv({...})`             | `"questpie/env"`             | No             |
-| `createClient<AppConfig>()`    | `"questpie/client"`          | No             |
-| `createQuestpieQueryOptions()` | `"@questpie/tanstack-query"` | No             |
+| Factory                             | Import From                  | Needs Codegen? |
+| ----------------------------------- | ---------------------------- | -------------- |
+| `collection(name)`                  | `#questpie/factories`        | Yes            |
+| `global(name)`                      | `#questpie/factories`        | Yes            |
+| `block(name)`                       | `#questpie/factories`        | Yes            |
+| `channel(pattern)`                  | `"questpie/channels"`        | Yes            |
+| `adminConfig({...})`                | `#questpie/factories`        | Yes            |
+| `route()`                           | `"questpie"`                 | No             |
+| `job({...})`                        | `"questpie"`                 | No             |
+| `service()`                         | `"questpie"`                 | No             |
+| `email({...})`                      | `"questpie"`                 | No             |
+| `migration({...})`                  | `"questpie"`                 | No             |
+| `seed({...})` / `seed.steps({...})` | `"questpie"`                 | No             |
+| `runtimeConfig({...})`              | `"questpie/app"`             | No             |
+| `appConfig({...})`                  | `"questpie/app"`             | No             |
+| `authConfig({...})`                 | `"questpie/app"`             | No             |
+| `env({...})`                        | `"questpie/env"`             | No             |
+| `clientEnv({...})`                  | `"questpie/env"`             | No             |
+| `createClient<AppConfig>()`         | `"questpie/client"`          | No             |
+| `createQuestpieQueryOptions()`      | `"@questpie/tanstack-query"` | No             |
 
 ## Module And Plugin Configuration - Critical
 
@@ -88,13 +89,13 @@ export default authConfig({
 
 After `questpie generate`, the generated server files are the source of truth for what exists in the app. Inspect them before inventing imports, names, fields, or casts:
 
-| Need to know                         | Ground truth                                                                 |
-| ------------------------------------ | ---------------------------------------------------------------------------- |
+| Need to know                           | Ground truth                                                                                                                     |
+| -------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
 | Collections, globals, routes, services | `src/questpie/server/.generated/entities.gen.ts` and `AppCollections`, `AppGlobals`, `AppRoutes`, `AppServices` from `#questpie` |
-| Relation target keys                 | `src/questpie/server/.generated/names.gen.ts`                                |
-| Handler, hook, route, block context  | `src/questpie/server/.generated/context.gen.ts` and `Questpie.AppContext`    |
-| Session and auth user shape          | `AppSession`, `AppSessionUser`, and `AppConfig.auth` from `#questpie`        |
-| Enabled field and builder methods    | `src/questpie/server/.generated/factories.ts`                                |
+| Relation target keys                   | `src/questpie/server/.generated/names.gen.ts`                                                                                    |
+| Handler, hook, route, block context    | `src/questpie/server/.generated/context.gen.ts` and `Questpie.AppContext`                                                        |
+| Session and auth user shape            | `AppSession`, `AppSessionUser`, and `AppConfig.auth` from `#questpie`                                                            |
+| Enabled field and builder methods      | `src/questpie/server/.generated/factories.ts`                                                                                    |
 
 Files starting with `_`, `index.ts`, declaration files, tests, and specs are intentionally invisible to codegen. If something is missing from the generated surface, fix discovery, modules, or config and rerun `questpie generate`; do not add `any`, re-export barrels, or duplicate registries at the call site.
 
@@ -102,47 +103,48 @@ Files starting with `_`, `index.ts`, declaration files, tests, and specs are int
 
 ### Core
 
-| Topic             | File                            | Covers                                                             |
-| ----------------- | ------------------------------- | ------------------------------------------------------------------ |
-| Architecture      | `references/architecture.md`    | Framework overview, tech stack, project structure, file conventions, app bootstrap, data flow |
-| Quickstart        | `references/quickstart.md`      | Scaffold, configure, codegen, migrate, serve, zero to running app |
-| Data Modeling     | `references/data-modeling.md`   | Collections, globals, fields, relations, options, localization     |
-| Field Types       | `references/field-types.md`     | All built-in field types with options and operators                |
+| Topic             | File                            | Covers                                                                                                             |
+| ----------------- | ------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| Architecture      | `references/architecture.md`    | Framework overview, tech stack, project structure, file conventions, app bootstrap, data flow                      |
+| Quickstart        | `references/quickstart.md`      | Scaffold, configure, codegen, migrate, serve, zero to running app                                                  |
+| Data Modeling     | `references/data-modeling.md`   | Collections, globals, fields, relations, options, localization                                                     |
+| Field Types       | `references/field-types.md`     | All built-in field types with options and operators                                                                |
 | Type Inference    | `references/type-inference.md`  | The infer-first map: `CollectionDoc` / `CollectionWhere`, `AccessContext` helpers, per-op rule typing, cycle rules |
-| Rules             | `references/rules.md`           | Access control (row/field level), hooks lifecycle, validation, derived request context |
-| Business Logic    | `references/business-logic.md`  | Routes, jobs, services, email templates, context injection         |
-| AppContext        | `references/app-context.md`     | The `AppContext` runtime interface, where it's available, `getContext`, partial context overrides |
-| Durable Workflows | `references/workflows.md`       | Long-running workflows, steps, events, cron, admin UI              |
-| Sandboxed Code    | `references/sandbox.md`         | `ctx.executor.run()`, isolation modes, capability model, Deno engine deployment |
-| CRUD API          | `references/crud-api.md`        | `find`, `create`, `updateById`/`updateMany`, `deleteById`/`deleteMany`, atomic conditional updates, globals API |
+| Rules             | `references/rules.md`           | Access control (row/field level), hooks lifecycle, validation, derived request context                             |
+| Business Logic    | `references/business-logic.md`  | Routes, jobs, services, email templates, context injection                                                         |
+| AppContext        | `references/app-context.md`     | The `AppContext` runtime interface, where it's available, `getContext`, partial context overrides                  |
+| Durable Workflows | `references/workflows.md`       | Long-running workflows, steps, events, cron, admin UI                                                              |
+| Sandboxed Code    | `references/sandbox.md`         | `ctx.executor.run()`, isolation modes, capability model, Deno engine deployment                                    |
+| CRUD API          | `references/crud-api.md`        | `find`, `create`, `updateById`/`updateMany`, `deleteById`/`deleteMany`, atomic conditional updates, globals API    |
 | Seeds             | `references/seeds.md`           | `seed()` vs `seed.steps()`, idempotency, checkpointed steps, categories, `dependsOn`, `undo`, `autoSeed`, seed CLI |
-| Query Operators   | `references/query-operators.md` | `where` clause operators by field type                             |
-| Realtime          | `references/realtime.md`        | Live queries over SSE, automatic broadcasts, `live()`/`liveIter()`, wire protocol, keepalive |
+| Query Operators   | `references/query-operators.md` | `where` clause operators by field type                                                                             |
+| Realtime          | `references/realtime.md`        | Transactional outbox, reconciliation, live queries, broker/client transport seams, admission                       |
+| Channels          | `references/channels.md`        | Typed application events, authorization, publish contexts, client, presence, TanStack Query                        |
 
 ### Infrastructure
 
-| Topic      | File                                    | Covers                                                       |
-| ---------- | --------------------------------------- | ------------------------------------------------------------ |
-| Production | `references/production.md`              | Queue, search, realtime, storage, email, KV adapter setup    |
-| Environment | `references/env.md`                    | `env.ts` + `env.client.ts`: boot-validated, typed env, generated client modules |
-| Auth       | `references/auth.md`                    | Better Auth integration, session, providers, access patterns |
-| Adapters   | `references/infrastructure-adapters.md` | All adapter configs: pg-boss, S3, SMTP, pgNotify, Redis      |
-| MCP        | `references/mcp.md`                     | MCP setup, CRUD tools, route tools, custom tools, security   |
+| Topic       | File                                    | Covers                                                                          |
+| ----------- | --------------------------------------- | ------------------------------------------------------------------------------- |
+| Production  | `references/production.md`              | Queue, search, realtime, storage, email, KV adapter setup                       |
+| Environment | `references/env.md`                     | `env.ts` + `env.client.ts`: boot-validated, typed env, generated client modules |
+| Auth        | `references/auth.md`                    | Better Auth integration, session, providers, access patterns                    |
+| Adapters    | `references/infrastructure-adapters.md` | All adapter configs: pg-boss, S3, SMTP, pgNotify, Redis                         |
+| MCP         | `references/mcp.md`                     | MCP setup, CRUD tools, route tools, custom tools, security                      |
 
 ### Extend
 
-| Topic              | File                               | Covers                                                       |
-| ------------------ | ---------------------------------- | ------------------------------------------------------------ |
-| Extend             | `references/extend.md`             | Custom modules, fields, operators, adapters, codegen plugins |
+| Topic              | File                               | Covers                                                                                                                   |
+| ------------------ | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| Extend             | `references/extend.md`             | Custom modules, fields, operators, adapters, codegen plugins                                                             |
 | Module Authoring   | `references/module-authoring.md`   | How modules are created: convention dirs → codegen `.generated/module.ts`; NEVER hand-write `module.ts`/inline `route()` |
-| Codegen Plugin API | `references/codegen-plugin-api.md` | Plugin architecture, category declarations, templates        |
-| Multi-Tenancy      | `references/multi-tenancy.md`      | `appConfig({ context })` resolver, scope isolation, ScopeProvider |
+| Codegen Plugin API | `references/codegen-plugin-api.md` | Plugin architecture, category declarations, templates                                                                    |
+| Multi-Tenancy      | `references/multi-tenancy.md`      | `appConfig({ context })` resolver, scope isolation, ScopeProvider                                                        |
 
 ### Client
 
-| Topic          | File                           | Covers                                                           |
-| -------------- | ------------------------------ | ---------------------------------------------------------------- |
-| TanStack Query | `references/tanstack-query.md` | `q.collections.*`, `q.globals.*`, `q.routes.*`, realtime queries |
+| Topic          | File                           | Covers                                                                                    |
+| -------------- | ------------------------------ | ----------------------------------------------------------------------------------------- |
+| TanStack Query | `references/tanstack-query.md` | `q.collections.*`, `q.globals.*`, `q.routes.*`, realtime snapshots, channel subscriptions |
 
 ## Key Patterns, Quick Reference
 
@@ -257,19 +259,19 @@ await queue.sendReminder.publish({ userId: "abc" });
 
 ## Common Mistakes
 
-| Severity | Mistake                                                | Fix                                                                                   |
-| -------- | ------------------------------------------------------ | ------------------------------------------------------------------------------------- |
-| CRITICAL | Files in wrong directory                               | Collections in `collections/`, routes in `routes/`, etc.                              |
-| CRITICAL | Convention file has no export                          | Codegen needs one export, `export default` or a named `export const`/`function` both discovered; a file with no export is skipped. Factory categories key from the factory string (`collection("blog-posts")` -> `blogPosts`); non-factory categories key from the filename |
-| CRITICAL | Importing route/job/service from `#questpie/factories` | Use `"questpie"`, only collection/global/block/adminConfig use `#questpie/factories` |
-| CRITICAL | Redefining a module collection (e.g. starter `user`) from scratch | `.merge(starterModule.collections.user)` then add fields, see Extend pattern        |
-| CRITICAL | Casting `session.user` to `any` for admin role checks | Use `session?.user.role`; if it is not typed, fix `modules.ts`, `config/auth.ts`, and regenerated output |
-| HIGH     | Forgetting `questpie generate` after adding files      | Re-run codegen on any file add/remove in convention dirs                              |
-| HIGH     | Job handler uses `input` instead of `payload`          | Jobs destructure `{ payload }`, routes destructure `{ input }`                        |
-| HIGH     | `queue.send("name", data)`                             | Use `queue.jobName.publish(data)`                                                     |
-| HIGH     | `beforeCreate` / `afterCreate` hook names              | Use `beforeChange` / `afterChange` with `operation === "create"` guard                |
-| MEDIUM   | Using npm/yarn instead of Bun                          | QUESTPIE requires Bun as package manager                                              |
-| MEDIUM   | Editing `.generated/` files                            | Never edit, re-run `questpie generate`                                               |
+| Severity | Mistake                                                           | Fix                                                                                                                                                                                                                                                                         |
+| -------- | ----------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| CRITICAL | Files in wrong directory                                          | Collections in `collections/`, routes in `routes/`, etc.                                                                                                                                                                                                                    |
+| CRITICAL | Convention file has no export                                     | Codegen needs one export, `export default` or a named `export const`/`function` both discovered; a file with no export is skipped. Factory categories key from the factory string (`collection("blog-posts")` -> `blogPosts`); non-factory categories key from the filename |
+| CRITICAL | Importing route/job/service from `#questpie/factories`            | Use `"questpie"`, only collection/global/block/adminConfig use `#questpie/factories`                                                                                                                                                                                        |
+| CRITICAL | Redefining a module collection (e.g. starter `user`) from scratch | `.merge(starterModule.collections.user)` then add fields, see Extend pattern                                                                                                                                                                                                |
+| CRITICAL | Casting `session.user` to `any` for admin role checks             | Use `session?.user.role`; if it is not typed, fix `modules.ts`, `config/auth.ts`, and regenerated output                                                                                                                                                                    |
+| HIGH     | Forgetting `questpie generate` after adding files                 | Re-run codegen on any file add/remove in convention dirs                                                                                                                                                                                                                    |
+| HIGH     | Job handler uses `input` instead of `payload`                     | Jobs destructure `{ payload }`, routes destructure `{ input }`                                                                                                                                                                                                              |
+| HIGH     | `queue.send("name", data)`                                        | Use `queue.jobName.publish(data)`                                                                                                                                                                                                                                           |
+| HIGH     | `beforeCreate` / `afterCreate` hook names                         | Use `beforeChange` / `afterChange` with `operation === "create"` guard                                                                                                                                                                                                      |
+| MEDIUM   | Using npm/yarn instead of Bun                                     | QUESTPIE requires Bun as package manager                                                                                                                                                                                                                                    |
+| MEDIUM   | Editing `.generated/` files                                       | Never edit, re-run `questpie generate`                                                                                                                                                                                                                                      |
 
 ## Preview And Workflow Rules
 
@@ -5510,100 +5512,183 @@ const result = await collections.products.find({
 
 # Realtime
 
-Live queries over SSE. **Broadcasts are automatic**, every collection/global create/update/delete already writes a change event to the `questpie_realtime_log` outbox and notifies subscribers. Do NOT write `afterChange` hooks that "emit" realtime events; a custom emitter double-fires against the built-in broadcast hook.
+Realtime powers two distinct products:
 
-## How It Works
+- **Live queries** re-run a collection/global query under the subscriber's session and deliver the latest access-controlled snapshot. Snapshot wakes are coalescable.
+- **Channels** deliver schema-validated application events in channel-local order. Events are not coalesced. See `references/channels.md`.
 
-1. Every CRUD write appends a change event to the outbox; an adapter (pg_notify / Redis Streams) or 2s polling wakes subscribers
-2. The server **re-runs the subscribed query under the subscriber's auth** and pushes the full result as a `snapshot`, clients never receive raw change events (no `operation`/`recordId` on the client; snapshots are access-controlled)
-3. One SSE connection multiplexes all topics (`POST /realtime`)
+Enable it with `realtime: true`. Do not write CRUD hooks to emit live-query changes: every logical create/update/delete, including bulk operations, already appends one `questpie_realtime_log` row **inside the business transaction**.
 
-Snapshots are idempotent state, not diffs, filtered subscriptions may receive unchanged snapshots on update/delete (over-refresh by design). Always render from the snapshot.
+## Correctness model
 
-## Client-Side Usage
+1. The mutation and outbox row commit or roll back together.
+2. A `ChangeBroker` wake tells instances to drain quickly. Wakes are notice-only, unordered, at-most-once, and may be coalesced.
+3. An unconditional reconciliation poll drains missed outbox rows. Default: 15s with push, 2s without; provider failure tightens to at most 2s.
+4. The server re-runs matching queries under the subscriber's session, including row/field access and `afterRead`, then a `ClientTransport` delivers authorized frames.
+
+The broker is a latency hint; the transactional outbox plus reconciliation is the guarantee. Brokers must never carry rows or snapshots. Equivalent snapshot work is shared per principal by default, never across users unless the application proves deterministic access equivalence.
+
+## Client usage
 
 ```ts
-// React + TanStack Query, typed second arg, no casts needed
+const stop = client.collections.posts.live(
+	{ where: { status: "published" }, with: { author: true }, limit: 50 },
+	(snapshot) => render(snapshot.docs),
+	{ onError: console.error },
+);
+
+for await (const snapshot of client.collections.posts.liveIter(
+	{ where: { status: "published" } },
+	{ signal: controller.signal },
+)) {
+	render(snapshot.docs);
+}
+
+client.globals.siteSettings.live(undefined, (settings) => applyTheme(settings));
+```
+
+`live()` accepts the query options supported by the wire contract: `where`, `with`, `limit`, `offset`, `orderBy`, and `locale`. Prefer these typed wrappers over raw `client.realtime.subscribe()`.
+
+TanStack Query uses the stream for its initial result too; it does not issue a duplicate REST fetch:
+
+```tsx
 const { data } = useQuery(
-	qp.collections.posts.find(
-		{ where: { event: eventId }, limit: 50 },
+	q.collections.posts.find(
+		{ where: { status: "published" }, limit: 20 },
 		{ realtime: true },
 	),
 );
-
-// Vanilla TS, live() is the live form of find(): same options in, same result type out
-const stop = client.collections.posts.live(
-	{
-		where: { event: eventId },
-		with: { author: true },
-		orderBy: { createdAt: "desc" },
-	},
-	(snap) => render(snap.docs), // snap.docs[i].author is typed
-	{ onError: (e) => console.error(e) },
-);
-stop(); // unsubscribe
-
-// Async-iterable form (workers, agents, tests), terminate via AbortSignal
-for await (const snap of client.collections.posts.liveIter(
-	{ where: { event: eventId } },
-	{ signal: controller.signal },
-)) {
-	render(snap.docs);
-}
-
-// Globals mirror get()
-client.globals.siteSettings.live(undefined, (settings) => applyTheme(settings));
-
-// Low-level escape hatch, topic objects, never channel strings; data is untyped
-client.realtime.subscribe(
-	{ resourceType: "collection", resource: "posts", where: { event: eventId } },
-	(data) => {}, // unknown, prefer the typed live() wrappers
-);
 ```
 
-Live options carry exactly what the wire protocol supports: `where`, `with`, `limit`, `offset`, `orderBy`, `locale` (no `columns`/`groupBy`/`search`, compile error).
+`count(..., { realtime: true })` yields a number, not a paginated snapshot. `findOne()` and `findVersions()` do not have realtime forms.
 
-## Wire Protocol (stable contract)
+## Transport selection
 
-`POST <basePath>/realtime` body `{ topics: [{ id, resourceType: "collection" | "global", resource, where?, with?, limit?, offset?, orderBy?, locale? }] }` → SSE events:
+SSE is the default `ClientTransport`; no browser transport config is required. With a normal Postgres URL the server auto-wires `pg_notify`; otherwise it polls every 2s. Explicit pg, Redis, and Cloudflare adapters remain supported as notice brokers.
 
-| Event      | Payload                  | Meaning                                               |
-| ---------- | ------------------------ | ----------------------------------------------------- |
-| `snapshot` | `{ topicId, seq, data }` | Full `find()`/`get()` result under subscriber's auth  |
-| `error`    | `{ topicId, message }`   | Topic-level failure (unknown resource, access denied) |
-| `ping`     | `{ ts }`                 | Keep-alive (default every 8s)                         |
-
-Ignore unknown SSE event types (forward compat).
-
-## Keepalive (Bun)
-
-The stream pings every 8s by default (`realtime.keepAliveIntervalMs`). Bun's default `idleTimeout` is 10s, the default ping survives it, but set headroom explicitly in the server entry:
+For managed WebSockets and native presence, select the isolated Pusher/Soketi preset:
 
 ```ts
-export default { port: 3000, idleTimeout: 30, fetch: server.fetch };
+import { pusherRealtime } from "questpie/adapters/pusher";
+import { runtimeConfig } from "questpie/app";
+
+const managed = pusherRealtime({
+	appId: env.PUSHER_APP_ID,
+	key: env.PUSHER_KEY,
+	secret: env.PUSHER_SECRET,
+	cluster: env.PUSHER_CLUSTER,
+});
+
+export default runtimeConfig({ realtime: { ...managed } });
 ```
 
-## Realtime Adapters
+`pusherRealtime()` supplies both the notice broker and client transport. App-facing `live()`, TanStack, and channel APIs do not change. Direct provider client events are off by default because they bypass framework publish authorization, Zod validation, rate limits, ordered ledger, and replay.
 
-Without an adapter, subscribers wake on a 2s poll. For push-based delivery, configure a realtime adapter in `runtimeConfig`:
+## Admission and lifecycle
+
+Default SSE limits are 20 topics per connection, 5 connections per authenticated principal, `find` limit 100, nested `with` depth 3, 4 concurrent initial snapshots, and 1 MiB buffered snapshot bytes per edge session. Slow consumers are bounded and disconnected rather than allowed unbounded memory growth.
+
+Keep `keepAliveIntervalMs` (default 8s) below the server/proxy idle timeout. `live()` without server `realtime` errors explicitly; it does not silently fall back to a normal query.
+
+Full adapter options and deployment guidance: `references/infrastructure-adapters.md`.
+
+---
+
+# Channels
+
+Channels are typed, ordered application-event streams over the realtime runtime. Use them for chat notifications, progress, typing, or presence. The bounded replay ledger is delivery infrastructure, not durable application history; persist events users must retrieve later in a collection.
+
+## Define and generate
+
+```ts title="channels/chat-room.ts"
+import { channel } from "questpie/channels";
+import { z } from "zod";
+
+export default channel("chat-room-[roomId]")
+	.events({
+		message: z.object({ id: z.string(), text: z.string() }),
+		typing: z.object({ active: z.boolean() }),
+	})
+	.authorize({
+		subscribe: ({ session }) => Boolean(session?.user),
+		publish: ({ session }) => Boolean(session?.user),
+	})
+	.presence(({ params, session }) => ({
+		id: session!.user.id,
+		roomId: params.roomId,
+	}));
+```
+
+The default-export filename derives the registry/API key (`chatRoom`); the builder string is the stable wire pattern. `[roomId]` becomes a required typed parameter. Run `bunx questpie generate` after adding or renaming a channel.
+
+Authorization rules:
+
+- With no `.authorize()`, subscribe is public and browser publish is denied.
+- `.authorize(rule)` uses the rule for subscribe and as the publish fallback.
+- `.authorize({ subscribe, publish })` separates both permissions; omitted publish falls back to subscribe.
+- Server/system contexts may publish; browser publish always uses the framework route, authorization, rate limits, and Zod parsing.
+
+## Publish on the server
+
+Framework handlers and hooks receive a generated `channels` service:
 
 ```ts
-import { pgNotifyAdapter } from "questpie/adapters/pg-notify";
+.handler(async ({ input, channels }) => {
+	return channels.publish("chatRoom", {
+		params: { roomId: input.roomId },
+		event: "message",
+		data: { id: input.id, text: input.text },
+	});
+});
 
-runtimeConfig({
-	realtime: {
-		adapter: pgNotifyAdapter({ connectionString: env.DATABASE_URL }),
-	},
+.hooks({
+	afterChange: [async ({ data, channels }) => {
+		await channels.publish("chatRoom", {
+			params: { roomId: data.roomId },
+			event: "message",
+			data: { id: data.id, text: data.text },
+		});
+	}],
 });
 ```
 
-| Adapter                 | Description                  |
-| ----------------------- | ---------------------------- |
-| _None_ (default)        | Polling-based (every 2s)     |
-| `pgNotifyAdapter()`     | PostgreSQL LISTEN/NOTIFY     |
-| `redisStreamsAdapter()` | Redis Streams consumer group |
+In collection/global/hook files, use the injected `{ channels }`. Never import the generated `app` or defer lookup through ambient `getContext()`; the injected service is generated-type-safe and mutation-context aware.
 
-Full adapter configuration (connection options, multi-instance setup): see `references/infrastructure-adapters.md`.
+## Client, presence, and TanStack Query
+
+```ts
+const stop = client.channels.chatRoom.subscribe({ roomId }, (message) => {
+	if (message.event === "message") console.log(message.data.text);
+});
+
+await client.channels.chatRoom.publish({
+	params: { roomId },
+	event: "typing",
+	data: { active: true },
+});
+
+const members = await client.channels.chatRoom.presence({ roomId });
+stop();
+```
+
+Async consumers use `client.channels.chatRoom.iter(params, { signal })`. TanStack Query exposes an accumulating event query:
+
+```tsx
+const { data: messages = [] } = useQuery(
+	q.channels.chatRoom.subscription({ roomId }),
+);
+```
+
+This differs from live-query `{ realtime: true }`, which retains only the latest snapshot.
+
+## Delivery and security
+
+- Events are ordered per resolved channel and never coalesced. Reconnect can replay an id; clients deduplicate it.
+- Falling behind the bounded replay horizon raises an explicit gap. Recover from persisted state or subscribe from now.
+- Payloads must be JSON-serializable and at most 10,000 UTF-8 bytes.
+- Cookie-authenticated authority routes require an exact trusted Origin; configure extra origins under `realtime.channelSecurity.trustedOrigins`.
+- Client publish token buckets default to 10/s with burst 20 per session and principal.
+- Pusher/Soketi is an opt-in transport preset. Direct provider client events are a separate unsafe capability and are off by default.
 
 ---
 
@@ -6402,7 +6487,7 @@ The exhaustive catalog of adapter config shapes for QUESTPIE infrastructure. For
 - [Database](#database)
 - [Storage](#storage), local, S3, R2, signed URLs
 - [Queue](#queue), pg-boss, BullMQ
-- [Realtime](#realtime), pgNotify, Redis Streams
+- [Realtime](#realtime), SSE, pgNotify, Redis Streams, Cloudflare, Pusher/Soketi
 - [Search](#search), Postgres FTS, pgvector semantic
 - [Email](#email), SMTP, Console, Resend, Plunk, custom
 - [KV Store](#kv-store), Redis, custom, in-memory
@@ -6575,8 +6660,19 @@ Serving stays collection-scoped, the file route verifies the token **and** the c
 ```ts
 import { buildStorageFileUrl, generateSignedUrlToken } from "questpie/storage";
 
-const token = await generateSignedUrlToken(asset.key, app.config.secret!, 900, "assets");
-const url = buildStorageFileUrl(app.config.app.url, "/api", "assets", asset.key, token);
+const token = await generateSignedUrlToken(
+	asset.key,
+	app.config.secret!,
+	900,
+	"assets",
+);
+const url = buildStorageFileUrl(
+	app.config.app.url,
+	"/api",
+	"assets",
+	asset.key,
+	token,
+);
 ```
 
 (`verifySignedUrlToken` is the verification half the serve route runs, you rarely call it yourself.)
@@ -6639,11 +6735,13 @@ handler: async ({ queue }) => {
 
 ## Realtime
 
-SSE-based live updates.
+The realtime runtime writes its outbox row in the business transaction and always reconciles missed notices. `ChangeBroker` handles notice-only cross-instance wakes; `ClientTransport` handles already-authorized edge frames. SSE is the default client transport.
 
-### pgNotify (Single Instance)
+With `realtime: true`, a normal Postgres URL auto-selects `pg_notify`; without a push broker, the outbox is polled every 2s. With push, reconciliation still runs every 15s so a lost wake cannot permanently stall subscribers.
 
-Uses PostgreSQL `LISTEN/NOTIFY`. Best for single-server deployments:
+### pgNotify
+
+Uses PostgreSQL `LISTEN/NOTIFY`. Every listening instance receives the same notice:
 
 ```ts
 import { runtimeConfig } from "questpie/app";
@@ -6660,9 +6758,9 @@ export default runtimeConfig({
 });
 ```
 
-### Redis Streams (Multi-Instance)
+### Redis Streams
 
-Required for horizontal scaling across multiple server instances. Takes a connected, redis-shaped `client` (the node-redis command surface: `xAdd`, `xReadGroup`, `xGroupCreate`, `xAck`), not a URL:
+Takes a connected Redis-shaped `client` with `xAdd` and `xRead`, not a URL. Every app instance owns an independent `XREAD` cursor so notices fan out; consumer groups must not be used because they load-balance wakes and strand subscribers on other instances.
 
 ```ts
 import { createClient } from "redis";
@@ -6681,13 +6779,42 @@ export default runtimeConfig({
 });
 ```
 
+The adapter duplicates the client for its blocking reader when supported; otherwise provide a dedicated `reader`. The `group` and `consumer` options are deprecated compatibility inputs and do not restore consumer-group behavior.
+
+### Pusher/Soketi managed WebSockets
+
+Use the isolated preset when managed WebSocket delivery and native presence are required:
+
+```ts
+import { pusherRealtime } from "questpie/adapters/pusher";
+import { runtimeConfig } from "questpie/app";
+
+const managed = pusherRealtime({
+	appId: env.PUSHER_APP_ID,
+	key: env.PUSHER_KEY,
+	secret: env.PUSHER_SECRET,
+	cluster: env.PUSHER_CLUSTER,
+});
+
+export default runtimeConfig({ realtime: { ...managed } });
+```
+
+The preset supplies a notice-only Pusher `ChangeBroker` and a Pusher `ClientTransport`. Direct provider client events are off by default; they bypass QUESTPIE channel schemas, publish authorization, rate limits, ordered ledger, and replay.
+
+### Cloudflare Durable Objects
+
+`cloudflareRealtimeAdapter()` is a notice-only broker for Workers. It shards Durable Objects by resource type and resource name, and notification work is attached to `waitUntil` so CRUD commits do not wait on the broker. The Worker still reads the durable outbox, re-runs access-controlled snapshots, and performs reconciliation.
+
 ### When to Use Which
 
-| Adapter                    | Use Case                                              |
-| -------------------------- | ----------------------------------------------------- |
-| `pgNotifyAdapter`          | Single server, development, simple deployments        |
-| `redisStreamsAdapter`      | Multiple servers, horizontal scaling, high throughput |
-| `cloudflareRealtimeAdapter` | Cloudflare Workers (Durable Objects)                  |
+| Selection                   | Use case                                                          |
+| --------------------------- | ----------------------------------------------------------------- |
+| Implicit pg + SSE           | Default Postgres deployment                                       |
+| Poll + SSE                  | Zero extra infrastructure without a push-capable database         |
+| `pgNotifyAdapter` + SSE     | Explicit Postgres connection/channel                              |
+| `redisStreamsAdapter` + SSE | Cross-instance Redis notice fan-out                               |
+| `cloudflareRealtimeAdapter` | Cloudflare Workers notice fan-out through sharded Durable Objects |
+| `pusherRealtime`            | Managed WebSockets, native presence, and shared channel delivery  |
 
 ## Search
 
@@ -7109,15 +7236,15 @@ const spec = generateOpenApiSpec(app, {
 
 ## Migrations CLI
 
-| Command                          | Description                                      |
-| -------------------------------- | ------------------------------------------------ |
-| `bunx questpie push`             | Direct schema sync (dev only, no migration file) |
-| `bunx questpie migrate:create`   | Generate migration from schema diff              |
-| `bunx questpie migrate`          | Run pending migrations                           |
-| `bunx questpie migrate:down`     | Rollback last migration                          |
-| `bunx questpie migrate:fresh`    | Drop all and re-run (DESTRUCTIVE)                |
-| `bunx questpie migrate:reset`    | Reset migration tracking                         |
-| `bunx questpie seed`             | Run seed files                                   |
+| Command                        | Description                                      |
+| ------------------------------ | ------------------------------------------------ |
+| `bunx questpie push`           | Direct schema sync (dev only, no migration file) |
+| `bunx questpie migrate:create` | Generate migration from schema diff              |
+| `bunx questpie migrate`        | Run pending migrations                           |
+| `bunx questpie migrate:down`   | Rollback last migration                          |
+| `bunx questpie migrate:fresh`  | Drop all and re-run (DESTRUCTIVE)                |
+| `bunx questpie migrate:reset`  | Reset migration tracking                         |
+| `bunx questpie seed`           | Run seed files                                   |
 
 ## Complete Production Config Example
 
@@ -8263,6 +8390,7 @@ examples/city-portal/
 - [Type Inference](#type-inference), `AppConfig` flow
 - [Direct Client Usage (without TanStack Query)](#direct-client-usage-without-tanstack-query)
 - [Realtime](#realtime), `{ realtime: true }`, adapters, topic builders
+- [Channel Subscriptions](#channel-subscriptions), typed ordered application events
 - [Framework Adapters](#framework-adapters), TanStack Start, Next.js, Hono, Elysia
 - [Common Mistakes](#common-mistakes)
 
@@ -8650,7 +8778,7 @@ client.setLocale("sk"); // Set locale for localized content
 
 ## Realtime
 
-Pass `{ realtime: true }` as the **typed** second argument (`RealtimeQueryConfig`) to `find()`, `count()`, or `get()`, initial data via a normal fetch, then the server pushes full access-controlled snapshots on every matching change. `findOne()` and `findVersions()` have no realtime form (a second argument there is a compile error).
+Pass `{ realtime: true }` as the **typed** second argument (`RealtimeQueryConfig`) to `find()`, `count()`, or `get()`. The stream supplies the initial value and later access-controlled snapshots, so there is no duplicate REST fetch. `findOne()` and `findVersions()` have no realtime form (a second argument there is a compile error). Realtime `count()` remains a scalar number.
 
 ```tsx
 const { data } = useQuery(
@@ -8661,7 +8789,7 @@ const { data } = useQuery(
 );
 ```
 
-Works zero-config (2s polling); add a realtime adapter for instant push:
+Server realtime must be enabled. SSE is the default client transport; a normal Postgres URL auto-wires `pg_notify`, while setups without a push broker reconcile by polling every 2s. An explicit adapter can select a broker:
 
 ```ts
 import { runtimeConfig } from "questpie/app";
@@ -8674,18 +8802,36 @@ export default runtimeConfig({
 });
 ```
 
-Subscriptions are query-shaped topic objects (`{ resourceType, resource, where?, with? }`), there are no channel strings. Outside React, use the typed live form of the same query: `client.collections.posts.live(options, onSnapshot)` / `liveIter(options)` (see AGENTS.md §19 Realtime).
+Live-query subscriptions are query-shaped topic objects (`{ resourceType, resource, where?, with? }`), not application channel strings. Outside React, use the typed live form of the same query: `client.collections.posts.live(options, onSnapshot)` / `liveIter(options)` (see `references/realtime.md`).
 
 To build those topic objects yourself, e.g. manual cache invalidation or a raw `client.realtime.subscribe` call that must match the topic a query subscribed with, use the exported builders instead of hand-writing the shape:
 
 ```ts
-import { buildCollectionTopic, buildGlobalTopic } from "@questpie/tanstack-query"; // re-exported from questpie/client
+import {
+	buildCollectionTopic,
+	buildGlobalTopic,
+} from "@questpie/tanstack-query"; // re-exported from questpie/client
 
-const topic = buildCollectionTopic("posts", { where: { status: "published" }, limit: 20 });
+const topic = buildCollectionTopic("posts", {
+	where: { status: "published" },
+	limit: 20,
+});
 const settingsTopic = buildGlobalTopic("siteSettings");
 ```
 
-For multi-instance deployments, create a Redis client and use `redisStreamsAdapter({ client })`.
+Push is a latency optimization; the transactional outbox and reconciliation poll recover missed broker wakes. See `references/realtime.md`.
+
+## Channel Subscriptions
+
+Generated channels expose an accumulating query option. Unlike live queries, ordered channel events are appended rather than reduced to the newest snapshot:
+
+```tsx
+const { data: messages = [] } = useQuery(
+	q.channels.chatRoom.subscription({ roomId }),
+);
+```
+
+The result is a typed array of `{ event, eventId, data }` unions. The query's abort signal closes the underlying channel iterator. Channel definition, authorization, server publish, and presence are covered in `references/channels.md`.
 
 ## Framework Adapters
 
@@ -8746,20 +8892,9 @@ const posts = await fetch("/api/collections/posts").then((r) => r.json());
 const { docs } = await client.collections.posts.find({ limit: 10 });
 ```
 
-### MEDIUM: Not setting up realtime adapter
+### MEDIUM: Forgetting to enable server realtime
 
-Collection changes do not auto-refresh when realtime is enabled but no adapter is configured. Add a realtime adapter in `questpie.config.ts`:
-
-```ts
-import { runtimeConfig } from "questpie/app";
-import { pgNotifyAdapter } from "questpie/adapters/pg-notify";
-
-export default runtimeConfig({
-	realtime: {
-		adapter: pgNotifyAdapter({ connectionString: process.env.DATABASE_URL }),
-	},
-});
-```
+`{ realtime: true }` is not a request to silently fall back to a normal query. Set `realtime: true` or a realtime object in server runtime config; otherwise the subscription reports an error.
 
 ### MEDIUM: Importing from `questpie/client` in server code or vice versa
 

--- a/skills/questpie/SKILL.md
+++ b/skills/questpie/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: questpie
-description: QUESTPIE framework, server-first TypeScript CMS. File-convention codegen, collections, globals, routes, jobs, services, emails, blocks, typed client SDK, TanStack Query integration, adapters (queue, search, realtime, storage, email, KV). Use when building, reviewing, or refactoring any QUESTPIE project.
+description: QUESTPIE framework, server-first TypeScript CMS. File-convention codegen, collections, globals, routes, jobs, services, emails, blocks, typed channels, realtime, typed client SDK, TanStack Query integration, and infrastructure adapters. Use when building, reviewing, or refactoring any QUESTPIE project.
 license: MIT
 metadata:
   author: questpie
@@ -15,7 +15,7 @@ Server-first TypeScript application framework. Define your data schema once usin
 
 Reference these guidelines when:
 
-- Creating or modifying collections, globals, routes, jobs, services, emails, blocks
+- Creating or modifying collections, globals, routes, jobs, services, emails, blocks, or channels
 - Working with file conventions or codegen pipeline
 - Configuring adapters (queue, search, storage, realtime, email, KV)
 - Setting up access control, hooks, or validation
@@ -26,25 +26,26 @@ Reference these guidelines when:
 
 ## Import Paths, Critical
 
-| Factory                        | Import From                  | Needs Codegen? |
-| ------------------------------ | ---------------------------- | -------------- |
-| `collection(name)`             | `#questpie/factories`        | Yes            |
-| `global(name)`                 | `#questpie/factories`        | Yes            |
-| `block(name)`                  | `#questpie/factories`        | Yes            |
-| `adminConfig({...})`           | `#questpie/factories`        | Yes            |
-| `route()`                      | `"questpie"`                 | No             |
-| `job({...})`                   | `"questpie"`                 | No             |
-| `service()`                    | `"questpie"`                 | No             |
-| `email({...})`                 | `"questpie"`                 | No             |
-| `migration({...})`             | `"questpie"`                 | No             |
-| `seed({...})` / `seed.steps({...})` | `"questpie"`            | No             |
-| `runtimeConfig({...})`         | `"questpie/app"`             | No             |
-| `appConfig({...})`             | `"questpie/app"`             | No             |
-| `authConfig({...})`            | `"questpie/app"`             | No             |
-| `env({...})`                   | `"questpie/env"`             | No             |
-| `clientEnv({...})`             | `"questpie/env"`             | No             |
-| `createClient<AppConfig>()`    | `"questpie/client"`          | No             |
-| `createQuestpieQueryOptions()` | `"@questpie/tanstack-query"` | No             |
+| Factory                             | Import From                  | Needs Codegen? |
+| ----------------------------------- | ---------------------------- | -------------- |
+| `collection(name)`                  | `#questpie/factories`        | Yes            |
+| `global(name)`                      | `#questpie/factories`        | Yes            |
+| `block(name)`                       | `#questpie/factories`        | Yes            |
+| `channel(pattern)`                  | `"questpie/channels"`        | Yes            |
+| `adminConfig({...})`                | `#questpie/factories`        | Yes            |
+| `route()`                           | `"questpie"`                 | No             |
+| `job({...})`                        | `"questpie"`                 | No             |
+| `service()`                         | `"questpie"`                 | No             |
+| `email({...})`                      | `"questpie"`                 | No             |
+| `migration({...})`                  | `"questpie"`                 | No             |
+| `seed({...})` / `seed.steps({...})` | `"questpie"`                 | No             |
+| `runtimeConfig({...})`              | `"questpie/app"`             | No             |
+| `appConfig({...})`                  | `"questpie/app"`             | No             |
+| `authConfig({...})`                 | `"questpie/app"`             | No             |
+| `env({...})`                        | `"questpie/env"`             | No             |
+| `clientEnv({...})`                  | `"questpie/env"`             | No             |
+| `createClient<AppConfig>()`         | `"questpie/client"`          | No             |
+| `createQuestpieQueryOptions()`      | `"@questpie/tanstack-query"` | No             |
 
 ## Module And Plugin Configuration - Critical
 
@@ -91,13 +92,13 @@ export default authConfig({
 
 After `questpie generate`, the generated server files are the source of truth for what exists in the app. Inspect them before inventing imports, names, fields, or casts:
 
-| Need to know                         | Ground truth                                                                 |
-| ------------------------------------ | ---------------------------------------------------------------------------- |
+| Need to know                           | Ground truth                                                                                                                     |
+| -------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
 | Collections, globals, routes, services | `src/questpie/server/.generated/entities.gen.ts` and `AppCollections`, `AppGlobals`, `AppRoutes`, `AppServices` from `#questpie` |
-| Relation target keys                 | `src/questpie/server/.generated/names.gen.ts`                                |
-| Handler, hook, route, block context  | `src/questpie/server/.generated/context.gen.ts` and `Questpie.AppContext`    |
-| Session and auth user shape          | `AppSession`, `AppSessionUser`, and `AppConfig.auth` from `#questpie`        |
-| Enabled field and builder methods    | `src/questpie/server/.generated/factories.ts`                                |
+| Relation target keys                   | `src/questpie/server/.generated/names.gen.ts`                                                                                    |
+| Handler, hook, route, block context    | `src/questpie/server/.generated/context.gen.ts` and `Questpie.AppContext`                                                        |
+| Session and auth user shape            | `AppSession`, `AppSessionUser`, and `AppConfig.auth` from `#questpie`                                                            |
+| Enabled field and builder methods      | `src/questpie/server/.generated/factories.ts`                                                                                    |
 
 Files starting with `_`, `index.ts`, declaration files, tests, and specs are intentionally invisible to codegen. If something is missing from the generated surface, fix discovery, modules, or config and rerun `questpie generate`; do not add `any`, re-export barrels, or duplicate registries at the call site.
 
@@ -105,47 +106,48 @@ Files starting with `_`, `index.ts`, declaration files, tests, and specs are int
 
 ### Core
 
-| Topic             | File                            | Covers                                                             |
-| ----------------- | ------------------------------- | ------------------------------------------------------------------ |
-| Architecture      | `references/architecture.md`    | Framework overview, tech stack, project structure, file conventions, app bootstrap, data flow |
-| Quickstart        | `references/quickstart.md`      | Scaffold, configure, codegen, migrate, serve, zero to running app |
-| Data Modeling     | `references/data-modeling.md`   | Collections, globals, fields, relations, options, localization     |
-| Field Types       | `references/field-types.md`     | All built-in field types with options and operators                |
+| Topic             | File                            | Covers                                                                                                             |
+| ----------------- | ------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| Architecture      | `references/architecture.md`    | Framework overview, tech stack, project structure, file conventions, app bootstrap, data flow                      |
+| Quickstart        | `references/quickstart.md`      | Scaffold, configure, codegen, migrate, serve, zero to running app                                                  |
+| Data Modeling     | `references/data-modeling.md`   | Collections, globals, fields, relations, options, localization                                                     |
+| Field Types       | `references/field-types.md`     | All built-in field types with options and operators                                                                |
 | Type Inference    | `references/type-inference.md`  | The infer-first map: `CollectionDoc` / `CollectionWhere`, `AccessContext` helpers, per-op rule typing, cycle rules |
-| Rules             | `references/rules.md`           | Access control (row/field level), hooks lifecycle, validation, derived request context |
-| Business Logic    | `references/business-logic.md`  | Routes, jobs, services, email templates, context injection         |
-| AppContext        | `references/app-context.md`     | The `AppContext` runtime interface, where it's available, `getContext`, partial context overrides |
-| Durable Workflows | `references/workflows.md`       | Long-running workflows, steps, events, cron, admin UI              |
-| Sandboxed Code    | `references/sandbox.md`         | `ctx.executor.run()`, isolation modes, capability model, Deno engine deployment |
-| CRUD API          | `references/crud-api.md`        | `find`, `create`, `updateById`/`updateMany`, `deleteById`/`deleteMany`, atomic conditional updates, globals API |
+| Rules             | `references/rules.md`           | Access control (row/field level), hooks lifecycle, validation, derived request context                             |
+| Business Logic    | `references/business-logic.md`  | Routes, jobs, services, email templates, context injection                                                         |
+| AppContext        | `references/app-context.md`     | The `AppContext` runtime interface, where it's available, `getContext`, partial context overrides                  |
+| Durable Workflows | `references/workflows.md`       | Long-running workflows, steps, events, cron, admin UI                                                              |
+| Sandboxed Code    | `references/sandbox.md`         | `ctx.executor.run()`, isolation modes, capability model, Deno engine deployment                                    |
+| CRUD API          | `references/crud-api.md`        | `find`, `create`, `updateById`/`updateMany`, `deleteById`/`deleteMany`, atomic conditional updates, globals API    |
 | Seeds             | `references/seeds.md`           | `seed()` vs `seed.steps()`, idempotency, checkpointed steps, categories, `dependsOn`, `undo`, `autoSeed`, seed CLI |
-| Query Operators   | `references/query-operators.md` | `where` clause operators by field type                             |
-| Realtime          | `references/realtime.md`        | Live queries over SSE, automatic broadcasts, `live()`/`liveIter()`, wire protocol, keepalive |
+| Query Operators   | `references/query-operators.md` | `where` clause operators by field type                                                                             |
+| Realtime          | `references/realtime.md`        | Transactional outbox, reconciliation, live queries, broker/client transport seams, admission                       |
+| Channels          | `references/channels.md`        | Typed application events, authorization, publish contexts, client, presence, TanStack Query                        |
 
 ### Infrastructure
 
-| Topic      | File                                    | Covers                                                       |
-| ---------- | --------------------------------------- | ------------------------------------------------------------ |
-| Production | `references/production.md`              | Queue, search, realtime, storage, email, KV adapter setup    |
-| Environment | `references/env.md`                    | `env.ts` + `env.client.ts`: boot-validated, typed env, generated client modules |
-| Auth       | `references/auth.md`                    | Better Auth integration, session, providers, access patterns |
-| Adapters   | `references/infrastructure-adapters.md` | All adapter configs: pg-boss, S3, SMTP, pgNotify, Redis      |
-| MCP        | `references/mcp.md`                     | MCP setup, CRUD tools, route tools, custom tools, security   |
+| Topic       | File                                    | Covers                                                                          |
+| ----------- | --------------------------------------- | ------------------------------------------------------------------------------- |
+| Production  | `references/production.md`              | Queue, search, realtime, storage, email, KV adapter setup                       |
+| Environment | `references/env.md`                     | `env.ts` + `env.client.ts`: boot-validated, typed env, generated client modules |
+| Auth        | `references/auth.md`                    | Better Auth integration, session, providers, access patterns                    |
+| Adapters    | `references/infrastructure-adapters.md` | All adapter configs: pg-boss, S3, SMTP, pgNotify, Redis                         |
+| MCP         | `references/mcp.md`                     | MCP setup, CRUD tools, route tools, custom tools, security                      |
 
 ### Extend
 
-| Topic              | File                               | Covers                                                       |
-| ------------------ | ---------------------------------- | ------------------------------------------------------------ |
-| Extend             | `references/extend.md`             | Custom modules, fields, operators, adapters, codegen plugins |
+| Topic              | File                               | Covers                                                                                                                   |
+| ------------------ | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| Extend             | `references/extend.md`             | Custom modules, fields, operators, adapters, codegen plugins                                                             |
 | Module Authoring   | `references/module-authoring.md`   | How modules are created: convention dirs → codegen `.generated/module.ts`; NEVER hand-write `module.ts`/inline `route()` |
-| Codegen Plugin API | `references/codegen-plugin-api.md` | Plugin architecture, category declarations, templates        |
-| Multi-Tenancy      | `references/multi-tenancy.md`      | `appConfig({ context })` resolver, scope isolation, ScopeProvider |
+| Codegen Plugin API | `references/codegen-plugin-api.md` | Plugin architecture, category declarations, templates                                                                    |
+| Multi-Tenancy      | `references/multi-tenancy.md`      | `appConfig({ context })` resolver, scope isolation, ScopeProvider                                                        |
 
 ### Client
 
-| Topic          | File                           | Covers                                                           |
-| -------------- | ------------------------------ | ---------------------------------------------------------------- |
-| TanStack Query | `references/tanstack-query.md` | `q.collections.*`, `q.globals.*`, `q.routes.*`, realtime queries |
+| Topic          | File                           | Covers                                                                                    |
+| -------------- | ------------------------------ | ----------------------------------------------------------------------------------------- |
+| TanStack Query | `references/tanstack-query.md` | `q.collections.*`, `q.globals.*`, `q.routes.*`, realtime snapshots, channel subscriptions |
 
 ## Key Patterns, Quick Reference
 
@@ -260,19 +262,19 @@ await queue.sendReminder.publish({ userId: "abc" });
 
 ## Common Mistakes
 
-| Severity | Mistake                                                | Fix                                                                                   |
-| -------- | ------------------------------------------------------ | ------------------------------------------------------------------------------------- |
-| CRITICAL | Files in wrong directory                               | Collections in `collections/`, routes in `routes/`, etc.                              |
-| CRITICAL | Convention file has no export                          | Codegen needs one export, `export default` or a named `export const`/`function` both discovered; a file with no export is skipped. Factory categories key from the factory string (`collection("blog-posts")` -> `blogPosts`); non-factory categories key from the filename |
-| CRITICAL | Importing route/job/service from `#questpie/factories` | Use `"questpie"`, only collection/global/block/adminConfig use `#questpie/factories` |
-| CRITICAL | Redefining a module collection (e.g. starter `user`) from scratch | `.merge(starterModule.collections.user)` then add fields, see Extend pattern        |
-| CRITICAL | Casting `session.user` to `any` for admin role checks | Use `session?.user.role`; if it is not typed, fix `modules.ts`, `config/auth.ts`, and regenerated output |
-| HIGH     | Forgetting `questpie generate` after adding files      | Re-run codegen on any file add/remove in convention dirs                              |
-| HIGH     | Job handler uses `input` instead of `payload`          | Jobs destructure `{ payload }`, routes destructure `{ input }`                        |
-| HIGH     | `queue.send("name", data)`                             | Use `queue.jobName.publish(data)`                                                     |
-| HIGH     | `beforeCreate` / `afterCreate` hook names              | Use `beforeChange` / `afterChange` with `operation === "create"` guard                |
-| MEDIUM   | Using npm/yarn instead of Bun                          | QUESTPIE requires Bun as package manager                                              |
-| MEDIUM   | Editing `.generated/` files                            | Never edit, re-run `questpie generate`                                               |
+| Severity | Mistake                                                           | Fix                                                                                                                                                                                                                                                                         |
+| -------- | ----------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| CRITICAL | Files in wrong directory                                          | Collections in `collections/`, routes in `routes/`, etc.                                                                                                                                                                                                                    |
+| CRITICAL | Convention file has no export                                     | Codegen needs one export, `export default` or a named `export const`/`function` both discovered; a file with no export is skipped. Factory categories key from the factory string (`collection("blog-posts")` -> `blogPosts`); non-factory categories key from the filename |
+| CRITICAL | Importing route/job/service from `#questpie/factories`            | Use `"questpie"`, only collection/global/block/adminConfig use `#questpie/factories`                                                                                                                                                                                        |
+| CRITICAL | Redefining a module collection (e.g. starter `user`) from scratch | `.merge(starterModule.collections.user)` then add fields, see Extend pattern                                                                                                                                                                                                |
+| CRITICAL | Casting `session.user` to `any` for admin role checks             | Use `session?.user.role`; if it is not typed, fix `modules.ts`, `config/auth.ts`, and regenerated output                                                                                                                                                                    |
+| HIGH     | Forgetting `questpie generate` after adding files                 | Re-run codegen on any file add/remove in convention dirs                                                                                                                                                                                                                    |
+| HIGH     | Job handler uses `input` instead of `payload`                     | Jobs destructure `{ payload }`, routes destructure `{ input }`                                                                                                                                                                                                              |
+| HIGH     | `queue.send("name", data)`                                        | Use `queue.jobName.publish(data)`                                                                                                                                                                                                                                           |
+| HIGH     | `beforeCreate` / `afterCreate` hook names                         | Use `beforeChange` / `afterChange` with `operation === "create"` guard                                                                                                                                                                                                      |
+| MEDIUM   | Using npm/yarn instead of Bun                                     | QUESTPIE requires Bun as package manager                                                                                                                                                                                                                                    |
+| MEDIUM   | Editing `.generated/` files                                       | Never edit, re-run `questpie generate`                                                                                                                                                                                                                                      |
 
 ## Preview And Workflow Rules
 

--- a/skills/questpie/references/channels.md
+++ b/skills/questpie/references/channels.md
@@ -1,0 +1,104 @@
+---
+name: questpie-core/channels
+description:
+  QUESTPIE typed channels channel factory schema validated application events subscribe publish authorization presence replay SSE Pusher Soketi TanStack Query
+  - questpie-core
+---
+
+This skill builds on questpie-core.
+
+# Channels
+
+Channels are typed, ordered application-event streams over the realtime runtime. Use them for chat notifications, progress, typing, or presence. The bounded replay ledger is delivery infrastructure, not durable application history; persist events users must retrieve later in a collection.
+
+## Define and generate
+
+```ts title="channels/chat-room.ts"
+import { channel } from "questpie/channels";
+import { z } from "zod";
+
+export default channel("chat-room-[roomId]")
+	.events({
+		message: z.object({ id: z.string(), text: z.string() }),
+		typing: z.object({ active: z.boolean() }),
+	})
+	.authorize({
+		subscribe: ({ session }) => Boolean(session?.user),
+		publish: ({ session }) => Boolean(session?.user),
+	})
+	.presence(({ params, session }) => ({
+		id: session!.user.id,
+		roomId: params.roomId,
+	}));
+```
+
+The default-export filename derives the registry/API key (`chatRoom`); the builder string is the stable wire pattern. `[roomId]` becomes a required typed parameter. Run `bunx questpie generate` after adding or renaming a channel.
+
+Authorization rules:
+
+- With no `.authorize()`, subscribe is public and browser publish is denied.
+- `.authorize(rule)` uses the rule for subscribe and as the publish fallback.
+- `.authorize({ subscribe, publish })` separates both permissions; omitted publish falls back to subscribe.
+- Server/system contexts may publish; browser publish always uses the framework route, authorization, rate limits, and Zod parsing.
+
+## Publish on the server
+
+Framework handlers and hooks receive a generated `channels` service:
+
+```ts
+.handler(async ({ input, channels }) => {
+	return channels.publish("chatRoom", {
+		params: { roomId: input.roomId },
+		event: "message",
+		data: { id: input.id, text: input.text },
+	});
+});
+
+.hooks({
+	afterChange: [async ({ data, channels }) => {
+		await channels.publish("chatRoom", {
+			params: { roomId: data.roomId },
+			event: "message",
+			data: { id: data.id, text: data.text },
+		});
+	}],
+});
+```
+
+In collection/global/hook files, use the injected `{ channels }`. Never import the generated `app` or defer lookup through ambient `getContext()`; the injected service is generated-type-safe and mutation-context aware.
+
+## Client, presence, and TanStack Query
+
+```ts
+const stop = client.channels.chatRoom.subscribe({ roomId }, (message) => {
+	if (message.event === "message") console.log(message.data.text);
+});
+
+await client.channels.chatRoom.publish({
+	params: { roomId },
+	event: "typing",
+	data: { active: true },
+});
+
+const members = await client.channels.chatRoom.presence({ roomId });
+stop();
+```
+
+Async consumers use `client.channels.chatRoom.iter(params, { signal })`. TanStack Query exposes an accumulating event query:
+
+```tsx
+const { data: messages = [] } = useQuery(
+	q.channels.chatRoom.subscription({ roomId }),
+);
+```
+
+This differs from live-query `{ realtime: true }`, which retains only the latest snapshot.
+
+## Delivery and security
+
+- Events are ordered per resolved channel and never coalesced. Reconnect can replay an id; clients deduplicate it.
+- Falling behind the bounded replay horizon raises an explicit gap. Recover from persisted state or subscribe from now.
+- Payloads must be JSON-serializable and at most 10,000 UTF-8 bytes.
+- Cookie-authenticated authority routes require an exact trusted Origin; configure extra origins under `realtime.channelSecurity.trustedOrigins`.
+- Client publish token buckets default to 10/s with burst 20 per session and principal.
+- Pusher/Soketi is an opt-in transport preset. Direct provider client events are a separate unsafe capability and are off by default.

--- a/skills/questpie/references/infrastructure-adapters.md
+++ b/skills/questpie/references/infrastructure-adapters.md
@@ -5,7 +5,7 @@ The exhaustive catalog of adapter config shapes for QUESTPIE infrastructure. For
 - [Database](#database)
 - [Storage](#storage), local, S3, R2, signed URLs
 - [Queue](#queue), pg-boss, BullMQ
-- [Realtime](#realtime), pgNotify, Redis Streams
+- [Realtime](#realtime), SSE, pgNotify, Redis Streams, Cloudflare, Pusher/Soketi
 - [Search](#search), Postgres FTS, pgvector semantic
 - [Email](#email), SMTP, Console, Resend, Plunk, custom
 - [KV Store](#kv-store), Redis, custom, in-memory
@@ -178,8 +178,19 @@ Serving stays collection-scoped, the file route verifies the token **and** the c
 ```ts
 import { buildStorageFileUrl, generateSignedUrlToken } from "questpie/storage";
 
-const token = await generateSignedUrlToken(asset.key, app.config.secret!, 900, "assets");
-const url = buildStorageFileUrl(app.config.app.url, "/api", "assets", asset.key, token);
+const token = await generateSignedUrlToken(
+	asset.key,
+	app.config.secret!,
+	900,
+	"assets",
+);
+const url = buildStorageFileUrl(
+	app.config.app.url,
+	"/api",
+	"assets",
+	asset.key,
+	token,
+);
 ```
 
 (`verifySignedUrlToken` is the verification half the serve route runs, you rarely call it yourself.)
@@ -242,11 +253,13 @@ handler: async ({ queue }) => {
 
 ## Realtime
 
-SSE-based live updates.
+The realtime runtime writes its outbox row in the business transaction and always reconciles missed notices. `ChangeBroker` handles notice-only cross-instance wakes; `ClientTransport` handles already-authorized edge frames. SSE is the default client transport.
 
-### pgNotify (Single Instance)
+With `realtime: true`, a normal Postgres URL auto-selects `pg_notify`; without a push broker, the outbox is polled every 2s. With push, reconciliation still runs every 15s so a lost wake cannot permanently stall subscribers.
 
-Uses PostgreSQL `LISTEN/NOTIFY`. Best for single-server deployments:
+### pgNotify
+
+Uses PostgreSQL `LISTEN/NOTIFY`. Every listening instance receives the same notice:
 
 ```ts
 import { runtimeConfig } from "questpie/app";
@@ -263,9 +276,9 @@ export default runtimeConfig({
 });
 ```
 
-### Redis Streams (Multi-Instance)
+### Redis Streams
 
-Required for horizontal scaling across multiple server instances. Takes a connected, redis-shaped `client` (the node-redis command surface: `xAdd`, `xReadGroup`, `xGroupCreate`, `xAck`), not a URL:
+Takes a connected Redis-shaped `client` with `xAdd` and `xRead`, not a URL. Every app instance owns an independent `XREAD` cursor so notices fan out; consumer groups must not be used because they load-balance wakes and strand subscribers on other instances.
 
 ```ts
 import { createClient } from "redis";
@@ -284,13 +297,42 @@ export default runtimeConfig({
 });
 ```
 
+The adapter duplicates the client for its blocking reader when supported; otherwise provide a dedicated `reader`. The `group` and `consumer` options are deprecated compatibility inputs and do not restore consumer-group behavior.
+
+### Pusher/Soketi managed WebSockets
+
+Use the isolated preset when managed WebSocket delivery and native presence are required:
+
+```ts
+import { pusherRealtime } from "questpie/adapters/pusher";
+import { runtimeConfig } from "questpie/app";
+
+const managed = pusherRealtime({
+	appId: env.PUSHER_APP_ID,
+	key: env.PUSHER_KEY,
+	secret: env.PUSHER_SECRET,
+	cluster: env.PUSHER_CLUSTER,
+});
+
+export default runtimeConfig({ realtime: { ...managed } });
+```
+
+The preset supplies a notice-only Pusher `ChangeBroker` and a Pusher `ClientTransport`. Direct provider client events are off by default; they bypass QUESTPIE channel schemas, publish authorization, rate limits, ordered ledger, and replay.
+
+### Cloudflare Durable Objects
+
+`cloudflareRealtimeAdapter()` is a notice-only broker for Workers. It shards Durable Objects by resource type and resource name, and notification work is attached to `waitUntil` so CRUD commits do not wait on the broker. The Worker still reads the durable outbox, re-runs access-controlled snapshots, and performs reconciliation.
+
 ### When to Use Which
 
-| Adapter                    | Use Case                                              |
-| -------------------------- | ----------------------------------------------------- |
-| `pgNotifyAdapter`          | Single server, development, simple deployments        |
-| `redisStreamsAdapter`      | Multiple servers, horizontal scaling, high throughput |
-| `cloudflareRealtimeAdapter` | Cloudflare Workers (Durable Objects)                  |
+| Selection                   | Use case                                                          |
+| --------------------------- | ----------------------------------------------------------------- |
+| Implicit pg + SSE           | Default Postgres deployment                                       |
+| Poll + SSE                  | Zero extra infrastructure without a push-capable database         |
+| `pgNotifyAdapter` + SSE     | Explicit Postgres connection/channel                              |
+| `redisStreamsAdapter` + SSE | Cross-instance Redis notice fan-out                               |
+| `cloudflareRealtimeAdapter` | Cloudflare Workers notice fan-out through sharded Durable Objects |
+| `pusherRealtime`            | Managed WebSockets, native presence, and shared channel delivery  |
 
 ## Search
 
@@ -712,15 +754,15 @@ const spec = generateOpenApiSpec(app, {
 
 ## Migrations CLI
 
-| Command                          | Description                                      |
-| -------------------------------- | ------------------------------------------------ |
-| `bunx questpie push`             | Direct schema sync (dev only, no migration file) |
-| `bunx questpie migrate:create`   | Generate migration from schema diff              |
-| `bunx questpie migrate`          | Run pending migrations                           |
-| `bunx questpie migrate:down`     | Rollback last migration                          |
-| `bunx questpie migrate:fresh`    | Drop all and re-run (DESTRUCTIVE)                |
-| `bunx questpie migrate:reset`    | Reset migration tracking                         |
-| `bunx questpie seed`             | Run seed files                                   |
+| Command                        | Description                                      |
+| ------------------------------ | ------------------------------------------------ |
+| `bunx questpie push`           | Direct schema sync (dev only, no migration file) |
+| `bunx questpie migrate:create` | Generate migration from schema diff              |
+| `bunx questpie migrate`        | Run pending migrations                           |
+| `bunx questpie migrate:down`   | Rollback last migration                          |
+| `bunx questpie migrate:fresh`  | Drop all and re-run (DESTRUCTIVE)                |
+| `bunx questpie migrate:reset`  | Reset migration tracking                         |
+| `bunx questpie seed`           | Run seed files                                   |
 
 ## Complete Production Config Example
 

--- a/skills/questpie/references/realtime.md
+++ b/skills/questpie/references/realtime.md
@@ -1,6 +1,7 @@
 ---
 name: questpie-core/realtime
-description: QUESTPIE realtime live queries SSE subscriptions snapshots automatic broadcast outbox questpie_realtime_log live liveIter subscribe wire protocol keepalive idleTimeout pg-notify redis-streams polling
+description:
+  QUESTPIE realtime v2 live queries transactional outbox reconciliation SSE Pusher Soketi ChangeBroker ClientTransport pg-notify Redis Streams Cloudflare admission privacy live liveIter
   - questpie-core
 ---
 
@@ -8,97 +9,82 @@ This skill builds on questpie-core.
 
 # Realtime
 
-Live queries over SSE. **Broadcasts are automatic**, every collection/global create/update/delete already writes a change event to the `questpie_realtime_log` outbox and notifies subscribers. Do NOT write `afterChange` hooks that "emit" realtime events; a custom emitter double-fires against the built-in broadcast hook.
+Realtime powers two distinct products:
 
-## How It Works
+- **Live queries** re-run a collection/global query under the subscriber's session and deliver the latest access-controlled snapshot. Snapshot wakes are coalescable.
+- **Channels** deliver schema-validated application events in channel-local order. Events are not coalesced. See `references/channels.md`.
 
-1. Every CRUD write appends a change event to the outbox; an adapter (pg_notify / Redis Streams) or 2s polling wakes subscribers
-2. The server **re-runs the subscribed query under the subscriber's auth** and pushes the full result as a `snapshot`, clients never receive raw change events (no `operation`/`recordId` on the client; snapshots are access-controlled)
-3. One SSE connection multiplexes all topics (`POST /realtime`)
+Enable it with `realtime: true`. Do not write CRUD hooks to emit live-query changes: every logical create/update/delete, including bulk operations, already appends one `questpie_realtime_log` row **inside the business transaction**.
 
-Snapshots are idempotent state, not diffs, filtered subscriptions may receive unchanged snapshots on update/delete (over-refresh by design). Always render from the snapshot.
+## Correctness model
 
-## Client-Side Usage
+1. The mutation and outbox row commit or roll back together.
+2. A `ChangeBroker` wake tells instances to drain quickly. Wakes are notice-only, unordered, at-most-once, and may be coalesced.
+3. An unconditional reconciliation poll drains missed outbox rows. Default: 15s with push, 2s without; provider failure tightens to at most 2s.
+4. The server re-runs matching queries under the subscriber's session, including row/field access and `afterRead`, then a `ClientTransport` delivers authorized frames.
+
+The broker is a latency hint; the transactional outbox plus reconciliation is the guarantee. Brokers must never carry rows or snapshots. Equivalent snapshot work is shared per principal by default, never across users unless the application proves deterministic access equivalence.
+
+## Client usage
 
 ```ts
-// React + TanStack Query, typed second arg, no casts needed
+const stop = client.collections.posts.live(
+	{ where: { status: "published" }, with: { author: true }, limit: 50 },
+	(snapshot) => render(snapshot.docs),
+	{ onError: console.error },
+);
+
+for await (const snapshot of client.collections.posts.liveIter(
+	{ where: { status: "published" } },
+	{ signal: controller.signal },
+)) {
+	render(snapshot.docs);
+}
+
+client.globals.siteSettings.live(undefined, (settings) => applyTheme(settings));
+```
+
+`live()` accepts the query options supported by the wire contract: `where`, `with`, `limit`, `offset`, `orderBy`, and `locale`. Prefer these typed wrappers over raw `client.realtime.subscribe()`.
+
+TanStack Query uses the stream for its initial result too; it does not issue a duplicate REST fetch:
+
+```tsx
 const { data } = useQuery(
-	qp.collections.posts.find(
-		{ where: { event: eventId }, limit: 50 },
+	q.collections.posts.find(
+		{ where: { status: "published" }, limit: 20 },
 		{ realtime: true },
 	),
 );
-
-// Vanilla TS, live() is the live form of find(): same options in, same result type out
-const stop = client.collections.posts.live(
-	{
-		where: { event: eventId },
-		with: { author: true },
-		orderBy: { createdAt: "desc" },
-	},
-	(snap) => render(snap.docs), // snap.docs[i].author is typed
-	{ onError: (e) => console.error(e) },
-);
-stop(); // unsubscribe
-
-// Async-iterable form (workers, agents, tests), terminate via AbortSignal
-for await (const snap of client.collections.posts.liveIter(
-	{ where: { event: eventId } },
-	{ signal: controller.signal },
-)) {
-	render(snap.docs);
-}
-
-// Globals mirror get()
-client.globals.siteSettings.live(undefined, (settings) => applyTheme(settings));
-
-// Low-level escape hatch, topic objects, never channel strings; data is untyped
-client.realtime.subscribe(
-	{ resourceType: "collection", resource: "posts", where: { event: eventId } },
-	(data) => {}, // unknown, prefer the typed live() wrappers
-);
 ```
 
-Live options carry exactly what the wire protocol supports: `where`, `with`, `limit`, `offset`, `orderBy`, `locale` (no `columns`/`groupBy`/`search`, compile error).
+`count(..., { realtime: true })` yields a number, not a paginated snapshot. `findOne()` and `findVersions()` do not have realtime forms.
 
-## Wire Protocol (stable contract)
+## Transport selection
 
-`POST <basePath>/realtime` body `{ topics: [{ id, resourceType: "collection" | "global", resource, where?, with?, limit?, offset?, orderBy?, locale? }] }` → SSE events:
+SSE is the default `ClientTransport`; no browser transport config is required. With a normal Postgres URL the server auto-wires `pg_notify`; otherwise it polls every 2s. Explicit pg, Redis, and Cloudflare adapters remain supported as notice brokers.
 
-| Event      | Payload                  | Meaning                                               |
-| ---------- | ------------------------ | ----------------------------------------------------- |
-| `snapshot` | `{ topicId, seq, data }` | Full `find()`/`get()` result under subscriber's auth  |
-| `error`    | `{ topicId, message }`   | Topic-level failure (unknown resource, access denied) |
-| `ping`     | `{ ts }`                 | Keep-alive (default every 8s)                         |
-
-Ignore unknown SSE event types (forward compat).
-
-## Keepalive (Bun)
-
-The stream pings every 8s by default (`realtime.keepAliveIntervalMs`). Bun's default `idleTimeout` is 10s, the default ping survives it, but set headroom explicitly in the server entry:
+For managed WebSockets and native presence, select the isolated Pusher/Soketi preset:
 
 ```ts
-export default { port: 3000, idleTimeout: 30, fetch: server.fetch };
-```
+import { pusherRealtime } from "questpie/adapters/pusher";
+import { runtimeConfig } from "questpie/app";
 
-## Realtime Adapters
-
-Without an adapter, subscribers wake on a 2s poll. For push-based delivery, configure a realtime adapter in `runtimeConfig`:
-
-```ts
-import { pgNotifyAdapter } from "questpie/adapters/pg-notify";
-
-runtimeConfig({
-	realtime: {
-		adapter: pgNotifyAdapter({ connectionString: env.DATABASE_URL }),
-	},
+const managed = pusherRealtime({
+	appId: env.PUSHER_APP_ID,
+	key: env.PUSHER_KEY,
+	secret: env.PUSHER_SECRET,
+	cluster: env.PUSHER_CLUSTER,
 });
+
+export default runtimeConfig({ realtime: { ...managed } });
 ```
 
-| Adapter                 | Description                  |
-| ----------------------- | ---------------------------- |
-| _None_ (default)        | Polling-based (every 2s)     |
-| `pgNotifyAdapter()`     | PostgreSQL LISTEN/NOTIFY     |
-| `redisStreamsAdapter()` | Redis Streams consumer group |
+`pusherRealtime()` supplies both the notice broker and client transport. App-facing `live()`, TanStack, and channel APIs do not change. Direct provider client events are off by default because they bypass framework publish authorization, Zod validation, rate limits, ordered ledger, and replay.
 
-Full adapter configuration (connection options, multi-instance setup): see `references/infrastructure-adapters.md`.
+## Admission and lifecycle
+
+Default SSE limits are 20 topics per connection, 5 connections per authenticated principal, `find` limit 100, nested `with` depth 3, 4 concurrent initial snapshots, and 1 MiB buffered snapshot bytes per edge session. Slow consumers are bounded and disconnected rather than allowed unbounded memory growth.
+
+Keep `keepAliveIntervalMs` (default 8s) below the server/proxy idle timeout. `live()` without server `realtime` errors explicitly; it does not silently fall back to a normal query.
+
+Full adapter options and deployment guidance: `references/infrastructure-adapters.md`.

--- a/skills/questpie/references/tanstack-query.md
+++ b/skills/questpie/references/tanstack-query.md
@@ -23,6 +23,7 @@ description:
 - [Type Inference](#type-inference), `AppConfig` flow
 - [Direct Client Usage (without TanStack Query)](#direct-client-usage-without-tanstack-query)
 - [Realtime](#realtime), `{ realtime: true }`, adapters, topic builders
+- [Channel Subscriptions](#channel-subscriptions), typed ordered application events
 - [Framework Adapters](#framework-adapters), TanStack Start, Next.js, Hono, Elysia
 - [Common Mistakes](#common-mistakes)
 
@@ -410,7 +411,7 @@ client.setLocale("sk"); // Set locale for localized content
 
 ## Realtime
 
-Pass `{ realtime: true }` as the **typed** second argument (`RealtimeQueryConfig`) to `find()`, `count()`, or `get()`, initial data via a normal fetch, then the server pushes full access-controlled snapshots on every matching change. `findOne()` and `findVersions()` have no realtime form (a second argument there is a compile error).
+Pass `{ realtime: true }` as the **typed** second argument (`RealtimeQueryConfig`) to `find()`, `count()`, or `get()`. The stream supplies the initial value and later access-controlled snapshots, so there is no duplicate REST fetch. `findOne()` and `findVersions()` have no realtime form (a second argument there is a compile error). Realtime `count()` remains a scalar number.
 
 ```tsx
 const { data } = useQuery(
@@ -421,7 +422,7 @@ const { data } = useQuery(
 );
 ```
 
-Works zero-config (2s polling); add a realtime adapter for instant push:
+Server realtime must be enabled. SSE is the default client transport; a normal Postgres URL auto-wires `pg_notify`, while setups without a push broker reconcile by polling every 2s. An explicit adapter can select a broker:
 
 ```ts
 import { runtimeConfig } from "questpie/app";
@@ -434,18 +435,36 @@ export default runtimeConfig({
 });
 ```
 
-Subscriptions are query-shaped topic objects (`{ resourceType, resource, where?, with? }`), there are no channel strings. Outside React, use the typed live form of the same query: `client.collections.posts.live(options, onSnapshot)` / `liveIter(options)` (see AGENTS.md §19 Realtime).
+Live-query subscriptions are query-shaped topic objects (`{ resourceType, resource, where?, with? }`), not application channel strings. Outside React, use the typed live form of the same query: `client.collections.posts.live(options, onSnapshot)` / `liveIter(options)` (see `references/realtime.md`).
 
 To build those topic objects yourself, e.g. manual cache invalidation or a raw `client.realtime.subscribe` call that must match the topic a query subscribed with, use the exported builders instead of hand-writing the shape:
 
 ```ts
-import { buildCollectionTopic, buildGlobalTopic } from "@questpie/tanstack-query"; // re-exported from questpie/client
+import {
+	buildCollectionTopic,
+	buildGlobalTopic,
+} from "@questpie/tanstack-query"; // re-exported from questpie/client
 
-const topic = buildCollectionTopic("posts", { where: { status: "published" }, limit: 20 });
+const topic = buildCollectionTopic("posts", {
+	where: { status: "published" },
+	limit: 20,
+});
 const settingsTopic = buildGlobalTopic("siteSettings");
 ```
 
-For multi-instance deployments, create a Redis client and use `redisStreamsAdapter({ client })`.
+Push is a latency optimization; the transactional outbox and reconciliation poll recover missed broker wakes. See `references/realtime.md`.
+
+## Channel Subscriptions
+
+Generated channels expose an accumulating query option. Unlike live queries, ordered channel events are appended rather than reduced to the newest snapshot:
+
+```tsx
+const { data: messages = [] } = useQuery(
+	q.channels.chatRoom.subscription({ roomId }),
+);
+```
+
+The result is a typed array of `{ event, eventId, data }` unions. The query's abort signal closes the underlying channel iterator. Channel definition, authorization, server publish, and presence are covered in `references/channels.md`.
 
 ## Framework Adapters
 
@@ -506,20 +525,9 @@ const posts = await fetch("/api/collections/posts").then((r) => r.json());
 const { docs } = await client.collections.posts.find({ limit: 10 });
 ```
 
-### MEDIUM: Not setting up realtime adapter
+### MEDIUM: Forgetting to enable server realtime
 
-Collection changes do not auto-refresh when realtime is enabled but no adapter is configured. Add a realtime adapter in `questpie.config.ts`:
-
-```ts
-import { runtimeConfig } from "questpie/app";
-import { pgNotifyAdapter } from "questpie/adapters/pg-notify";
-
-export default runtimeConfig({
-	realtime: {
-		adapter: pgNotifyAdapter({ connectionString: process.env.DATABASE_URL }),
-	},
-});
-```
+`{ realtime: true }` is not a request to silently fall back to a normal query. Set `realtime: true` or a realtime object in server runtime config; otherwise the subscription reports an error.
 
 ### MEDIUM: Importing from `questpie/client` in server code or vice versa
 


### PR DESCRIPTION
## Summary
- correct realtime docs for the transactional outbox, reconciliation, admission/privacy, and two transport seams
- document typed channels across server handlers/hooks, client, presence, TanStack Query, and SSE/Pusher selection
- update and regenerate the questpie and questpie-admin skills

## Verification
- `cd apps/docs && bun run build`
- `bun run scripts/build-skill-docs.ts`
- `cd packages/questpie && bun run check-types`