### PR TITLE
fix(questpie): close app after migration CLI commands

### DIFF
--- a/.changeset/quiet-ravens-close-migrations.md
+++ b/.changeset/quiet-ravens-close-migrations.md
@@ -1,0 +1,7 @@
+---
+"questpie": patch
+---
+
+Always destroy the loaded app after migration CLI commands so production
+deployment init containers exit even when configured adapters keep event-loop
+resources open.

--- a/packages/questpie/src/cli/commands/run.ts
+++ b/packages/questpie/src/cli/commands/run.ts
@@ -45,73 +45,82 @@ export async function runMigrationCommand(
 	const cmsConfig = await loadQuestpieConfig(resolvedConfigPath);
 	const app = cmsConfig.app;
 
-	// Get migrations from Questpie config
-	// Supports both flat array (new codegen) and legacy nested format { migrations: [...] }
-	const migrations: Migration[] =
-		(Array.isArray(app.config.migrations)
-			? app.config.migrations
-			: app.config.migrations?.migrations) || [];
+	try {
+		// Get migrations from Questpie config
+		// Supports both flat array (new codegen) and legacy nested format { migrations: [...] }
+		const migrations: Migration[] =
+			(Array.isArray(app.config.migrations)
+				? app.config.migrations
+				: app.config.migrations?.migrations) || [];
 
-	if (migrations.length === 0) {
-		console.log("ℹ️  No migrations found");
-		console.log(
-			"\n💡 Tip: Place migration files in migrations/*.ts and run questpie generate",
-		);
-		return;
-	}
-
-	console.log(`📦 Found ${migrations.length} migrations\n`);
-
-	if (options.dryRun) {
-		console.log(
-			"🔍 DRY RUN - Would execute the following migration operation:",
-		);
-		console.log(`Action: ${options.action}`);
-		if (options.targetMigration)
-			console.log(`Target migration: ${options.targetMigration}`);
-		if (options.batch) console.log(`Target batch: ${options.batch}`);
-		console.log("");
-		return;
-	}
-
-	// Create migration runner
-	const runner = new MigrationRunner(app.db);
-
-	// Execute the requested action
-	switch (options.action) {
-		case "up":
-			await app.migrations.up({
-				targetMigration: options.targetMigration,
-			});
-			break;
-
-		case "down":
-			if (options.batch !== undefined) {
-				await runner.rollbackBatch(migrations, options.batch);
-			} else if (options.targetMigration) {
-				await runner.rollbackToMigration(migrations, options.targetMigration);
-			} else {
-				await runner.rollbackLastBatch(migrations);
-			}
-			break;
-
-		case "reset":
-			await runner.reset(migrations);
-			break;
-
-		case "fresh": {
-			await app.migrations.fresh();
-			// Also reset seed tracking since DB is fresh
-			const seedRunner = new SeedRunner(app);
-			await seedRunner.reset();
-			break;
+		if (migrations.length === 0) {
+			console.log("ℹ️  No migrations found");
+			console.log(
+				"\n💡 Tip: Place migration files in migrations/*.ts and run questpie generate",
+			);
+			return;
 		}
 
-		case "status":
-			await runner.status(migrations);
-			break;
+		console.log(`📦 Found ${migrations.length} migrations\n`);
 
-		default:
-			throw new Error(`Unknown action: ${options.action}`);
+		if (options.dryRun) {
+			console.log(
+				"🔍 DRY RUN - Would execute the following migration operation:",
+			);
+			console.log(`Action: ${options.action}`);
+			if (options.targetMigration)
+				console.log(`Target migration: ${options.targetMigration}`);
+			if (options.batch) console.log(`Target batch: ${options.batch}`);
+			console.log("");
+			return;
+		}
+
+		// Create migration runner
+		const runner = new MigrationRunner(app.db);
+
+		// Execute the requested action
+		switch (options.action) {
+			case "up":
+				await app.migrations.up({
+					targetMigration: options.targetMigration,
+				});
+				break;
+
+			case "down":
+				if (options.batch !== undefined) {
+					await runner.rollbackBatch(migrations, options.batch);
+				} else if (options.targetMigration) {
+					await runner.rollbackToMigration(migrations, options.targetMigration);
+				} else {
+					await runner.rollbackLastBatch(migrations);
+				}
+				break;
+
+			case "reset":
+				await runner.reset(migrations);
+				break;
+
+			case "fresh": {
+				await app.migrations.fresh();
+				// Also reset seed tracking since DB is fresh
+				const seedRunner = new SeedRunner(app);
+				await seedRunner.reset();
+				break;
+			}
+
+			case "status":
+				await runner.status(migrations);
+				break;
+
+			default:
+				throw new Error(`Unknown action: ${options.action}`);
+		}
+	} finally {
+		// Tear down the app so the CLI process exits — `migrate` builds the full
+		// app (adapters included) exactly like `push`, and without this it hangs
+		// after finishing once any adapter keeps the event loop alive. This is the
+		// command deploys run in their init container, so a hang = pod stuck in
+		// Init. Mirrors push.ts / seed.ts.
+		await app.destroy();
 	}
 }

--- a/packages/questpie/test/cli/run-migration-command.test.ts
+++ b/packages/questpie/test/cli/run-migration-command.test.ts
@@ -1,0 +1,89 @@
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	setDefaultTimeout,
+	spyOn,
+} from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { runMigrationCommand } from "../../src/cli/commands/run.js";
+import type { Migration } from "../../src/server/migration/types.js";
+import { buildMockApp } from "../utils/mocks/mock-app-builder.js";
+
+setDefaultTimeout(30_000);
+
+const migration: Migration = {
+	id: "test_migration",
+	async up() {},
+	async down() {},
+};
+
+describe("runMigrationCommand", () => {
+	let setup: Awaited<ReturnType<typeof buildMockApp>>;
+	let tempDir: string;
+	let configPath: string;
+
+	beforeEach(async () => {
+		setup = await buildMockApp({});
+		tempDir = await mkdtemp(join(tmpdir(), "questpie-migrate-command-"));
+		configPath = join(tempDir, "questpie.config.ts");
+		(globalThis as Record<string, unknown>).questpieMigrateTestApp = setup.app;
+		await writeFile(
+			configPath,
+			"export default { app: globalThis.questpieMigrateTestApp };\n",
+			"utf8",
+		);
+	});
+
+	afterEach(async () => {
+		delete (globalThis as Record<string, unknown>).questpieMigrateTestApp;
+		await setup.cleanup();
+		await rm(tempDir, { recursive: true, force: true });
+	});
+
+	it("destroys the app for empty, dry-run, and successful migrations", async () => {
+		const destroy = spyOn(setup.app, "destroy").mockResolvedValue(undefined);
+		const up = spyOn(setup.app.migrations, "up").mockResolvedValue(undefined);
+		const log = spyOn(console, "log").mockImplementation(() => {});
+
+		await runMigrationCommand({ action: "up", configPath });
+		expect(destroy).toHaveBeenCalledTimes(1);
+		expect(up).not.toHaveBeenCalled();
+
+		setup.app.config.migrations = [migration];
+		await runMigrationCommand({ action: "up", configPath, dryRun: true });
+		expect(destroy).toHaveBeenCalledTimes(2);
+		expect(up).not.toHaveBeenCalled();
+
+		await runMigrationCommand({ action: "up", configPath });
+		expect(destroy).toHaveBeenCalledTimes(3);
+		expect(up).toHaveBeenCalledTimes(1);
+
+		log.mockRestore();
+		up.mockRestore();
+		destroy.mockRestore();
+	});
+
+	it("destroys the app when a migration fails", async () => {
+		setup.app.config.migrations = [migration];
+		const destroy = spyOn(setup.app, "destroy").mockResolvedValue(undefined);
+		const up = spyOn(setup.app.migrations, "up").mockRejectedValue(
+			new Error("migration failed"),
+		);
+		const log = spyOn(console, "log").mockImplementation(() => {});
+
+		await expect(
+			runMigrationCommand({ action: "up", configPath }),
+		).rejects.toThrow("migration failed");
+		expect(destroy).toHaveBeenCalledTimes(1);
+
+		log.mockRestore();
+		up.mockRestore();
+		destroy.mockRestore();
+	});
+});


### PR DESCRIPTION
## Summary

- always destroy the loaded QUESTPIE app after every `migrate` action
- cover empty, dry-run, successful, and failing migration paths
- add a patch changeset for `questpie`

## Production impact

Production deploys must use committed migrations via `questpie migrate`, never `questpie push`. The migration CLI builds the full app, including adapters. Without teardown, those adapters can keep the event loop alive after a successful migration and leave a Kubernetes init container stuck in `Init`.

## Verification

- `bun test packages/questpie/test/cli/run-migration-command.test.ts packages/questpie/test/cli/push-command.test.ts` — 4 pass
- `bun run check-types` in `packages/questpie` — pass
- `bun run build` in `packages/questpie` — pass
- changed-file oxlint — 0 warnings/errors
- changed-file oxfmt check — pass
- `git diff --check origin/main...HEAD` — pass

Root baselines unrelated to this three-file patch remain: global lint/design-system errors, global format drift, and the barbershop example cannot resolve the unbuilt local `@questpie/vite-plugin-iconify` during root typecheck.