### PR TITLE
feat(openapi): spec quality v1 — route meta, per-op security, 3.1 validation

### DIFF
--- a/.changeset/openapi-quality-v1.md
+++ b/.changeset/openapi-quality-v1.md
@@ -1,0 +1,5 @@
+---
+"@questpie/openapi": minor
+---
+
+Improve generated OpenAPI 3.1 specs with route metadata, per-operation security, asynchronous Better Auth schema derivation, complete module-route coverage, and input-aware Zod transform conversion.

--- a/bun.lock
+++ b/bun.lock
@@ -507,6 +507,7 @@
       },
       "devDependencies": {
         "@electric-sql/pglite": "^0.3.14",
+        "@seriousme/openapi-schema-validator": "^2.9.0",
         "@types/html-to-text": "^9.0.4",
         "@types/nodemailer": "^8.0.1",
         "@types/pg": "^8.16.0",
@@ -1385,6 +1386,8 @@
 
     "@selderee/plugin-htmlparser2": ["@selderee/plugin-htmlparser2@0.11.0", "", { "dependencies": { "domhandler": "^5.0.3", "selderee": "^0.11.0" } }, "sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ=="],
 
+    "@seriousme/openapi-schema-validator": ["@seriousme/openapi-schema-validator@2.9.0", "", { "dependencies": { "ajv": "^8.18.0", "ajv-draft-04": "^1.0.0", "ajv-formats": "^3.0.1", "yaml": "^2.8.3" }, "bin": { "validate-api": "bin/validate-api-cli.js", "bundle-api": "bin/bundle-api-cli.js" } }, "sha512-bP/48Il7RMxhohq36Vg0c25tnCKOO+oEv8XSxDefuUBj0W8fYzL2Yb6C8tji0WBXykZ1S/79AWbrzGLfCG2dYw=="],
+
     "@shikijs/core": ["@shikijs/core@4.0.2", "", { "dependencies": { "@shikijs/primitive": "4.0.2", "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-hxT0YF4ExEqB8G/qFdtJvpmHXBYJ2lWW7qTHDarVkIudPFE6iCIrqdgWxGn5s+ppkGXI0aEGlibI0PAyzP3zlw=="],
 
     "@shikijs/engine-javascript": ["@shikijs/engine-javascript@4.0.2", "", { "dependencies": { "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2", "oniguruma-to-es": "^4.3.4" } }, "sha512-7PW0Nm49DcoUIQEXlJhNNBHyoGMjalRETTCcjMqEaMoJRLljy1Bi/EGV3/qLBgLKQejdspiiYuHGQW6dX94Nag=="],
@@ -1796,6 +1799,8 @@
     "ai": ["ai@7.0.0-canary.173", "", { "dependencies": { "@ai-sdk/gateway": "4.0.0-canary.105", "@ai-sdk/provider": "4.0.0-canary.18", "@ai-sdk/provider-utils": "5.0.0-canary.48" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ehK+jSMvXx0sHNDDqIaK/vWAxo7DkQnZ/lEmnj+Q7WlC3NioRfC1L9jxvElRUQgDNU376Q275r7vjOV1EIejtw=="],
 
     "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
+
+    "ajv-draft-04": ["ajv-draft-04@1.0.0", "", { "peerDependencies": { "ajv": "^8.5.0" }, "optionalPeers": ["ajv"] }, "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw=="],
 
     "ajv-errors": ["ajv-errors@3.0.0", "", { "peerDependencies": { "ajv": "^8.0.1" } }, "sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ=="],
 
@@ -3543,6 +3548,8 @@
 
     "yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
 
+    "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
+
     "yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
 
     "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
@@ -3650,6 +3657,8 @@
     "@radix-ui/react-tabs/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
 
     "@radix-ui/react-visually-hidden/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
+
+    "@seriousme/openapi-schema-validator/ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
 
     "@shikijs/rehype/@shikijs/types": ["@shikijs/types@3.23.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ=="],
 

--- a/examples/tanstack-barbershop/test/openapi-spec.test.ts
+++ b/examples/tanstack-barbershop/test/openapi-spec.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "bun:test";
+
+import { generateOpenApiSpec } from "@questpie/openapi/server";
+
+import coreModule from "../../../packages/questpie/src/server/modules/core/.generated/module";
+import modules from "../src/questpie/server/modules";
+import createBooking from "../src/questpie/server/routes/create-booking";
+import getActiveBarbers from "../src/questpie/server/routes/get-active-barbers";
+import getAvailableTimeSlots from "../src/questpie/server/routes/get-available-time-slots";
+import getRevenueStats from "../src/questpie/server/routes/get-revenue-stats";
+
+function collectModuleRoutes(
+	input: readonly Record<string, any>[],
+): Record<string, unknown> {
+	const routes: Record<string, unknown> = {};
+	for (const module of input) {
+		if (Array.isArray(module.modules)) {
+			Object.assign(routes, collectModuleRoutes(module.modules));
+		}
+		Object.assign(routes, module.routes ?? {});
+	}
+	return routes;
+}
+
+describe("barbershop generated OpenAPI route snapshot", () => {
+	it("includes application and post-realtime-v2 module routes", async () => {
+		const routes = {
+			...coreModule.routes,
+			...collectModuleRoutes(modules),
+			createBooking,
+			getActiveBarbers,
+			getAvailableTimeSlots,
+			getRevenueStats,
+		};
+		const app = {
+			getCollections: () => ({}),
+			getGlobals: () => ({}),
+			config: { routes },
+		};
+		const spec = await generateOpenApiSpec(app, {
+			basePath: "/api",
+			auth: false,
+			search: false,
+			info: { title: "Barbershop API", version: "1.0.0" },
+		});
+
+		const selectedPaths = [
+			"/api/channels/auth",
+			"/api/channels/config",
+			"/api/channels/publish",
+			"/api/realtime",
+			"/api/realtime/auth",
+			"/api/realtime/config",
+			"/api/create-booking",
+			"/api/get-active-barbers",
+			"/api/get-available-time-slots",
+			"/api/get-revenue-stats",
+		];
+		const routeSnapshot = {
+			pathCount: Object.keys(spec.paths).length,
+			methods: Object.fromEntries(
+				selectedPaths.map((path) => [
+					path,
+					Object.keys(spec.paths[path] ?? {}).sort(),
+				]),
+			),
+		};
+
+		expect(routeSnapshot).toEqual({
+			pathCount: 56,
+			methods: {
+				"/api/channels/auth": ["options", "post"],
+				"/api/channels/config": ["get"],
+				"/api/channels/publish": ["options", "post"],
+				"/api/create-booking": ["post"],
+				"/api/get-active-barbers": ["post"],
+				"/api/get-available-time-slots": ["post"],
+				"/api/get-revenue-stats": ["post"],
+				"/api/realtime": ["post"],
+				"/api/realtime/auth": ["post"],
+				"/api/realtime/config": ["get"],
+			},
+		});
+	});
+});

--- a/packages/openapi/src/generator/auth.ts
+++ b/packages/openapi/src/generator/auth.ts
@@ -1,24 +1,178 @@
 /**
  * Auth routes -> OpenAPI paths generator.
- * Documents common Better Auth endpoints.
+ *
+ * When the Better Auth instance has the official `openAPI()` plugin configured,
+ * the full auth OpenAPI document (all core + configured-plugin endpoints, with
+ * real request/response schemas) is derived from
+ * `app.auth.api.generateOpenAPISchema()`. Otherwise a minimal hardcoded set of
+ * the four most common endpoints is used as a fallback so spec generation never
+ * crashes and always documents the basics.
  */
+
+import type { Questpie } from "questpie";
 
 import type { OpenApiConfig, PathOperation } from "../types.js";
 import { jsonRequestBody, jsonResponse } from "./schemas.js";
 
+const AUTH_TAG = "Auth";
+
+/** Prefix applied to Better Auth component schema names to avoid colliding with QUESTPIE schemas. */
+const AUTH_SCHEMA_PREFIX = "Auth";
+
 /**
  * Generate OpenAPI paths for Better Auth endpoints.
+ *
+ * Async so the schema can be derived from Better Auth's async
+ * `auth.api.generateOpenAPISchema()` provider when the `openAPI()` plugin is
+ * configured. Falls back to a hardcoded minimal set when the app/plugin/method
+ * is unavailable or the call throws.
  */
-export function generateAuthPaths(config: OpenApiConfig): {
+export async function generateAuthPaths(
+	config: OpenApiConfig,
+	app?: Questpie<any>,
+): Promise<{
 	paths: Record<string, Record<string, PathOperation>>;
+	schemas: Record<string, unknown>;
+	securitySchemes: Record<string, unknown>;
 	tags: Array<{ name: string; description?: string }>;
-} {
+}> {
 	if (config.auth === false) {
-		return { paths: {}, tags: [] };
+		return { paths: {}, schemas: {}, securitySchemes: {}, tags: [] };
 	}
 
+	// The `openAPI()` better-auth plugin exposes `generateOpenAPISchema` on
+	// `auth.api`. The generator operates over `Questpie<any>`, so the plugin's
+	// endpoints aren't known at the type level — read the method defensively.
+	const authApi = app?.auth?.api as
+		| { generateOpenAPISchema?: () => Promise<unknown> }
+		| undefined;
+	const generate = authApi?.generateOpenAPISchema;
+	if (typeof generate === "function") {
+		try {
+			const doc = await generate.call(authApi);
+			const derived = mapBetterAuthDoc(doc, config);
+			if (derived) return derived;
+		} catch {
+			// Fall through to the hardcoded minimal set below.
+		}
+	}
+
+	return fallbackAuthPaths(config);
+}
+
+/**
+ * Map a Better Auth OpenAPI document (from the `openAPI()` plugin) into the
+ * QUESTPIE spec shape: prefix every path with `<basePath>/auth`, namespace the
+ * component schemas + their `$ref`s to avoid collisions, retag operations under
+ * the `Auth` tag, and surface the auth security schemes for merging.
+ */
+function mapBetterAuthDoc(
+	doc: unknown,
+	config: OpenApiConfig,
+):
+	| {
+			paths: Record<string, Record<string, PathOperation>>;
+			schemas: Record<string, unknown>;
+			securitySchemes: Record<string, unknown>;
+			tags: Array<{ name: string; description?: string }>;
+	  }
+	| undefined {
+	if (!doc || typeof doc !== "object") return undefined;
+	const source = doc as {
+		paths?: Record<string, Record<string, PathOperation>>;
+		components?: {
+			schemas?: Record<string, unknown>;
+			securitySchemes?: Record<string, unknown>;
+		};
+	};
+	if (!source.paths || typeof source.paths !== "object") return undefined;
+
 	const basePath = config.basePath ?? "/";
-	const tag = "Auth";
+	const authPrefix = `${basePath}/auth`;
+
+	// Namespace schema names so QUESTPIE collection/route schemas never collide
+	// with Better Auth's (User, Session, Account, ...). We rename the schema keys
+	// and rewrite every `$ref` in both the schemas and the operations.
+	const sourceSchemas = source.components?.schemas ?? {};
+	const renameMap: Record<string, string> = {};
+	for (const name of Object.keys(sourceSchemas)) {
+		renameMap[name] = `${AUTH_SCHEMA_PREFIX}${name}`;
+	}
+	const rewriteRefs = (value: unknown): unknown =>
+		remapSchemaRefs(value, renameMap);
+
+	const schemas: Record<string, unknown> = {};
+	for (const [name, schema] of Object.entries(sourceSchemas)) {
+		schemas[renameMap[name] ?? name] = rewriteRefs(schema);
+	}
+
+	const paths: Record<string, Record<string, PathOperation>> = {};
+	for (const [path, operations] of Object.entries(source.paths)) {
+		if (!operations || typeof operations !== "object") continue;
+		const prefixedPath = `${authPrefix}${path}`;
+		const mappedOps: Record<string, PathOperation> = {};
+		for (const [method, operation] of Object.entries(operations)) {
+			if (!operation || typeof operation !== "object") continue;
+			const op = rewriteRefs(operation) as PathOperation;
+			// Retag under a single, meaningful "Auth" tag (Better Auth emits
+			// generic "Default"/plugin tags that read poorly in the merged spec).
+			op.tags = [AUTH_TAG];
+			mappedOps[method] = op;
+		}
+		paths[prefixedPath] = mappedOps;
+	}
+
+	return {
+		paths,
+		schemas,
+		securitySchemes: source.components?.securitySchemes ?? {},
+		tags: [{ name: AUTH_TAG, description: "Authentication endpoints (Better Auth)" }],
+	};
+}
+
+/**
+ * Recursively rewrite `#/components/schemas/<Name>` `$ref`s according to the
+ * rename map so namespaced schemas resolve.
+ */
+function remapSchemaRefs(
+	value: unknown,
+	renameMap: Record<string, string>,
+): unknown {
+	if (Array.isArray(value)) {
+		return value.map((item) => remapSchemaRefs(item, renameMap));
+	}
+	if (value && typeof value === "object") {
+		const out: Record<string, unknown> = {};
+		for (const [key, val] of Object.entries(value)) {
+			if (
+				key === "$ref" &&
+				typeof val === "string" &&
+				val.startsWith("#/components/schemas/")
+			) {
+				const original = val.slice("#/components/schemas/".length);
+				out[key] = `#/components/schemas/${renameMap[original] ?? original}`;
+			} else {
+				out[key] = remapSchemaRefs(val, renameMap);
+			}
+		}
+		return out;
+	}
+	return value;
+}
+
+/**
+ * Minimal hardcoded fallback for the four most common Better Auth endpoints.
+ * Used when the `openAPI()` plugin is not configured (or its schema generation
+ * throws) so the spec still documents the basics without crashing.
+ */
+function fallbackAuthPaths(config: OpenApiConfig): {
+	paths: Record<string, Record<string, PathOperation>>;
+	schemas: Record<string, unknown>;
+	securitySchemes: Record<string, unknown>;
+	tags: Array<{ name: string; description?: string }>;
+} {
+	const basePath = config.basePath ?? "/";
+	const tag = AUTH_TAG;
 	const paths: Record<string, Record<string, PathOperation>> = {};
 
 	// POST /auth/sign-in/email
@@ -110,8 +264,8 @@ export function generateAuthPaths(config: OpenApiConfig): {
 
 	return {
 		paths,
-		tags: [
-			{ name: tag, description: "Authentication endpoints (Better Auth)" },
-		],
+		schemas: {},
+		securitySchemes: {},
+		tags: [{ name: tag, description: "Authentication endpoints (Better Auth)" }],
 	};
 }

--- a/packages/openapi/src/generator/index.ts
+++ b/packages/openapi/src/generator/index.ts
@@ -14,12 +14,18 @@ import { generateSearchPaths } from "./search.js";
 
 /**
  * Generate a complete OpenAPI 3.1 spec from a Questpie app instance and optional routes tree.
+ *
+ * Async-capable: sync sources (collections/globals/routes/search) are merged
+ * eagerly, while the auth fragment is `await`ed so a later task can source it
+ * from an async provider (e.g. Better Auth's `auth.api.generateOpenAPISchema()`)
+ * without changing this signature. For apps whose fragments are all sync
+ * (today's case), the resolved spec is byte-identical to the sync output.
  */
-export function generateOpenApiSpec(
+export async function generateOpenApiSpec(
 	app: Questpie<any>,
 	routes?: RoutesTree,
 	config: OpenApiConfig = {},
-): OpenApiSpec {
+): Promise<OpenApiSpec> {
 	const allPaths: OpenApiSpec["paths"] = {};
 	const allSchemas: Record<string, unknown> = { ...baseComponentSchemas() };
 	const allTags: OpenApiSpec["tags"] = [];
@@ -42,8 +48,8 @@ export function generateOpenApiSpec(
 	Object.assign(allSchemas, routeResult.schemas);
 	allTags.push(...routeResult.tags);
 
-	// Auth
-	const auth = generateAuthPaths(config);
+	// Auth — awaited so an async auth-schema fragment can be merged here later.
+	const auth = await generateAuthPaths(config);
 	Object.assign(allPaths, auth.paths);
 	allTags.push(...auth.tags);
 

--- a/packages/openapi/src/generator/index.ts
+++ b/packages/openapi/src/generator/index.ts
@@ -48,15 +48,32 @@ export async function generateOpenApiSpec(
 	Object.assign(allSchemas, routeResult.schemas);
 	allTags.push(...routeResult.tags);
 
-	// Auth — awaited so an async auth-schema fragment can be merged here later.
-	const auth = await generateAuthPaths(config);
+	// Auth — awaited so the async Better Auth openAPI-plugin schema fragment
+	// (`app.auth.api.generateOpenAPISchema()`) can be derived and merged here.
+	const auth = await generateAuthPaths(config, app);
 	Object.assign(allPaths, auth.paths);
+	Object.assign(allSchemas, auth.schemas);
 	allTags.push(...auth.tags);
 
 	// Search
 	const search = generateSearchPaths(config);
 	Object.assign(allPaths, search.paths);
 	allTags.push(...search.tags);
+
+	// Security schemes — QUESTPIE's defaults, with any Better-Auth-derived
+	// schemes merged in (deduped; QUESTPIE's own definitions win on key clash).
+	const securitySchemes: Record<string, unknown> = {
+		...auth.securitySchemes,
+		bearerAuth: {
+			type: "http",
+			scheme: "bearer",
+		},
+		cookieAuth: {
+			type: "apiKey",
+			in: "cookie",
+			name: "better-auth.session_token",
+		},
+	};
 
 	return {
 		openapi: "3.1.0",
@@ -69,17 +86,7 @@ export async function generateOpenApiSpec(
 		paths: allPaths,
 		components: {
 			schemas: allSchemas,
-			securitySchemes: {
-				bearerAuth: {
-					type: "http",
-					scheme: "bearer",
-				},
-				cookieAuth: {
-					type: "apiKey",
-					in: "cookie",
-					name: "better-auth.session_token",
-				},
-			},
+			securitySchemes,
 		},
 		tags: allTags,
 		security: [{ bearerAuth: [] }, { cookieAuth: [] }],

--- a/packages/openapi/src/generator/routes.test.ts
+++ b/packages/openapi/src/generator/routes.test.ts
@@ -178,3 +178,79 @@ describe("generateRoutePaths — route meta", () => {
 		);
 	});
 });
+
+describe("generateRoutePaths — per-operation security from access", () => {
+	it("emits security: [] for an explicitly public route (access(true))", () => {
+		const publicRoute = route()
+			.get()
+			.access(true)
+			.schema(z.object({}))
+			.handler(() => ({ ok: true }));
+
+		const routes = { health: publicRoute } as any;
+
+		const result = generateRoutePaths(routes, { basePath: "/api" });
+
+		const op = result.paths["/api/health"].get as any;
+		expect(op.security).toEqual([]);
+	});
+
+	it("emits no per-op security for a gated route (function access rule)", () => {
+		const gatedRoute = route()
+			.get()
+			.access(() => true)
+			.schema(z.object({}))
+			.handler(() => ({ ok: true }));
+
+		const routes = { secret: gatedRoute } as any;
+
+		const result = generateRoutePaths(routes, { basePath: "/api" });
+
+		const op = result.paths["/api/secret"].get as any;
+		expect(op.security).toBeUndefined();
+	});
+
+	it("emits no per-op security when no access is declared", () => {
+		const defaultRoute = route()
+			.get()
+			.schema(z.object({}))
+			.handler(() => ({ ok: true }));
+
+		const routes = { thing: defaultRoute } as any;
+
+		const result = generateRoutePaths(routes, { basePath: "/api" });
+
+		const op = result.paths["/api/thing"].get as any;
+		expect(op.security).toBeUndefined();
+	});
+
+	it("treats access({ execute: true }) as explicitly public (security: [])", () => {
+		const publicRoute = route()
+			.get()
+			.access({ execute: true })
+			.raw()
+			.handler(() => new Response("ok"));
+
+		const routes = { ping: publicRoute } as any;
+
+		const result = generateRoutePaths(routes, { basePath: "/api" });
+
+		const op = result.paths["/api/ping"].get as any;
+		expect(op.security).toEqual([]);
+	});
+
+	it("does not mark access(false) as public", () => {
+		const closedRoute = route()
+			.get()
+			.access(false)
+			.schema(z.object({}))
+			.handler(() => ({ ok: true }));
+
+		const routes = { closed: closedRoute } as any;
+
+		const result = generateRoutePaths(routes, { basePath: "/api" });
+
+		const op = result.paths["/api/closed"].get as any;
+		expect(op.security).toBeUndefined();
+	});
+});

--- a/packages/openapi/src/generator/routes.test.ts
+++ b/packages/openapi/src/generator/routes.test.ts
@@ -61,6 +61,25 @@ describe("generateRoutePaths — method suffix routes", () => {
 		);
 	});
 
+	it("keeps the default summary and Routes: <top> tag when no meta is set", () => {
+		const list = route()
+			.get()
+			.schema(z.object({}))
+			.handler(() => ({ ok: true }));
+
+		const routes = { widgets: { list } } as any;
+
+		const result = generateRoutePaths(routes, { basePath: "/api" });
+
+		const op = result.paths["/api/widgets/list"].get as any;
+		expect(op.summary).toBe("widgets/list");
+		expect(op.tags).toEqual(["Routes: widgets"]);
+		expect(op.description).toBeUndefined();
+		expect(result.tags).toEqual([
+			{ name: "Routes: widgets", description: "Routes under widgets" },
+		]);
+	});
+
 	it("converts [param] and [...slug] segments to {param} templates with path parameters", () => {
 		const getOne = route()
 			.get()
@@ -95,5 +114,67 @@ describe("generateRoutePaths — method suffix routes", () => {
 		expect((filePath.get as any).parameters).toEqual([
 			{ name: "key", in: "path", required: true, schema: { type: "string" } },
 		]);
+	});
+});
+
+describe("generateRoutePaths — route meta", () => {
+	it("maps meta.title/description/tags onto the operation and registers tags", () => {
+		const createBooking = route()
+			.post()
+			.schema(z.object({ name: z.string() }))
+			.meta({
+				title: "Create a booking",
+				description: "Creates a booking for the current user.",
+				tags: ["Bookings", "Public API"],
+			})
+			.handler(() => ({ ok: true }));
+
+		const routes = { bookings: createBooking } as any;
+
+		const result = generateRoutePaths(routes, { basePath: "/api" });
+
+		const op = result.paths["/api/bookings"].post as any;
+		expect(op.summary).toBe("Create a booking");
+		expect(op.description).toBe("Creates a booking for the current user.");
+		expect(op.tags).toEqual(["Bookings", "Public API"]);
+		// meta.tags surface in the top-level tags array (no orphans), and the
+		// default `Routes: bookings` bucket is NOT registered when overridden.
+		expect(result.tags).toEqual([
+			{ name: "Bookings" },
+			{ name: "Public API" },
+		]);
+	});
+
+	it("uses meta.description for a raw route instead of the default blurb", () => {
+		const webhook = route()
+			.post()
+			.raw()
+			.meta({ description: "Stripe webhook receiver." })
+			.handler(() => new Response("ok"));
+
+		const routes = { webhooks: { stripe: webhook } } as any;
+
+		const result = generateRoutePaths(routes, { basePath: "/api" });
+
+		const op = result.paths["/api/webhooks/stripe"].post as any;
+		expect(op.description).toBe("Stripe webhook receiver.");
+	});
+
+	it("falls back to the default raw description when meta has no description", () => {
+		const webhook = route()
+			.post()
+			.raw()
+			.meta({ title: "Stripe webhook" })
+			.handler(() => new Response("ok"));
+
+		const routes = { webhooks: { stripe: webhook } } as any;
+
+		const result = generateRoutePaths(routes, { basePath: "/api" });
+
+		const op = result.paths["/api/webhooks/stripe"].post as any;
+		expect(op.summary).toBe("Stripe webhook");
+		expect(op.description).toBe(
+			"Raw route - accepts any request body and returns a raw response.",
+		);
 	});
 });

--- a/packages/openapi/src/generator/routes.ts
+++ b/packages/openapi/src/generator/routes.ts
@@ -194,9 +194,7 @@ export function generateRoutePaths(
 		// `Routes: <topLevel>` bucket. Register whichever set is used at the
 		// spec level so there are no orphan tags.
 		const metaTags =
-			Array.isArray(meta?.tags) && meta.tags.length > 0
-				? meta.tags
-				: undefined;
+			Array.isArray(meta?.tags) && meta.tags.length > 0 ? meta.tags : undefined;
 		const operationTags = metaTags ?? [`Routes: ${topLevel}`];
 
 		if (metaTags) {
@@ -279,14 +277,14 @@ export function generateRoutePaths(
 
 			if (def.schema) {
 				const schemaName = `${schemaOperationId}_Input`;
-				const converted = zodToJsonSchema(def.schema);
+				const converted = zodToJsonSchema(def.schema, "input");
 				schemas[schemaName] = converted;
 				inputSchema = { $ref: `#/components/schemas/${schemaName}` };
 			}
 
 			if (def.outputSchema) {
 				const schemaName = `${schemaOperationId}_Output`;
-				const converted = zodToJsonSchema(def.outputSchema);
+				const converted = zodToJsonSchema(def.outputSchema, "output");
 				schemas[schemaName] = converted;
 				outputSchema = { $ref: `#/components/schemas/${schemaName}` };
 			}

--- a/packages/openapi/src/generator/routes.ts
+++ b/packages/openapi/src/generator/routes.ts
@@ -163,8 +163,34 @@ export function generateRoutePaths(
 
 		const topLevel = patternSegments[0] ?? "routes";
 
-		if (!tagSet.has(topLevel)) {
-			tagSet.add(topLevel);
+		// Serializable route metadata (`.meta({ title, description, tags })`),
+		// the single seam shared with route introspection + MCP.
+		const meta = (def.meta ?? undefined) as
+			| {
+					title?: string;
+					description?: string;
+					tags?: string[];
+			  }
+			| undefined;
+
+		// Operation tags: prefer explicit `meta.tags`, else the default
+		// `Routes: <topLevel>` bucket. Register whichever set is used at the
+		// spec level so there are no orphan tags.
+		const metaTags =
+			Array.isArray(meta?.tags) && meta.tags.length > 0
+				? meta.tags
+				: undefined;
+		const operationTags = metaTags ?? [`Routes: ${topLevel}`];
+
+		if (metaTags) {
+			for (const tag of metaTags) {
+				if (!tagSet.has(tag)) {
+					tagSet.add(tag);
+					tags.push({ name: tag });
+				}
+			}
+		} else if (!tagSet.has(`Routes: ${topLevel}`)) {
+			tagSet.add(`Routes: ${topLevel}`);
 			tags.push({
 				name: `Routes: ${topLevel}`,
 				description: `Routes under ${topLevel}`,
@@ -189,16 +215,21 @@ export function generateRoutePaths(
 
 		const operation: PathOperation = {
 			operationId: baseOperationId,
-			summary: entry.path,
-			tags: [`Routes: ${topLevel}`],
+			// `meta.title` -> summary, falling back to the URL path string.
+			summary: meta?.title ?? entry.path,
+			tags: operationTags,
+			...(meta?.description ? { description: meta.description } : {}),
 			...(parameters.length > 0 ? { parameters } : {}),
 			responses: {},
 		};
 
 		if (isRaw) {
-			// Raw routes take a raw request and return a raw response
-			operation.description =
-				"Raw route - accepts any request body and returns a raw response.";
+			// Raw routes take a raw request and return a raw response. Keep the
+			// default blurb only when `meta.description` did not already set one.
+			if (!operation.description) {
+				operation.description =
+					"Raw route - accepts any request body and returns a raw response.";
+			}
 			operation.requestBody = {
 				content: {
 					"application/json": { schema: {} },

--- a/packages/openapi/src/generator/routes.ts
+++ b/packages/openapi/src/generator/routes.ts
@@ -46,6 +46,23 @@ function patternSegmentToOpenApi(segment: string): {
 	return { out: segment };
 }
 
+/**
+ * Whether a route's `access` declaration marks it explicitly public.
+ *
+ * Mirrors the runtime's `extractAccessRule` (routes/execute.ts): `access` is
+ * either a rule (`boolean | fn`) or `{ execute?: rule }`. A route is public iff
+ * the resolved execute rule is exactly the boolean `true` — i.e. `access(true)`
+ * or `access({ execute: true })`. A function rule, `false`, or no `access`
+ * declaration is NOT treated as public here (it inherits the global scheme).
+ */
+function isExplicitlyPublicRouteAccess(access: unknown): boolean {
+	const rule =
+		access !== null && typeof access === "object" && "execute" in access
+			? (access as { execute?: unknown }).execute
+			: access;
+	return rule === true;
+}
+
 interface FlatRouteEntry {
 	/** URL path pattern with file-convention brackets (e.g. "user/[id]"). */
 	path: string;
@@ -213,6 +230,11 @@ export function generateRoutePaths(
 			schema: { type: "string" },
 		}));
 
+		// Explicitly public routes (`access(true)`) opt out of the spec-level
+		// security scheme via an empty `security: []`; gated routes (function
+		// rule or no access) inherit the global scheme by emitting nothing.
+		const isPublic = isExplicitlyPublicRouteAccess(def.access);
+
 		const operation: PathOperation = {
 			operationId: baseOperationId,
 			// `meta.title` -> summary, falling back to the URL path string.
@@ -220,6 +242,7 @@ export function generateRoutePaths(
 			tags: operationTags,
 			...(meta?.description ? { description: meta.description } : {}),
 			...(parameters.length > 0 ? { parameters } : {}),
+			...(isPublic ? { security: [] } : {}),
 			responses: {},
 		};
 

--- a/packages/openapi/src/generator/schemas.test.ts
+++ b/packages/openapi/src/generator/schemas.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "bun:test";
+
+import { z } from "zod";
+
+import { zodToJsonSchema } from "./schemas.js";
+
+describe("zodToJsonSchema", () => {
+	it("preserves the input contract for transformed request schemas", () => {
+		const schema = z.object({
+			quantity: z
+				.string()
+				.min(1)
+				.transform((value) => Number(value)),
+		});
+
+		expect(zodToJsonSchema(schema, "input")).toEqual({
+			$schema: "https://json-schema.org/draft/2020-12/schema",
+			type: "object",
+			properties: {
+				quantity: { type: "string", minLength: 1 },
+			},
+			required: ["quantity"],
+		});
+	});
+
+	it("does not mislabel an unrepresentable transformed response as an object", () => {
+		const schema = z.string().transform((value) => Number(value));
+
+		expect(zodToJsonSchema(schema, "output")).toEqual({
+			description:
+				"This Zod output schema cannot be represented in JSON Schema; runtime validation remains authoritative.",
+		});
+	});
+
+	it("retains representable constraints from refinements", () => {
+		const schema = z
+			.string()
+			.min(3)
+			.refine((value) => value !== "reserved");
+
+		expect(zodToJsonSchema(schema, "input")).toMatchObject({
+			type: "string",
+			minLength: 3,
+		});
+	});
+});

--- a/packages/openapi/src/generator/schemas.ts
+++ b/packages/openapi/src/generator/schemas.ts
@@ -165,18 +165,40 @@ export function jsonRequestBody(schema: unknown, description?: string) {
 }
 
 /**
- * Safely convert a Zod schema to JSON Schema.
- * Falls back to a permissive object schema on failure.
+ * Safely convert a Zod schema to JSON Schema for the requested I/O side.
+ * Request schemas use Zod's input contract so transforms retain their
+ * pre-transform validation shape. Unrepresentable output transforms remain
+ * unconstrained instead of being incorrectly described as objects.
  */
-export function zodToJsonSchema(schema: unknown): unknown {
+export function zodToJsonSchema(
+	schema: unknown,
+	io: "input" | "output" = "input",
+): unknown {
 	try {
 		if (schema && typeof schema === "object" && "_def" in schema) {
-			return z.toJSONSchema(schema as z.ZodType);
+			return z.toJSONSchema(schema as z.ZodType, { io });
 		}
 	} catch {
-		// Zod schema couldn't be converted (e.g. transforms, refinements)
+		if (io === "output") {
+			return {
+				description:
+					"This Zod output schema cannot be represented in JSON Schema; runtime validation remains authoritative.",
+			};
+		}
+
+		try {
+			return z.toJSONSchema(schema as z.ZodType, {
+				io: "input",
+				unrepresentable: "any",
+			});
+		} catch {
+			// Fall through to an honest unconstrained schema.
+		}
 	}
-	return { type: "object", description: "Schema could not be generated" };
+	return {
+		description:
+			"Schema could not be represented in JSON Schema; runtime validation remains authoritative.",
+	};
 }
 
 /**

--- a/packages/openapi/src/generator/workflow-stage-openapi.test.ts
+++ b/packages/openapi/src/generator/workflow-stage-openapi.test.ts
@@ -13,7 +13,7 @@ function hasStageParameter(operation: any): boolean {
 }
 
 describe("OpenAPI workflow stage parameters", () => {
-	it("includes stage query params on workflow-aware endpoints", () => {
+	it("includes stage query params on workflow-aware endpoints", async () => {
 		const app = {
 			getCollections: () => ({
 				posts: {
@@ -35,7 +35,7 @@ describe("OpenAPI workflow stage parameters", () => {
 			}),
 		} as any;
 
-		const spec = generateOpenApiSpec(app, undefined, {
+		const spec = await generateOpenApiSpec(app, undefined, {
 			basePath: "/api",
 		});
 

--- a/packages/openapi/src/server.ts
+++ b/packages/openapi/src/server.ts
@@ -80,7 +80,7 @@ export function openApiConfig(
  * ```ts
  * import { generateOpenApiSpec } from "@questpie/openapi/server";
  *
- * const spec = generateOpenApiSpec(app, {
+ * const spec = await generateOpenApiSpec(app, {
  *   info: { title: "My API", version: "1.0.0" },
  * });
  * ```
@@ -88,7 +88,7 @@ export function openApiConfig(
 export function generateOpenApiSpec(
 	app: unknown,
 	config?: OpenApiConfig,
-): OpenApiSpec {
+): Promise<OpenApiSpec> {
 	const routes = (app as any).config?.routes;
 	return generate(app as any, routes, config);
 }
@@ -99,11 +99,11 @@ export function generateOpenApiSpec(
 
 const specCache = new WeakMap<object, { json: string; etag: string }>();
 
-function getCachedSpec(app: unknown, config: OpenApiConfig | undefined) {
+async function getCachedSpec(app: unknown, config: OpenApiConfig | undefined) {
 	const appObj = app as object;
 	let cached = specCache.get(appObj);
 	if (!cached) {
-		const spec = generateOpenApiSpec(app, config);
+		const spec = await generateOpenApiSpec(app, config);
 		const json = JSON.stringify(spec);
 		// Simple hash for ETag — deterministic per spec content
 		let hash = 0;
@@ -159,7 +159,7 @@ export function openApiRoute(
 		.handler(async (ctx) => {
 			const app = (ctx as any).app as Questpie<any>;
 			const resolved = resolveOpenApiConfig(app, config);
-			const { json, etag } = getCachedSpec(app, resolved);
+			const { json, etag } = await getCachedSpec(app, resolved);
 
 			if (ctx.request.headers.get("if-none-match") === etag) {
 				return new Response(null, { status: 304 });
@@ -200,7 +200,7 @@ export function docsRoute(
 			const resolved = resolveOpenApiConfig(app, openApiConfig);
 			const scalarOpts =
 				scalarConfig ?? (resolved as OpenApiModuleConfig)?.scalar;
-			const spec = generateOpenApiSpec(app, resolved);
+			const spec = await generateOpenApiSpec(app, resolved);
 			return serveScalarUI(spec, scalarOpts);
 		});
 }

--- a/packages/questpie/package.json
+++ b/packages/questpie/package.json
@@ -147,6 +147,7 @@
 	},
 	"devDependencies": {
 		"@electric-sql/pglite": "^0.3.14",
+		"@seriousme/openapi-schema-validator": "^2.9.0",
 		"@types/html-to-text": "^9.0.4",
 		"@types/nodemailer": "^8.0.1",
 		"@types/pg": "^8.16.0",

--- a/packages/questpie/src/server/modules/starter/config/auth.ts
+++ b/packages/questpie/src/server/modules/starter/config/auth.ts
@@ -1,6 +1,7 @@
 /**
  * Default auth config for the starter module: the admin plugin (role/ban
- * management), the bearer token plugin, and email/password sign-in.
+ * management), bearer token plugin, and openAPI plugin (which exposes
+ * `auth.api.generateOpenAPISchema()` for @questpie/openapi).
  *
  * The OAuth 2.1 provider (`oauthProvider()` + `jwt()`) and the OAuth tables
  * (`collections/oauth-*.ts`, `jwks`) live in `oauthModule`, which `starterModule`
@@ -11,12 +12,12 @@
  * User projects can override or extend via their own `config/auth.ts`. Plugins
  * are deduped by ID during merge (see auth/merge.ts), so duplicates are safe.
  */
-import { admin, bearer } from "better-auth/plugins";
+import { admin, bearer, openAPI } from "better-auth/plugins";
 
 import { authConfig } from "#questpie/server/config/factories.js";
 
 export default authConfig({
-	plugins: [admin(), bearer()],
+	plugins: [admin(), bearer(), openAPI()],
 	emailAndPassword: {
 		enabled: true,
 		requireEmailVerification: true,

--- a/packages/questpie/test/openapi/openapi-module.test.ts
+++ b/packages/questpie/test/openapi/openapi-module.test.ts
@@ -33,7 +33,7 @@ function createMockApp(opts?: {
 // ---------------------------------------------------------------------------
 
 describe("generateOpenApiSpec (public API)", () => {
-	it("generates a valid OpenAPI 3.1 spec", () => {
+	it("generates a valid OpenAPI 3.1 spec", async () => {
 		const app = createMockApp({
 			collections: {
 				posts: collection("posts").fields(({ f }) => ({
@@ -42,7 +42,7 @@ describe("generateOpenApiSpec (public API)", () => {
 			},
 		});
 
-		const spec = generateOpenApiSpec(app, {
+		const spec = await generateOpenApiSpec(app, {
 			info: { title: "Test", version: "2.0.0" },
 		});
 
@@ -53,15 +53,15 @@ describe("generateOpenApiSpec (public API)", () => {
 		expect(spec.components.securitySchemes).toBeDefined();
 	});
 
-	it("uses default title and version when not provided", () => {
+	it("uses default title and version when not provided", async () => {
 		const app = createMockApp();
-		const spec = generateOpenApiSpec(app);
+		const spec = await generateOpenApiSpec(app);
 
 		expect(spec.info.title).toBe("QUESTPIE API");
 		expect(spec.info.version).toBe("1.0.0");
 	});
 
-	it("includes collections in the spec", () => {
+	it("includes collections in the spec", async () => {
 		const app = createMockApp({
 			collections: {
 				posts: collection("posts").fields(({ f }) => ({
@@ -70,13 +70,13 @@ describe("generateOpenApiSpec (public API)", () => {
 			},
 		});
 
-		const spec = generateOpenApiSpec(app, { basePath: "/api" });
+		const spec = await generateOpenApiSpec(app, { basePath: "/api" });
 
 		expect(spec.paths["/api/posts"]).toBeDefined();
 		expect(spec.components.schemas?.PostsInsert).toBeDefined();
 	});
 
-	it("includes globals in the spec", () => {
+	it("includes globals in the spec", async () => {
 		const app = createMockApp({
 			globals: {
 				settings: global("settings").fields(({ f }) => ({
@@ -85,12 +85,12 @@ describe("generateOpenApiSpec (public API)", () => {
 			},
 		});
 
-		const spec = generateOpenApiSpec(app, { basePath: "/api" });
+		const spec = await generateOpenApiSpec(app, { basePath: "/api" });
 
 		expect(spec.paths["/api/globals/settings"]).toBeDefined();
 	});
 
-	it("respects exclude config", () => {
+	it("respects exclude config", async () => {
 		const app = createMockApp({
 			collections: {
 				posts: collection("posts").fields(({ f }) => ({
@@ -102,7 +102,7 @@ describe("generateOpenApiSpec (public API)", () => {
 			},
 		});
 
-		const spec = generateOpenApiSpec(app, {
+		const spec = await generateOpenApiSpec(app, {
 			basePath: "/api",
 			exclude: { collections: ["internal"] },
 		});
@@ -159,6 +159,46 @@ describe("openApiRoute", () => {
 		expect((routeDef as any).mode).toBe("raw");
 		expect((routeDef as any).method).toBe("GET");
 		expect(typeof (routeDef as any).handler).toBe("function");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// openApiRoute — ETag / 304 caching (async seam preserves cache semantics)
+// ---------------------------------------------------------------------------
+
+describe("openApiRoute — ETag / 304 caching", () => {
+	function invoke(routeDef: any, app: object, ifNoneMatch?: string) {
+		const headers = new Headers();
+		if (ifNoneMatch) headers.set("if-none-match", ifNoneMatch);
+		const ctx = { app, request: new Request("http://x/api/openapi.json", { headers }) };
+		return routeDef.handler(ctx) as Promise<Response>;
+	}
+
+	it("returns identical ETag on two consecutive requests and 304 on if-none-match", async () => {
+		const app = createMockApp({
+			collections: {
+				posts: collection("posts").fields(({ f }) => ({ title: f.text() })),
+			},
+		});
+		const routeDef = openApiRoute({ basePath: "/api" });
+
+		const first = await invoke(routeDef, app);
+		expect(first.status).toBe(200);
+		const etag = first.headers.get("ETag");
+		expect(etag).toBeTruthy();
+		expect(first.headers.get("Cache-Control")).toBe(
+			"public, max-age=3600, stale-while-revalidate=43200",
+		);
+
+		// Second request (served from the per-app WeakMap cache) → same ETag.
+		const second = await invoke(routeDef, app);
+		expect(second.status).toBe(200);
+		expect(second.headers.get("ETag")).toBe(etag);
+
+		// Conditional request with the ETag → 304 Not Modified, empty body.
+		const conditional = await invoke(routeDef, app, etag!);
+		expect(conditional.status).toBe(304);
+		expect(await conditional.text()).toBe("");
 	});
 });
 
@@ -253,7 +293,7 @@ describe("openApiPlugin", () => {
 // ---------------------------------------------------------------------------
 
 describe("Routes in OpenAPI spec", () => {
-	it("generates flat paths for routes", () => {
+	it("generates flat paths for routes", async () => {
 		const app = createMockApp();
 		const { z } = require("zod");
 
@@ -265,7 +305,7 @@ describe("Routes in OpenAPI spec", () => {
 			},
 		};
 
-		const spec = generateInternal(app as any, routes, {
+		const spec = await generateInternal(app as any, routes, {
 			basePath: "/api",
 		});
 
@@ -274,7 +314,7 @@ describe("Routes in OpenAPI spec", () => {
 		expect(spec.paths["/api/greet"].post.operationId).toBe("route_greet");
 	});
 
-	it("generates nested flat paths for routes", () => {
+	it("generates nested flat paths for routes", async () => {
 		const app = createMockApp();
 
 		const routes = {
@@ -290,7 +330,7 @@ describe("Routes in OpenAPI spec", () => {
 			},
 		};
 
-		const spec = generateInternal(app as any, routes, {
+		const spec = await generateInternal(app as any, routes, {
 			basePath: "/api",
 		});
 

--- a/packages/questpie/test/openapi/openapi-schema.test.ts
+++ b/packages/questpie/test/openapi/openapi-schema.test.ts
@@ -229,6 +229,238 @@ describe("OpenAPI schema generation", () => {
 		});
 	});
 
+	describe("auth schemas", () => {
+		// A faithful slice of what Better Auth's `openAPI()` plugin emits from
+		// `auth.api.generateOpenAPISchema()`: paths relative to /api/auth, real
+		// request/response schemas, `$ref`s into components, and securitySchemes.
+		function betterAuthOpenApiDoc() {
+			return {
+				openapi: "3.1.1",
+				info: { title: "Better Auth", description: "", version: "1.0" },
+				components: {
+					securitySchemes: {
+						apiKeyCookie: {
+							type: "apiKey",
+							in: "cookie",
+							name: "better-auth.session_token",
+							description: "",
+						},
+						bearerAuth: { type: "http", scheme: "bearer", description: "" },
+					},
+					schemas: {
+						User: {
+							type: "object",
+							properties: {
+								id: { type: "string" },
+								email: { type: "string" },
+							},
+							required: ["id", "email"],
+						},
+						Session: {
+							type: "object",
+							properties: { id: { type: "string" } },
+							required: ["id"],
+						},
+					},
+				},
+				security: [{ apiKeyCookie: [], bearerAuth: [] }],
+				servers: [{ url: "http://localhost:3000/api/auth" }],
+				tags: [{ name: "Default", description: "" }],
+				paths: {
+					"/sign-in/email": {
+						post: {
+							tags: ["Default"],
+							operationId: "signInEmail",
+							requestBody: {
+								content: {
+									"application/json": {
+										schema: {
+											type: "object",
+											properties: {
+												email: { type: "string" },
+												password: { type: "string" },
+											},
+											required: ["email", "password"],
+										},
+									},
+								},
+							},
+							responses: {
+								"200": {
+									description: "Success",
+									content: {
+										"application/json": {
+											schema: {
+												type: "object",
+												properties: {
+													user: { $ref: "#/components/schemas/User" },
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					"/get-session": {
+						get: {
+							tags: ["Default"],
+							operationId: "getSession",
+							responses: {
+								"200": {
+									description: "Success",
+									content: {
+										"application/json": {
+											schema: {
+												type: ["object", "null"],
+												properties: {
+													session: { $ref: "#/components/schemas/Session" },
+													user: { $ref: "#/components/schemas/User" },
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					"/admin/list-users": {
+						get: {
+							tags: ["Default"],
+							operationId: "listUsers",
+							responses: {
+								"200": {
+									description: "Success",
+									content: {
+										"application/json": {
+											schema: { type: "object" },
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			};
+		}
+
+		it("derives real auth paths + schemas from the better-auth openAPI plugin", async () => {
+			const mockCms = {
+				getCollections: () => ({}),
+				getGlobals: () => ({}),
+				auth: {
+					api: {
+						generateOpenAPISchema: async () => betterAuthOpenApiDoc(),
+					},
+				},
+			};
+
+			const spec = await generateOpenApiSpec(mockCms as any, undefined, {
+				info: { title: "Test API", version: "1.0.0" },
+				basePath: "/",
+			});
+
+			// Core endpoints are present and correctly prefixed <basePath>/auth/...
+			expect(spec.paths?.["//auth/sign-in/email"]?.post).toBeDefined();
+			expect(spec.paths?.["//auth/get-session"]?.get).toBeDefined();
+			// Configured-plugin endpoints (admin/*) come through too.
+			expect(spec.paths?.["//auth/admin/list-users"]?.get).toBeDefined();
+
+			// Response schemas are NON-opaque: sign-in references a real schema,
+			// not { type: "object" } with an empty `user`.
+			const signIn = spec.paths?.["//auth/sign-in/email"]?.post as any;
+			const userRef =
+				signIn.responses["200"].content["application/json"].schema.properties
+					.user.$ref;
+			// $ref must be rewritten to the namespaced schema name.
+			expect(userRef).toBe("#/components/schemas/AuthUser");
+
+			// Namespaced component schemas exist and are not empty.
+			const authUser = spec.components?.schemas?.AuthUser as any;
+			expect(authUser).toBeDefined();
+			expect(authUser.type).toBe("object");
+			expect(Object.keys(authUser.properties || {}).length).toBeGreaterThan(0);
+			expect(spec.components?.schemas?.AuthSession).toBeDefined();
+			// Bare (un-namespaced) names must NOT leak into the merged spec.
+			expect(spec.components?.schemas?.User).toBeUndefined();
+
+			// Auth operations are retagged under a single "Auth" tag.
+			expect(signIn.tags).toEqual(["Auth"]);
+			expect(spec.tags?.some((t) => t.name === "Auth")).toBe(true);
+
+			// Better Auth security schemes are merged in (deduped).
+			expect(spec.components?.securitySchemes?.apiKeyCookie).toBeDefined();
+			expect(spec.components?.securitySchemes?.bearerAuth).toBeDefined();
+			// QUESTPIE's own defaults still present.
+			expect(spec.components?.securitySchemes?.cookieAuth).toBeDefined();
+		});
+
+		it("falls back to the hardcoded minimal set when app.auth is absent", async () => {
+			const mockCms = {
+				getCollections: () => ({}),
+				getGlobals: () => ({}),
+			};
+
+			const spec = await generateOpenApiSpec(mockCms as any, undefined, {
+				info: { title: "Test API", version: "1.0.0" },
+				basePath: "/",
+			});
+
+			// The four hardcoded fallback endpoints are documented.
+			expect(spec.paths?.["//auth/sign-in/email"]?.post).toBeDefined();
+			expect(spec.paths?.["//auth/sign-up/email"]?.post).toBeDefined();
+			expect(spec.paths?.["//auth/get-session"]?.get).toBeDefined();
+			expect(spec.paths?.["//auth/sign-out"]?.post).toBeDefined();
+			// The richer plugin-only endpoints are NOT present in the fallback.
+			expect(spec.paths?.["//auth/admin/list-users"]).toBeUndefined();
+		});
+
+		it("falls back when generateOpenAPISchema throws", async () => {
+			const mockCms = {
+				getCollections: () => ({}),
+				getGlobals: () => ({}),
+				auth: {
+					api: {
+						generateOpenAPISchema: async () => {
+							throw new Error("boom");
+						},
+					},
+				},
+			};
+
+			const spec = await generateOpenApiSpec(mockCms as any, undefined, {
+				info: { title: "Test API", version: "1.0.0" },
+				basePath: "/",
+			});
+
+			// Graceful fallback: no crash, hardcoded set present.
+			expect(spec.paths?.["//auth/sign-in/email"]?.post).toBeDefined();
+			expect(spec.paths?.["//auth/admin/list-users"]).toBeUndefined();
+		});
+
+		it("omits auth entirely when config.auth === false", async () => {
+			const mockCms = {
+				getCollections: () => ({}),
+				getGlobals: () => ({}),
+				auth: {
+					api: {
+						generateOpenAPISchema: async () => betterAuthOpenApiDoc(),
+					},
+				},
+			};
+
+			const spec = await generateOpenApiSpec(mockCms as any, undefined, {
+				info: { title: "Test API", version: "1.0.0" },
+				basePath: "/",
+				auth: false,
+			});
+
+			expect(spec.paths?.["//auth/sign-in/email"]).toBeUndefined();
+			expect(spec.paths?.["//auth/admin/list-users"]).toBeUndefined();
+			expect(spec.components?.schemas?.AuthUser).toBeUndefined();
+		});
+	});
+
 	describe("global schemas", () => {
 		it("generates proper JSON schema for global fields", async () => {
 			const settings = global("settings").fields(({ f }) => ({

--- a/packages/questpie/test/openapi/openapi-schema.test.ts
+++ b/packages/questpie/test/openapi/openapi-schema.test.ts
@@ -5,7 +5,7 @@ import { collection, global } from "../../src/exports/index.js";
 
 describe("OpenAPI schema generation", () => {
 	describe("collection schemas", () => {
-		it("generates proper JSON schema for collection fields", () => {
+		it("generates proper JSON schema for collection fields", async () => {
 			const posts = collection("posts").fields(({ f }) => ({
 				title: f.text(255).required(),
 				content: f.textarea(),
@@ -24,7 +24,7 @@ describe("OpenAPI schema generation", () => {
 				getGlobals: () => ({}),
 			};
 
-			const spec = generateOpenApiSpec(mockCms as any, undefined, {
+			const spec = await generateOpenApiSpec(mockCms as any, undefined, {
 				info: { title: "Test API", version: "1.0.0" },
 				basePath: "/",
 			});
@@ -52,7 +52,7 @@ describe("OpenAPI schema generation", () => {
 			expect(insertSchema.required).toContain("title");
 		});
 
-		it("generates document schema with id and timestamps", () => {
+		it("generates document schema with id and timestamps", async () => {
 			const posts = collection("posts").fields(({ f }) => ({
 				title: f.text().required(),
 			}));
@@ -62,7 +62,7 @@ describe("OpenAPI schema generation", () => {
 				getGlobals: () => ({}),
 			};
 
-			const spec = generateOpenApiSpec(mockCms as any, undefined, {
+			const spec = await generateOpenApiSpec(mockCms as any, undefined, {
 				info: { title: "Test API", version: "1.0.0" },
 				basePath: "/",
 			});
@@ -81,7 +81,7 @@ describe("OpenAPI schema generation", () => {
 			expect(baseSchema.properties?.updatedAt).toBeDefined();
 		});
 
-		it("handles relation fields", () => {
+		it("handles relation fields", async () => {
 			const authors = collection("authors").fields(({ f }) => ({
 				name: f.text().required(),
 			}));
@@ -96,7 +96,7 @@ describe("OpenAPI schema generation", () => {
 				getGlobals: () => ({}),
 			};
 
-			const spec = generateOpenApiSpec(mockCms as any, undefined, {
+			const spec = await generateOpenApiSpec(mockCms as any, undefined, {
 				info: { title: "Test API", version: "1.0.0" },
 				basePath: "/",
 			});
@@ -108,7 +108,7 @@ describe("OpenAPI schema generation", () => {
 			expect(insertSchema.properties.author).toBeDefined();
 		});
 
-		it("separates inputFalse and outputFalse fields in collection schemas", () => {
+		it("separates inputFalse and outputFalse fields in collection schemas", async () => {
 			const credentials = collection("credentials").fields(({ f }) => ({
 				title: f.text(255).required(),
 				serverOnly: f.text(255).inputFalse(),
@@ -120,7 +120,7 @@ describe("OpenAPI schema generation", () => {
 				getGlobals: () => ({}),
 			};
 
-			const spec = generateOpenApiSpec(mockCms as any, undefined, {
+			const spec = await generateOpenApiSpec(mockCms as any, undefined, {
 				info: { title: "Test API", version: "1.0.0" },
 				basePath: "/",
 			});
@@ -140,7 +140,7 @@ describe("OpenAPI schema generation", () => {
 			expect(documentFields.properties.secret).toBeUndefined();
 		});
 
-		it("does not generate empty schemas", () => {
+		it("does not generate empty schemas", async () => {
 			const posts = collection("posts").fields(({ f }) => ({
 				title: f.text(100).required(),
 				content: f.textarea(),
@@ -152,7 +152,7 @@ describe("OpenAPI schema generation", () => {
 				getGlobals: () => ({}),
 			};
 
-			const spec = generateOpenApiSpec(mockCms as any, undefined, {
+			const spec = await generateOpenApiSpec(mockCms as any, undefined, {
 				info: { title: "Test API", version: "1.0.0" },
 				basePath: "/",
 			});
@@ -170,7 +170,7 @@ describe("OpenAPI schema generation", () => {
 			expect(insertSchema.properties.views).toBeDefined();
 		});
 
-		it("generates collection versioning paths", () => {
+		it("generates collection versioning paths", async () => {
 			const posts = collection("posts")
 				.fields(({ f }) => ({
 					title: f.text().required(),
@@ -182,7 +182,7 @@ describe("OpenAPI schema generation", () => {
 				getGlobals: () => ({}),
 			};
 
-			const spec = generateOpenApiSpec(mockCms as any, undefined, {
+			const spec = await generateOpenApiSpec(mockCms as any, undefined, {
 				info: { title: "Test API", version: "1.0.0" },
 				basePath: "/",
 			});
@@ -191,7 +191,7 @@ describe("OpenAPI schema generation", () => {
 			expect(spec.paths?.["//posts/{id}/revert"]?.post).toBeDefined();
 		});
 
-		it("generates transition path for workflow-enabled collections", () => {
+		it("generates transition path for workflow-enabled collections", async () => {
 			const posts = collection("posts")
 				.fields(({ f }) => ({
 					title: f.text().required(),
@@ -214,7 +214,7 @@ describe("OpenAPI schema generation", () => {
 				getGlobals: () => ({}),
 			};
 
-			const spec = generateOpenApiSpec(mockCms as any, undefined, {
+			const spec = await generateOpenApiSpec(mockCms as any, undefined, {
 				info: { title: "Test API", version: "1.0.0" },
 				basePath: "/",
 			});
@@ -230,7 +230,7 @@ describe("OpenAPI schema generation", () => {
 	});
 
 	describe("global schemas", () => {
-		it("generates proper JSON schema for global fields", () => {
+		it("generates proper JSON schema for global fields", async () => {
 			const settings = global("settings").fields(({ f }) => ({
 				siteName: f.text(100).required(),
 				siteDescription: f.textarea(),
@@ -242,7 +242,7 @@ describe("OpenAPI schema generation", () => {
 				getGlobals: () => ({ settings }),
 			};
 
-			const spec = generateOpenApiSpec(mockCms as any, undefined, {
+			const spec = await generateOpenApiSpec(mockCms as any, undefined, {
 				info: { title: "Test API", version: "1.0.0" },
 			});
 
@@ -255,7 +255,7 @@ describe("OpenAPI schema generation", () => {
 			expect(updateSchema.properties.maintenanceMode).toBeDefined();
 		});
 
-		it("separates inputFalse and outputFalse fields in global schemas", () => {
+		it("separates inputFalse and outputFalse fields in global schemas", async () => {
 			const settings = global("settings").fields(({ f }) => ({
 				siteName: f.text(100).required(),
 				serverOnly: f.text(100).inputFalse(),
@@ -267,7 +267,7 @@ describe("OpenAPI schema generation", () => {
 				getGlobals: () => ({ settings }),
 			};
 
-			const spec = generateOpenApiSpec(mockCms as any, undefined, {
+			const spec = await generateOpenApiSpec(mockCms as any, undefined, {
 				info: { title: "Test API", version: "1.0.0" },
 			});
 
@@ -283,7 +283,7 @@ describe("OpenAPI schema generation", () => {
 			expect(valueFields.properties.secret).toBeUndefined();
 		});
 
-		it("generates global versioning paths", () => {
+		it("generates global versioning paths", async () => {
 			const settings = global("settings")
 				.fields(({ f }) => ({
 					siteName: f.text().required(),
@@ -295,7 +295,7 @@ describe("OpenAPI schema generation", () => {
 				getGlobals: () => ({ settings }),
 			};
 
-			const spec = generateOpenApiSpec(mockCms as any, undefined, {
+			const spec = await generateOpenApiSpec(mockCms as any, undefined, {
 				info: { title: "Test API", version: "1.0.0" },
 				basePath: "/",
 			});
@@ -304,7 +304,7 @@ describe("OpenAPI schema generation", () => {
 			expect(spec.paths?.["//globals/settings/revert"]?.post).toBeDefined();
 		});
 
-		it("generates transition path for workflow-enabled globals", () => {
+		it("generates transition path for workflow-enabled globals", async () => {
 			const settings = global("settings")
 				.fields(({ f }) => ({
 					siteName: f.text().required(),
@@ -327,7 +327,7 @@ describe("OpenAPI schema generation", () => {
 				getGlobals: () => ({ settings, nav }),
 			};
 
-			const spec = generateOpenApiSpec(mockCms as any, undefined, {
+			const spec = await generateOpenApiSpec(mockCms as any, undefined, {
 				info: { title: "Test API", version: "1.0.0" },
 				basePath: "/",
 			});

--- a/packages/questpie/test/openapi/openapi-test-utils.ts
+++ b/packages/questpie/test/openapi/openapi-test-utils.ts
@@ -1,0 +1,202 @@
+/**
+ * Shared OpenAPI test utilities.
+ *
+ * Reusable assertion helpers for the `@questpie/openapi` generator test suite.
+ * The full-spec 3.1 validity gate (`assertValidOpenApi31`) plus small
+ * operation-level assertions (`getOperation`, `assertHasSummary`,
+ * `assertSecurityEmpty`, `assertPathParam`, `assertResponse`, `assertRequestBody`)
+ * are consumed by the other generator-hardening task tests (status codes,
+ * filter/query DSL, schema/meta responses, route meta, per-op security) so that
+ * every one of them can prove "still valid OpenAPI 3.1 + intended content present".
+ *
+ * The validator is `@seriousme/openapi-schema-validator` — an AJV-backed
+ * validator that resolves the real OpenAPI **3.1** meta-schema (it reports the
+ * detected version, accepts valid 3.1 documents, and rejects schema violations
+ * such as a missing `responses`, a response without `description`, an invalid
+ * `components.schemas` key, or a path parameter without `schema`).
+ */
+
+import { expect } from "bun:test";
+import { Validator } from "@seriousme/openapi-schema-validator";
+
+import type { OpenApiSpec, PathOperation } from "../../../openapi/src/types.js";
+
+/** Any OpenAPI document shape — spec generators emit plain objects. */
+export type AnyOpenApiSpec = OpenApiSpec | Record<string, unknown>;
+
+/** HTTP methods that can appear on a path item. */
+export type HttpMethod =
+	| "get"
+	| "put"
+	| "post"
+	| "delete"
+	| "options"
+	| "head"
+	| "patch"
+	| "trace";
+
+/**
+ * Validate a document against the OpenAPI **3.1** meta-schema.
+ *
+ * Returns the parsed result so callers can inspect it; use
+ * {@link assertValidOpenApi31} when you just want a passing assertion with a
+ * readable failure message.
+ */
+export async function validateOpenApi31(spec: AnyOpenApiSpec): Promise<{
+	valid: boolean;
+	version: string;
+	errors: string;
+}> {
+	const validator = new Validator();
+	const result = await validator.validate(spec as Record<string, unknown>);
+	const errors =
+		typeof result.errors === "string"
+			? result.errors
+			: JSON.stringify(result.errors ?? [], null, 2);
+	return { valid: result.valid, version: validator.version, errors };
+}
+
+/**
+ * Assert a generated document is a VALID OpenAPI 3.1 spec.
+ *
+ * Fails with the concrete validator errors (and the version the validator
+ * detected) so a regression points straight at the offending node.
+ *
+ * @example
+ * ```ts
+ * const spec = await generateOpenApiSpec(app, { info: { title: "T", version: "1" } });
+ * await assertValidOpenApi31(spec);
+ * ```
+ */
+export async function assertValidOpenApi31(
+	spec: AnyOpenApiSpec,
+): Promise<void> {
+	const { valid, version, errors } = await validateOpenApi31(spec);
+	if (!valid) {
+		throw new Error(
+			`Expected a valid OpenAPI 3.1 spec (validator detected "${version}"), but found schema violations:\n${errors}`,
+		);
+	}
+	// Guard against a validator that silently downgrades to an older meta-schema.
+	expect(version).toBe("3.1");
+}
+
+/**
+ * Look up a single operation by path + method. Throws a helpful error when the
+ * path or method is missing so failing assertions read clearly.
+ */
+export function getOperation(
+	spec: AnyOpenApiSpec,
+	path: string,
+	method: HttpMethod,
+): PathOperation {
+	const paths = (spec as OpenApiSpec).paths ?? {};
+	const pathItem = paths[path];
+	if (!pathItem) {
+		throw new Error(
+			`No path "${path}" in spec. Available paths: ${Object.keys(paths).join(", ")}`,
+		);
+	}
+	const op = (pathItem as Record<string, unknown>)[method] as
+		| PathOperation
+		| undefined;
+	if (!op) {
+		throw new Error(
+			`No "${method.toUpperCase()}" operation on path "${path}". Available methods: ${Object.keys(
+				pathItem,
+			).join(", ")}`,
+		);
+	}
+	return op;
+}
+
+/**
+ * Assert an operation has a non-empty `summary` (optionally an exact value).
+ */
+export function assertHasSummary(
+	op: PathOperation,
+	expected?: string,
+): void {
+	expect(typeof op.summary).toBe("string");
+	expect((op.summary ?? "").length).toBeGreaterThan(0);
+	if (expected !== undefined) {
+		expect(op.summary).toBe(expected);
+	}
+}
+
+/**
+ * Assert an operation opts out of the spec-level security requirement — i.e. it
+ * carries an explicit empty `security: []` (the marker for a public route).
+ */
+export function assertSecurityEmpty(op: PathOperation): void {
+	expect(op.security).toEqual([]);
+}
+
+/**
+ * Assert an operation is protected: it does NOT declare `security: []`, so it
+ * inherits the global security scheme.
+ */
+export function assertSecurityInherited(op: PathOperation): void {
+	expect(op.security).not.toEqual([]);
+}
+
+/**
+ * Assert an operation declares a required `path` parameter with the given name
+ * (and, by default, a string schema — matching the generator's path templates).
+ */
+export function assertPathParam(
+	op: PathOperation,
+	name: string,
+): void {
+	const params = (op.parameters ?? []) as Array<Record<string, unknown>>;
+	const param = params.find((p) => p.name === name && p.in === "path");
+	if (!param) {
+		throw new Error(
+			`Operation "${op.operationId ?? "?"}" has no path parameter "${name}". Parameters: ${JSON.stringify(
+				params,
+			)}`,
+		);
+	}
+	expect(param.required).toBe(true);
+	expect(param.schema).toBeDefined();
+}
+
+/**
+ * Assert an operation declares a response for `status`, returning that response
+ * object for further inspection (e.g. `content`, `$ref`). Used by the
+ * status-code task to prove non-2xx responses are emitted.
+ */
+export function assertResponse(
+	op: PathOperation,
+	status: string | number,
+): Record<string, unknown> {
+	const responses = (op.responses ?? {}) as Record<string, unknown>;
+	const key = String(status);
+	const response = responses[key];
+	if (response === undefined) {
+		throw new Error(
+			`Operation "${op.operationId ?? "?"}" has no "${key}" response. Statuses: ${Object.keys(
+				responses,
+			).join(", ")}`,
+		);
+	}
+	return response as Record<string, unknown>;
+}
+
+/**
+ * Assert an operation has a JSON request body, returning the
+ * `content["application/json"].schema` node for further inspection (e.g. to
+ * check a `$ref` or the filter/query DSL shape).
+ */
+export function assertRequestBody(op: PathOperation): Record<string, unknown> {
+	const body = op.requestBody as
+		| { content?: Record<string, { schema?: unknown }> }
+		| undefined;
+	const schema = body?.content?.["application/json"]?.schema;
+	if (schema === undefined) {
+		throw new Error(
+			`Operation "${op.operationId ?? "?"}" has no application/json request body schema.`,
+		);
+	}
+	return schema as Record<string, unknown>;
+}

--- a/packages/questpie/test/openapi/openapi-validation.test.ts
+++ b/packages/questpie/test/openapi/openapi-validation.test.ts
@@ -1,0 +1,369 @@
+/**
+ * OpenAPI 3.1 validation gate + `/api/docs` regression coverage.
+ *
+ * This is the shared verify harness for the generator-hardening work: it proves
+ * the emitted document is a VALID OpenAPI 3.1 spec (not just "it generates"),
+ * and it locks the historically-500'd `/api/openapi.json` + `/api/docs`
+ * endpoints at 200 through the real HTTP adapter.
+ *
+ * Reusable assertion helpers live in `./openapi-test-utils.ts` and are consumed
+ * by the sibling task tests (status codes, filter/query DSL, schema/meta
+ * responses, route meta, per-op security).
+ */
+
+import { describe, expect, it } from "bun:test";
+import { route } from "questpie";
+import { z } from "zod";
+
+import { generateOpenApiSpec } from "../../../openapi/src/generator/index.js";
+import { openApiModule } from "../../../openapi/src/server.js";
+import { collection, global } from "../../src/exports/index.js";
+import { createFetchHandler } from "../../src/server/adapters/http.js";
+import { buildMockApp } from "../utils/mocks/mock-app-builder.js";
+import { runTestDbMigrations } from "../utils/test-db.js";
+import {
+	assertHasSummary,
+	assertPathParam,
+	assertResponse,
+	assertSecurityEmpty,
+	assertValidOpenApi31,
+	getOperation,
+	validateOpenApi31,
+} from "./openapi-test-utils.js";
+
+// ---------------------------------------------------------------------------
+// A representative app: collections + globals + routes exercising the full
+// generator surface (CRUD, versioning, workflow, relations, input/output-false
+// fields, JSON + raw routes, path-param raw routes, method-suffix siblings,
+// public + gated access, route meta, auth + search sections).
+// ---------------------------------------------------------------------------
+
+const authors = collection("authors").fields(({ f }) => ({
+	name: f.text().required(),
+}));
+
+const posts = collection("posts")
+	.fields(({ f }) => ({
+		title: f.text(255).required(),
+		content: f.textarea(),
+		viewCount: f.number().default(0),
+		published: f.boolean().default(false),
+		tags: f.text().array(),
+		author: f.relation("authors"),
+		serverOnly: f.text().inputFalse(),
+		secret: f.text().outputFalse(),
+	}))
+	.options({
+		versioning: {
+			workflow: {
+				stages: ["draft", "published"],
+				initialStage: "draft",
+			},
+		},
+	});
+
+const pages = collection("pages")
+	.fields(({ f }) => ({
+		title: f.text().required(),
+	}))
+	.options({ versioning: true });
+
+const settings = global("settings").fields(({ f }) => ({
+	siteName: f.text().required(),
+	maintenance: f.boolean().default(false),
+}));
+
+const nav = global("nav").fields(({ f }) => ({
+	items: f.text().array(),
+}));
+
+const representativeRoutes = {
+	// Public JSON route with an output schema.
+	health: route()
+		.get()
+		.access(true)
+		.outputSchema(z.object({ ok: z.boolean() }))
+		.handler(() => ({ ok: true })),
+	// JSON route with an input schema + author-provided meta.
+	bookings: route()
+		.post()
+		.schema(z.object({ name: z.string() }))
+		.meta({
+			title: "Create a booking",
+			description: "Creates a booking for the current user.",
+			tags: ["Bookings"],
+		})
+		.handler(() => ({ ok: true })),
+	// Method-suffixed raw sibling routes on one catch-all path.
+	"auth/[...path]:GET": route()
+		.get()
+		.raw()
+		.handler(() => new Response("ok")),
+	"auth/[...path]:POST": route()
+		.post()
+		.raw()
+		.handler(() => new Response("ok")),
+	// Nested + path-param raw route.
+	files: {
+		"[...key]": route()
+			.get()
+			.raw()
+			.handler(() => new Response("ok")),
+	},
+	// Gated (function access) nested JSON route with an output schema.
+	admin: {
+		stats: route()
+			.get()
+			.access(() => true)
+			.outputSchema(z.object({ total: z.number() }))
+			.handler(() => ({ total: 0 })),
+	},
+};
+
+function representativeApp() {
+	return {
+		getCollections: () => ({ authors, posts, pages }),
+		getGlobals: () => ({ settings, nav }),
+		config: { routes: representativeRoutes },
+	};
+}
+
+const representativeConfig = {
+	basePath: "/api",
+	info: { title: "Representative API", version: "1.0.0" },
+	auth: true,
+	search: true,
+} as const;
+
+// ---------------------------------------------------------------------------
+// Core: full-spec 3.1 validity
+// ---------------------------------------------------------------------------
+
+describe("OpenAPI 3.1 spec validity (full representative spec)", () => {
+	it("validates the representative spec against the OpenAPI 3.1 meta-schema with ZERO errors", async () => {
+		const spec = await generateOpenApiSpec(
+			representativeApp() as any,
+			representativeRoutes as any,
+			representativeConfig,
+		);
+
+		// Sanity: the spec is genuinely comprehensive, not a trivial stub.
+		expect(spec.openapi).toBe("3.1.0");
+		expect(Object.keys(spec.paths).length).toBeGreaterThan(20);
+		expect(Object.keys(spec.components.schemas).length).toBeGreaterThan(10);
+
+		await assertValidOpenApi31(spec);
+	});
+
+	it("validates the default spec (no config) — collections + globals + routes present", async () => {
+		const spec = await generateOpenApiSpec(
+			representativeApp() as any,
+			representativeRoutes as any,
+			{ basePath: "/api" },
+		);
+		await assertValidOpenApi31(spec);
+	});
+
+	it("validates an empty app (no collections/globals/routes) — graceful skeleton", async () => {
+		const emptyApp = {
+			getCollections: () => ({}),
+			getGlobals: () => ({}),
+			config: { routes: {} },
+		};
+		const spec = await generateOpenApiSpec(emptyApp as any, {}, {});
+		await assertValidOpenApi31(spec);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// The validator gate is REAL: it rejects a deliberately-malformed spec.
+// (Proves "generates a valid spec" can actually fail — the gate has teeth.)
+// ---------------------------------------------------------------------------
+
+describe("OpenAPI 3.1 validator gate has teeth", () => {
+	it("rejects a path parameter missing its required `schema`/`content`", async () => {
+		const broken = {
+			openapi: "3.1.0",
+			info: { title: "Broken", version: "1.0.0" },
+			paths: {
+				"/x/{id}": {
+					get: {
+						// A path parameter must carry a `schema` (or `content`).
+						parameters: [{ name: "id", in: "path", required: true }],
+						responses: { "200": { description: "ok" } },
+					},
+				},
+			},
+			components: { schemas: {} },
+		};
+		const { valid, version } = await validateOpenApi31(broken);
+		expect(version).toBe("3.1");
+		expect(valid).toBe(false);
+	});
+
+	it("rejects a response object missing the required `description`", async () => {
+		const broken = {
+			openapi: "3.1.0",
+			info: { title: "Broken", version: "1.0.0" },
+			paths: {
+				"/x": {
+					get: { responses: { "200": { foo: "bar" } } },
+				},
+			},
+			components: { schemas: {} },
+		};
+		const { valid } = await validateOpenApi31(broken);
+		expect(valid).toBe(false);
+	});
+
+	it("rejects an invalid `components.schemas` key (must match ^[a-zA-Z0-9._-]+$)", async () => {
+		const broken = {
+			openapi: "3.1.0",
+			info: { title: "Broken", version: "1.0.0" },
+			paths: {},
+			components: { schemas: { "bad key with spaces": { type: "object" } } },
+		};
+		const { valid } = await validateOpenApi31(broken);
+		expect(valid).toBe(false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Reusable helpers exercised against the real spec (so the sibling tasks can
+// rely on them). Also documents the intended content of key operations.
+// ---------------------------------------------------------------------------
+
+describe("reusable assert helpers (used against the real spec)", () => {
+	it("getOperation + assertHasSummary read a route's author-provided meta", async () => {
+		const spec = await generateOpenApiSpec(
+			representativeApp() as any,
+			representativeRoutes as any,
+			representativeConfig,
+		);
+		const op = getOperation(spec, "/api/bookings", "post");
+		assertHasSummary(op, "Create a booking");
+		expect(op.description).toBe("Creates a booking for the current user.");
+		expect(op.tags).toEqual(["Bookings"]);
+	});
+
+	it("assertSecurityEmpty confirms a public route opts out of global security", async () => {
+		const spec = await generateOpenApiSpec(
+			representativeApp() as any,
+			representativeRoutes as any,
+			representativeConfig,
+		);
+		const op = getOperation(spec, "/api/health", "get");
+		assertSecurityEmpty(op);
+	});
+
+	it("assertPathParam confirms a collection {id} operation declares the path param", async () => {
+		const spec = await generateOpenApiSpec(
+			representativeApp() as any,
+			representativeRoutes as any,
+			representativeConfig,
+		);
+		const op = getOperation(spec, "/api/posts/{id}", "get");
+		assertPathParam(op, "id");
+	});
+
+	it("assertResponse reads a declared response off a collection operation", async () => {
+		const spec = await generateOpenApiSpec(
+			representativeApp() as any,
+			representativeRoutes as any,
+			representativeConfig,
+		);
+		const op = getOperation(spec, "/api/posts/{id}", "get");
+		const ok = assertResponse(op, 200);
+		expect(ok.description).toBeDefined();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Regression: /api/openapi.json + /api/docs must return 200 through the real
+// HTTP adapter. These endpoints historically 500'd; this locks them.
+// ---------------------------------------------------------------------------
+
+describe("openApiModule endpoints (e2e through createFetchHandler)", () => {
+	async function setupHandler() {
+		const setup = await buildMockApp({
+			modules: [openApiModule as any],
+			collections: {
+				posts: collection("posts").fields(({ f }) => ({
+					title: f.text().required(),
+				})),
+			},
+			globals: {
+				settings: global("settings").fields(({ f }) => ({
+					siteName: f.text().required(),
+				})),
+			},
+		});
+		await runTestDbMigrations(setup.app);
+		const handler = createFetchHandler(setup.app, {
+			basePath: "/api",
+			requestLogging: false,
+			getSession: async () => null,
+		});
+		return { setup, handler };
+	}
+
+	it("GET /api/openapi.json → 200 with a valid OpenAPI 3.1 JSON spec", async () => {
+		const { setup, handler } = await setupHandler();
+		try {
+			const res = await handler(
+				new Request("http://localhost/api/openapi.json"),
+			);
+			expect(res?.status).toBe(200);
+			expect(res?.headers.get("content-type")).toContain("application/json");
+
+			const spec = (await res!.json()) as any;
+			expect(spec.openapi).toBe("3.1.0");
+			// The module serves with the basePath from `config/openapi.ts`
+			// (unset here → default "/"), so collection/global paths are present
+			// regardless of the exact leading prefix.
+			const pathKeys = Object.keys(spec.paths);
+			expect(pathKeys.some((p) => p.endsWith("/posts"))).toBe(true);
+			expect(pathKeys.some((p) => p.endsWith("/globals/settings"))).toBe(true);
+
+			// The served document is itself valid OpenAPI 3.1.
+			await assertValidOpenApi31(spec);
+		} finally {
+			await setup.cleanup();
+		}
+	});
+
+	it("GET /api/docs → 200 Scalar HTML", async () => {
+		const { setup, handler } = await setupHandler();
+		try {
+			const res = await handler(new Request("http://localhost/api/docs"));
+			expect(res?.status).toBe(200);
+			expect(res?.headers.get("content-type")).toContain("text/html");
+
+			const html = await res!.text();
+			// Scalar UI references the spec via the openapi.json route.
+			expect(html.toLowerCase()).toContain("<html");
+		} finally {
+			await setup.cleanup();
+		}
+	});
+
+	it("GET /api/openapi.json honours conditional requests (304 on matching ETag)", async () => {
+		const { setup, handler } = await setupHandler();
+		try {
+			const first = await handler(
+				new Request("http://localhost/api/openapi.json"),
+			);
+			const etag = first?.headers.get("etag");
+			expect(etag).toBeTruthy();
+
+			const second = await handler(
+				new Request("http://localhost/api/openapi.json", {
+					headers: { "if-none-match": etag! },
+				}),
+			);
+			expect(second?.status).toBe(304);
+		} finally {
+			await setup.cleanup();
+		}
+	});
+});

--- a/packages/questpie/test/openapi/openapi-validation.test.ts
+++ b/packages/questpie/test/openapi/openapi-validation.test.ts
@@ -12,6 +12,7 @@
  */
 
 import { describe, expect, it } from "bun:test";
+
 import { route } from "questpie";
 import { z } from "zod";
 
@@ -19,6 +20,7 @@ import { generateOpenApiSpec } from "../../../openapi/src/generator/index.js";
 import { openApiModule } from "../../../openapi/src/server.js";
 import { collection, global } from "../../src/exports/index.js";
 import { createFetchHandler } from "../../src/server/adapters/http.js";
+import coreModule from "../../src/server/modules/core/.generated/module.js";
 import { buildMockApp } from "../utils/mocks/mock-app-builder.js";
 import { runTestDbMigrations } from "../utils/test-db.js";
 import {
@@ -171,6 +173,56 @@ describe("OpenAPI 3.1 spec validity (full representative spec)", () => {
 			config: { routes: {} },
 		};
 		const spec = await generateOpenApiSpec(emptyApp as any, {}, {});
+		await assertValidOpenApi31(spec);
+	});
+});
+
+describe("post-realtime-v2 core module route coverage", () => {
+	it("includes the channels and realtime route definitions with exact methods", async () => {
+		const app = {
+			getCollections: () => ({}),
+			getGlobals: () => ({}),
+			config: { routes: coreModule.routes },
+		};
+		const spec = await generateOpenApiSpec(
+			app as any,
+			coreModule.routes as any,
+			{ basePath: "/api", auth: false, search: false },
+		);
+
+		const modulePaths = Object.fromEntries(
+			Object.entries(spec.paths)
+				.filter(
+					([path]) =>
+						path.startsWith("/api/channels/") ||
+						path.startsWith("/api/realtime"),
+				)
+				.map(([path, operations]) => [path, Object.keys(operations).sort()]),
+		);
+
+		expect(modulePaths).toEqual({
+			"/api/channels/auth": ["options", "post"],
+			"/api/channels/config": ["get"],
+			"/api/channels/publish": ["options", "post"],
+			"/api/realtime": ["post"],
+			"/api/realtime/auth": ["post"],
+			"/api/realtime/config": ["get"],
+		});
+
+		for (const path of [
+			"/api/channels/auth",
+			"/api/channels/config",
+			"/api/channels/publish",
+			"/api/realtime/auth",
+			"/api/realtime/config",
+		]) {
+			for (const operation of Object.values(spec.paths[path])) {
+				expect(operation.security).toEqual([]);
+				expect(operation.description).toContain("Raw route");
+			}
+		}
+
+		expect(spec.paths["/api/realtime"].post.security).toBeUndefined();
 		await assertValidOpenApi31(spec);
 	});
 });


### PR DESCRIPTION
## Summary

- wire route metadata into operation summaries, descriptions, and tags
- derive per-operation security from route access and async Better Auth OpenAPI schemas
- include generated core module routes, including realtime v2 and typed channels
- preserve transformed request schemas via Zod input-mode conversion and avoid false object schemas for unrepresentable outputs
- add OpenAPI 3.1 validation, endpoint regressions, and a deterministic barbershop route snapshot

## Verification

- `cd packages/openapi && bun test` — 16 pass, 0 fail
- `cd packages/openapi && bunx tsc --noEmit -p tsconfig.json` — pass
- `cd packages/openapi && bun run build` — pass
- framework OpenAPI suite — 48 pass, 0 fail, including OpenAPI 3.1 validation
- barbershop snapshot — 1 pass, 56 deterministic paths
- live barbershop app — OpenAPI 3.1.0, 305 paths, exact channels/realtime methods present
- targeted oxfmt + oxlint — clean

## Known v1 limitation

Path parameters are still emitted as `{ type: "string" }` in `generator/collections.ts`; typed path-parameter inference is intentionally deferred.

## Repo-wide baseline gates

Root `format:check`, `lint`, and `check-types` still fail in unchanged files (generated agent-run JSON, design-system/docs/AI lint debt, and existing barbershop/admin type errors). The changed files pass targeted format/lint, the OpenAPI package typecheck passes, and the failing source files are outside this branch diff.
