### PR TITLE
fix(mcp): unblock published OAuth onboarding

### DIFF
--- a/.changeset/create-questpie-mcp-module.md
+++ b/.changeset/create-questpie-mcp-module.md
@@ -1,0 +1,5 @@
+---
+"create-questpie": minor
+---
+
+Release the MCP module scaffold option so `--module mcp` installs `@questpie/mcp` and registers `mcpModule` in generated projects.

--- a/.changeset/mcp-oauth-basepath-fix.md
+++ b/.changeset/mcp-oauth-basepath-fix.md
@@ -1,0 +1,5 @@
+---
+"@questpie/mcp": patch
+---
+
+Advertise OAuth protected-resource metadata at the actual MCP adapter mount path, including generated apps mounted under `/api`.

--- a/.changeset/mcp-oauth-basepath-fix.md
+++ b/.changeset/mcp-oauth-basepath-fix.md
@@ -1,5 +1,6 @@
 ---
 "@questpie/mcp": patch
+"questpie": patch
 ---
 
-Advertise OAuth protected-resource metadata at the actual MCP adapter mount path, including generated apps mounted under `/api`.
+Advertise OAuth protected-resource metadata at the actual MCP adapter mount path, including generated apps mounted under `/api`, and allow public MCP clients to complete dynamic client registration before the user signs in.

--- a/packages/mcp/src/server/mcp-http.ts
+++ b/packages/mcp/src/server/mcp-http.ts
@@ -55,19 +55,27 @@ function withCors(response: Response, request: Request): Response {
 /**
  * Build the `WWW-Authenticate` challenge value for an unauthenticated HTTP MCP
  * request. `resource_metadata` points at this app's Protected Resource metadata
- * document (RFC 9728), served at the server root by the core `oauth-protected-
- * resource` route (MO4). An MCP client reads it to discover the authorization
- * server and start the OAuth 2.1 flow.
+ * document (RFC 9728), served beside the MCP route by the core
+ * `oauth-protected-resource` route (MO4). An MCP client reads it to discover
+ * the authorization server and start the OAuth 2.1 flow.
  *
- * The origin is derived from `app.config.app.url` — the same base MO2/MO6 use to
- * bind and verify token audience — so the advertised metadata URL always matches
- * where discovery actually lives. `new URL(...).origin` strips any path/query and
- * yields a bare `scheme://host[:port]`, so an app URL with a subpath still
- * produces a root-mounted metadata URL.
+ * The public origin comes from `app.config.app.url`, while the mount path comes
+ * from the actual MCP request. This keeps the canonical external host used for
+ * token audience binding, and also preserves adapter base paths such as `/api`.
  */
-function protectedResourceChallenge(appUrl: string): string {
-	const origin = new URL(appUrl).origin;
-	return `Bearer resource_metadata="${origin}/.well-known/oauth-protected-resource"`;
+function protectedResourceChallenge(
+	appUrl: string,
+	requestUrl: string,
+): string {
+	const request = new URL(requestUrl);
+	request.pathname = request.pathname.replace(/\/+$/, "");
+	const metadataPath = new URL(".well-known/oauth-protected-resource", request)
+		.pathname;
+	const metadataUrl = new URL(appUrl);
+	metadataUrl.pathname = metadataPath;
+	metadataUrl.search = "";
+	metadataUrl.hash = "";
+	return `Bearer resource_metadata="${metadataUrl.href}"`;
 }
 
 /**
@@ -100,7 +108,10 @@ export async function mcpHandler(ctx: RawRouteHandlerArgs): Promise<Response> {
 			new Response(null, {
 				status: 401,
 				headers: {
-					"WWW-Authenticate": protectedResourceChallenge(app.config.app.url),
+					"WWW-Authenticate": protectedResourceChallenge(
+						app.config.app.url,
+						request.url,
+					),
 				},
 			}),
 			request,

--- a/packages/mcp/test/mcp-route-auth.test.ts
+++ b/packages/mcp/test/mcp-route-auth.test.ts
@@ -77,9 +77,7 @@ async function readJsonRpc(response: Response): Promise<any> {
 	try {
 		return JSON.parse(text);
 	} catch {
-		const line = text
-			.split("\n")
-			.find((l) => l.startsWith("data:"));
+		const line = text.split("\n").find((l) => l.startsWith("data:"));
 		return line ? JSON.parse(line.slice("data:".length).trim()) : undefined;
 	}
 }
@@ -112,6 +110,43 @@ describe("MO9 HTTP MCP route auth gate", () => {
 		);
 		// No internal error details leaked in the body.
 		expect(await response!.text()).toBe("");
+	});
+
+	it("advertises reachable protected-resource metadata when mounted under /api", async () => {
+		const appUrl = "https://cms.example.com";
+		const setup = await buildMockApp(
+			{
+				modules: [starterModule, mcpModule],
+				auth: {
+					emailAndPassword: {
+						enabled: true,
+						requireEmailVerification: false,
+					},
+				},
+			},
+			{
+				app: { url: appUrl },
+				secret: "test-auth-secret-with-more-than-32-chars",
+			},
+		);
+		cleanup = setup.cleanup;
+		await runTestDbMigrations(setup.app);
+		const handler = createFetchHandler(setup.app, { basePath: "/api" });
+
+		const response = await handler(toolsListRequest(`${appUrl}/api/mcp`));
+		const challenge = response!.headers.get("WWW-Authenticate");
+		const metadataUrl = challenge?.match(/resource_metadata="([^"]+)"/)?.[1];
+
+		expect(response!.status).toBe(401);
+		expect(metadataUrl).toBe(
+			`${appUrl}/api/.well-known/oauth-protected-resource`,
+		);
+
+		const metadataResponse = await handler(new Request(metadataUrl!));
+		expect(metadataResponse!.status).toBe(200);
+		expect(await metadataResponse!.json()).toMatchObject({
+			resource: `${appUrl}/api/mcp`,
+		});
 	});
 
 	it("derives the challenge origin from app.config.app.url even when it carries a path/port", async () => {

--- a/packages/mcp/test/oauth-mcp-e2e.test.ts
+++ b/packages/mcp/test/oauth-mcp-e2e.test.ts
@@ -156,7 +156,9 @@ async function obtainAccessToken(
 	const regRes = await auth.handler(
 		new Request(`${AUTH_BASE}/oauth2/register`, {
 			method: "POST",
-			headers: { "content-type": "application/json", cookie },
+			// DCR precedes user authorization, so a new external client has no
+			// QUESTPIE session cookie yet.
+			headers: { "content-type": "application/json" },
 			body: JSON.stringify({
 				redirect_uris: [REDIRECT_URI],
 				client_name: "MO13 MCP Client",
@@ -255,6 +257,39 @@ async function connectStdio(server: McpServer) {
 // ---------------------------------------------------------------------------
 
 describe("MO13 end-to-end OAuth MCP flow + system mode", () => {
+	it("lets a public MCP client register before the user signs in", async () => {
+		const setup = await buildMockApp(
+			{ modules: [starterModule] },
+			{
+				app: { url: ORIGIN },
+				secret: "test-auth-secret-with-more-than-32-chars",
+			},
+		);
+
+		try {
+			await runTestDbMigrations(setup.app);
+			const response = await setup.app.auth.handler(
+				new Request(`${AUTH_BASE}/oauth2/register`, {
+					method: "POST",
+					headers: { "content-type": "application/json" },
+					body: JSON.stringify({
+						redirect_uris: [REDIRECT_URI],
+						client_name: "Unauthenticated MCP Client",
+						token_endpoint_auth_method: "none",
+						grant_types: ["authorization_code"],
+						response_types: ["code"],
+						scope: "openid",
+					}),
+				}),
+			);
+
+			expect(response.status).toBe(200);
+			expect((await response.json()).client_id).toBeString();
+		} finally {
+			await setup.cleanup();
+		}
+	});
+
 	async function setupApp() {
 		const setup = await buildMockApp(
 			{
@@ -278,7 +313,7 @@ describe("MO13 end-to-end OAuth MCP flow + system mode", () => {
 							loginPage: "/admin/login",
 							consentPage: "/admin/oauth/consent",
 							allowDynamicClientRegistration: true,
-							allowUnauthenticatedClientRegistration: false,
+							allowUnauthenticatedClientRegistration: true,
 							validAudiences: [MCP_AUD],
 							accessTokenExpiresIn: 3600,
 						}),

--- a/packages/questpie/src/server/modules/oauth/config/auth.ts
+++ b/packages/questpie/src/server/modules/oauth/config/auth.ts
@@ -77,10 +77,12 @@ export default authConfig({
 			advertisedMetadata: {
 				scopes_supported: ["openid", "profile", "email"],
 			},
-			// RFC 7591 dynamic client registration — MCP clients self-register —
-			// but keep it gated: unauthenticated registration stays off.
+			// RFC 7591 dynamic client registration happens before the user signs in,
+			// so an external MCP client cannot already carry an app session here.
+			// Registration only creates a public PKCE client; it grants no user data
+			// or scopes until the separate authorization + consent flow succeeds.
 			allowDynamicClientRegistration: true,
-			allowUnauthenticatedClientRegistration: false,
+			allowUnauthenticatedClientRegistration: true,
 			// OAuth 2.1: PKCE. There is no global plugin toggle; the provider
 			// enforces PKCE for every DCR-registered (public) client — a client
 			// registering with `require_pkce: false` is rejected. MCP clients

--- a/scripts/publish-manifest.test.ts
+++ b/scripts/publish-manifest.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+
+import mcpPackageJson from "../packages/mcp/package.json";
+import {
+	assertNoWorkspaceProtocols,
+	replaceWorkspaceVersions,
+} from "./publish-manifest";
+
+describe("publish manifest workspace dependencies", () => {
+	test("resolves @questpie/mcp's questpie dependency before publish", () => {
+		const dependencies = replaceWorkspaceVersions(
+			mcpPackageJson.dependencies,
+			new Map([["questpie", "3.15.0"]]),
+		);
+
+		expect(dependencies?.questpie).toBe("^3.15.0");
+		assertNoWorkspaceProtocols({
+			...mcpPackageJson,
+			dependencies,
+		});
+	});
+
+	test("rejects a manifest that would publish a workspace protocol", () => {
+		expect(() => assertNoWorkspaceProtocols(mcpPackageJson)).toThrow(
+			"dependencies.questpie=workspace:*",
+		);
+	});
+});

--- a/scripts/publish-manifest.ts
+++ b/scripts/publish-manifest.ts
@@ -1,0 +1,47 @@
+type DependencyMap = Record<string, string>;
+
+type PublishManifest = {
+	dependencies?: DependencyMap;
+	optionalDependencies?: DependencyMap;
+	peerDependencies?: DependencyMap;
+};
+
+export function replaceWorkspaceVersions(
+	dependencies: DependencyMap | undefined,
+	versions: ReadonlyMap<string, string>,
+): DependencyMap | undefined {
+	if (!dependencies) return dependencies;
+
+	return Object.fromEntries(
+		Object.entries(dependencies).map(([name, version]) => {
+			if (!version.startsWith("workspace:")) return [name, version];
+
+			const actualVersion = versions.get(name);
+			if (!actualVersion) return [name, version];
+			if (version === "workspace:~") return [name, `~${actualVersion}`];
+			return [name, `^${actualVersion}`];
+		}),
+	);
+}
+
+export function assertNoWorkspaceProtocols(manifest: PublishManifest): void {
+	const unresolved: string[] = [];
+
+	for (const key of [
+		"dependencies",
+		"optionalDependencies",
+		"peerDependencies",
+	] as const) {
+		for (const [name, version] of Object.entries(manifest[key] ?? {})) {
+			if (version.startsWith("workspace:")) {
+				unresolved.push(`${key}.${name}=${version}`);
+			}
+		}
+	}
+
+	if (unresolved.length > 0) {
+		throw new Error(
+			`Refusing to publish unresolved workspace protocols: ${unresolved.join(", ")}`,
+		);
+	}
+}

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -18,6 +18,11 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { promisify } from "node:util";
 
+import {
+	assertNoWorkspaceProtocols,
+	replaceWorkspaceVersions,
+} from "./publish-manifest";
+
 const execAsync = promisify(exec);
 
 const ROOT_DIR = path.join(import.meta.dirname, "..");
@@ -82,41 +87,6 @@ function getWorkspaceVersions(
 	return versions;
 }
 
-// Replace workspace:* with actual versions in a dependencies object
-function replaceWorkspaceVersions(
-	deps: Record<string, string> | undefined,
-	versions: Map<string, string>,
-): Record<string, string> | undefined {
-	if (!deps) return deps;
-
-	const result: Record<string, string> = {};
-
-	for (const [name, version] of Object.entries(deps)) {
-		if (version.startsWith("workspace:")) {
-			const actualVersion = versions.get(name);
-			if (actualVersion) {
-				if (version === "workspace:*" || version === "workspace:^") {
-					result[name] = `^${actualVersion}`;
-				} else if (version === "workspace:~") {
-					result[name] = `~${actualVersion}`;
-				} else {
-					result[name] = `^${actualVersion}`;
-				}
-				console.log(`    ${name}: ${version} -> ${result[name]}`);
-			} else {
-				console.warn(
-					`    ⚠️  ${name}: workspace version not found, keeping as-is`,
-				);
-				result[name] = version;
-			}
-		} else {
-			result[name] = version;
-		}
-	}
-
-	return result;
-}
-
 // Topological sort — returns packages in publish order (leaf deps first)
 function topoSort(
 	packages: Map<string, { dir: string; pkg: PackageJson }>,
@@ -133,10 +103,7 @@ function topoSort(
 		if (!entry) return;
 
 		// Visit all workspace dependencies first
-		for (const deps of [
-			entry.pkg.dependencies,
-			entry.pkg.peerDependencies,
-		]) {
+		for (const deps of [entry.pkg.dependencies, entry.pkg.peerDependencies]) {
 			if (!deps) continue;
 			for (const dep of Object.keys(deps)) {
 				if (names.has(dep)) visit(dep);
@@ -171,7 +138,7 @@ async function main() {
 	const originals = new Map<string, string>();
 
 	// Save originals and apply transformations
-	for (const [name, { dir }] of packages) {
+	for (const [, { dir }] of packages) {
 		const packageJsonPath = path.join(dir, "package.json");
 		const original = fs.readFileSync(packageJsonPath, "utf-8");
 		originals.set(packageJsonPath, original);
@@ -221,6 +188,8 @@ async function main() {
 				modified = true;
 			}
 		}
+
+		assertNoWorkspaceProtocols(packageJson);
 
 		if (modified) {
 			fs.writeFileSync(


### PR DESCRIPTION
## Summary

- preserve the actual adapter mount path in MCP OAuth protected-resource discovery challenges, including `/api` scaffolds
- allow standards-compliant public MCP clients to register before the user signs in; PKCE, consent, scopes, and RBAC remain mandatory
- reject unresolved `workspace:` dependency protocols before npm publish and cover the real `@questpie/mcp` manifest
- release the already-implemented `create-questpie --module mcp` option with a minor changeset

## Verification

- `cd packages/mcp && bun test` — 77 pass, 0 fail
- `cd packages/mcp && bun run check-types && bun run build`
- `cd packages/questpie && bun run check-types`
- `cd packages/create-questpie && bun test` — 11 pass, 0 fail
- `cd packages/create-questpie && bun run check-types && bun run build`
- `bun test scripts/publish-manifest.test.ts` — 2 pass, 0 fail
- direct source CLI scaffold with `--modules admin,openapi,mcp` emitted `@questpie/mcp` and `mcpModule`
- targeted oxfmt, oxlint, and `git diff --check` pass

## Release follow-up

After merge, the owner-gated release must be regenerated/updated and the published artifacts verified with a fresh `create-questpie@latest` scaffold plus `bun add @questpie/mcp@latest`.