### PR TITLE
docs: guard public pages from provenance leaks

### DIFF
--- a/apps/docs/content/docs/adapters/kv.mdx
+++ b/apps/docs/content/docs/adapters/kv.mdx
@@ -105,7 +105,7 @@ await adapter?.invalidateByTags?.(["post:123", "post:124"]);
 ```
 
 <Callout type="warn" title="On the zero-config default, `app.config.kv?.adapter` is `undefined`">
-`app.config` is your *raw* config object. When you omit `kv.adapter`, the default `MemoryKVAdapter` is constructed **inside** `KVService` (`service.ts:11`) and never written back to `app.config`, so on the default setup `app.config.kv?.adapter` is `undefined` and the `?.` calls above **silently do nothing**, even though `MemoryKVAdapter` fully implements `setWithTags` / `invalidateByTag` (`memory.ts:28`). Tag invalidation is only reachable when you construct an adapter explicitly: either set `kv.adapter` in config and read it back via `app.config.kv?.adapter`, or, cleaner, keep your own reference to the adapter you built and call its tag methods directly.
+`app.config` is your *raw* config object. When you omit `kv.adapter`, the default `MemoryKVAdapter` is constructed **inside** `KVService` and never written back to `app.config`, so on the default setup `app.config.kv?.adapter` is `undefined` and the `?.` calls above **silently do nothing**, even though `MemoryKVAdapter` fully implements `setWithTags` / `invalidateByTag`. Tag invalidation is only reachable when you construct an adapter explicitly: either set `kv.adapter` in config and read it back via `app.config.kv?.adapter`, or, cleaner, keep your own reference to the adapter you built and call its tag methods directly.
 </Callout>
 
 <Callout type="info" title="Tag methods live on the adapter, not the service">
@@ -114,7 +114,7 @@ await adapter?.invalidateByTags?.(["post:123", "post:124"]);
 
 ## Configuration
 
-KV is configured under the `kv` key of your `questpie.config.ts` (`QuestpieConfig.kv`, source: `packages/questpie/src/server/config/types.ts:554`). The shape is `KVConfig`:
+KV is configured under the `kv` key of your `questpie.config.ts`. The shape is `KVConfig`:
 
 ```ts
 interface KVConfig {
@@ -130,7 +130,7 @@ interface KVConfig {
 | `adapter` | `KVAdapter` | `new MemoryKVAdapter()` | The backend. Omit for in-memory. |
 | `defaultTtl` | `number` | _(none)_ | Seconds. Applied by `KVService.set` only when the call omits its own `ttl`. |
 
-Source for the default + `defaultTtl` fallback: `kv/service.ts:11,19`.
+When a call omits its own TTL, the service uses `defaultTtl`.
 
 ## Adapters
 
@@ -180,7 +180,7 @@ export default runtimeConfig({
 });
 ```
 
-`redisKVAdapter` options (source: `kv/adapters/redis.ts:29`):
+`redisKVAdapter` accepts these options:
 
 | Option | Type | Default | Notes |
 |---|---|---|---|
@@ -214,7 +214,7 @@ export default runtimeConfig({
 });
 ```
 
-`cloudflareKVAdapter` options (source: `kv/adapters/cloudflare-kv.ts:41`):
+`cloudflareKVAdapter` accepts these options:
 
 | Option | Type | Default | Notes |
 |---|---|---|---|
@@ -249,7 +249,7 @@ export class MyKVAdapter implements KVAdapter {
 }
 ```
 
-Wire it under `kv.adapter` exactly like the built-ins. The five core methods are required; the three tag methods are optional. `ttl` is always in **seconds**. Source for the contract: `packages/questpie/src/server/modules/core/integrated/kv/adapter.ts:4`. For the full pattern that applies to every adapter kind, see [Building a plugin](/docs/extend/build-a-plugin).
+Wire it under `kv.adapter` exactly like the built-ins. The five core methods are required; the three tag methods are optional. `ttl` is always in **seconds**. For the full pattern that applies to every adapter kind, see [Building a plugin](/docs/extend/build-a-plugin).
 
 ## TypeScript
 

--- a/apps/docs/content/docs/adapters/realtime.mdx
+++ b/apps/docs/content/docs/adapters/realtime.mdx
@@ -48,12 +48,12 @@ That's the whole server requirement. Subscribe from the client with `client.coll
 
 The flow, from a write to a pushed snapshot:
 
-| Step                           | What happens                                                                                                                                                        | Source                                             |
-| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
-| 1. Transaction captures change | A create/update/delete appends one row to `questpie_realtime_log` using the mutation-bound `db`; the business row and outbox row commit or roll back together.      | `realtime/service.ts`; transactional capture hooks |
-| 2. Signal                      | The adapter `notify(event)` broadcasts a minimal `RealtimeNotice` (`{ seq, resourceType, resource, operation }`) to every instance.                                 | `realtime/adapter.ts:9`; `realtime/service.ts:249` |
-| 3. Drain                       | Each instance reacts to the notice (or a poll tick) by `drain()`ing new outbox rows past its watermark.                                                             | `realtime/service.ts:418-426`                      |
-| 4. Re-run + push               | For each affected subscription, the server re-runs the query **under the subscriber's session** and pushes the fresh snapshot over its `POST /realtime` SSE stream. | `realtime/service.ts` (drain → listeners)          |
+| Step                           | What happens                                                                                                                                                        |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1. Transaction captures change | A create/update/delete appends one row to `questpie_realtime_log` using the mutation-bound `db`; the business row and outbox row commit or roll back together.      |
+| 2. Signal                      | The adapter `notify(event)` broadcasts a minimal `RealtimeNotice` (`{ seq, resourceType, resource, operation }`) to every instance.                                 |
+| 3. Drain                       | Each instance reacts to the notice (or a poll tick) by `drain()`ing new outbox rows past its watermark.                                                             |
+| 4. Re-run + push               | For each affected subscription, the server re-runs the query **under the subscriber's session** and pushes the fresh snapshot over its `POST /realtime` SSE stream. |
 
 The broker is only a _latency hint_ (steps 2-3). The outbox (step 1), unconditional reconciliation, and access-controlled re-run (step 4) provide correctness regardless of which driver you pick. Wakes are intentionally unordered, at-most-once, and coalescable.
 

--- a/apps/docs/content/docs/concepts/blocks.mdx
+++ b/apps/docs/content/docs/concepts/blocks.mdx
@@ -316,7 +316,7 @@ export function HeroRenderer({ values, data, children }: BlockProps<"hero">) {
 }
 ```
 
-`values` is typed from the block's `.fields()`; `data` is typed from its `.prefetch()`. Layout blocks (`.allowChildren()`) render their nested blocks through `children`. Sources: `packages/admin/src/client/blocks/block-renderer.tsx`, `examples/tanstack-barbershop/src/components/pages/PageRenderer.tsx`, `examples/tanstack-barbershop/src/questpie/admin/blocks/hero.tsx`.
+`values` is typed from the block's `.fields()`; `data` is typed from its `.prefetch()`. Layout blocks (`.allowChildren()`) render their nested blocks through `children`. The runnable [TanStack barbershop example](https://github.com/questpie/questpie/tree/main/examples/tanstack-barbershop) shows a complete page renderer paired with admin block components.
 
 <Callout type="info" title="What `BlockRenderer` actually passes each renderer">
 At runtime, `BlockRenderer` passes each renderer component `id`, `type` (the block type name, an extra prop the typed shape below omits), `values`, `data`, and the rendered `children`, and nothing else. The `isSelected` / `isPreview` fields in the renderer-props type are **reserved and not wired by `BlockRenderer`**: they are always `undefined` here, so don't build rendering logic on them (selection state lives on the editor wrapper, not the renderer). Stick to `values`, `data`, and `children`.
@@ -369,7 +369,7 @@ type HeroProps = BlockProps<"hero">;
 import type { BlocksDocument, BlockNode } from "@questpie/admin/fields";
 ```
 
-If you build blocks programmatically (a plugin), `block`, `BlockBuilder`, `AdminBlockConfig`, `BlockCategoryConfig`, `AdminConfigContext`, `BlockPrefetchContext`, and the inference helpers `InferBlockValues` / `InferBlockData` are exported from `@questpie/admin/factories` (and `@questpie/admin/server`); `BlockRenderer`, `BlockRendererProps`, `BlockContent`, `BlockNode`, and `isBlockContent` from `@questpie/admin/client`. Sources: `packages/admin/src/exports/{server,factories,fields,client}.ts`.
+If you build blocks programmatically (a plugin), `block`, `BlockBuilder`, `AdminBlockConfig`, `BlockCategoryConfig`, `AdminConfigContext`, `BlockPrefetchContext`, and the inference helpers `InferBlockValues` / `InferBlockData` are exported from `@questpie/admin/factories` (and `@questpie/admin/server`); `BlockRenderer`, `BlockRendererProps`, `BlockContent`, `BlockNode`, and `isBlockContent` from `@questpie/admin/client`.
 
 <Callout type="info" title="Import `block` from `#questpie/factories`, not `@questpie/admin/server`">
 In app code, always import `block` from `#questpie/factories`. The generated factory wraps the field proxy with your enabled modules so `f.richText()` / `f.blocks()` are available inside a block's `.fields()`; the bare `block()` from `@questpie/admin/server` only sees builtin fields.

--- a/apps/docs/content/docs/concepts/collections.mdx
+++ b/apps/docs/content/docs/concepts/collections.mdx
@@ -209,7 +209,7 @@ The rule context spreads the full `AppContext` (`db`, `session`, `kv`, `queue`, 
 A rule that returns an `AccessWhere` object grants *filtered* access, rows are narrowed by that condition. A rule function that **throws** denies with a reason. Beyond CRUD, two extra rules exist: `serve` (upload-byte access, resolves `serve` → `read` → `defaultAccess.serve` → allow) and `introspect` (admin schema visibility, visible iff any CRUD op is allowed). Field-level rules go under `access.fields` and can only allow/deny (no filtering); their context is slim (`{ req?, user?, doc?, operation }`), not the full `AppContext`.
 
 <Callout type="warn" title="Secure by default">
-An **undefined** access rule is not "open", it requires a session. Leave `read` unset and anonymous reads are rejected. Set `read: true` to make a collection public on purpose. The enforcement is one line, `if (rule === undefined) return !!context.session;`, in `packages/questpie/src/server/collection/crud/shared/access-control.ts:85` (doc-commented "secure by default" at `:54-65`).
+An **undefined** access rule is not "open", it requires a session. Leave `read` unset and anonymous reads are rejected. Set `read: true` to make a collection public on purpose.
 </Callout>
 
 <Callout type="info" title="`.access()` replaces; `.merge()` shallow-merges">

--- a/apps/docs/content/docs/concepts/configuration.mdx
+++ b/apps/docs/content/docs/concepts/configuration.mdx
@@ -186,7 +186,7 @@ Everything below `app`/`db` is optional. The full `RuntimeConfigInput` shape:
 | `autoSeed`     | `boolean \| SeedCategory \| SeedCategory[]` | Run [seeds](/docs/concepts/seeds) on startup.                                  |
 | `cli`          | `{ migrations?, seeds? }`                   | Override generated-migration / [seed](/docs/concepts/seeds) directories.       |
 
-The input type is `RuntimeConfigInput` at `packages/questpie/src/server/config/module-types.ts:407`, defined as `Partial<Pick<RuntimeConfig, "app" | "db">> & Omit<RuntimeConfig, "app" | "db">`, i.e. the resolved `RuntimeConfig` interface (`:308`, where every adapter type lives) with `app` and `db` made optional. `DbConfig` itself is a union, `{ url }`, `{ pglite }`, `{ drizzle }` (a pre-built client, for Neon / Vercel Postgres / Hyperdrive), or `{ create }` (a lazy factory, preferred for Cloudflare Workers).
+The input type is `RuntimeConfigInput`, defined as `Partial<Pick<RuntimeConfig, "app" | "db">> & Omit<RuntimeConfig, "app" | "db">`: the resolved `RuntimeConfig` interface with `app` and `db` made optional. `DbConfig` itself is a union, `{ url }`, `{ pglite }`, `{ drizzle }` (a pre-built client, for Neon / Vercel Postgres / Hyperdrive), or `{ create }` (a lazy factory, preferred for Cloudflare Workers).
 
 <Callout type="info" title="`plugins` is for codegen plugins, not modules">
 	`runtimeConfig({plugins})` registers **codegen plugins** (the thing that adds
@@ -433,7 +433,7 @@ export const blogModule = module({
 	anything in `questpie.config.ts`, adding the module to `modules.ts` is enough.
 </Callout>
 
-The full module surface (`ModuleDefinition`), how modules contribute each category, and the depth-first merge are covered in the Extend → Modules section. The full `module()` and `ModuleDefinition` reference lives at `packages/questpie/src/server/config/create-app.ts:58` and `module-types.ts:94`.
+The full module surface (`ModuleDefinition`), how modules contribute each category, and the depth-first merge are covered in [Extend → Modules](/docs/extend/modules).
 
 ## CLI config
 

--- a/apps/docs/content/docs/concepts/fields.mdx
+++ b/apps/docs/content/docs/concepts/fields.mdx
@@ -62,7 +62,7 @@ const posts = collection("posts").fields(({ f }) => ({
 // }
 ```
 
-How the type maps are derived (read-only reference): `ExtractInputType` / `ExtractSelectType` / `ExtractWhereType` in `packages/questpie/src/server/fields/field-class-types.ts`.
+The public `ExtractInputType`, `ExtractSelectType`, and `ExtractWhereType` helpers expose the corresponding type maps for plugin and library authors.
 
 ## Field types
 
@@ -105,7 +105,7 @@ contact: f.email().required(),             // validated z.string().email()
 website: f.url(),                          // validated z.string().url(), len 2048
 ```
 
-For `text`/`textarea`/`email`/`url`, `.min(n)` / `.max(n)` constrain **string length** (they map to `minLength` / `maxLength`). `email` and `url` add `.email()` / `.url()` format validation automatically. Sources: `packages/questpie/src/server/modules/core/fields/{text,textarea,email,url}.ts`.
+For `text`/`textarea`/`email`/`url`, `.min(n)` / `.max(n)` constrain **string length** (they map to `minLength` / `maxLength`). `email` and `url` add `.email()` / `.url()` format validation automatically.
 
 <Callout type="warn">
   `.trim()`, `.lowercase()`, and `.uppercase()` set runtime state but are **not currently applied to the Zod schema**, `derive-schema.ts` only emits `maxLength` / `minLength` / `pattern` for strings, so these three do not transform or validate the value yet. To normalize input, use a `.zod()` refinement or a field hook instead.
@@ -153,7 +153,7 @@ birthday: f.date(),                                    // ISO date string
 opensAt: f.time(),                                     // "09:00:00"
 ```
 
-`datetime` reads back as a real `Date`; `date` and `time` read back as strings. `.autoNow()` sets a `() => new Date()` default; `.autoNowUpdate()` adds a `beforeChange` hook that stamps the current time on every write. The classic pair is `.autoNow().inputFalse()` for `createdAt` and `.autoNowUpdate().inputFalse()` for `updatedAt`. Sources: `packages/questpie/src/server/modules/core/fields/{date,datetime,time}.ts`.
+`datetime` reads back as a real `Date`; `date` and `time` read back as strings. `.autoNow()` sets a `() => new Date()` default; `.autoNowUpdate()` adds a `beforeChange` hook that stamps the current time on every write. The classic pair is `.autoNow().inputFalse()` for `createdAt` and `.autoNowUpdate().inputFalse()` for `updatedAt`.
 
 ### Select
 
@@ -178,7 +178,7 @@ tags: f.select([
 ]).array(),
 ```
 
-Passing static options narrows the field's read type to the **literal union** of those values. Multi-select is `.array()`, there is no separate multi factory. Dynamic, server-driven options (search + pagination) use an `OptionsConfig` `{ handler, deps? }`; the read type then widens to `string`. `.enum(name)` creates a fresh `pgEnum` from the option values. Sources: `packages/questpie/src/server/modules/core/fields/select.ts`, `packages/questpie/src/server/fields/reactive-types.ts`.
+Passing static options narrows the field's read type to the **literal union** of those values. Multi-select is `.array()`, there is no separate multi factory. Dynamic, server-driven options (search + pagination) use an `OptionsConfig` `{ handler, deps? }`; the read type then widens to `string`. `.enum(name)` creates a fresh `pgEnum` from the option values.
 
 ### Relation
 
@@ -289,7 +289,7 @@ content: f.richText({ mode: "markdown" }),// stored as markdown text
 body: f.blocks(),                          // block-based page builder
 ```
 
-These two are contributed by `@questpie/admin` and are only on `f` when the admin module is active. `richText` defaults to a TipTap JSON document (`mode: "markdown"` stores a markdown string instead). `blocks` stores a block tree built from your `block(name)` declarations. Sources: `packages/admin/src/server/fields/{rich-text,blocks}.ts`.
+These two are contributed by `@questpie/admin` and are only on `f` when the admin module is active. `richText` defaults to a TipTap JSON document (`mode: "markdown"` stores a markdown string instead). `blocks` stores a block tree built from your `block(name)` declarations.
 
 <Callout type="info">
   `f.richText()` and `f.blocks()` exist only when the admin module is registered, they ride in on the generated `f` alongside the 15 core types. Without the admin module, accessing them throws the "Unknown field type" error.
@@ -374,7 +374,7 @@ phone: f.text(50).admin({ placeholder: "+1 (555) 000-0000" }),
 createdAt: f.datetime().drizzle((c) => c.default(sql`now()`)),
 ```
 
-Full method source: `packages/questpie/src/server/fields/field-class.ts`.
+The shared methods above are available on every registered field type.
 
 ## Advanced
 
@@ -388,7 +388,7 @@ A new field type is declared with `fieldType(name, { create, methods })`, the de
 
 ### Custom operator sets
 
-`.operators(ops)` overrides the WHERE operators for a field. Build a set with `operator<TValue>((col, value, ctx) => SQL)` / `operatorSet(...)`. The built-in sets, `stringOps`, `numberOps`, `booleanOps`, `dateOps`, `selectSingleOps`, `belongsToOps`, …, live in `packages/questpie/src/server/operators/builtin.ts`.
+`.operators(ops)` overrides the WHERE operators for a field. Build a set with `operator<TValue>((col, value, ctx) => SQL)` / `operatorSet(...)`. Built-in field types register their corresponding string, number, boolean, date, select, and relation operator sets automatically.
 
 ## TypeScript
 
@@ -401,7 +401,7 @@ type Post = CollectionDoc<"posts">;          // the read shape
 type PostFilter = CollectionWhere<"posts">;  // the typed where clause
 ```
 
-If you need the field primitives themselves (building a plugin or a custom field type), they are exported from `questpie` and `questpie/builders`: `Field`, `field`, `fieldType`, `FieldState`, `FieldWithMethods`, the `Extract*Type` helpers, and the reactive types. Admin's `richText` / `blocks` and their state/document types come from `@questpie/admin/fields`. Sources: `packages/questpie/src/exports/index.ts`, `packages/admin/src/exports/fields.ts`.
+If you need the field primitives themselves (building a plugin or a custom field type), they are exported from `questpie` and `questpie/builders`: `Field`, `field`, `fieldType`, `FieldState`, `FieldWithMethods`, the `Extract*Type` helpers, and the reactive types. Admin's `richText` / `blocks` and their state/document types come from `@questpie/admin/fields`.
 
 <Callout type="info">
   You don't import the field factories (`text`, `relation`, …) directly in app code, they ride in on the destructured `f` inside `.fields()`. Direct factory imports are for library/plugin authors building custom `f` proxies via `createFieldBuilder`.

--- a/apps/docs/content/docs/concepts/fields/array.mdx
+++ b/apps/docs/content/docs/concepts/fields/array.mdx
@@ -60,10 +60,10 @@ The inner field is preserved on the state (`innerField` / `innerState`), so per-
 
 `.array()` itself takes no arguments. The two modifiers that only make sense on an array are:
 
-| Method | Effect | Source |
-|---|---|---|
-| `.minItems(n)` | Array must have **at least** `n` elements (`z.array(...).min(n)`). | `field-class.ts:336` |
-| `.maxItems(n)` | Array may have **at most** `n` elements (`z.array(...).max(n)`). | `field-class.ts:341` |
+| Method | Effect |
+|---|---|
+| `.minItems(n)` | Array must have **at least** `n` elements (`z.array(...).min(n)`). |
+| `.maxItems(n)` | Array may have **at most** `n` elements (`z.array(...).max(n)`). |
 
 Everything else is a [shared modifier](/docs/concepts/fields#shared-methods) and applies to the array as a whole:
 

--- a/apps/docs/content/docs/concepts/fields/number.mdx
+++ b/apps/docs/content/docs/concepts/fields/number.mdx
@@ -69,7 +69,7 @@ collection("orders").fields(({ f }) => ({
 }));
 ```
 
-All five refinements are applied to the derived Zod schema in `applyRefinements` (`packages/questpie/src/server/fields/derive-schema.ts:136`). They run on create and update.
+All five refinements are applied to the derived Zod schema during create and update validation.
 
 <Callout type="info" title="`.min()` / `.max()` here are VALUE bounds, not string length">
 On a number field, `.min(n)` / `.max(n)` constrain the numeric **value**. On [`f.text()`](/docs/concepts/fields/text) the same method names constrain **string length** (they map to `minLength` / `maxLength`). Same names, different meaning, sized by the field's type.

--- a/apps/docs/content/docs/concepts/fields/rich-text.mdx
+++ b/apps/docs/content/docs/concepts/fields/rich-text.mdx
@@ -156,7 +156,7 @@ The field-level `.admin()` accepts `unknown`, it does not type-check the editor 
 </Callout>
 
 <Callout type="warn" title="Markdown mode round-trips through the markdown extension">
-A `markdown`-mode field stores a plain markdown string. The editor loads and saves it via the `tiptap-markdown` extension, which is wired up from the field's `outputMode`. If you author a custom editor or drop the extension, the body can render empty and autosave an empty string over your content, a real regression that's covered by a dedicated test (`packages/admin/test/client/rich-text-markdown.test.ts`). Stick with the built-in editor for markdown fields.
+A `markdown`-mode field stores a plain markdown string. The editor loads and saves it via the `tiptap-markdown` extension, which is wired up from the field's `outputMode`. If you author a custom editor or drop the extension, the body can render empty and autosave an empty string over your content. Stick with the built-in editor for markdown fields.
 </Callout>
 
 ## TypeScript

--- a/apps/docs/content/docs/concepts/fields/textarea.mdx
+++ b/apps/docs/content/docs/concepts/fields/textarea.mdx
@@ -54,7 +54,7 @@ const posts = collection("posts").fields(({ f }) => ({
 // }
 ```
 
-Like every field, `textarea` is optional and nullable by default; `.required()` makes the column `NOT NULL` and the value required on insert. The read/insert/where shapes are derived by `ExtractSelectType` / `ExtractInputType` / `ExtractWhereType` in `packages/questpie/src/server/fields/field-class-types.ts`.
+Like every field, `textarea` is optional and nullable by default; `.required()` makes the column `NOT NULL` and the value required on insert. The public `ExtractSelectType`, `ExtractInputType`, and `ExtractWhereType` helpers expose its derived read, insert, and filter shapes.
 
 ## Constructor & methods
 
@@ -69,7 +69,7 @@ Like every field, `textarea` is optional and nullable by default; `.required()` 
 bio: f.textarea().min(10).max(2000),   // 10-2000 characters, validated on write
 ```
 
-`.min(n)` / `.max(n)` set length bounds only, they do **not** change the column type, which stays unbounded Postgres `text` regardless. The bounds are applied to the derived Zod schema in `packages/questpie/src/server/fields/derive-schema.ts` (string refinements: `maxLength` / `minLength` / `pattern`).
+`.min(n)` / `.max(n)` set length bounds only, they do **not** change the column type, which stays unbounded Postgres `text` regardless. The bounds are applied to the derived Zod schema during create and update validation.
 
 Everything else comes from the [shared field modifiers](/docs/concepts/fields#shared-methods), `.required()`, `.default()`, `.localized()`, `.label()`, `.description()`, `.hooks()`, `.access()`, `.admin()`, `.zod()`, and the rest. They behave identically on `textarea` as on any field.
 
@@ -103,7 +103,7 @@ await app.collections.posts.find({
 });
 ```
 
-The set is defined as `stringOps` in `packages/questpie/src/server/fields/operators/builtin.ts`. These same operators type the `where` clause on the server (`app.collections.*`) and on the typed client.
+These same string operators type the `where` clause on the server (`app.collections.*`) and on the typed client.
 
 <Callout type="warn" title="No full-text search">
 `contains` / `ilike` are SQL `LIKE` scans, not full-text search, fine for filtering, but not built for ranked search over large prose. For relevance-ranked search across long text, mark the collection `.searchable()` and use the search adapter (pg_trgm / pgvector) rather than a `contains` filter.

--- a/apps/docs/content/docs/concepts/fields/url.mdx
+++ b/apps/docs/content/docs/concepts/fields/url.mdx
@@ -63,7 +63,7 @@ On a `url` field, `.min(n)` / `.max(n)` constrain the **number of characters** (
 </Callout>
 
 <Callout type="info" title="URL validation is always on; tighten it with `.zod()`">
-The `.url()` refinement is appended automatically (`derive-schema.ts:131`), you don't add it and you can't turn it off through a field method. To go further (e.g. allow only `https`, or restrict hosts), use the `.zod()` escape hatch: `f.url().zod((s) => s.refine((v) => v.startsWith("https://")))`.
+The `.url()` refinement is appended automatically, you don't add it and you can't turn it off through a field method. To go further (e.g. allow only `https`, or restrict hosts), use the `.zod()` escape hatch: `f.url().zod((s) => s.refine((v) => v.startsWith("https://")))`.
 </Callout>
 
 ## Filtering, operators

--- a/apps/docs/content/docs/concepts/globals.mdx
+++ b/apps/docs/content/docs/concepts/globals.mdx
@@ -59,7 +59,7 @@ Import `global` from **`#questpie/factories`**, not from `questpie` directly. Th
 
 ## Reading and writing
 
-At runtime a global lives on `app.globals.<name>`, and on `ctx.globals.<name>` inside hooks, routes, jobs, blocks, and seeds, since the context spreads the full app. The CRUD surface is `get()` and `update()` (plus version/workflow methods when enabled). This is the `GlobalCRUD` interface in `global/crud/types.ts:210`.
+At runtime a global lives on `app.globals.<name>`, and on `ctx.globals.<name>` inside hooks, routes, jobs, blocks, and seeds, since the context spreads the full app. The public `GlobalCRUD` interface exposes `get()` and `update()` plus version/workflow methods when enabled.
 
 ### get(options?, context?)
 
@@ -83,7 +83,7 @@ const settings = await app.globals.siteSettings.get(
 );
 ```
 
-`GlobalGetOptions` (`global/crud/types.ts:64`) accepts exactly: `with` (relations), `columns` (partial selection), `locale`, `localeFallback`, and `stage` (workflow). There is no `where`, `limit`, `offset`, or `orderBy`, a singleton has nothing to filter or paginate.
+`GlobalGetOptions` accepts exactly: `with` (relations), `columns` (partial selection), `locale`, `localeFallback`, and `stage` (workflow). There is no `where`, `limit`, `offset`, or `orderBy`, a singleton has nothing to filter or paginate.
 
 <Callout type="warn" title="`get()` returns `null` until the row exists, and `.default()` does not change that">
 A global has no row until something writes it: a seed, an admin save, or an `update()`. Field `.default(...)` values describe the **admin form's initial state**, not a database default, they are *not* auto-inserted on first read. Always handle `null` on the first read (or seed the global at boot).
@@ -136,7 +136,7 @@ await app.globals.siteSettings.revertToVersion({ version: 3 });
 await app.globals.siteSettings.transitionStage({ stage: "published" });
 ```
 
-`transitionStage()` exists only on workflow-enabled globals; its `scheduledAt` param schedules the transition for a future date instead of running it now (`GlobalTransitionStageParams`, `global/crud/types.ts:121`). `revertToVersion()` accepts `{ version }`, `{ versionId }`, or `{ id }` (`GlobalRevertVersionOptions`, `global/crud/types.ts:134`).
+`transitionStage()` exists only on workflow-enabled globals; its `scheduledAt` param schedules the transition for a future date instead of running it now (`GlobalTransitionStageParams`). `revertToVersion()` accepts `{ version }`, `{ versionId }`, or `{ id }` (`GlobalRevertVersionOptions`).
 
 <Callout type="info" title="`GlobalVersionRecord` has no `versionStage`">
 A collection's version record carries the workflow stage; a global's does not, read the current stage via the `stage` option on `get()` instead.
@@ -157,11 +157,11 @@ const schema = await client.globals.siteSettings.schema(); // full introspection
 const meta = await client.globals.siteSettings.meta();     // timestamps/versioning/localized
 ```
 
-The client surface is `get`, `update`, `schema`, `meta`, `findVersions`, `revertToVersion`, and `transitionStage` (`GlobalAPI` in `client/index.ts:670`). Live subscriptions (`live()`) are available when the realtime adapter is configured.
+The `GlobalAPI` client surface is `get`, `update`, `schema`, `meta`, `findVersions`, `revertToVersion`, and `transitionStage`. Live subscriptions (`live()`) are available when the realtime adapter is configured.
 
 ## Builder API
 
-`global(name)` returns a `GlobalBuilder`. Every method returns the builder, so you chain them and export the result, **codegen calls `.build()` for you**; you never call it yourself in app code. Each method below is grounded in `packages/questpie/src/server/global/builder/`.
+`global(name)` returns a `GlobalBuilder`. Every method returns the builder, so you chain them and export the result, **codegen calls `.build()` for you**; you never call it yourself in app code.
 
 <Callout type="info" title="Method order does not matter">
 `.fields()`, `.options()`, `.access()`, `.hooks()`, `.admin()`, and `.form()` can appear in any order. The barbershop example places `.options()` and `.access()` last; the quick start places them first. Both are valid.
@@ -201,7 +201,7 @@ Mark a field `.localized()` and QUESTPIE generates a `<name>_i18n` table behind 
 })
 ```
 
-`GlobalOptions` (`global/builder/types.ts:31`) is a strict, four-key shape:
+`GlobalOptions` is a strict, four-key shape:
 
 | Option | Type | Default | Effect |
 |---|---|---|---|
@@ -224,7 +224,7 @@ Control who can read and write the global. A rule is a `boolean` or a function r
 })
 ```
 
-`GlobalAccess` (`global/builder/types.ts:211`):
+`GlobalAccess` supports:
 
 | Rule | When it runs | `ctx.data` |
 |---|---|---|
@@ -252,7 +252,7 @@ Run logic around reads and writes. Each hook is a function (or array of function
 })
 ```
 
-`GlobalHooks` (`global/builder/types.ts:153`) are: `beforeUpdate`, `afterUpdate`, `beforeRead`, `afterRead`, `beforeChange`, `afterChange` (the last two are shorthands that run on update), `beforeTransition`, and `afterTransition`. There are **no `create` or `delete` hooks**, a global is never created or deleted, only updated.
+`GlobalHooks` are: `beforeUpdate`, `afterUpdate`, `beforeRead`, `afterRead`, `beforeChange`, `afterChange` (the last two are shorthands that run on update), `beforeTransition`, and `afterTransition`. There are **no `create` or `delete` hooks**, a global is never created or deleted, only updated.
 
 <Callout type="warn" title="Global hooks replace; collection hooks merge">
 Calling `.hooks()` twice on a global keeps only the **last** call's hooks (the builder overwrites `state.hooks`). Collections instead merge successive `.hooks()` into arrays. Put all of a global's hooks in one `.hooks({ … })` call. The same replace-not-merge behavior applies to `.access()`.

--- a/apps/docs/content/docs/concepts/services.mdx
+++ b/apps/docs/content/docs/concepts/services.mdx
@@ -147,7 +147,7 @@ export default service({
 });
 ```
 
-When `lifecycle` is omitted, the container decides; the framework's built-in core services set `"singleton"` explicitly, for example the email service at `packages/questpie/src/server/modules/core/services/email.ts:9`.
+When `lifecycle` is omitted, the container decides; the framework's built-in core services, including email, set `"singleton"` explicitly.
 
 <Callout type="warn" title="Singletons outlive every request, don't store request state on them">
 A `"singleton"` is shared across all requests for the life of the process. Never cache the current user, a request's locale, or a per-request transaction on a singleton, it leaks across requests and corrupts data. Put per-request state on a `"request"` service, or read `ctx.session` / `ctx.locale` fresh inside the method that needs it.
@@ -159,7 +159,7 @@ The **public** enum is `"singleton" | "request"`. There is a separate, **non-exp
 
 ## Consuming a service
 
-Wherever you get a handler `ctx`, you get your services on it, routes, hooks, jobs, email handlers, and seeds all share the same context builder (`extractAppServices`, `packages/questpie/src/server/config/app-context.ts:356`). Default-namespace services live under `ctx.services`:
+Wherever you get a handler `ctx`, you get your services on it; routes, hooks, jobs, email handlers, and seeds all share the same context builder. Default-namespace services live under `ctx.services`:
 
 ```ts title="In a route"
 import { route } from "questpie/services";
@@ -229,7 +229,7 @@ The only field a usable service needs. `ctx` is the resolved app surface; whatev
 
 ### `lifecycle`
 
-`"singleton"` or `"request"`. See [Lifecycle](#lifecycle-singleton-vs-request). When omitted, the container decides; built-in core services set `"singleton"` explicitly (e.g. the email service, `packages/questpie/src/server/modules/core/services/email.ts:9`).
+`"singleton"` or `"request"`. See [Lifecycle](#lifecycle-singleton-vs-request). When omitted, the container decides; built-in core services such as email set `"singleton"` explicitly.
 
 ### `dispose(instance)`
 
@@ -252,7 +252,7 @@ export default service({
 
 ### `namespace`
 
-Controls **where** the resolved instance lands on `ctx`. It accepts `string | null` only (not `undefined`, to use the default bucket, just omit the field). The placement rules live in `extractAppServices` (`packages/questpie/src/server/config/app-context.ts:407`):
+Controls **where** the resolved instance lands on `ctx`. It accepts `string | null` only (not `undefined`, to use the default bucket, just omit the field):
 
 | `namespace` value | Lands at | Example |
 |---|---|---|
@@ -272,7 +272,7 @@ export default service({
 ```
 
 <Callout type="warn" title="A `null`-namespace service won't override a built-in `ctx` key">
-Top-level keys like `db`, `session`, `email`, `collections`, `globals`, `queue`, `storage`, `kv`, `logger` are populated directly by the context builder. A `namespace: null` service whose key collides with one of these is **silently skipped**, the existing built-in wins (`if (!(name in result))`, `packages/questpie/src/server/config/app-context.ts:415`). Pick a unique key, or leave it in the default `ctx.services` bucket where collisions can't happen.
+Top-level keys like `db`, `session`, `email`, `collections`, `globals`, `queue`, `storage`, `kv`, `logger` are populated directly by the context builder. A `namespace: null` service whose key collides with one of these is **silently skipped** and the existing built-in wins. Pick a unique key, or leave it in the default `ctx.services` bucket where collisions can't happen.
 </Callout>
 
 ## Built-in services

--- a/apps/docs/content/docs/extend/build-a-plugin.mdx
+++ b/apps/docs/content/docs/extend/build-a-plugin.mdx
@@ -97,7 +97,7 @@ export function color() {
 `field` comes from `questpie/builders`; `FieldRuntimeState` requires an `operatorSet`, so reusing `stringOps` gives a `color` field `eq` / `in` / `ilike` / `isNull` and friends for free.
 
 <Callout type="warn" title="`operator` / `operatorSet` / `stringOps` are not public exports">
-The operator-authoring primitives, `operator()`, `operatorSet()`, `extendOperatorSet()`, and the builtin sets (`stringOps`, `numberOps`, …), live at the internal path `#questpie/server/fields/operators/index.js` and are **not** re-exported from `questpie` or `questpie/builders`. Only their *types* (`OperatorFn`, `OperatorMap`, `ContextualOperators`) are public. The public-export surface is verified in `packages/questpie/src/exports/builders.ts`.
+The operator-authoring primitives, `operator()`, `operatorSet()`, `extendOperatorSet()`, and the builtin sets (`stringOps`, `numberOps`, …), live at the internal path `#questpie/server/fields/operators/index.js` and are **not** re-exported from `questpie` or `questpie/builders`. Only their *types* (`OperatorFn`, `OperatorMap`, `ContextualOperators`) are public.
 </Callout>
 
 ### Adding chain methods with `fieldType()`
@@ -160,7 +160,7 @@ When a module declares a `fields` record, codegen extracts those factories (the 
 In a **root app** (not a package), the same effect comes from a single `src/questpie/server/fields.ts` *bundle* file that exports your factories, codegen discovers it via the `fields` discover pattern, spreads its default export into the runtime field map, and augments the type-level `FieldTypesMap`.
 
 <Callout type="info" title="Two `fields` mechanisms, don't confuse them">
-The core plugin has *both* a `fields.ts` single-file discover pattern (the root-app bundle, index.ts:145) and a `fieldTypes` *category* that scans the `fields/` directory for `fieldType()` calls (index.ts:131, `dirs: ["fields"]`). The category feeds the `~fieldTypes` Registry and module extraction; it does **not** auto-inject loose `fields/`-directory files into a root app's `f` proxy. Register via a module's `fields` record (packages) or the `fields.ts` bundle (root apps).
+The core plugin has *both* a `fields.ts` single-file discover pattern for the root-app bundle and a `fieldTypes` *category* that scans the `fields/` directory for `fieldType()` calls. The category feeds the `~fieldTypes` Registry and module extraction; it does **not** auto-inject loose `fields/`-directory files into a root app's `f` proxy. Register via a module's `fields` record (packages) or the `fields.ts` bundle (root apps).
 </Callout>
 
 The full field surface, every common method (`.zod()`, `.drizzle()`, `.array()`, `.access()`, `.hooks()`, …), the `FieldRuntimeState` shape, and the per-type metadata, is in [Fields](/docs/concepts/fields). What's above is the minimum to add your own.
@@ -204,13 +204,13 @@ Infrastructure in QUESTPIE is adapter-shaped. Every subsystem, queue, search, re
 
 Each subsystem has one interface. A few of them:
 
-| Subsystem | Interface | Wire it as | Source |
-|---|---|---|---|
-| Search | `SearchAdapter` | `runtimeConfig({ search })` | `…/integrated/search/types.ts:671` |
-| Realtime | `RealtimeAdapter` | `runtimeConfig({ realtime: { adapter } })` | `…/integrated/realtime/adapter.ts:6` |
-| KV | `KVAdapter` | `runtimeConfig({ kv: { adapter } })` | `…/integrated/kv/adapter.ts:4` |
-| Executor | `ExecutorAdapter` | `runtimeConfig({ executor: { sandboxed } })` | `…/integrated/executor/adapter.ts:146` |
-| Storage | `files-sdk` `Adapter` | `runtimeConfig({ storage: { adapter } })` | `packages/questpie/src/exports/storage.ts:1` |
+| Subsystem | Interface | Wire it as |
+|---|---|---|
+| Search | `SearchAdapter` | `runtimeConfig({ search })` |
+| Realtime | `RealtimeAdapter` | `runtimeConfig({ realtime: { adapter } })` |
+| KV | `KVAdapter` | `runtimeConfig({ kv: { adapter } })` |
+| Executor | `ExecutorAdapter` | `runtimeConfig({ executor: { sandboxed } })` |
+| Storage | `files-sdk` `Adapter` | `runtimeConfig({ storage: { adapter } })` |
 
 A `RealtimeAdapter` is the smallest contract, four methods. Here is the shape of a custom transport adapter:
 

--- a/apps/docs/content/docs/integrations/mcp-oauth.mdx
+++ b/apps/docs/content/docs/integrations/mcp-oauth.mdx
@@ -51,10 +51,10 @@ export default modules;
 questpie generate
 ```
 
-That is the whole setup on an admin-enabled app: `adminModule` provides the OAuth provider + tables + discovery (via the starter it bundles), and `mcpModule` mounts the OAuth-gated `/api/mcp` route. This is exactly the composition the end-to-end test (`packages/mcp/test/oauth-mcp-e2e.test.ts`) exercises.
+That is the whole setup on an admin-enabled app: `adminModule` provides the OAuth provider + tables + discovery (via the starter it bundles), and `mcpModule` mounts the OAuth-gated `/api/mcp` route. This composition is covered end to end by the framework test suite.
 
 <Callout type="info" title="Headless runtimes (Hono, Elysia) add the OAuth provider with `oauthModule`">
-The OAuth provider lives in a self-contained, composable **`oauthModule`** (`packages/questpie/src/server/modules/oauth/`), the `oauthProvider()` + `jwt()` plugins, the `oauth-*` tables + `jwks`, and the discovery routes. `starterModule` bundles it and `adminModule` pulls the starter in, so an admin-enabled app gets it for free (as above). A **headless / custom-auth** app that ships neither can add `oauthModule` on top of its own better-auth model to get the same provider + tables + discovery, HTTP MCP then works there too. (This shipped in 3.3.0, it is no longer a hand-wire-it-yourself follow-up.) With no provider at all, `/api/mcp` still mounts but stays `401` with nothing to discover. Local [stdio](/docs/integrations/mcp#stdio-transport) needs no OAuth and works everywhere.
+The OAuth provider lives in the self-contained, composable **`oauthModule`**, alongside the `oauthProvider()` + `jwt()` plugins, the `oauth-*` tables + `jwks`, and the discovery routes. `starterModule` bundles it and `adminModule` pulls the starter in, so an admin-enabled app gets it for free (as above). A **headless / custom-auth** app that ships neither can add `oauthModule` on top of its own better-auth model to get the same provider + tables + discovery, HTTP MCP then works there too. (This shipped in 3.3.0, it is no longer a hand-wire-it-yourself follow-up.) With no provider at all, `/api/mcp` still mounts but stays `401` with nothing to discover. Local [stdio](/docs/integrations/mcp#stdio-transport) needs no OAuth and works everywhere.
 </Callout>
 
 ## The flow

--- a/apps/docs/content/docs/integrations/mcp.mdx
+++ b/apps/docs/content/docs/integrations/mcp.mdx
@@ -157,7 +157,7 @@ export default mcpConfig({
 
 ### `McpConfig` reference
 
-The full config interface (`packages/mcp/src/server/types.ts:76`):
+The full `McpConfig` interface:
 
 ```ts
 interface McpConfig {
@@ -196,7 +196,7 @@ interface McpConfig {
 
 ### `McpEntityPolicy`, per-entity control
 
-A collection/global/route entry is either a boolean or an object (`packages/mcp/src/server/types.ts:23`):
+A collection/global/route entry is either a boolean or an object:
 
 ```ts
 type McpEntityPolicy =
@@ -222,7 +222,7 @@ Per-transport CRUD defaults differ on purpose. Over **HTTP**, collections defaul
 
 ### Access rules on tools
 
-Anywhere a policy field accepts a rule, you can pass a function (`McpAccessRule`, `packages/mcp/src/server/types.ts:19`):
+Anywhere a policy field accepts a rule, you can pass an `McpAccessRule` function:
 
 ```ts
 type McpAccessRule =
@@ -281,7 +281,7 @@ Scaffold one with `questpie add mcp-tool recalculate-stats`, which creates the f
 
 `mcpTool(name, config)` returns a builder; call `.handler(fn)` to get the frozen definition.
 
-**`config` (`McpToolConfig`)**, all optional (`packages/mcp/src/server/types.ts:102`):
+**`config` (`McpToolConfig`)**, all optional:
 
 | Field | Type | Notes |
 |---|---|---|
@@ -293,7 +293,7 @@ Scaffold one with `questpie add mcp-tool recalculate-stats`, which creates the f
 | `access` | `McpAccessRule` | Evaluated per call; a falsy result hides the tool / denies the call. |
 | `_meta` | `Record<string, unknown>` | Arbitrary metadata passed through to the MCP tool. |
 
-**Handler args (`McpToolHandlerArgs`)** (`packages/mcp/src/server/types.ts:94`):
+**Handler args (`McpToolHandlerArgs`)**:
 
 | Arg | Type | Notes |
 |---|---|---|

--- a/scripts/validate-docs.test.ts
+++ b/scripts/validate-docs.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+
+import { findPublicDocsProvenance } from "./validate-docs";
+
+describe("public docs provenance guard", () => {
+	test("rejects audit markers and internal source paths in public prose", () => {
+		const issues = findPublicDocsProvenance(`---
+title: Collections
+---
+
+Sources: packages/questpie/src/server/collection/crud.ts:42
+`);
+
+		expect(issues.map((issue) => issue.id)).toEqual([
+			"provenance-marker",
+			"internal-repository-path",
+			"file-line-reference",
+		]);
+	});
+
+	test("allows public imports and source-shaped paths inside code examples", () => {
+		const issues = findPublicDocsProvenance(`---
+title: Collections
+---
+
+Read the [runnable example](https://github.com/questpie/questpie/tree/main/examples/city-portal).
+
+\`\`\`ts title="packages/example/src/index.ts"
+import { collection } from "#questpie/factories";
+\`\`\`
+`);
+
+		expect(issues).toEqual([]);
+	});
+});

--- a/scripts/validate-docs.ts
+++ b/scripts/validate-docs.ts
@@ -113,7 +113,7 @@ const DRIFT_RULES: Array<{
 	severity: Severity;
 	pattern: RegExp;
 	message: string;
-	scope?: "docs-and-skills";
+	scope?: "docs-and-skills" | "skills-only";
 	allowedPaths?: RegExp;
 }> = [
 	{
@@ -159,14 +159,17 @@ const DRIFT_RULES: Array<{
 			/\bimport\s+\{[^}]*\bcollection\b[^}]*\}\s+from\s+["']questpie["']/g,
 		message:
 			"Convention files should import `collection` from `#questpie/factories`. Keep `questpie` imports only for package/module code.",
+		// Internal contributor guidance intentionally shows package-authoring imports;
+		// it is not rendered by the public docs app.
+		allowedPaths: /^docs\/CODING-GUIDELINES\.md$/,
 	},
 	{
-		id: "user-facing-source-marker",
+		id: "skill-facing-source-marker",
 		severity: "error",
-		pattern: /^\s*Source:\s+/gm,
+		pattern: /^\s*Sources?:\s+/gm,
 		message:
-			"Do not expose source-file provenance in Markdown docs or skills. Keep implementation references out of user-facing guidance.",
-		scope: "docs-and-skills",
+			"Do not expose source-file provenance in skills. Keep implementation references out of user-facing guidance.",
+		scope: "skills-only",
 	},
 	{
 		id: "user-facing-verification-marker",
@@ -328,6 +331,65 @@ function walkDocs(
 
 function stripCodeFences(content: string): string {
 	return content.replace(/```[\s\S]*?```/g, "");
+}
+
+function maskCodeFences(content: string): string {
+	return content.replace(/```[\s\S]*?```/g, (block) =>
+		block.replace(/[^\n]/g, " "),
+	);
+}
+
+export interface PublicDocsProvenanceIssue {
+	id: "provenance-marker" | "internal-repository-path" | "file-line-reference";
+	line: number;
+	message: string;
+}
+
+export function findPublicDocsProvenance(
+	content: string,
+): PublicDocsProvenanceIssue[] {
+	const issues: PublicDocsProvenanceIssue[] = [];
+	const prose = maskCodeFences(content);
+	const rules: Array<{
+		id: PublicDocsProvenanceIssue["id"];
+		pattern: RegExp;
+		message: string;
+	}> = [
+		{
+			id: "provenance-marker",
+			pattern: /^\s*Sources?:\s+.+$/gim,
+			message:
+				"Public docs must explain the API directly instead of exposing an internal Source/Sources audit marker.",
+		},
+		{
+			id: "internal-repository-path",
+			pattern:
+				/(?<![\w/])packages\/[a-z0-9@._-]+\/(?:src|test)\/[a-z0-9_./{}*-]+(?::\d+(?:-\d+)?)?/gi,
+			message:
+				"Public prose must not use an internal packages/* source or test path as provenance. Link a stable public API or explain the behavior directly.",
+		},
+		{
+			id: "file-line-reference",
+			pattern:
+				/(?<![\w/])(?:[a-z0-9_.-]+\/)*[a-z0-9_.-]+\.(?:ts|tsx):\d+(?:-\d+)?/gi,
+			message:
+				"Public prose must not depend on an internal file-and-line reference. Explain the public contract directly.",
+		},
+	];
+
+	for (const rule of rules) {
+		let match: RegExpExecArray | null;
+		rule.pattern.lastIndex = 0;
+		while ((match = rule.pattern.exec(prose))) {
+			issues.push({
+				id: rule.id,
+				line: lineForIndex(prose, match.index),
+				message: `${rule.message} (${rule.id})`,
+			});
+		}
+	}
+
+	return issues;
 }
 
 function extractCodeBlocks(content: string): CodeBlock[] {
@@ -545,8 +607,17 @@ function isDocsOrSkillFile(file: string): boolean {
 }
 
 function validateDriftRules(file: string, content: string, issues: Issue[]) {
+	if (file.startsWith(DOCS_ROOT) && extname(file) === ".mdx") {
+		for (const issue of findPublicDocsProvenance(content)) {
+			addIssue(issues, "drift", "error", file, issue.line, issue.message);
+		}
+	}
+
 	for (const rule of DRIFT_RULES) {
 		if (rule.scope === "docs-and-skills" && !isDocsOrSkillFile(file)) {
+			continue;
+		}
+		if (rule.scope === "skills-only" && !file.startsWith(SKILL_DOCS_ROOT)) {
 			continue;
 		}
 		if (rule.allowedPaths?.test(toDisplayPath(file))) continue;
@@ -920,4 +991,4 @@ function main() {
 	process.exit(hasErrors && !args.report ? 1 : 0);
 }
 
-main();
+if (import.meta.main) main();


### PR DESCRIPTION
## Summary
- remove internal audit/file-line provenance from public documentation while preserving public examples and links
- make `validate:docs` reject provenance markers, internal source/test paths, and file-line references in public prose
- add focused regression tests and explicitly classify the non-public contributor guide

## Verification
- `bun test scripts/validate-docs.test.ts`
- `bun run validate:docs` (0 errors, 0 warnings)
- `bun run --cwd apps/docs types:check`
- Oxlint and Oxfmt checks for the validator files
- agent-board verify: 6/6 passed

Docs-only change; no changeset or npm release.