### PR TITLE
docs: add verified MCP agent tutorial

### DIFF
--- a/apps/docs/content/docs/getting-started/mcp-ai-agent.mdx
+++ b/apps/docs/content/docs/getting-started/mcp-ai-agent.mdx
@@ -1,0 +1,267 @@
+---
+title: Connect an AI agent with MCP and OAuth
+description: Scaffold a QUESTPIE app with MCP, expose safe CRUD and a custom tool, then connect Claude and VS Code through per-user OAuth 2.1.
+---
+
+This tutorial starts with a fresh TanStack Start app and ends with two AI clients calling your QUESTPIE data through the remote MCP endpoint:
+
+- Claude, through a remote custom connector.
+- VS Code, through a workspace `mcp.json` entry.
+
+Both clients authenticate as a real QUESTPIE user. They register through Dynamic Client Registration (DCR), use authorization code + PKCE, show the user a consent screen, and receive a token bound to this app's `/api/mcp` endpoint. Every tool call is then limited by all three gates:
+
+```text
+MCP policy ∩ consented OAuth scopes ∩ collection/access rules
+```
+
+You will expose read and write tools for the starter `posts` collection, keep delete disabled, and add a typed `posts.countPublished` custom tool.
+
+## Prerequisites
+
+- [Bun](https://bun.sh) 1.3 or newer.
+- [Docker](https://www.docker.com/) for the local Postgres database.
+- A public HTTPS deployment for Claude. Claude's remote connectors run from Anthropic's cloud, including when you use Claude Desktop, so they cannot reach a server that only exists on `localhost`. See [Anthropic's remote connector network requirements](https://support.claude.com/en/articles/11175166-get-started-with-custom-connectors-using-remote-mcp).
+- VS Code with GitHub Copilot if you want to follow the IDE section. VS Code can connect to a local or remote HTTP MCP server.
+
+## 1. Scaffold the app with MCP
+
+Run the published scaffolder non-interactively:
+
+```bash title="Terminal"
+bunx create-questpie@latest questpie-mcp-agent \
+  --template tanstack-start \
+  --modules admin,openapi,mcp \
+  --yes
+cd questpie-mcp-agent
+```
+
+Explicit module selection replaces the defaults, so include all three modules. The result contains:
+
+- `adminModule`, which also brings the OAuth provider, account tables, login, and consent UI.
+- `openApiModule`, for the REST reference at `/api/docs`.
+- `mcpModule`, for the OAuth-protected Streamable HTTP endpoint at `/api/mcp`.
+
+Verify the generated app before changing it:
+
+```bash
+bun run scaffold:verify
+```
+
+This command regenerates the app and runs TypeScript. It does not mutate the database.
+
+## 2. Start the local database
+
+Start Postgres, then create the local development schema:
+
+```bash
+docker compose up -d
+bun run db:push
+```
+
+<Callout type="warn" title="db:push is local development only">
+	`bun run db:push` calls `questpie push`. Never run it against production, in a
+	deployment job, or in an init container. `--force` does not make it
+	production-safe. For production, generate a migration with `bun run
+	migrate:create`, review and commit it, then apply it with `bun run migrate`
+	during deployment.
+</Callout>
+
+Start the app:
+
+```bash
+bun run dev
+```
+
+Open [http://localhost:3000/admin](http://localhost:3000/admin). The first visit redirects to the one-time setup screen. Create the first admin account and keep those credentials for the OAuth sign-in later.
+
+## 3. Open only the MCP operations you need
+
+HTTP MCP is read-only by default. Add `config/mcp.ts` to allow authenticated agents to read and create/update posts while keeping deletion closed:
+
+```ts title="src/questpie/server/config/mcp.ts"
+import { mcpConfig } from "@questpie/mcp";
+
+export default mcpConfig({
+	crud: {
+		collections: {
+			posts: { read: true, write: true, delete: false },
+		},
+		globals: {
+			siteSettings: { read: true, write: false },
+		},
+	},
+});
+```
+
+This contributes these relevant tools:
+
+| Tool                                       | MCP policy | OAuth scope                                      |
+| ------------------------------------------ | ---------- | ------------------------------------------------ |
+| `collections.posts.list` / `count` / `get` | allowed    | `collections:posts:read` or `collections:read`   |
+| `collections.posts.create` / `update`      | allowed    | `collections:posts:write` or `collections:write` |
+| `collections.posts.delete`                 | hidden     | unavailable even if a token has a delete scope   |
+| `globals.siteSettings.get`                 | allowed    | `globals:siteSettings:read`                      |
+| `globals.siteSettings.update`              | hidden     | unavailable                                      |
+
+The OAuth scope does not grant database access by itself. The signed-in user's normal collection `.access()` rules still run and can further narrow every operation.
+
+## 4. Add a typed custom tool
+
+Create a file-convention MCP tool that counts published posts:
+
+```ts title="src/questpie/server/mcp-tools/count-published-posts.ts"
+import { mcpTool } from "@questpie/mcp";
+import { z } from "zod";
+
+export default mcpTool("posts.countPublished", {
+	description: "Count published posts.",
+	inputSchema: z.object({}),
+	outputSchema: z.object({ count: z.number() }),
+	annotations: { readOnlyHint: true },
+}).handler(async ({ ctx }) => {
+	const count = await ctx.collections.posts.count({
+		where: { published: true },
+	});
+
+	return {
+		structuredContent: { count },
+		content: [{ type: "text", text: `${count} published posts` }],
+	};
+});
+```
+
+Custom tool results include both `structuredContent` for the model and an MCP `content` block. The public handler type requires `content`; do not return only `structuredContent`.
+
+This example does not declare an extra custom-tool scope. The HTTP endpoint still requires an authenticated principal, and the `ctx.collections.posts.count()` call still runs the user's collection access rules. Add `scopes` or `access` to the tool when it needs a narrower rule; see [custom tool scopes](/docs/integrations/mcp-oauth#custom-tool-scopes).
+
+Regenerate and type-check both new files:
+
+```bash
+bun run scaffold:verify
+```
+
+Codegen should report one discovered `mcpTools` entry.
+
+## 5. Understand the OAuth flow
+
+Pointing a compliant client at `/api/mcp` is enough to start the flow:
+
+1. The unauthenticated MCP request receives `401` and a `WWW-Authenticate` challenge pointing to protected-resource metadata.
+2. The client reads `/.well-known/oauth-protected-resource` and `/.well-known/oauth-authorization-server`.
+3. DCR creates a public OAuth client at `/api/auth/oauth2/register`; no hand-created client secret is needed.
+4. The client opens `/api/auth/oauth2/authorize` with a PKCE challenge and the `/api/mcp` resource indicator.
+5. You sign in at `/admin/login` and approve the requested scopes at `/admin/oauth/consent`.
+6. The client exchanges the code at `/api/auth/oauth2/token`, then retries `/api/mcp` with the audience-bound access token.
+
+The access token expires after one hour. Its effective permission is the intersection of consented scopes and the signed-in user's RBAC; OAuth can narrow access but cannot elevate it.
+
+You can inspect discovery on a running deployment without obtaining a token:
+
+```bash
+curl https://cms.example.com/.well-known/oauth-protected-resource
+curl https://cms.example.com/.well-known/oauth-authorization-server
+curl -i https://cms.example.com/api/mcp
+```
+
+The final request should be unauthorized and include the discovery challenge. A public `200` from `/api/mcp` without a session or token is a security problem.
+
+## 6. Prepare the public deployment
+
+Set the deployed app origin exactly; OAuth uses it to bind tokens to the MCP audience:
+
+```bash title="Production environment"
+APP_URL=https://cms.example.com
+BETTER_AUTH_SECRET=<a-strong-production-secret>
+DATABASE_URL=<production-postgres-url>
+```
+
+Generate the migration in development, review it, and commit it:
+
+```bash
+bun run migrate:create
+git add src/questpie/server/migrations
+git commit -m "chore: add initial database migration"
+```
+
+During deployment, apply only committed migrations:
+
+```bash
+bun run migrate
+```
+
+<Callout type="warn" title="Never replace migrate with push">
+	Production uses `questpie migrate`, not `questpie push`. Do not put `push`,
+	`db:push`, or `push --force` in a container command, init container, CI deploy
+	step, or production runbook.
+</Callout>
+
+Before connecting a client, confirm that `/api/mcp`, both root `/.well-known/*` documents, `/api/auth/oauth2/register`, `/admin/login`, and `/admin/oauth/consent` all route to the same deployment.
+
+## 7. Connect Claude
+
+Claude remote custom connectors support Streamable HTTP, OAuth, and DCR. QUESTPIE therefore needs only the endpoint URL; leave the optional advanced client ID and secret empty.
+
+For an individual account:
+
+1. Open **Customize → Connectors**.
+2. Select **+ → Add custom connector**.
+3. Enter a name and `https://cms.example.com/api/mcp`.
+4. Leave advanced OAuth credentials empty and add the connector.
+5. Select **Connect**, sign in with the admin account you created, and review the consent screen before approving it.
+6. Enable the connector for a conversation from the **+ → Connectors** menu.
+
+Team and Enterprise plans require an Owner to add the connector under **Organization settings → Connectors** before members connect their own accounts. Anthropic documents both flows in [Get started with custom connectors using remote MCP](https://support.claude.com/en/articles/11175166-get-started-with-custom-connectors-using-remote-mcp).
+
+Do not put this remote server in `claude_desktop_config.json`. That file is for local stdio servers; Claude's remote connectors are configured through Connectors and run from Anthropic's cloud.
+
+## 8. Connect VS Code
+
+Add a workspace MCP configuration:
+
+```json title=".vscode/mcp.json"
+{
+	"servers": {
+		"questpie": {
+			"type": "http",
+			"url": "https://cms.example.com/api/mcp"
+		}
+	}
+}
+```
+
+There is intentionally no static token and no `oauth.clientId`: VS Code starts with DCR when the server advertises it. See the official [VS Code MCP developer guide](https://code.visualstudio.com/api/extension-guides/ai/mcp) and [MCP server configuration guide](https://code.visualstudio.com/docs/agent-customization/mcp-servers).
+
+Open the Command Palette and run **MCP: List Servers**. Start `questpie`, confirm that you trust the server, then complete the browser login and consent flow. VS Code lists the discovered tools in Chat's tool picker. If you need to discard a stale DCR registration, run **Authentication: Remove Dynamic Authentication Providers** and reconnect.
+
+For local-only testing, change the URL to `http://localhost:3000/api/mcp`. Keep `APP_URL=http://localhost:3000` so the issued token's audience matches the endpoint exactly.
+
+## 9. Exercise CRUD and the custom tool
+
+Ask the connected client to make explicit calls while you learn the surface:
+
+```text
+Use collections.posts.list to show the titles and published state of my posts.
+```
+
+```text
+Use collections.posts.create to create a draft post titled "MCP is connected".
+```
+
+```text
+Call posts.countPublished and return the count.
+```
+
+Then open `/admin/collections/posts` and confirm that the created draft exists. If the write tool is missing, check both sides of the gate:
+
+- `config/mcp.ts` must set `posts.write: true`.
+- The OAuth grant must include `collections:posts:write` or `collections:write`.
+- The signed-in user must pass the collection's normal create/update access rules.
+
+Delete remains unavailable because the server policy set `delete: false`, regardless of what the model asks for.
+
+## What to read next
+
+- [MCP integration](/docs/integrations/mcp) is the complete tool, resource, policy, transport, and custom-tool reference.
+- [MCP over OAuth 2.1](/docs/integrations/mcp-oauth) covers DCR, PKCE, consent, scopes, token verification, and `scopes ∩ RBAC` in depth.
+- [AI integration](/docs/integrations/ai) is the separate server-side worker and resumable execution package. You do not need `@questpie/ai` to expose an MCP server to Claude or an IDE.
+- [Access control](/docs/concepts/access-control) is the security boundary beneath MCP policy and OAuth scopes.

--- a/apps/docs/content/docs/getting-started/meta.json
+++ b/apps/docs/content/docs/getting-started/meta.json
@@ -1,4 +1,4 @@
 {
 	"title": "Getting Started",
-	"pages": ["index", "tanstack-start"]
+	"pages": ["index", "tanstack-start", "mcp-ai-agent"]
 }

--- a/apps/docs/content/docs/integrations/mcp-oauth.mdx
+++ b/apps/docs/content/docs/integrations/mcp-oauth.mdx
@@ -182,7 +182,10 @@ export default mcpTool("recalculate-stats", {
   access: ({ session }) => session?.user?.role === "admin",
 }).handler(async ({ input, ctx }) => {
   const updated = await ctx.services.stats.recompute(input.since);
-  return { structuredContent: { updated } };
+  return {
+    structuredContent: { updated },
+    content: [{ type: "text", text: `Updated ${updated} rows.` }],
+  };
 });
 ```
 
@@ -202,6 +205,7 @@ Because effective permission is `scopes ∩ RBAC`, an over-broad scope grant can
 
 ## Related
 
+- [Connect an AI agent with MCP and OAuth](/docs/getting-started/mcp-ai-agent) - scaffold, configure, deploy, and connect Claude plus VS Code end to end.
 - [MCP integration](/docs/integrations/mcp) - the base MCP module: how collections/globals/routes become tools, `config/mcp.ts`, custom tools, and the stdio transport.
 - [Access control](/docs/concepts/access-control) - the `.access()` RBAC rules that every OAuth tool call runs through first; scopes narrow, never widen, what they allow.
 - [Admin auth](/docs/admin/auth) - the auth config the OAuth provider ships in, and the `/admin/login` page the flow redirects to.

--- a/apps/docs/content/docs/integrations/mcp.mdx
+++ b/apps/docs/content/docs/integrations/mcp.mdx
@@ -303,7 +303,7 @@ Scaffold one with `questpie add mcp-tool recalculate-stats`, which creates the f
 | `accessMode` | `"user" \| "system"` | The resolved access mode. |
 | `request` | `Request \| undefined` | The underlying HTTP request, when available. |
 
-The handler returns a `CallToolResult` (`{ content?, structuredContent?, isError? }`). If you return only `structuredContent`, the runtime synthesizes a JSON `content` block for you.
+The handler returns a `CallToolResult`. Include an MCP `content` array; add `structuredContent` when the model should also receive a machine-readable result. The public handler type requires `content`, so a custom tool must not return only `structuredContent`.
 
 Modules can also contribute tools by declaring `mcpTools` on their `ModuleDefinition`, so an installed package can ship MCP tools.
 
@@ -373,6 +373,7 @@ CRUD tools mirror your collection's columns. Use `fields: { exclude: [...] }` (o
 
 ## Related
 
+- [Connect an AI agent with MCP and OAuth](/docs/getting-started/mcp-ai-agent), a complete scaffold-to-Claude-and-VS-Code tutorial.
 - [Routes](/docs/concepts/routes), where `meta.mcp.expose` is declared to turn a route into an MCP tool; routes are public-by-default, the inverse of collections.
 - [Access control](/docs/concepts/access-control), the `.access()` rules and `session` typing that every HTTP MCP tool call runs through; the MCP policy layers on top.
 - [Collections](/docs/concepts/collections), the entities whose `list`/`get`/`create`/`update`/`delete` become MCP tools.

--- a/skills/questpie/AGENTS.md
+++ b/skills/questpie/AGENTS.md
@@ -7530,7 +7530,10 @@ Custom tools declare their own scope (no default mapping exists for them, so omi
 export default mcpTool("reports.generate", {
 	inputSchema: z.object({ period: z.string() }),
 	scopes: "routes:reports/generate:invoke",
-}).handler(async ({ input, ctx }) => ({ structuredContent: {} }));
+}).handler(async ({ input, ctx }) => ({
+	structuredContent: {},
+	content: [{ type: "text", text: "Report generated" }],
+}));
 ```
 
 ## Route Tools
@@ -7587,6 +7590,7 @@ export default mcpTool("generate-report", {
 	access: ({ session }) => !!session,
 }).handler(async ({ input, ctx }) => ({
 	structuredContent: await ctx.services.reports.generate(input),
+	content: [{ type: "text", text: "Report generated" }],
 }));
 ```
 
@@ -7611,7 +7615,7 @@ await startStdioServer(app);
 - HTTP callers are always `user` or `oauth`, never `system` - HTTP cannot be elevated to system mode. External access goes through OAuth (bounded by `scopes ∩ RBAC`), not system mode. Only stdio is `system`.
 - Field filtering is top-level only.
 - Raw routes and unannotated routes are not tools.
-- Custom tool results should use `structuredContent` for machine-readable output.
+- Custom tool results must include `content`; add `structuredContent` for machine-readable output.
 
 ---
 

--- a/skills/questpie/references/mcp.md
+++ b/skills/questpie/references/mcp.md
@@ -152,7 +152,10 @@ Custom tools declare their own scope (no default mapping exists for them, so omi
 export default mcpTool("reports.generate", {
 	inputSchema: z.object({ period: z.string() }),
 	scopes: "routes:reports/generate:invoke",
-}).handler(async ({ input, ctx }) => ({ structuredContent: {} }));
+}).handler(async ({ input, ctx }) => ({
+	structuredContent: {},
+	content: [{ type: "text", text: "Report generated" }],
+}));
 ```
 
 ## Route Tools
@@ -209,6 +212,7 @@ export default mcpTool("generate-report", {
 	access: ({ session }) => !!session,
 }).handler(async ({ input, ctx }) => ({
 	structuredContent: await ctx.services.reports.generate(input),
+	content: [{ type: "text", text: "Report generated" }],
 }));
 ```
 
@@ -233,4 +237,4 @@ await startStdioServer(app);
 - HTTP callers are always `user` or `oauth`, never `system` - HTTP cannot be elevated to system mode. External access goes through OAuth (bounded by `scopes ∩ RBAC`), not system mode. Only stdio is `system`.
 - Field filtering is top-level only.
 - Raw routes and unannotated routes are not tools.
-- Custom tool results should use `structuredContent` for machine-readable output.
+- Custom tool results must include `content`; add `structuredContent` for machine-readable output.


### PR DESCRIPTION
## Summary

- add a scaffold-to-Claude-and-VS-Code MCP/OAuth tutorial under Getting Started
- verify the commands against create-questpie 2.2.2 and QUESTPIE 3.15.2
- correct the custom MCP tool result contract in public docs and the canonical skill
- document the production migration rule: migrate only, never push

## Verification

- fresh published scaffold plus documented MCP config and custom tool: scaffold:verify passed
- bun run scripts/build-skill-docs.ts --check
- targeted oxfmt check
- bun run validate:docs (163 files, 0 errors, 0 warnings)
- bun run --cwd apps/docs types:check
- bun run --cwd apps/docs build

Docs-only; no changeset.