### PR TITLE
fix(docs): source landing version from package metadata

### DIFF
--- a/apps/docs/src/components/landing/index-sections.tsx
+++ b/apps/docs/src/components/landing/index-sections.tsx
@@ -4,6 +4,7 @@ import { type ReactNode, useState } from "react";
 import { buttonVariants } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
+import questpiePackage from "../../../../../packages/questpie/package.json";
 import {
 	accentButtonStyle,
 	type CodeLine,
@@ -70,7 +71,7 @@ export function Hero() {
 						<Reveal>
 							<div style={{ marginBottom: 22 }}>
 								<Eyebrow dot color="var(--success)">
-									MIT · TypeScript · Bun + Node
+									v{questpiePackage.version} · MIT · TypeScript · Bun + Node
 								</Eyebrow>
 							</div>
 						</Reveal>


### PR DESCRIPTION
## What changed

- source the landing hero version from `packages/questpie/package.json`
- render the exact framework version included in the docs build instead of maintaining a hardcoded value

## Why

The deployed landing still exposes the old hardcoded `v3.6`. Version copy can drift whenever the framework is released. Reading the core package metadata at build time keeps the badge aligned with the code being built without adding a runtime request to the npm registry.

## Impact

The current build renders `v3.15.2`. Future version PRs update the same package metadata, so rebuilt landing images pick up the new version automatically.

## Verification

- focused Oxfmt and Oxlint: pass
- docs TypeScript check: pass
- docs production build and prerender: pass
- root workspace typecheck: 16/16 tasks pass
- docs validator: 0 errors, 0 warnings
- desktop and 390 px mobile browser QA: `v3.15.2` present, `v3.6` absent, no horizontal overflow, no JS or network errors

## Deployment note

The current Woodpecker job pushes a mutable `latest` image but does not change the GitOps deployment, so merging this PR does not by itself guarantee a rollout. After merge, deploy an immutable commit tag/digest through GitOps and verify the public landing and docs routes.
