### PR TITLE
chore: unify runtime package versions

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -9,9 +9,13 @@
 		[
 			"questpie",
 			"@questpie/admin",
+			"@questpie/ai",
 			"@questpie/elysia",
 			"@questpie/hono",
+			"@questpie/mcp",
 			"@questpie/next",
+			"@questpie/openapi",
+			"@questpie/sandbox",
 			"@questpie/tanstack-query",
 			"@questpie/workflows"
 		]


### PR DESCRIPTION
## Summary

- add `@questpie/ai`, `@questpie/mcp`, `@questpie/openapi`, and `@questpie/sandbox` to the existing runtime fixed-version group
- keep `create-questpie`, `@questpie/vite-plugin-iconify`, and private workspace packages on independent version tracks
- preserve the existing pending changesets so the generated changelogs retain the full release narrative

## Why

QUESTPIE runtime packages ship as one compatibility train. Keeping the runtime packages in one Changesets fixed group makes their public version unambiguous and ensures they are versioned and published together.

The pending release plan resolves all 11 runtime packages to `3.15.0`, while `create-questpie` remains `2.2.0`.

## Validation

- `jq empty .changeset/config.json`
- `bunx oxfmt --check .changeset/config.json`
- `git diff --check`
- `bunx @changesets/cli status --output /tmp/questpie-unified-release-plan.json`
- asserted exactly 11 runtime releases at `3.15.0`, `create-questpie@2.2.0`, and no vite-plugin release
