### PR TITLE
fix(docs): restore production build and add concept-first guides

### DIFF
--- a/apps/docs/AGENTS.md
+++ b/apps/docs/AGENTS.md
@@ -1,0 +1,30 @@
+# Documentation Authoring
+
+These rules apply to public documentation under `content/docs/`.
+
+## Reader contract
+
+- Write for a developer learning or operating QUESTPIE, never for an agent inspecting the repository.
+- Explain what to use, how it works, and the contract readers can rely on.
+- Do not inventory missing helpers, rejected guesses, internal investigation paths, or symbols readers should not search for.
+- State API shapes positively. Prefer “Global queries expose `get` and `update`” over “Globals have no `find`”.
+- Keep real security, compatibility, and production constraints. Pair each constraint with its effect and the supported path.
+
+## Information architecture
+
+Use this order for every capability:
+
+1. A tutorial or quick start shows a working outcome.
+2. A concept page explains the lifecycle, data flow, guarantees, and public API.
+3. An adapter page documents backend selection, configuration, capabilities, and operations.
+4. Reference pages enumerate exact types and signatures when needed.
+
+Every adapter page must link to the concept it implements. If a capability has no concept page, create that page before expanding its adapter reference.
+
+## Prose
+
+- Lead with the supported path.
+- Keep paragraphs focused and short.
+- Use examples to teach behavior; use tables for exact contracts.
+- Keep internal implementation details only when they define an observable guarantee or an extension contract.
+- Avoid commentary about how documentation or code was researched.

--- a/apps/docs/content/docs/adapters/email.mdx
+++ b/apps/docs/content/docs/adapters/email.mdx
@@ -3,14 +3,14 @@ title: Email adapter
 description: The email adapter is the delivery backend for outgoing mail, set one in config and QUESTPIE sends every template and one-off message through it. Swap SMTP, Resend, Plunk, or Console without touching a single template.
 ---
 
-The **email adapter** is the one piece of config that decides *how* your mail is delivered. QUESTPIE ships four, `ConsoleAdapter`, `SmtpAdapter`, `ResendAdapter`, `PlunkAdapter`, and you pick exactly one. Your templates and your `ctx.email.send(...)` / `ctx.email.sendTemplate(...)` calls never change when you swap providers; only the `adapter` in `runtimeConfig` does.
+The **email adapter** is the one piece of config that decides _how_ your mail is delivered. QUESTPIE ships four, `ConsoleAdapter`, `SmtpAdapter`, `ResendAdapter`, `PlunkAdapter`, and you pick exactly one. Your templates and your `ctx.email.send(...)` / `ctx.email.sendTemplate(...)` calls never change when you swap providers; only the `adapter` in `runtimeConfig` does.
 
 > **Prerequisites:** read [Emails](/docs/concepts/emails) first, it owns templates, `EmailResult`, and the `ctx.email` send service. This page owns the adapter slot: which provider delivers the mail, and how to configure each one.
 
 ## What it does
 
 - **Swap providers in one line.** Point `email.adapter` at Console, SMTP, Resend, or Plunk; nothing in your templates or send calls changes.
-- **One contract, four implementations.** Every adapter extends `MailAdapter` and implements a single method, `send(options)`. The framework's own four use that exact base class, there is no privileged internal API.
+- **One contract, four implementations.** Every built-in and custom adapter extends `MailAdapter` and implements `send(options)`.
 - **Console for local dev.** `ConsoleAdapter` logs the rendered email to your logger instead of sending it, no SMTP server, no API key.
 - **Production-ready HTTP and SMTP.** `ResendAdapter` and `PlunkAdapter` POST to their providers' HTTP APIs; `SmtpAdapter` wraps nodemailer for any SMTP server.
 - **Bring your own.** Implement `MailAdapter.send` and wire your class in, the same way the built-in adapters do.
@@ -31,10 +31,7 @@ export default runtimeConfig({
   db: { url: env.DATABASE_URL },
   email: {
     // The provider that delivers mail. Pick exactly one.
-    adapter:
-      env.NODE_ENV === "production"
-        ? new SmtpAdapter({ transport: env.SMTP_URL })
-        : new ConsoleAdapter(),
+    adapter: env.NODE_ENV === "production" ? new SmtpAdapter({ transport: env.SMTP_URL }) : new ConsoleAdapter(),
     defaults: { from: "no-reply@example.com" }, // fallback From for every message
   },
 });
@@ -56,7 +53,7 @@ abstract class MailAdapter {
 }
 ```
 
-By the time `send` is called, the mailer has already **serialized** the message: it filled `from` (from the call, then `defaults.from`, then `"noreply@example.com"`), derived plain `text` from `html` when `text` was missing, and guaranteed at least one body exists. So `from`, `text`, and `html` always arrive as present `string`s (never `undefined`), you never re-derive them. Note the nuance: `from` is always non-empty (it's defaulted), and *at least one* of `text`/`html` is non-empty, but the other may be the empty string `""`. A plain-text-only send (`text` set, `html` omitted) reaches your adapter with `html: ""`, guard for that if your provider rejects an empty HTML body.
+By the time `send` is called, the mailer has already **serialized** the message: it filled `from` (from the call, then `defaults.from`, then `"noreply@example.com"`), derived plain `text` from `html` when `text` was missing, and guaranteed at least one body exists. So `from`, `text`, and `html` always arrive as present `string`s (never `undefined`), you never re-derive them. Note the nuance: `from` is always non-empty (it's defaulted), and _at least one_ of `text`/`html` is non-empty, but the other may be the empty string `""`. A plain-text-only send (`text` set, `html` omitted) reaches your adapter with `html: ""`, guard for that if your provider rejects an empty HTML body.
 
 ```ts
 type SerializableMailOptions = {
@@ -69,11 +66,13 @@ type SerializableMailOptions = {
   html: string; // present; may be "" on a text-only send
   replyTo?: string;
   headers?: Record<string, string>;
-  attachments?: Array<{ filename: string; content: Buffer | string; contentType?: string }>;
+  attachments?: Array<{
+    filename: string;
+    content: Buffer | string;
+    contentType?: string;
+  }>;
 };
 ```
-
-
 
 The concrete adapters are **not** re-exported from the root `questpie` barrel, only the abstract `MailAdapter` base and the mailer types are (via `questpie/mailer`). Import each adapter from its own subpath: `questpie/adapters/console`, `questpie/adapters/smtp`, `questpie/adapters/resend`, `questpie/adapters/plunk`.
 
@@ -88,10 +87,10 @@ new ConsoleAdapter(); // both options optional
 new ConsoleAdapter({ logHtml: true }); // also print the HTML body
 ```
 
-| Option | Type | Default | Notes |
-|---|---|---|---|
-| `logHtml` | `boolean` | `false` | When `false`, the HTML body is replaced with a one-line hint instead of printed (HTML is verbose). |
-| `logger` | `(message: string) => void` | `console.log` | Where each line goes. |
+| Option    | Type                        | Default       | Notes                                                                                              |
+| --------- | --------------------------- | ------------- | -------------------------------------------------------------------------------------------------- |
+| `logHtml` | `boolean`                   | `false`       | When `false`, the HTML body is replaced with a one-line hint instead of printed (HTML is verbose). |
+| `logger`  | `(message: string) => void` | `console.log` | Where each line goes.                                                                              |
 
 It logs `From / To / CC / BCC / Reply-To / Subject`, the plain-text body, attachment filenames, and (only when `logHtml: true`) the HTML. It never sends.
 
@@ -115,10 +114,10 @@ new SmtpAdapter({
 new SmtpAdapter({ transport: "smtp://user:pass@smtp.example.com:587" });
 ```
 
-| Option | Type | Notes |
-|---|---|---|
-| `transport` | `SMTPTransport \| SMTPTransport.Options \| string` | Passed straight to `nodemailer.createTransport`, an options object, an `SMTPTransport` instance, or a connection-string URL. |
-| `afterSendCallback` | `(info: SentMessageInfo) => void \| Promise<void>` | Runs after each send. Handy for logging provider message IDs or preview URLs. |
+| Option              | Type                                               | Notes                                                                                                                        |
+| ------------------- | -------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `transport`         | `SMTPTransport \| SMTPTransport.Options \| string` | Passed straight to `nodemailer.createTransport`, an options object, an `SMTPTransport` instance, or a connection-string URL. |
+| `afterSendCallback` | `(info: SentMessageInfo) => void \| Promise<void>` | Runs after each send. Handy for logging provider message IDs or preview URLs.                                                |
 
 `SmtpAdapter` also exposes `verify(): Promise<boolean>`, which proxies nodemailer's SMTP connection check.
 
@@ -147,14 +146,14 @@ import { resendAdapter } from "questpie/adapters/resend";
 resendAdapter({ apiKey: env.RESEND_API_KEY });
 ```
 
-| Option | Type | Default | Notes |
-|---|---|---|---|
-| `apiKey` | `string` | none *(required)* | Your Resend API key (or a key for a Resend-compatible provider). |
-| `baseUrl` | `string` | `"https://api.resend.com"` | Point at a Resend-compatible API. Trailing slashes are stripped. |
-| `userAgent` | `string` | `"questpie-resend-adapter"` | Resend requires a `User-Agent` for direct HTTP calls. |
-| `idempotencyKey` | `string \| ((options) => string \| undefined)` | none | Static or per-email. When present, sets the `Idempotency-Key` header. |
-| `fetch` | `typeof fetch` | global `fetch` | Override for tests or non-standard runtimes. |
-| `afterSendCallback` | `(response: ResendSendResponse, options) => void \| Promise<void>` | none | Runs with the parsed JSON body (e.g. the message `id`) after Resend accepts the email. |
+| Option              | Type                                                               | Default                     | Notes                                                                                  |
+| ------------------- | ------------------------------------------------------------------ | --------------------------- | -------------------------------------------------------------------------------------- |
+| `apiKey`            | `string`                                                           | none _(required)_           | Your Resend API key (or a key for a Resend-compatible provider).                       |
+| `baseUrl`           | `string`                                                           | `"https://api.resend.com"`  | Point at a Resend-compatible API. Trailing slashes are stripped.                       |
+| `userAgent`         | `string`                                                           | `"questpie-resend-adapter"` | Resend requires a `User-Agent` for direct HTTP calls.                                  |
+| `idempotencyKey`    | `string \| ((options) => string \| undefined)`                     | none                        | Static or per-email. When present, sets the `Idempotency-Key` header.                  |
+| `fetch`             | `typeof fetch`                                                     | global `fetch`              | Override for tests or non-standard runtimes.                                           |
+| `afterSendCallback` | `(response: ResendSendResponse, options) => void \| Promise<void>` | none                        | Runs with the parsed JSON body (e.g. the message `id`) after Resend accepts the email. |
 
 Buffer attachments are base64-encoded automatically. On a non-2xx response it throws `Resend API error (<status> <statusText>): <body>`.
 
@@ -168,30 +167,30 @@ import { plunkAdapter } from "questpie/adapters/plunk";
 plunkAdapter({ apiKey: env.PLUNK_SECRET_KEY });
 ```
 
-| Option | Type | Default | Notes |
-|---|---|---|---|
-| `apiKey` | `string` | none *(required)* | A Plunk **secret** key, public keys only track events. |
-| `baseUrl` | `string` | `"https://next-api.useplunk.com"` | Override for self-hosted Plunk. |
-| `fromName` | `string` | none | Display name, applied only when `from` is a bare email (no `"Name <email>"` form). |
-| `subscribed` | `boolean` | none | Subscribe recipients to marketing in Plunk. Leave unset for transactional mail. |
-| `fetch` | `typeof fetch` | global `fetch` | Override for tests or non-standard runtimes. |
-| `afterSendCallback` | `(response: PlunkSendResponse, options) => void \| Promise<void>` | none | Runs with the parsed body after Plunk accepts the email. |
+| Option              | Type                                                              | Default                           | Notes                                                                              |
+| ------------------- | ----------------------------------------------------------------- | --------------------------------- | ---------------------------------------------------------------------------------- |
+| `apiKey`            | `string`                                                          | none _(required)_                 | A Plunk **secret** key, public keys only track events.                             |
+| `baseUrl`           | `string`                                                          | `"https://next-api.useplunk.com"` | Override for self-hosted Plunk.                                                    |
+| `fromName`          | `string`                                                          | none                              | Display name, applied only when `from` is a bare email (no `"Name <email>"` form). |
+| `subscribed`        | `boolean`                                                         | none                              | Subscribe recipients to marketing in Plunk. Leave unset for transactional mail.    |
+| `fetch`             | `typeof fetch`                                                    | global `fetch`                    | Override for tests or non-standard runtimes.                                       |
+| `afterSendCallback` | `(response: PlunkSendResponse, options) => void \| Promise<void>` | none                              | Runs with the parsed body after Plunk accepts the email.                           |
 
 <Callout type="warn" title="Plunk rejects CC and BCC">
-`PlunkAdapter` throws if a message sets `cc` or `bcc`, Plunk's transactional API doesn't document those fields. It also treats a `success: false` body as an error even on an HTTP 2xx response. If you need CC/BCC, use SMTP or Resend.
+  `PlunkAdapter` throws if a message sets `cc` or `bcc`, Plunk's transactional API doesn't document those fields. It also treats a `success: false` body as an error even on an HTTP 2xx response. If you need CC/BCC, use SMTP or Resend.
 </Callout>
 
 ## Choosing an adapter
 
 One recommended path, not a menu:
 
-| Environment | Use | Why |
-|---|---|---|
-| Local development | `ConsoleAdapter` | No external service; the rendered email lands in your logs. |
-| Production (generic SMTP) | `SmtpAdapter` | Works with any SMTP provider; full message support (CC/BCC/attachments). |
-| Production (Resend) | `resendAdapter()` | First-class HTTP API with idempotency keys. |
-| Production (Plunk) | `plunkAdapter()` | Plunk's transactional API (no CC/BCC). |
-| Automated tests with a real inbox | `createEtherealSmtpAdapter()` | Throwaway account + a preview URL per send. |
+| Environment                       | Use                           | Why                                                                      |
+| --------------------------------- | ----------------------------- | ------------------------------------------------------------------------ |
+| Local development                 | `ConsoleAdapter`              | No external service; the rendered email lands in your logs.              |
+| Production (generic SMTP)         | `SmtpAdapter`                 | Works with any SMTP provider; full message support (CC/BCC/attachments). |
+| Production (Resend)               | `resendAdapter()`             | First-class HTTP API with idempotency keys.                              |
+| Production (Plunk)                | `plunkAdapter()`              | Plunk's transactional API (no CC/BCC).                                   |
+| Automated tests with a real inbox | `createEtherealSmtpAdapter()` | Throwaway account + a preview URL per send.                              |
 
 A common setup branches on `NODE_ENV` (see the Quick start) so dev logs to the console and production sends for real.
 
@@ -200,12 +199,12 @@ A common setup branches on `NODE_ENV` (see the Quick start) so dev logs to the c
 - **The adapter is required even in dev**, the core email service asserts it at app build. See the Quick-start callout.
 - **`defaults.from` is the only fallback sender.** If a send call omits `from` and you set no `defaults.from`, mail goes out as `noreply@example.com`. Set `defaults.from` in config.
 - **`adapter` may be a `Promise`.** `MailerConfig.adapter` accepts `MailAdapter | Promise<MailAdapter>`; the promise is awaited lazily on the first send (how `createEtherealSmtpAdapter()` plugs in).
-- **HTTP adapters surface provider errors as thrown `Error`s**, wrap sends you can't afford to lose, or dispatch them from a [job](/docs/concepts/jobs) so failures retry. Resend throws on non-2xx; Plunk throws on non-2xx *or* `success: false`.
+- **HTTP adapters surface provider errors as thrown `Error`s**, wrap sends you can't afford to lose, or dispatch them from a [job](/docs/concepts/jobs) so failures retry. Resend throws on non-2xx; Plunk throws on non-2xx _or_ `success: false`.
 - **Plunk drops CC/BCC**, it throws rather than silently dropping them. See the Plunk callout.
 
 ## Custom adapter
 
-The adapter is an extension point: any class extending `MailAdapter` works, and the framework's own four use that exact base class, there's no internal-only API. Implement the single `send(options: SerializableMailOptions)` method. Because the mailer serializes before handing off, `from`, `text`, and `html` are already present `string`s, so you don't re-derive plain text or default the sender. Just remember that one of `text`/`html` may be `""` (a text-only send forwards `html: ""`), if your provider rejects an empty field, omit it instead of passing the empty string:
+Any class extending `MailAdapter` can provide delivery. Implement `send(options: SerializableMailOptions)`. The mailer passes `from`, `text`, and `html` as strings; one body variant can be empty, so omit empty fields when a provider rejects them:
 
 ```ts title="src/questpie/server/lib/my-mail-adapter.ts"
 import { MailAdapter } from "questpie/mailer";

--- a/apps/docs/content/docs/adapters/index.mdx
+++ b/apps/docs/content/docs/adapters/index.mdx
@@ -9,24 +9,23 @@ This is the QUESTPIE principle in action: **core, modules, and your own code rea
 
 ## Adapter kinds
 
-QUESTPIE ships six adapter slots. Each page below covers the whole vertical: which backend to choose, how to configure it, and the contract to implement your own.
+QUESTPIE ships seven infrastructure adapter slots. Learn the feature contract on its concept page, then use the adapter page to choose and configure a backend.
 
-| Adapter | What it does | Default |
-|---|---|---|
-| **[Queue](/docs/adapters/queue)** | Where background [jobs](/docs/concepts/jobs) run, store, schedule, and hand work to a worker. | pg-boss (Postgres) |
-| **[Search](/docs/adapters/search)** | Full-text and semantic search behind [`.searchable()`](/docs/concepts/collections#searchable) and `app.search`. | Postgres (FTS + trigram) |
-| **[Realtime](/docs/adapters/realtime)** | The server-side transport that fans out live-query changes across every app instance. | poll-based |
-| **[Storage](/docs/adapters/storage)** | Where uploaded file bytes physically live, plus signed URLs and visibility. | local filesystem |
-| **[Email](/docs/adapters/email)** | The delivery backend for every outgoing [email](/docs/concepts/emails) template and one-off message. | console (dev) |
-| **[KV](/docs/adapters/kv)** | A typed key-value store on `ctx.kv` with TTL and tag-based invalidation. | in-memory |
+| Feature           | Concept                                         | Adapter                                     | Default                  |
+| ----------------- | ----------------------------------------------- | ------------------------------------------- | ------------------------ |
+| Background work   | [Jobs](/docs/concepts/jobs)                     | [Queue](/docs/adapters/queue)               | pg-boss (Postgres)       |
+| Search            | [Search](/docs/concepts/search)                 | [Search adapter](/docs/adapters/search)     | Postgres (FTS + trigram) |
+| Realtime          | [Realtime](/docs/concepts/realtime)             | [Realtime adapter](/docs/adapters/realtime) | poll-based               |
+| File storage      | [Storage](/docs/concepts/storage)               | [Storage adapter](/docs/adapters/storage)   | local filesystem         |
+| Email             | [Emails](/docs/concepts/emails)                 | [Email adapter](/docs/adapters/email)       | console (dev)            |
+| Key-value storage | [KV](/docs/concepts/kv)                         | [KV adapter](/docs/adapters/kv)             | in-memory                |
+| Dynamic code      | [Sandboxed code](/docs/concepts/sandboxed-code) | [Sandbox adapter](/docs/adapters/sandbox)   | trusted only             |
 
 ## How they wire in
 
 You select an adapter once, in `questpie.config.ts` (or the `.build({ ... })` call), and the rest of your code is untouched. See [Configuration](/docs/concepts/configuration) for where each slot lives and how the runtime resolves it.
 
-<Callout type="info">
-Each adapter declares its own capabilities, so the runtime can fail fast or branch, for example, a queue adapter advertises whether it supports long-running workers or push delivery. The per-adapter pages document the relevant flags.
-</Callout>
+<Callout type="info">Each adapter declares its own capabilities, so the runtime can fail fast or branch, for example, a queue adapter advertises whether it supports long-running workers or push delivery. The per-adapter pages document the relevant flags.</Callout>
 
 ## Custom adapters
 
@@ -36,4 +35,4 @@ Every adapter is defined by a public contract, `QueueAdapter`, `SearchAdapter`, 
 
 - [Configuration](/docs/concepts/configuration), where every adapter slot lives and how it's wired.
 - [Building a plugin](/docs/extend/build-a-plugin), implement any adapter contract for a custom backend.
-- [Jobs](/docs/concepts/jobs) · [Search](/docs/adapters/search) · [Emails](/docs/concepts/emails), the features each adapter powers.
+- [Jobs](/docs/concepts/jobs) · [Search](/docs/concepts/search) · [Realtime](/docs/concepts/realtime) · [Storage](/docs/concepts/storage) · [Emails](/docs/concepts/emails) · [KV](/docs/concepts/kv) · [Sandboxed code](/docs/concepts/sandboxed-code), the concepts each adapter implements.

--- a/apps/docs/content/docs/adapters/kv.mdx
+++ b/apps/docs/content/docs/adapters/kv.mdx
@@ -3,10 +3,10 @@ title: KV adapter
 description: A typed key-value store on your app context, ctx.kv.get/set/delete/has/clear with TTL and tag-based invalidation. In-memory by default; swap to Redis or Cloudflare KV with one config line and no app-code change.
 ---
 
-QUESTPIE ships a small **key-value store** at `app.kv` (and `ctx.kv` in every handler). You call `get`, `set`, `delete`, `has`, and `clear` against a typed service; the actual storage is a swappable **adapter**. By default it's an in-process `Map`, good enough for dev and single-process deployments. Point one config line at Redis or Cloudflare KV and the same `ctx.kv` calls now hit a shared, persistent store. Your application code never changes.
+The **KV adapter** supplies the backend for the [Key-value storage](/docs/concepts/kv) service on `app.kv` and `ctx.kv`. Choose in-memory, Redis, or Cloudflare KV while application calls keep the same typed contract.
 
 <Callout type="info" title="Prerequisites">
-Read [Adapters](/docs/adapters) (what an adapter is and the full list of swappable backends) and [Configuration](/docs/concepts/configuration) (where the `kv` slot is wired into `questpie.config.ts` via `runtimeConfig`). KV has no separate feature page, the store *is* the adapter, so this page owns both.
+  Start with [Key-value storage](/docs/concepts/kv) for use cases, the core API, namespaces, tags, and consistency. This page covers backend configuration and adapter-specific behavior.
 </Callout>
 
 ## What it does
@@ -58,7 +58,8 @@ export default runtimeConfig({
 ```
 
 <Callout type="info" title="The default adapter is in-process and not shared">
-With no `kv.adapter` configured, `KVService` uses [`MemoryKVAdapter`](#in-memory-default), a plain `Map` local to **one** process. It is wiped on restart and **not shared** across server instances or workers. Fine for dev and single-process apps; for anything horizontally scaled, configure Redis or Cloudflare KV so all instances see the same data.
+  With no `kv.adapter` configured, `KVService` uses [`MemoryKVAdapter`](#in-memory-default), a plain `Map` local to **one** process. It is wiped on restart and **not shared** across server instances or workers. Fine for dev and single-process apps; for anything horizontally scaled, configure Redis or Cloudflare KV so
+  all instances see the same data.
 </Callout>
 
 ## Using the store
@@ -70,11 +71,13 @@ With no `kv.adapter` configured, `KVService` uses [`MemoryKVAdapter`](#in-memory
 const user = await ctx.kv.get<User>("user:42");
 
 // Write, ttl is OPTIONAL and in SECONDS (falls back to config.defaultTtl)
-await ctx.kv.set("user:42", user);        // no expiry
+await ctx.kv.set("user:42", user); // no expiry
 await ctx.kv.set("otp:42", "839201", 300); // expires in 5 minutes
 
 // Existence check (respects TTL, an expired key reports false)
-if (await ctx.kv.has("otp:42")) { /* ... */ }
+if (await ctx.kv.has("otp:42")) {
+  /* ... */
+}
 
 // Delete one key
 await ctx.kv.delete("otp:42");
@@ -84,7 +87,8 @@ await ctx.kv.clear();
 ```
 
 <Callout type="info" title="Values must be JSON-serializable on Redis & Cloudflare KV">
-The in-memory adapter stores your value by reference (any JS value works). The Redis and Cloudflare adapters `JSON.stringify` it on write and `JSON.parse` on read, and **throw** a `TypeError` if the value can't be serialized (e.g. a `function`, a `BigInt`, or a circular structure). Read back is best-effort: a stored string that isn't valid JSON is returned as the raw string. Keep KV values to plain data.
+  The in-memory adapter stores your value by reference (any JS value works). The Redis and Cloudflare adapters `JSON.stringify` it on write and `JSON.parse` on read, and **throw** a `TypeError` if the value can't be serialized (e.g. a `function`, a `BigInt`, or a circular structure). Read back is best-effort: a stored
+  string that isn't valid JSON is returned as the raw string. Keep KV values to plain data.
 </Callout>
 
 ### Tag-based invalidation
@@ -105,11 +109,14 @@ await adapter?.invalidateByTags?.(["post:123", "post:124"]);
 ```
 
 <Callout type="warn" title="On the zero-config default, `app.config.kv?.adapter` is `undefined`">
-`app.config` is your *raw* config object. When you omit `kv.adapter`, the default `MemoryKVAdapter` is constructed **inside** `KVService` and never written back to `app.config`, so on the default setup `app.config.kv?.adapter` is `undefined` and the `?.` calls above **silently do nothing**, even though `MemoryKVAdapter` fully implements `setWithTags` / `invalidateByTag`. Tag invalidation is only reachable when you construct an adapter explicitly: either set `kv.adapter` in config and read it back via `app.config.kv?.adapter`, or, cleaner, keep your own reference to the adapter you built and call its tag methods directly.
+  `app.config` is your *raw* config object. When you omit `kv.adapter`, the default `MemoryKVAdapter` is constructed **inside** `KVService` and never written back to `app.config`, so on the default setup `app.config.kv?.adapter` is `undefined` and the `?.` calls above **silently do nothing**, even though
+  `MemoryKVAdapter` fully implements `setWithTags` / `invalidateByTag`. Tag invalidation is only reachable when you construct an adapter explicitly: either set `kv.adapter` in config and read it back via `app.config.kv?.adapter`, or, cleaner, keep your own reference to the adapter you built and call its tag methods
+  directly.
 </Callout>
 
 <Callout type="info" title="Tag methods live on the adapter, not the service">
-`get` / `set` / `delete` / `has` / `clear` are the only methods on `KVService`. `setWithTags`, `invalidateByTag`, and `invalidateByTags` are **optional** members of the `KVAdapter` interface, every built-in adapter implements them, but a custom adapter may not. That's why they're typed as optional (`?.`) when you reach them off the config.
+  `get` / `set` / `delete` / `has` / `clear` are the only methods on `KVService`. `setWithTags`, `invalidateByTag`, and `invalidateByTags` are **optional** members of the `KVAdapter` interface, every built-in adapter implements them, but a custom adapter may not. That's why they're typed as optional (`?.`) when you
+  reach them off the config.
 </Callout>
 
 ## Configuration
@@ -125,10 +132,10 @@ interface KVConfig {
 }
 ```
 
-| Option | Type | Default | Notes |
-|---|---|---|---|
-| `adapter` | `KVAdapter` | `new MemoryKVAdapter()` | The backend. Omit for in-memory. |
-| `defaultTtl` | `number` | _(none)_ | Seconds. Applied by `KVService.set` only when the call omits its own `ttl`. |
+| Option       | Type        | Default                 | Notes                                                                       |
+| ------------ | ----------- | ----------------------- | --------------------------------------------------------------------------- |
+| `adapter`    | `KVAdapter` | `new MemoryKVAdapter()` | The backend. Omit for in-memory.                                            |
+| `defaultTtl` | `number`    | _(none)_                | Seconds. Applied by `KVService.set` only when the call omits its own `ttl`. |
 
 When a call omits its own TTL, the service uses `defaultTtl`.
 
@@ -136,11 +143,11 @@ When a call omits its own TTL, the service uses `defaultTtl`.
 
 QUESTPIE ships three KV adapters. The interface contract, `KVAdapter`, and the `KVConfig` type are the only things exported from `questpie/kv`; the concrete adapters each live in their own entry so you only pull in the client you actually use.
 
-| Adapter | Import | Backend | Shared / persistent |
-|---|---|---|---|
-| `MemoryKVAdapter` | `questpie/adapters/memory-kv` | in-process `Map` | no |
-| `redisKVAdapter` | `questpie/adapters/redis-kv` | Redis | yes |
-| `cloudflareKVAdapter` | `questpie/adapters/cloudflare-kv` | Cloudflare KV namespace | yes |
+| Adapter               | Import                            | Backend                 | Shared / persistent |
+| --------------------- | --------------------------------- | ----------------------- | ------------------- |
+| `MemoryKVAdapter`     | `questpie/adapters/memory-kv`     | in-process `Map`        | no                  |
+| `redisKVAdapter`      | `questpie/adapters/redis-kv`      | Redis                   | yes                 |
+| `cloudflareKVAdapter` | `questpie/adapters/cloudflare-kv` | Cloudflare KV namespace | yes                 |
 
 ### In-memory (default)
 
@@ -182,18 +189,19 @@ export default runtimeConfig({
 
 `redisKVAdapter` accepts these options:
 
-| Option | Type | Default | Notes |
-|---|---|---|---|
-| `client` | `RedisKVClient \| () => RedisKVClient` | none _(required)_ | A connected node-redis-shaped client, or a provider returning one (resolved once on first call). |
-| `keyPrefix` | `string` | `""` | Prepended to every key. Use it when one Redis db is shared by multiple logical caches. |
-| `tagIndexPrefix` | `string` | `"__questpie_tag:"` | Prefix for the internal tag-index sets, applied **after** `keyPrefix`. |
-| `scanCount` | `number` | `100` | Keys requested per `SCAN` page during `clear()` / tag cleanup. |
-| `allowFlushDb` | `boolean` | `false` | See the warning below. |
+| Option           | Type                                   | Default             | Notes                                                                                            |
+| ---------------- | -------------------------------------- | ------------------- | ------------------------------------------------------------------------------------------------ |
+| `client`         | `RedisKVClient \| () => RedisKVClient` | none _(required)_   | A connected node-redis-shaped client, or a provider returning one (resolved once on first call). |
+| `keyPrefix`      | `string`                               | `""`                | Prepended to every key. Use it when one Redis db is shared by multiple logical caches.           |
+| `tagIndexPrefix` | `string`                               | `"__questpie_tag:"` | Prefix for the internal tag-index sets, applied **after** `keyPrefix`.                           |
+| `scanCount`      | `number`                               | `100`               | Keys requested per `SCAN` page during `clear()` / tag cleanup.                                   |
+| `allowFlushDb`   | `boolean`                              | `false`             | See the warning below.                                                                           |
 
 Tags are stored as Redis SETs; TTL maps to the `EX` option on `SET`. `delete()` and `clear()` scan the keyspace (`SCAN`, not `KEYS`) to keep the tag index consistent.
 
 <Callout type="warn" title="`clear()` will not FLUSHDB a shared database by default">
-`ctx.kv.clear()` on Redis deletes only keys matching your `keyPrefix` (via `SCAN` + `DEL`). It calls `FLUSHDB` **only** when you have *no* `keyPrefix` **and** explicitly set `allowFlushDb: true`, a guard so a `clear()` can't wipe a Redis database shared with other apps. If you rely on `clear()` to be cheap and total, give the adapter its own database and opt in with `allowFlushDb: true`.
+  `ctx.kv.clear()` on Redis deletes only keys matching your `keyPrefix` (via `SCAN` + `DEL`). It calls `FLUSHDB` **only** when you have *no* `keyPrefix` **and** explicitly set `allowFlushDb: true`, a guard so a `clear()` can't wipe a Redis database shared with other apps. If you rely on `clear()` to be cheap and total,
+  give the adapter its own database and opt in with `allowFlushDb: true`.
 </Callout>
 
 The `RedisKVClient` interface (`get` / `set` / `del` / `exists` / `sAdd` / `sMembers` / `sRem` / `scanIterator` / optional `flushDb`) is a structural subset of node-redis, any client matching that shape works.
@@ -216,17 +224,18 @@ export default runtimeConfig({
 
 `cloudflareKVAdapter` accepts these options:
 
-| Option | Type | Default | Notes |
-|---|---|---|---|
-| `namespace` | `CloudflareKVNamespace \| () => CloudflareKVNamespace` | none _(required)_ | A KV namespace binding, or a provider returning one. |
-| `keyPrefix` | `string` | `""` | Prepended to every key. Use it when one namespace is shared by multiple logical caches. |
-| `tagIndexPrefix` | `string` | `"__questpie_tag:"` | Prefix for the internal tag-index entries, applied after `keyPrefix`. |
-| `listLimit` | `number` | `1000` | Keys requested per `list()` page during `clear()` / tag cleanup. |
+| Option           | Type                                                   | Default             | Notes                                                                                   |
+| ---------------- | ------------------------------------------------------ | ------------------- | --------------------------------------------------------------------------------------- |
+| `namespace`      | `CloudflareKVNamespace \| () => CloudflareKVNamespace` | none _(required)_   | A KV namespace binding, or a provider returning one.                                    |
+| `keyPrefix`      | `string`                                               | `""`                | Prepended to every key. Use it when one namespace is shared by multiple logical caches. |
+| `tagIndexPrefix` | `string`                                               | `"__questpie_tag:"` | Prefix for the internal tag-index entries, applied after `keyPrefix`.                   |
+| `listLimit`      | `number`                                               | `1000`              | Keys requested per `list()` page during `clear()` / tag cleanup.                        |
 
 TTL maps to Cloudflare's `expirationTtl`. Because Cloudflare KV has no SET type, tags are stored as JSON arrays under tag-index keys, and `clear()` / invalidation paginate with `list()` + `cursor`. The adapter also exposes `runtime = "cloudflare"`, the discriminator the Cloudflare fetch/queue handlers use to detect Cloudflare-backed adapters.
 
 <Callout type="warn" title="Cloudflare KV is eventually consistent">
-Cloudflare KV reads can lag writes by a short window, a value you just `set` may not be visible to the next `get` on a different edge location immediately. This is a property of the platform, not the adapter. Don't use it for read-after-write guarantees (e.g. one-time tokens you verify milliseconds later); use it for caches and config that tolerate brief staleness. See Cloudflare's KV consistency docs.
+  Cloudflare KV reads can lag writes by a short window, a value you just `set` may not be visible to the next `get` on a different edge location immediately. This is a property of the platform, not the adapter. Don't use it for read-after-write guarantees (e.g. one-time tokens you verify milliseconds later); use it for
+  caches and config that tolerate brief staleness. See Cloudflare's KV consistency docs.
 </Callout>
 
 The `cloudflareKVAdapter` factory and its `CloudflareKVNamespace` type are also re-exported from `questpie/adapters/cloudflare` alongside the other Cloudflare-runtime adapters, if you prefer a single import.
@@ -239,11 +248,21 @@ The KV store is just an interface, implement `KVAdapter` to back it with any sto
 import type { KVAdapter } from "questpie/kv";
 
 export class MyKVAdapter implements KVAdapter {
-  async get<T>(key: string): Promise<T | null> { /* ... */ }
-  async set(key: string, value: unknown, ttl?: number): Promise<void> { /* ... */ }
-  async delete(key: string): Promise<void> { /* ... */ }
-  async has(key: string): Promise<boolean> { /* ... */ }
-  async clear(): Promise<void> { /* ... */ }
+  async get<T>(key: string): Promise<T | null> {
+    /* ... */
+  }
+  async set(key: string, value: unknown, ttl?: number): Promise<void> {
+    /* ... */
+  }
+  async delete(key: string): Promise<void> {
+    /* ... */
+  }
+  async has(key: string): Promise<boolean> {
+    /* ... */
+  }
+  async clear(): Promise<void> {
+    /* ... */
+  }
   // Optional, implement to support tag invalidation:
   // setWithTags, invalidateByTag, invalidateByTags
 }

--- a/apps/docs/content/docs/adapters/queue.mdx
+++ b/apps/docs/content/docs/adapters/queue.mdx
@@ -5,7 +5,7 @@ description: Pick where your background jobs run, Postgres (pg-boss), Redis (Bul
 
 The **queue adapter** is the slot that decides where your background work runs. You write a [job](/docs/concepts/jobs) once; the adapter is the plug-in backend that stores, schedules, and hands jobs to a worker. Swap `pgBossAdapter` for `bullMQAdapter` and the exact same job code moves from Postgres to Redis, no handler change, no dispatch change. QUESTPIE ships three adapters and an open `QueueAdapter` contract so you can write your own.
 
-This page is the **infrastructure reference**: which adapter to choose, how each one is configured, the capability flags that gate `listen` / `runOnce` / `schedule`, and how to plug in a custom backend. For how to *define* and *dispatch* jobs (`job()`, `queue.<name>.publish`, the handler context), see [Jobs](/docs/concepts/jobs).
+This page is the **infrastructure reference**: which adapter to choose, how each one is configured, the capability flags that gate `listen` / `runOnce` / `schedule`, and how to plug in a custom backend. For how to _define_ and _dispatch_ jobs (`job()`, `queue.<name>.publish`, the handler context), see [Jobs](/docs/concepts/jobs).
 
 <Callout type="info" title="Prerequisites">
 Read [Jobs](/docs/concepts/jobs) first, it owns `job()`, `queue.<name>.publish/schedule`, and the worker entrypoints. This page assumes you know how a job is defined and dispatched, and focuses only on the adapter that backs the queue. See also [Configuration](/docs/concepts/configuration) for the `.build({ ... })` model.
@@ -41,38 +41,37 @@ If your app has at least one job but no `queue: { adapter }`, the queue service 
 
 ## Choosing an adapter
 
-| Adapter | Import | Backed by | Best for |
-|---|---|---|---|
-| **pg-boss** | `questpie/adapters/pg-boss` | Postgres | The default, reuse your app database, zero extra infrastructure. |
-| **BullMQ** | `questpie/adapters/bullmq` | Redis | High-throughput queues when you already run Redis. |
-| **Cloudflare Queues** | `questpie/adapters/cloudflare-queues` | CF Queues | Serverless on Cloudflare Workers (push delivery). |
+| Adapter               | Import                                | Backed by | Best for                                                         |
+| --------------------- | ------------------------------------- | --------- | ---------------------------------------------------------------- |
+| **pg-boss**           | `questpie/adapters/pg-boss`           | Postgres  | The default, reuse your app database, zero extra infrastructure. |
+| **BullMQ**            | `questpie/adapters/bullmq`            | Redis     | High-throughput queues when you already run Redis.               |
+| **Cloudflare Queues** | `questpie/adapters/cloudflare-queues` | CF Queues | Serverless on Cloudflare Workers (push delivery).                |
 
 Each adapter advertises what it can do through capability flags. These gate which worker methods you may call:
 
-| Capability | pg-boss | BullMQ | Cloudflare Queues |
-|---|---|---|---|
-| `longRunningConsumer` (`queue.listen()`) | yes | yes | no |
-| `runOnceConsumer` (`queue.runOnce()`) | yes | yes | no |
-| `pushConsumer` (`queue.createPushConsumer()`) | no | no | yes |
-| `scheduling` (`options.cron`, `queue.<n>.schedule()`) | yes | yes | no |
-| `singleton` (`singletonKey` dedup) | yes | yes | no |
-
-
+| Capability                                            | pg-boss | BullMQ | Cloudflare Queues |
+| ----------------------------------------------------- | ------- | ------ | ----------------- |
+| `longRunningConsumer` (`queue.listen()`)              | yes     | yes    | no                |
+| `runOnceConsumer` (`queue.runOnce()`)                 | yes     | yes    | no                |
+| `pushConsumer` (`queue.createPushConsumer()`)         | no      | no     | yes               |
+| `scheduling` (`options.cron`, `queue.<n>.schedule()`) | yes     | yes    | no                |
+| `singleton` (`singletonKey` dedup)                    | yes     | yes    | no                |
 
 <Callout type="info" title="Detect capabilities at runtime with `app.queue.capabilities`">
-The resolved flags are exposed on `app.queue.capabilities`, `longRunningConsumer`, `runOnceConsumer`, `pushConsumer`, `scheduling`, `singleton`. If one codebase targets multiple runtimes, check the relevant flag before calling `listen` / `runOnce` / `schedule` rather than catching the throw. When an adapter omits `capabilities`, the runtime infers them: `longRunningConsumer`/`runOnceConsumer`/`pushConsumer` default to *"is the matching method implemented?"*, `scheduling` to *"are both `schedule` and `unschedule` functions?"*, and `singleton` to `false`.
+  The resolved flags are exposed on `app.queue.capabilities`, `longRunningConsumer`, `runOnceConsumer`, `pushConsumer`, `scheduling`, `singleton`. If one codebase targets multiple runtimes, check the relevant flag before calling `listen` / `runOnce` / `schedule` rather than catching the throw. When an adapter omits
+  `capabilities`, the runtime infers them: `longRunningConsumer`/`runOnceConsumer`/`pushConsumer` default to *"is the matching method implemented?"*, `scheduling` to *"are both `schedule` and `unschedule` functions?"*, and `singleton` to `false`.
 </Callout>
 
 ## The consumer models
 
-The adapter's capabilities decide *how* a worker drains the queue. The mechanics of starting a worker live in [Jobs → Running a worker](/docs/concepts/jobs#running-a-worker); here's how each model maps to the adapters:
+The adapter's capabilities decide _how_ a worker drains the queue. The mechanics of starting a worker live in [Jobs → Running a worker](/docs/concepts/jobs#running-a-worker); here's how each model maps to the adapters:
 
 - **Long-running** (`queue.listen()`), a persistent process polls and runs jobs until stopped. pg-boss and BullMQ.
 - **Run-once** (`queue.runOnce()`), drain one bounded batch and exit, for a serverless function or scheduled tick. pg-boss and BullMQ.
 - **Push** (`queue.createPushConsumer()`), the platform delivers batches to your worker; you don't poll. Cloudflare Queues only.
 
-<Callout type="warn" title="There is no `questpie worker` CLI command">
-Workers start **programmatically**, you import your built app and call `app.queue.listen()` (long-running) or `app.queue.runOnce()` (serverless tick), or wire `app.queue.createPushConsumer()` to the platform's queue entrypoint. The `questpie` CLI has no queue command. The full entrypoint recipes are in [Jobs → Running a worker](/docs/concepts/jobs#running-a-worker).
+<Callout type="info" title="Workers start from application entrypoints">
+  Import the built app and call `app.queue.listen()` for a long-running worker, `app.queue.runOnce()` for a serverless tick, or wire `app.queue.createPushConsumer()` to the platform queue entrypoint. See [Jobs → Running a worker](/docs/concepts/jobs#running-a-worker).
 </Callout>
 
 ## pg-boss (Postgres)
@@ -94,8 +93,8 @@ import { pgBossAdapter } from "questpie/adapters/pg-boss";
 
 pgBossAdapter({
   connectionString: env.DATABASE_URL, // or pass `db`, `host`/`port`/`user`/…
-  schema: "pgboss",                    // dedicated schema for queue tables (pg-boss default)
-  max: 10,                             // connection pool size
+  schema: "pgboss", // dedicated schema for queue tables (pg-boss default)
+  max: 10, // connection pool size
 });
 ```
 
@@ -104,7 +103,7 @@ Behavior worth knowing:
 - **Queues are created on demand.** The adapter calls `createQueue(jobName)` the first time it touches a job and caches it, you never declare queues yourself.
 - **`PublishOptions` maps ~1:1** to pg-boss send options (`priority`, `startAfter`, `singletonKey`, `retryLimit`, `retryDelay`, `expireInSeconds`), passed through directly.
 - **Batches are processed serially.** pg-boss always hands an array to its `work()` callback; the adapter iterates items one at a time and reports per-item failures via `boss.fail(...)` so a sibling failure doesn't sink the rest of the batch.
-- **`runOnce` needs pg-boss `fetch()` support**, it throws *"PgBossAdapter.runOnce requires pg-boss fetch() support."* if the installed pg-boss version doesn't expose it.
+- **`runOnce` needs pg-boss `fetch()` support**, it throws _"PgBossAdapter.runOnce requires pg-boss fetch() support."_ if the installed pg-boss version doesn't expose it.
 
 Supports long-running workers, `runOnce`, cron scheduling, and native `singletonKey`.
 
@@ -128,8 +127,8 @@ import { bullMQAdapter } from "questpie/adapters/bullmq";
 
 ```ts
 interface BullMQAdapterOptions {
-  connection: ConnectionOptions;   // bullmq/ioredis connection (required)
-  queuePrefix?: string;            // namespace key prefix for queues/workers
+  connection: ConnectionOptions; // bullmq/ioredis connection (required)
+  queuePrefix?: string; // namespace key prefix for queues/workers
   workerOptions?: Omit<WorkerOptions, "connection" | "prefix">; // extra bullmq Worker opts
 }
 ```
@@ -138,11 +137,11 @@ Behavior worth knowing:
 
 - **Lazy connect.** `start()` is a no-op; queues and workers connect when first used.
 - **One `Worker` per job name.** `listen()` creates a BullMQ `Worker` for each job; `teamSize` maps to the worker's `concurrency`.
-- **Option mapping** (`PublishOptions` → BullMQ `JobsOptions`): `startAfter` → `delay` (ms), `singletonKey` → `jobId` (dedup *by id*, not a true singleton lock), `retryLimit` → `attempts` (`retryLimit + 1`), `retryDelay` → `backoff.delay` in **milliseconds** (`type: exponential` when `retryBackoff`, else `fixed`), `expireInSeconds` → `removeOnComplete: { age }`, `priority` → `priority`.
+- **Option mapping** (`PublishOptions` → BullMQ `JobsOptions`): `startAfter` → `delay` (ms), `singletonKey` → `jobId` (dedup _by id_, not a true singleton lock), `retryLimit` → `attempts` (`retryLimit + 1`), `retryDelay` → `backoff.delay` in **milliseconds** (`type: exponential` when `retryBackoff`, else `fixed`), `expireInSeconds` → `removeOnComplete: { age }`, `priority` → `priority`.
 - **Scheduling** uses BullMQ's repeatable jobs (`repeat: { pattern: cron, key: "questpie:<jobName>" }`); `unschedule()` removes every repeatable tied to that name.
 
 <Callout type="warn" title="`retryDelay` is still in seconds, even on BullMQ">
-You always pass `retryDelay` in **seconds**, matching every other adapter. The BullMQ adapter multiplies it by 1000 internally to get BullMQ's millisecond `backoff.delay`. Don't pre-multiply.
+  You always pass `retryDelay` in **seconds**, matching every other adapter. The BullMQ adapter multiplies it by 1000 internally to get BullMQ's millisecond `backoff.delay`. Don't pre-multiply.
 </Callout>
 
 Supports long-running workers, `runOnce`, cron scheduling, and `singletonKey` (id-dedup).
@@ -166,10 +165,7 @@ interface CloudflareQueuesAdapterOptions {
   // A Cloudflare Queues producer binding (or a function returning one).
   queue?: CloudflareQueueBinding | (() => MaybePromise<CloudflareQueueBinding>);
   // ...or your own enqueue function (returns a message id, or null).
-  enqueue?: (
-    message: CloudflareQueueEnvelope,
-    opts?: { delaySeconds?: number },
-  ) => Promise<string | null>;
+  enqueue?: (message: CloudflareQueueEnvelope, opts?: { delaySeconds?: number }) => Promise<string | null>;
   // Decode a raw pushed body into an envelope (defaults to requiring a `jobName` string).
   decode?: (body: unknown) => CloudflareQueueEnvelope | null;
 }
@@ -191,13 +187,11 @@ export default {
 
 Behavior worth knowing:
 
-- **Push-only.** `schedule()` / `unschedule()` **throw**, *"…does not support cron scheduling. Use platform cron triggers."* Use Cloudflare's [Cron Triggers](/docs/concepts/jobs#recurring-jobs) for recurring work, calling `runOnce`-style draining from a scheduled handler if needed.
+- **Push-only.** `schedule()` / `unschedule()` **throw**, _"…does not support cron scheduling. Use platform cron triggers."_ Use Cloudflare's [Cron Triggers](/docs/concepts/jobs#recurring-jobs) for recurring work, calling `runOnce`-style draining from a scheduled handler if needed.
 - **`publish()` returns `null`** with the `queue` binding form, because Cloudflare's `send()` exposes no stable message id.
 - **Delays cap at 24 hours.** `startAfter` → `delaySeconds` and `retryDelay` → retry `delaySeconds`, both throwing if they exceed 24h (or if `startAfter` is an invalid ISO string).
-- **Retry handling.** On a handler error the consumer calls `message.retry(...)`. The message is only acked (dropped) when a `retryLimit` was published *and* `attempts >= retryLimit + 1`; with no `retryLimit` set, a failing message always retries. Undecodable messages and messages with no matching handler are acked and skipped.
+- **Retry handling.** On a handler error the consumer calls `message.retry(...)`. The message is only acked (dropped) when a `retryLimit` was published _and_ `attempts >= retryLimit + 1`; with no `retryLimit` set, a failing message always retries. Undecodable messages and messages with no matching handler are acked and skipped.
 - **`runtime: "cloudflare"` marker.** The adapter carries this so QUESTPIE's [runtime-compatibility check](/docs/concepts/configuration) can verify a Cloudflare Workers deploy uses a push-based queue. A custom adapter targeting Workers must set `runtime: "cloudflare"` and implement `createPushConsumer()`.
-
-
 
 ## The `QueueAdapter` contract
 
@@ -211,8 +205,7 @@ interface QueueAdapter {
   start(): Promise<void>;
   stop(): Promise<void>;
   publish(jobName: string, payload: any, options?: PublishOptions): Promise<string | null>;
-  schedule(jobName: string, cron: string, payload: any,
-    options?: Omit<PublishOptions, "startAfter">): Promise<void>;
+  schedule(jobName: string, cron: string, payload: any, options?: Omit<PublishOptions, "startAfter">): Promise<void>;
   unschedule(jobName: string): Promise<void>;
   on(event: "error", handler: (error: Error) => void): void;
 
@@ -232,7 +225,7 @@ Two contract details adapter authors rely on:
 
 ## Extending: a custom adapter
 
-The queue backend is open. Implement `QueueAdapter`, declare your `capabilities`, and pass an instance to `.build({ queue: { adapter } })`, your adapter plugs into the exact same seam the three built-ins use, with no privileged internal API.
+Implement `QueueAdapter`, declare its `capabilities`, and pass an instance to `.build({ queue: { adapter } })`. Built-in and custom adapters use the same public contract.
 
 ```ts
 import type { QueueAdapter } from "questpie/queue";
@@ -246,17 +239,37 @@ class MyAdapter implements QueueAdapter {
     singleton: false,
   };
 
-  async start() { /* connect to broker */ }
-  async stop() { /* disconnect */ }
-  async publish(jobName, payload, options) { /* enqueue */ return "job-id"; }
-  async schedule(jobName, cron, payload, options) { /* register cron */ }
-  async unschedule(jobName) { /* cancel cron */ }
-  on(event, handler) { /* register an "error" listener */ }
+  async start() {
+    /* connect to broker */
+  }
+  async stop() {
+    /* disconnect */
+  }
+  async publish(jobName, payload, options) {
+    /* enqueue */ return "job-id";
+  }
+  async schedule(jobName, cron, payload, options) {
+    /* register cron */
+  }
+  async unschedule(jobName) {
+    /* cancel cron */
+  }
+  on(event, handler) {
+    /* register an "error" listener */
+  }
 
   // Optional, implement what your broker supports:
-  async listen(handlers, options) { /* long-running consumer */ }
-  async runOnce(handlers, options) { return { processed: 0 }; }
-  createPushConsumer(args) { return async (batch) => { /* drain a pushed batch */ }; }
+  async listen(handlers, options) {
+    /* long-running consumer */
+  }
+  async runOnce(handlers, options) {
+    return { processed: 0 };
+  }
+  createPushConsumer(args) {
+    return async (batch) => {
+      /* drain a pushed batch */
+    };
+  }
 }
 
 // .build({ queue: { adapter: new MyAdapter() } })
@@ -269,20 +282,11 @@ This is the QUESTPIE principle in action: **core, modules, and your own code rea
 The adapter contract types are public from `questpie/queue`; each adapter's option types come from its own subpath:
 
 ```ts
-import type {
-  QueueAdapter,
-  QueueAdapterCapabilities,
-  QueueHandlerMap,
-  QueueJobRecord,
-  QueuePushBatch,
-} from "questpie/queue";
+import type { QueueAdapter, QueueAdapterCapabilities, QueueHandlerMap, QueueJobRecord, QueuePushBatch } from "questpie/queue";
 
 import type { PgBossAdapterOptions } from "questpie/adapters/pg-boss";
 import type { BullMQAdapterOptions } from "questpie/adapters/bullmq";
-import type {
-  CloudflareQueuesAdapterOptions,
-  CloudflareQueueEnvelope,
-} from "questpie/adapters/cloudflare-queues";
+import type { CloudflareQueuesAdapterOptions, CloudflareQueueEnvelope } from "questpie/adapters/cloudflare-queues";
 ```
 
 `questpie/queue` re-exports the whole contract surface (`QueueAdapter`, the `Queue*` types, capabilities). The concrete adapters are deliberately **not** re-exported from `questpie/queue`, importing them from `questpie/adapters/*` keeps `pg-boss` / `bullmq` / Cloudflare bindings out of your bundle unless you use them. The job-facing types (`JobDefinition`, `PublishOptions`, `QueueClient`, `InferJobPayload`, …) are documented in [Jobs → TypeScript](/docs/concepts/jobs#typescript).

--- a/apps/docs/content/docs/adapters/realtime.mdx
+++ b/apps/docs/content/docs/adapters/realtime.mdx
@@ -3,14 +3,12 @@ title: Realtime adapter
 description: Configure the durable realtime runtime, its notice broker, SSE or Pusher/Soketi edge delivery, reconciliation, admission limits, privacy, and deployment-specific drivers.
 ---
 
-The **realtime runtime** powers live queries and typed channels. Set `realtime` in runtime config and each logical mutation writes one change row to the durable **outbox inside the business transaction**. A broker wake tells app instances to drain that state quickly; a reconciliation poll drains it even when the wake is missing. Authorized frames then leave through the default SSE edge transport or an opt-in Pusher/Soketi client transport.
+The **realtime adapter** supplies delivery for the [Realtime](/docs/concepts/realtime) lifecycle. It connects the durable outbox to every app instance, then carries authorized live-query snapshots and channel events through SSE or a managed transport.
 
-This page covers the **server** side: the `realtime` config, the outbox/poll model, and each transport adapter's options. The client API, `live()`, `liveIter()`, and the TanStack Query `{ realtime: true }` flag, is taught on [Realtime](/docs/client/realtime).
+This page covers server configuration, the outbox and broker topology, and each transport adapter. For application-level behavior, start with [Realtime concepts](/docs/concepts/realtime). For subscription signatures, use [Client realtime](/docs/client/realtime) and [Channels](/docs/client/channels).
 
 <Callout type="info" title="Prerequisites">
-	Read [Configuration](/docs/concepts/configuration) (where adapters are wired
-	in `questpie.config.ts`) and [Realtime](/docs/client/realtime) (the client
-	`live()` API this transport serves).
+  Read [Realtime concepts](/docs/concepts/realtime) first. Wiring the transport follows the [Configuration](/docs/concepts/configuration) runtime pattern.
 </Callout>
 
 ## What it does
@@ -33,8 +31,8 @@ import { runtimeConfig } from "questpie/app";
 import env from "./env"; // declared + validated in env.ts, see Environment
 
 export default runtimeConfig({
-	db: { url: env.DATABASE_URL },
-	realtime: true,
+  db: { url: env.DATABASE_URL },
+  realtime: true,
 });
 ```
 
@@ -67,20 +65,20 @@ Use `realtime: true` to turn on the default transport. Use an object when you wa
 
 ```ts
 interface RealtimeConfig {
-	observer?: RealtimeObserver;
-	rollout?: RealtimeRolloutConfig;
-	admission?: Partial<RealtimeAdmissionConfig>;
-	connectionAcceptPacingMs?: number;
-	adapter?: RealtimeAdapter; // existing broker compatibility adapter
-	changeBroker?: ChangeBroker; // v2 cross-instance notice seam
-	clientTransport?: ClientTransport; // managed edge transport; omit → SSE
-	channelEvents?: Partial<ChannelEventLedgerConfig>;
-	channelPresence?: Partial<ChannelPresenceConfig>;
-	channelSecurity?: ChannelSecurityConfig;
-	pollIntervalMs?: number; // 15000 with push, 2000 without
-	batchSize?: number; // default 500, max outbox rows read per drain
-	retentionDays?: number; // default 3; set 0 to disable time-based cleanup
-	keepAliveIntervalMs?: number; // default 8000, SSE keep-alive ping interval
+  observer?: RealtimeObserver;
+  rollout?: RealtimeRolloutConfig;
+  admission?: Partial<RealtimeAdmissionConfig>;
+  connectionAcceptPacingMs?: number;
+  adapter?: RealtimeAdapter; // existing broker compatibility adapter
+  changeBroker?: ChangeBroker; // v2 cross-instance notice seam
+  clientTransport?: ClientTransport; // managed edge transport; omit → SSE
+  channelEvents?: Partial<ChannelEventLedgerConfig>;
+  channelPresence?: Partial<ChannelPresenceConfig>;
+  channelSecurity?: ChannelSecurityConfig;
+  pollIntervalMs?: number; // 15000 with push, 2000 without
+  batchSize?: number; // default 500, max outbox rows read per drain
+  retentionDays?: number; // default 3; set 0 to disable time-based cleanup
+  keepAliveIntervalMs?: number; // default 8000, SSE keep-alive ping interval
 }
 ```
 
@@ -102,10 +100,7 @@ interface RealtimeConfig {
 | `keepAliveIntervalMs`      | `8000`                                        | Interval between `ping` keep-alive events on each `POST /realtime` SSE stream.                                                                                                                                           |
 
 <Callout type="warn" title="Keep `keepAliveIntervalMs` under your idle timeout">
-	The default `8000` ms is deliberately under Bun's default 10s `idleTimeout`,
-	so SSE streams survive on an untuned `Bun.serve`. Behind a proxy with a
-	shorter read timeout (some default to 30-60s, but custom ones can be lower),
-	drop it further so the connection never goes idle long enough to be culled.
+  The default `8000` ms is deliberately under Bun's default 10s `idleTimeout`, so SSE streams survive on an untuned `Bun.serve`. Behind a proxy with a shorter read timeout (some default to 30-60s, but custom ones can be lower), drop it further so the connection never goes idle long enough to be culled.
 </Callout>
 
 ### Admission defaults
@@ -143,21 +138,11 @@ Omitting `adapter` does **not** always mean naive polling. The runtime selects t
 3. **No adapter and no Postgres connection** → fall back to polling the outbox every `pollIntervalMs` (default 2s).
 
 <Callout type="info" title="Polling is the recovery guarantee">
-	The poll drains the same outbox and pushes the same access-controlled
-	snapshots. Without push it is the 2s primary path; with push it is the slower
-	15s reconciliation path. A notice lowers latency, but missing it does not
-	permanently stall an instance.
+  The poll drains the same outbox and pushes the same access-controlled snapshots. Without push it is the 2s primary path; with push it is the slower 15s reconciliation path. A notice lowers latency, but missing it does not permanently stall an instance.
 </Callout>
 
-<Callout
-	type="warn"
-	title="Multi-tier deployments need a broker every writer can reach"
->
-	The outbox and reconciliation preserve correctness when every tier shares the
-	same database, but latency and DB load degrade when split workers only poll.
-	Ensure API, worker, and subscriber-serving instances use the same explicit
-	pg/Redis/Pusher broker. Do not assume an implicit database URL exists in every
-	process.
+<Callout type="warn" title="Multi-tier deployments need a broker every writer can reach">
+  The outbox and reconciliation preserve correctness when every tier shares the same database, but latency and DB load degrade when split workers only poll. Ensure API, worker, and subscriber-serving instances use the same explicit pg/Redis/Pusher broker. Do not assume an implicit database URL exists in every process.
 </Callout>
 
 ## `pgNotifyAdapter`, Postgres `LISTEN`/`NOTIFY`
@@ -171,13 +156,13 @@ import { pgNotifyAdapter } from "questpie/adapters/pg-notify";
 import env from "./env";
 
 export default runtimeConfig({
-	db: { url: env.DATABASE_URL },
-	realtime: {
-		adapter: pgNotifyAdapter({
-			connectionString: env.DATABASE_URL,
-			// channel: "questpie_realtime", // default
-		}),
-	},
+  db: { url: env.DATABASE_URL },
+  realtime: {
+    adapter: pgNotifyAdapter({
+      connectionString: env.DATABASE_URL,
+      // channel: "questpie_realtime", // default
+    }),
+  },
 });
 ```
 
@@ -198,11 +183,8 @@ Behavior:
 - **Uses `LISTEN`/`UNLISTEN` + `pg_notify($1, $2)`.** The notice JSON (`{ seq, resourceType, resource, operation }`) is the channel payload.
 
 <Callout type="info" title="You usually don't need to write this">
-	On a Postgres app, `realtime: true` already auto-wires `pg_notify` on the
-	default channel (see [the default](#the-default-poll-vs-auto-pg-notify)
-	above). Configure `pgNotifyAdapter` explicitly only when you want a
-	**non-default channel**, want to **reuse an existing `pg` client**, or are
-	pointing realtime at a **different database** than your main `db`.
+  On a Postgres app, `realtime: true` already auto-wires `pg_notify` on the default channel (see [the default](#the-default-poll-vs-auto-pg-notify) above). Configure `pgNotifyAdapter` explicitly only when you want a **non-default channel**, want to **reuse an existing `pg` client**, or are pointing realtime at a
+  **different database** than your main `db`.
 </Callout>
 
 ## Pusher/Soketi preset, managed WebSockets
@@ -214,15 +196,15 @@ import { pusherRealtime } from "questpie/adapters/pusher";
 import { runtimeConfig } from "questpie/app";
 
 const managed = pusherRealtime({
-	appId: env.PUSHER_APP_ID,
-	key: env.PUSHER_KEY,
-	secret: env.PUSHER_SECRET,
-	cluster: env.PUSHER_CLUSTER,
-	// Soketi: host, port, wsHost, wsPort/wssPort, useTLS
+  appId: env.PUSHER_APP_ID,
+  key: env.PUSHER_KEY,
+  secret: env.PUSHER_SECRET,
+  cluster: env.PUSHER_CLUSTER,
+  // Soketi: host, port, wsHost, wsPort/wssPort, useTLS
 });
 
 export default runtimeConfig({
-	realtime: { ...managed },
+  realtime: { ...managed },
 });
 ```
 
@@ -257,15 +239,15 @@ const redis = createClient({ url: env.REDIS_URL });
 await redis.connect();
 
 export default runtimeConfig({
-	db: { url: env.DATABASE_URL },
-	realtime: {
-		adapter: redisStreamsAdapter({
-			client: redis,
-			// stream: "questpie:realtime",   // default
-			// blockMs: 5000, batchSize: 100, // defaults
-			// maxLen: 10_000,                // approximate stream cap
-		}),
-	},
+  db: { url: env.DATABASE_URL },
+  realtime: {
+    adapter: redisStreamsAdapter({
+      client: redis,
+      // stream: "questpie:realtime",   // default
+      // blockMs: 5000, batchSize: 100, // defaults
+      // maxLen: 10_000,                // approximate stream cap
+    }),
+  },
 });
 ```
 
@@ -284,7 +266,7 @@ export default runtimeConfig({
 
 Behavior:
 
-- **Broadcasts instead of load-balancing.** Every adapter tails from `$` with its own `XREAD` cursor, so all running app instances receive each new wake. There is no shared consumer group or pending-entry list.
+- **Broadcasts instead of load-balancing.** Every adapter tails from `$` with its own `XREAD` cursor, so each running app instance receives every new wake independently.
 - **Bounds the stream.** `notify()` uses `XADD MAXLEN ~ 10000` by default and stores only the notice fields (`seq`, `resourceType`, `resource`, `operation`).
 - **Resilient lifecycle.** A failed loop iteration is reported, backed off, and retried. `stop()` awaits the blocking read's exit before a later `start()` can create another loop.
 - **Driver-agnostic.** Any client matching the `RedisStreamsClient` shape works, the type is modeled on `node-redis` command names but isn't tied to it.
@@ -316,15 +298,15 @@ import { runtimeConfig } from "questpie/app";
 import { cloudflareRealtimeAdapter } from "questpie/adapters/cloudflare-realtime";
 
 export default runtimeConfig({
-	realtime: {
-		adapter: cloudflareRealtimeAdapter({
-			// A Durable Object namespace binding, or a zero-arg function that
-			// returns one (so you can resolve it lazily from your Worker env).
-			namespace: () => getEnv().QUESTPIE_REALTIME,
-			// objectName: "questpie-realtime",  // default shard-name prefix
-			// hubPath: "/__questpie/realtime",   // default internal hub path
-		}),
-	},
+  realtime: {
+    adapter: cloudflareRealtimeAdapter({
+      // A Durable Object namespace binding, or a zero-arg function that
+      // returns one (so you can resolve it lazily from your Worker env).
+      namespace: () => getEnv().QUESTPIE_REALTIME,
+      // objectName: "questpie-realtime",  // default shard-name prefix
+      // hubPath: "/__questpie/realtime",   // default internal hub path
+    }),
+  },
 });
 ```
 
@@ -341,10 +323,7 @@ export default runtimeConfig({
 This adapter carries a `runtime: "cloudflare"` discriminator so the Cloudflare fetch/queue handlers detect it, and it's wired together with the **`createCloudflareRealtimeDurableObjectHandler`** export (from `questpie/adapters/cloudflare`) that implements the DO itself. Durable Objects are sharded by `resourceType` and resource; mutation publish is non-blocking, only the minimal notice crosses the DO boundary, and snapshot queries stay in the requesting Worker.
 
 <Callout type="info" title="Cloudflare realtime is a deployment-specific setup">
-	Unlike `pg_notify` / Redis, this adapter requires a Durable Object class bound
-	in your `wrangler` config plus the DO handler. It's part of the Cloudflare
-	Workers deployment story rather than a drop-in line. The other two adapters
-	need no Workers-specific wiring.
+  Unlike `pg_notify` / Redis, this adapter requires a Durable Object class bound in your `wrangler` config plus the DO handler. It's part of the Cloudflare Workers deployment story rather than a drop-in line. The other two adapters need no Workers-specific wiring.
 </Callout>
 
 ## The outbox table
@@ -367,14 +346,14 @@ The transport contract and config types are exported from `questpie` (and `quest
 
 ```ts
 import type {
-	RealtimeAdapter, // the transport contract you implement for a custom adapter
-	RealtimeConfig, // the `realtime` config shape
-	RealtimeChangeEvent, // a full outbox event
-	RealtimeChangePayload, // { before, after } or { count, recordIds }
-	RealtimeEqualityProjection, // shallow scalar fields used for equality routing
-	RealtimeNotice, // the minimal broadcast notice
-	RealtimeOperation, // "create" | "update" | "delete" | "bulk_update" | "bulk_delete"
-	RealtimeResourceType, // "collection" | "global"
+  RealtimeAdapter, // the transport contract you implement for a custom adapter
+  RealtimeConfig, // the `realtime` config shape
+  RealtimeChangeEvent, // a full outbox event
+  RealtimeChangePayload, // { before, after } or { count, recordIds }
+  RealtimeEqualityProjection, // shallow scalar fields used for equality routing
+  RealtimeNotice, // the minimal broadcast notice
+  RealtimeOperation, // "create" | "update" | "delete" | "bulk_update" | "bulk_delete"
+  RealtimeResourceType, // "collection" | "global"
 } from "questpie/realtime";
 ```
 
@@ -388,10 +367,10 @@ The compatibility adapter shape is:
 
 ```ts
 interface RealtimeAdapter {
-	start(): Promise<void>;
-	stop(): Promise<void>;
-	notify(event: RealtimeChangeEvent): Promise<void>; // broadcast a change
-	subscribe(handler: (notice: RealtimeNotice) => void): () => void; // receive changes; returns unsubscribe
+  start(): Promise<void>;
+  stop(): Promise<void>;
+  notify(event: RealtimeChangeEvent): Promise<void>; // broadcast a change
+  subscribe(handler: (notice: RealtimeNotice) => void): () => void; // receive changes; returns unsubscribe
 }
 ```
 

--- a/apps/docs/content/docs/adapters/sandbox.mdx
+++ b/apps/docs/content/docs/adapters/sandbox.mdx
@@ -3,16 +3,16 @@ title: Sandbox adapter
 description: Run untrusted or dynamically-authored code behind a real resource-and-permission boundary, ctx.executor.run() executes guest code in a fresh Deno subprocess with a memory cap, denied filesystem/env, scoped net/import allowlists, and SSRF egress validation.
 ---
 
-The **executor** is the QUESTPIE primitive for running code you did not write, user plugins, AI-authored scripts, knowledge mini-apps, under a default-deny capability model. You call `ctx.executor.run({ source, capabilities, ... })`; the **sandbox adapter** (`@questpie/sandbox`) is the backend that actually enforces the boundary. It is a genuine *resource + permission* boundary, not just a `try/catch`: every run spawns a fresh `deno run` subprocess with a real V8 memory cap, filesystem/env/run/ffi denied, scoped `net`/`import` allowlists, and SSRF-aware egress validation. The main app image never contains Deno, it speaks a small JSON-over-HTTP contract to a standalone supervisor.
+The **sandbox adapter** enforces the isolated mode described in [Sandboxed code](/docs/concepts/sandboxed-code). `@questpie/sandbox` runs each guest in a fresh Deno subprocess with bounded memory, restricted permissions, scoped network and import allowlists, and validated egress.
 
 <Callout type="info" title="Prerequisites">
-This page covers the sandbox **adapter** and its Deno supervisor. The `ctx.executor.run()` API, isolation modes, and capability model are the primitive it powers, available on the app context wherever you write [business logic](/docs/concepts/services). `@questpie/sandbox` is unrelated to the local-host sandbox inside [`@questpie/ai`](/docs/integrations/ai), that one runs a coding agent on the host, this one isolates arbitrary guest code.
+  Start with [Sandboxed code](/docs/concepts/sandboxed-code) for execution modes, capabilities, brokered access, and lifecycle. This page covers the Deno supervisor, deployment, security layers, and platform limits. [`@questpie/ai`](/docs/integrations/ai) has a separate host execution model.
 </Callout>
 
 ## What it does
 
 - **Isolate untrusted code with a real boundary.** Each `ctx.executor.run()` spawns a fresh Deno subprocess with `--v8-flags=--max-old-space-size=<memoryMb>` (an enforced memory cap), `--allow-net=<hosts>` / `--allow-import=<hosts>` (independent allowlists), read scoped to the guest entry file only, and `--deny` on everything else. The supervisor runs the guest with `clearEnv: true`, so its own environment never leaks.
-- **Reject SSRF at the manifest.** Every `net` and `import` host is validated, in the adapter *and* the server, before a socket is opened: a host that is (or DNS-resolves to) private, loopback, link-local, CGNAT, or the `169.254.169.254` cloud-metadata address is rejected, with DNS failing closed.
+- **Reject SSRF at the manifest.** Every `net` and `import` host is validated, in the adapter _and_ the server, before a socket is opened: a host that is (or DNS-resolves to) private, loopback, link-local, CGNAT, or the `169.254.169.254` cloud-metadata address is rejected, with DNS failing closed.
 - **Harden the guest before it runs.** `globalThis.Worker` is nulled (orphan-CPU DoS), `SharedArrayBuffer`/`Atomics` are deleted (Spectre timers), `console.*` is captured into a capped log buffer, and the guest must `export default` a `function(input)`.
 - **Broker capabilities, never hand them out.** When you pass `appBindings`, the guest reaches your app's collections/files/services through a `globalThis.questpie` proxy whose calls are relayed server-to-server to a broker URL carrying a per-run token, the token never enters the guest process.
 
@@ -31,8 +31,7 @@ export default runtimeConfig({
       url: process.env.SANDBOX_URL ?? "http://127.0.0.1:8787",
     }),
     // Where the guest's brokered capability calls are relayed (server-to-server)
-    brokerUrl:
-      process.env.SANDBOX_BROKER_URL ?? "http://127.0.0.1:3000/api/sandbox/rpc",
+    brokerUrl: process.env.SANDBOX_BROKER_URL ?? "http://127.0.0.1:3000/api/sandbox/rpc",
   },
 });
 ```
@@ -82,7 +81,7 @@ const result = await executor.run({
   isolation: "sandboxed",
   capabilities,
   appBindings: target, // capability-scoped surface
-  brokerUrl,           // from config
+  brokerUrl, // from config
 });
 // inside the guest:
 //   const posts = await questpie.collections.posts.find({ limit: 10 });
@@ -91,13 +90,14 @@ const result = await executor.run({
 
 ## Security model
 
-- **Process-per-request, not a warm Worker.** A Worker is a permission boundary but *not* a resource boundary, `memoryMb` is unenforceable in-process and `worker.terminate()` doesn't reap grandchild Workers. A fresh subprocess gives a real V8 heap cap and clean teardown (SIGTERM → SIGKILL after a 250ms grace).
+- **Process-per-request, not a warm Worker.** A Worker is a permission boundary but _not_ a resource boundary, `memoryMb` is unenforceable in-process and `worker.terminate()` doesn't reap grandchild Workers. A fresh subprocess gives a real V8 heap cap and clean teardown (SIGTERM → SIGKILL after a 250ms grace).
 - **`net` and `import` are independent axes, and `import` fails open.** Omitting `--allow-import` does **not** deny, Deno silently grants ~7 default hosts (`esm.sh`, `jsr.io`, `deno.land`, …). So an empty import allowlist emits an explicit `--deny-import=<those hosts>`. Never alias the two axes.
 - **Brokered `fetch` on the bindings path.** When `appBindings` is present the guest runs at `--allow-net=[]` (no sockets at all) and its native `fetch` is replaced by a shim that RPCs `http.fetch` over stdio to the supervisor, which relays to your broker carrying a per-run token in `x-questpie-sandbox-token`. The token is supervisor-only, and the broker (`/api/sandbox/rpc`) re-checks the run's capabilities on every call.
 
 <Callout type="warn" title="Honest limitations">
-- **DNS-rebind pinning is not implemented.** Egress validation happens at manifest time; the exact socket IP is not re-pinned across redirects (`TODO(security)`). The brokered path is safe because the guest has no sockets at all (`--allow-net=[]`); a raw `net`-granted run is validated once, not continuously.
-- **The kernel egress firewall is Linux-only and belt-and-suspenders.** On Linux with `unshare`/`nft`/`ip` and the right capabilities, each run also gets a per-run network namespace + nftables ruleset (default-DROP, private CIDRs dropped, public allowlist accepted). Off Linux, or when those tools/caps are missing, it is **gracefully absent** (logs a notice and runs without it). Disable with `SANDBOX_DISABLE_NETNS_FIREWALL=1`. The ruleset logic is unit-tested; the actual kernel drop is only verified on a real Linux worker. Treat it as a second layer, the subprocess permission flags are the primary boundary.
+  - **DNS-rebind pinning is not implemented.** Egress validation happens at manifest time; the exact socket IP is not re-pinned across redirects (`TODO(security)`). The brokered path is safe because the guest has no sockets at all (`--allow-net=[]`); a raw `net`-granted run is validated once, not continuously. - **The
+  kernel egress firewall is Linux-only and belt-and-suspenders.** On Linux with `unshare`/`nft`/`ip` and the right capabilities, each run also gets a per-run network namespace + nftables ruleset (default-DROP, private CIDRs dropped, public allowlist accepted). Off Linux, or when those tools/caps are missing, it is
+  **gracefully absent** (logs a notice and runs without it). Disable with `SANDBOX_DISABLE_NETNS_FIREWALL=1`. The ruleset logic is unit-tested; the actual kernel drop is only verified on a real Linux worker. Treat it as a second layer, the subprocess permission flags are the primary boundary.
 </Callout>
 
 ## How it fits

--- a/apps/docs/content/docs/adapters/search.mdx
+++ b/apps/docs/content/docs/adapters/search.mdx
@@ -3,10 +3,10 @@ title: Search adapter
 description: Add full-text and semantic search to your collections with one adapter in questpie.config.ts, pg_trgm lexical search out of the box, pgvector + embeddings when you want meaning-based recall.
 ---
 
-The **search adapter** is the backend behind `app.search`, the client `search` API, and a collection's [`.searchable()`](/docs/concepts/collections#searchable) indexing. Wire one adapter into `questpie.config.ts` and every searchable collection becomes queryable by relevance, full-text and fuzzy matching with the default Postgres adapter, or semantic vector search when you add `pgvector` and an embedding provider. Swap the adapter; your `app.search.search(...)` calls and `.searchable()` config never change.
+The **search adapter** is the backend behind the [Search](/docs/concepts/search) lifecycle. It powers `app.search`, the client `search` API, and [`.searchable()`](/docs/concepts/collections#searchable) indexing. Swap the adapter and the application contract stays unchanged.
 
 <Callout type="info" title="Prerequisites">
-Read [Collections](/docs/concepts/collections) first, search indexes collection rows, and you opt a collection in (or out) with [`.searchable()`](/docs/concepts/collections#searchable). Wiring the adapter follows the [Configuration](/docs/concepts/configuration) `runtimeConfig` pattern.
+  Start with the [Search concept](/docs/concepts/search) for projection, indexing, querying, and consistency. This page covers backend selection, configuration, migrations, and adapter contracts.
 </Callout>
 
 ## What it does
@@ -71,7 +71,8 @@ const { docs, total } = await client.search.search({ query: "release notes" });
 ```
 
 <Callout type="warn" title="The default adapter needs the `pg_trgm` extension">
-Trigram fuzzy matching requires Postgres' `pg_trgm` extension, and **QUESTPIE does not auto-create extensions** (it is drizzle-native). On local dev, the `create-questpie` starters provision it for you (the `docker compose up` Postgres container runs `CREATE EXTENSION IF NOT EXISTS "pg_trgm";` on first init). Without the extension, `db:push` fails when it tries to build the trigram index. On managed Postgres, enable it through your provider. See [Required Postgres extensions](#required-postgres-extensions) below.
+  Trigram fuzzy matching requires Postgres' `pg_trgm` extension, and **QUESTPIE does not auto-create extensions** (it is drizzle-native). On local dev, the `create-questpie` starters provision it for you (the `docker compose up` Postgres container runs `CREATE EXTENSION IF NOT EXISTS "pg_trgm";` on first init). Without
+  the extension, `db:push` fails when it tries to build the trigram index. On managed Postgres, enable it through your provider. See [Required Postgres extensions](#required-postgres-extensions) below.
 </Callout>
 
 ## Example → real output
@@ -108,26 +109,24 @@ const res = await app.search.search({
 The **client** `search` returns the same data hydrated into full records (so you get the live row, not just the index snapshot): `{ docs, total, facets? }`, where each `doc` is your collection row plus a `_collection` name and a `_search` block (`score`, `highlights`, `indexedTitle`, `indexedContent`).
 
 <Callout type="info" title="Empty query = browse mode">
-Call `search` with `query: ""` and the adapter skips ranking and returns rows ordered by `updatedAt DESC` (still scoped by `collections`, `locale`, and `filters`). Useful for "latest in this collection" listings.
+  Call `search` with `query: ""` and the adapter skips ranking and returns rows ordered by `updatedAt DESC` (still scoped by `collections`, `locale`, and `filters`). Useful for "latest in this collection" listings.
 </Callout>
 
 ## Search options
 
 Both `app.search.search(...)` and `client.search.search(...)` take the same `SearchOptions`:
 
-| Option | Type | Default | Notes |
-|---|---|---|---|
-| `query` | `string` | none (required) | The search text. `""` = browse mode (no ranking). |
-| `collections` | `string[]` | all | Restrict to these collection names. |
-| `locale` | `string` | default locale | Which locale's index to search. |
-| `limit` | `number` | `10` | Page size. |
-| `offset` | `number` | `0` | Page offset. |
-| `mode` | `"lexical" \| "semantic" \| "hybrid"` | `"hybrid"` | Ranking strategy (see [Search modes](#search-modes)). |
-| `filters` | `Record<string, string \| string[]>` | none | Match against indexed `metadata`. Array = OR within a field; across fields = AND. |
-| `highlights` | `boolean` | `true` | Wrap matches in `<mark>` in the returned snippets. |
-| `facets` | `FacetDefinition[]` | none | Request facet aggregations (see [Facets](#facets)). |
-
-
+| Option        | Type                                  | Default         | Notes                                                                             |
+| ------------- | ------------------------------------- | --------------- | --------------------------------------------------------------------------------- |
+| `query`       | `string`                              | none (required) | The search text. `""` = browse mode (no ranking).                                 |
+| `collections` | `string[]`                            | all             | Restrict to these collection names.                                               |
+| `locale`      | `string`                              | default locale  | Which locale's index to search.                                                   |
+| `limit`       | `number`                              | `10`            | Page size.                                                                        |
+| `offset`      | `number`                              | `0`             | Page offset.                                                                      |
+| `mode`        | `"lexical" \| "semantic" \| "hybrid"` | `"hybrid"`      | Ranking strategy (see [Search modes](#search-modes)).                             |
+| `filters`     | `Record<string, string \| string[]>`  | none            | Match against indexed `metadata`. Array = OR within a field; across fields = AND. |
+| `highlights`  | `boolean`                             | `true`          | Wrap matches in `<mark>` in the returned snippets.                                |
+| `facets`      | `FacetDefinition[]`                   | none            | Request facet aggregations (see [Facets](#facets)).                               |
 
 `filters` matches the `metadata` you index per collection. For example, with `.searchable({ metadata: (r) => ({ status: r.status }) })`:
 
@@ -138,8 +137,8 @@ await app.search.search({
 });
 ```
 
-<Callout type="info" title="Access filtering is internal">
-`SearchOptions` also carries `accessFilters` server-side, which the core search route fills in from each collection's [access rules](/docs/concepts/access-control) so results respect row-level access. You don't pass it by hand, the HTTP `search` endpoint derives it. Reindexing is gated the same way: `POST /api/search/reindex/:collection` checks the adapter's `reindexAccess` config, which **defaults to the target collection's `update` access rule**.
+<Callout type="info" title="Client search enforces collection access">
+  The HTTP search endpoint derives row filters from each collection's [access rules](/docs/concepts/access-control) before returning hydrated documents. Reindexing uses the adapter's `reindexAccess` rule, which defaults to the target collection's `update` access rule.
 </Callout>
 
 ## Configuring the index: `.searchable()`
@@ -156,13 +155,17 @@ A facet returns counts (or ranges) for an indexed metadata field. Declare facet 
 collection("products").searchable({
   metadata: (r) => ({ category: r.category, price: r.price, tags: r.tags }),
   facets: {
-    category: true,                                       // distinct values + counts
-    tags: { type: "array" },                              // facet over array values
-    price: { type: "range", buckets: [                    // bucketed numeric ranges
-      { label: "Under $10", max: 10 },
-      { label: "$10-50", min: 10, max: 50 },
-    ] },
-    path: { type: "hierarchy", separator: "/" },          // hierarchical paths
+    category: true, // distinct values + counts
+    tags: { type: "array" }, // facet over array values
+    price: {
+      type: "range",
+      buckets: [
+        // bucketed numeric ranges
+        { label: "Under $10", max: 10 },
+        { label: "$10-50", min: 10, max: 50 },
+      ],
+    },
+    path: { type: "hierarchy", separator: "/" }, // hierarchical paths
   },
 });
 ```
@@ -181,16 +184,17 @@ A `FacetFieldConfig` is `true | { type: "array" } | { type: "range"; buckets } |
 
 `mode` picks the ranking strategy. What each mode does depends on the adapter's capabilities:
 
-| Mode | Postgres adapter | pgvector adapter |
-|---|---|---|
-| `lexical` | FTS only (`ts_rank_cd`) | FTS only, forwards `lexical` to the base adapter |
-| `hybrid` *(default)* | FTS + trigram fused (`ts_rank_cd×ftsWeight + similarity×(1−ftsWeight)`) | FTS + trigram fused, forwards `hybrid` to the base adapter (no semantic yet) |
-| `semantic` | not supported | embeds the query, ranks by cosine distance over the `embedding` column |
+| Mode                 | Postgres adapter                                                        | pgvector adapter                                                             |
+| -------------------- | ----------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| `lexical`            | FTS only (`ts_rank_cd`)                                                 | FTS only, forwards `lexical` to the base adapter                             |
+| `hybrid` _(default)_ | FTS + trigram fused (`ts_rank_cd×ftsWeight + similarity×(1−ftsWeight)`) | FTS + trigram fused, forwards `hybrid` to the base adapter (no semantic yet) |
+| `semantic`           | not supported                                                           | embeds the query, ranks by cosine distance over the `embedding` column       |
 
 The Postgres adapter's hybrid score combines the FTS rank (`ts_rank_cd`) with a trigram `similarity(title, query)` so typos and partial words still match; the trigram term lives in `hybrid`, not `lexical`. The pgvector adapter forwards every non-semantic mode to the base adapter unchanged, so its `lexical` and `hybrid` behave exactly like the Postgres adapter's.
 
 <Callout type="warn" title="pgvector `hybrid` doesn't fuse in the vector score yet">
-The pgvector adapter fully implements `semantic` (the vector path). Its `lexical` and `hybrid` modes forward to the base Postgres adapter, so `hybrid` gives you FTS + trigram fused, but **not** the semantic (vector) component. Fusing the embedding score into `hybrid` is a documented follow-up. If you want meaning-based recall today, request `mode: "semantic"` explicitly.
+  The pgvector adapter fully implements `semantic` (the vector path). Its `lexical` and `hybrid` modes forward to the base Postgres adapter, so `hybrid` gives you FTS + trigram fused, but **not** the semantic (vector) component. Fusing the embedding score into `hybrid` is a documented follow-up. If you want
+  meaning-based recall today, request `mode: "semantic"` explicitly.
 </Callout>
 
 ## The Postgres adapter (default)
@@ -202,14 +206,14 @@ import { createPostgresSearchAdapter } from "questpie/adapters/postgres-search";
 
 createPostgresSearchAdapter({
   trigramThreshold: 0.3, // similarity cutoff for trigram matching (0-1)
-  ftsWeight: 0.7,        // weight of FTS in hybrid score; trigram weight = 1 − this
+  ftsWeight: 0.7, // weight of FTS in hybrid score; trigram weight = 1 − this
 });
 ```
 
-| Option | Type | Default | Notes |
-|---|---|---|---|
-| `trigramThreshold` | `number` | `0.3` | Minimum trigram similarity (0-1) for a fuzzy match. |
-| `ftsWeight` | `number` | `0.7` | FTS weight in hybrid scoring; trigram weight is `1 − ftsWeight`. |
+| Option             | Type     | Default | Notes                                                            |
+| ------------------ | -------- | ------- | ---------------------------------------------------------------- |
+| `trigramThreshold` | `number` | `0.3`   | Minimum trigram similarity (0-1) for a fuzzy match.              |
+| `ftsWeight`        | `number` | `0.7`   | FTS weight in hybrid scoring; trigram weight is `1 − ftsWeight`. |
 
 Its capabilities are `{ lexical: true, trigram: true, semantic: false, hybrid: true, facets: true }`. FTS uses `to_tsvector('simple', …)`, a language-agnostic config with **no stemming** (so "run" won't match "running"; trigram matching softens this for typos and prefixes). The index lives in two tables, `questpie_search` and `questpie_search_facets`, which QUESTPIE creates through Drizzle from the adapter's `getTableSchemas()`.
 
@@ -228,26 +232,27 @@ export default runtimeConfig({
     embeddingProvider: createOpenAIEmbeddingProvider({
       apiKey: process.env.OPENAI_API_KEY!,
     }),
-    lexicalWeight: 0.4,   // hybrid weights (reserved for the fused re-rank)
+    lexicalWeight: 0.4, // hybrid weights (reserved for the fused re-rank)
     semanticWeight: 0.6,
     indexType: "ivfflat", // or "hnsw"
   }),
 });
 ```
 
-| Option | Type | Default | Notes |
-|---|---|---|---|
-| `embeddingProvider` | `EmbeddingProvider` | none (**required**) | Generates query + record vectors (see below). |
-| `lexicalWeight` | `number` | `0.4` | Lexical weight in the (future) fused hybrid score. |
-| `semanticWeight` | `number` | `0.6` | Semantic weight in the (future) fused hybrid score. |
-| `indexType` | `"ivfflat" \| "hnsw"` | `"ivfflat"` | Vector index. `ivfflat` uses `lists = 100`; `hnsw` builds an HNSW graph. |
-| `trigramThreshold` | `number` | `0.3` | Inherited, passed to the internal Postgres adapter. |
-| `ftsWeight` | `number` | `0.7` | Inherited, passed to the internal Postgres adapter. |
+| Option              | Type                  | Default             | Notes                                                                    |
+| ------------------- | --------------------- | ------------------- | ------------------------------------------------------------------------ |
+| `embeddingProvider` | `EmbeddingProvider`   | none (**required**) | Generates query + record vectors (see below).                            |
+| `lexicalWeight`     | `number`              | `0.4`               | Lexical weight in the (future) fused hybrid score.                       |
+| `semanticWeight`    | `number`              | `0.6`               | Semantic weight in the (future) fused hybrid score.                      |
+| `indexType`         | `"ivfflat" \| "hnsw"` | `"ivfflat"`         | Vector index. `ivfflat` uses `lists = 100`; `hnsw` builds an HNSW graph. |
+| `trigramThreshold`  | `number`              | `0.3`               | Inherited, passed to the internal Postgres adapter.                      |
+| `ftsWeight`         | `number`              | `0.7`               | Inherited, passed to the internal Postgres adapter.                      |
 
 Its capabilities are `{ lexical: true, trigram, semantic: true, hybrid: true, facets: true }`. On `index()`, it generates an embedding from the title + content (or uses one returned by your `.searchable({ embeddings })` override) and stores it in the `embedding vector(N)` column, where `N` is the provider's dimension count. Semantic search excludes rows whose `embedding` is still `NULL`.
 
 <Callout type="warn" title="pgvector embedding dimensions are fixed at migration time">
-The `embedding vector(N)` column is sized from your embedding provider's `dimensions` when the migration is generated. Changing the provider (or its `dimensions`) later means the column no longer matches, re-generate/alter the column and re-index. The `embedding` column is **pgvector-only**: it is managed by a raw-SQL migration, not the shared Drizzle schema, so the plain Postgres adapter never creates a `vector` column it can't back.
+  The `embedding vector(N)` column is sized from your embedding provider's `dimensions` when the migration is generated. Changing the provider (or its `dimensions`) later means the column no longer matches, re-generate/alter the column and re-index. The `embedding` column is **pgvector-only**: it is managed by a
+  raw-SQL migration, not the shared Drizzle schema, so the plain Postgres adapter never creates a `vector` column it can't back.
 </Callout>
 
 ### Embedding providers
@@ -261,20 +266,18 @@ import { createOpenAIEmbeddingProvider } from "questpie/search";
 
 createOpenAIEmbeddingProvider({
   apiKey: process.env.OPENAI_API_KEY!, // required
-  model: "text-embedding-3-small",     // default
-  dimensions: 1536,                    // default
+  model: "text-embedding-3-small", // default
+  dimensions: 1536, // default
   baseUrl: "https://api.openai.com/v1", // default, point at OpenAI-compatible proxies
 });
 ```
 
-| Option | Type | Default | Notes |
-|---|---|---|---|
-| `apiKey` | `string` | none (**required**) | OpenAI (or compatible) API key. |
-| `model` | `string` | `"text-embedding-3-small"` | Embedding model. |
-| `dimensions` | `number` | `1536` | Must match the model: `3-small` → 1536/512, `3-large` → 3072/256/1024, `ada-002` → 1536 fixed. |
-| `baseUrl` | `string` | `"https://api.openai.com/v1"` | Override for OpenAI-compatible APIs/proxies. |
-
-
+| Option       | Type     | Default                       | Notes                                                                                          |
+| ------------ | -------- | ----------------------------- | ---------------------------------------------------------------------------------------------- |
+| `apiKey`     | `string` | none (**required**)           | OpenAI (or compatible) API key.                                                                |
+| `model`      | `string` | `"text-embedding-3-small"`    | Embedding model.                                                                               |
+| `dimensions` | `number` | `1536`                        | Must match the model: `3-small` → 1536/512, `3-large` → 3072/256/1024, `ada-002` → 1536 fixed. |
+| `baseUrl`    | `string` | `"https://api.openai.com/v1"` | Override for OpenAI-compatible APIs/proxies.                                                   |
 
 **Custom / local**, `createCustomEmbeddingProvider(options)` wraps any embedding service (a local model, a different API). Provide `generate`; `generateBatch` is optional and falls back to `Promise.all` of `generate`:
 
@@ -289,15 +292,13 @@ createCustomEmbeddingProvider({
 });
 ```
 
-
-
 ## Required Postgres extensions
 
 QUESTPIE is **drizzle-native and does not auto-create Postgres extensions**, the search adapters declare the `CREATE EXTENSION` statements, but you must ensure the extension exists before `db:push` / migrations run the index DDL.
 
-| Adapter | Required extension | When it's needed |
-|---|---|---|
-| `createPostgresSearchAdapter` | `pg_trgm` | For the trigram fuzzy-match index. |
+| Adapter                       | Required extension                    | When it's needed                                                         |
+| ----------------------------- | ------------------------------------- | ------------------------------------------------------------------------ |
+| `createPostgresSearchAdapter` | `pg_trgm`                             | For the trigram fuzzy-match index.                                       |
 | `createPgVectorSearchAdapter` | `pg_trgm` **and** `vector` (pgvector) | Trigram (inherited) + the `embedding vector(N)` column and vector index. |
 
 How to provide them:
@@ -306,7 +307,7 @@ How to provide them:
 - **Managed Postgres:** enable the extension through your provider (most expose `pg_trgm` and `pgvector` as one-click or `CREATE EXTENSION` in a console).
 
 <Callout type="info" title="External adapters need no tables or extensions">
-The Postgres and pgvector adapters are *local*, they return their tables from `getTableSchemas()` so QUESTPIE includes them in Drizzle migrations, and they declare extensions. A search adapter that points at an external service (Meilisearch, Elasticsearch) returns no table schemas and needs no Postgres extensions.
+  The Postgres and pgvector adapters are *local*, they return their tables from `getTableSchemas()` so QUESTPIE includes them in Drizzle migrations, and they declare extensions. A search adapter that points at an external service (Meilisearch, Elasticsearch) returns no table schemas and needs no Postgres extensions.
 </Callout>
 
 ## Indexing
@@ -316,14 +317,21 @@ You almost never index by hand. Searchable collections are re-indexed automatica
 When you do need manual control, `app.search` exposes the service surface:
 
 ```ts
-await app.search.index({ collection: "posts", recordId, locale: "en", title, content });
-await app.search.indexBatch([...params]);          // upsert many
+await app.search.index({
+  collection: "posts",
+  recordId,
+  locale: "en",
+  title,
+  content,
+});
+await app.search.indexBatch([...params]); // upsert many
 await app.search.remove({ collection: "posts", recordId }); // omit locale → all locales
-await app.search.clear();                          // wipe the whole index
+await app.search.clear(); // wipe the whole index
 ```
 
 <Callout type="warn" title="`reindex()` on the local adapters is not implemented">
-`app.search.reindex(collection)` (and the client `reindex` / `POST /api/search/reindex/:collection` route) throw `"reindex() not yet implemented - requires app context"` on the Postgres and pgvector adapters. To rebuild the index today, re-save the records (or call `index()` / `indexBatch()` yourself) rather than relying on `reindex()`. The reindex route's [access](/docs/concepts/access-control) is governed by the `reindexAccess` adapter option (default = the collection's `update` rule), relevant once you wire a custom adapter that implements `reindex()`.
+  `app.search.reindex(collection)` (and the client `reindex` / `POST /api/search/reindex/:collection` route) throw `"reindex() not yet implemented - requires app context"` on the Postgres and pgvector adapters. To rebuild the index today, re-save the records (or call `index()` / `indexBatch()` yourself) rather than
+  relying on `reindex()`. The reindex route's [access](/docs/concepts/access-control) is governed by the `reindexAccess` adapter option (default = the collection's `update` rule), relevant once you wire a custom adapter that implements `reindex()`.
 </Callout>
 
 ## Extending: custom search adapters
@@ -346,22 +354,14 @@ interface SearchAdapter {
 }
 ```
 
-`initialize()` must **not** create tables, return Drizzle table objects from `getTableSchemas()` (local backends) so migrations own the DDL, or return `undefined` (external backends). `app.search.search(...)` and `.searchable()` work unchanged regardless of which adapter is wired. This is the QUESTPIE principle: the framework, modules, and your own code all reach the same `search` slot through one contract, there is no privileged internal search API.
+`initialize()` must **not** create tables. Return Drizzle table objects from `getTableSchemas()` for local backends so migrations own the DDL, or return `undefined` for external backends. Framework, module, and application code all use this public `SearchAdapter` contract.
 
 ## TypeScript
 
 The search types are exported from `questpie/search` (and `questpie`):
 
 ```ts
-import type {
-  SearchAdapter,
-  SearchOptions,
-  SearchResponse,
-  SearchResult,
-  SearchableConfig,
-  EmbeddingProvider,
-  FacetDefinition,
-} from "questpie/search";
+import type { SearchAdapter, SearchOptions, SearchResponse, SearchResult, SearchableConfig, EmbeddingProvider, FacetDefinition } from "questpie/search";
 ```
 
 Adapter and provider factories and their option types come from their own entry points: `createPostgresSearchAdapter` / `PostgresSearchAdapterOptions` from `questpie/adapters/postgres-search`, `createPgVectorSearchAdapter` / `PgVectorSearchAdapterOptions` from `questpie/adapters/pgvector-search`, and the embedding providers from `questpie/search`.

--- a/apps/docs/content/docs/adapters/storage.mdx
+++ b/apps/docs/content/docs/adapters/storage.mdx
@@ -3,9 +3,9 @@ title: Storage adapter
 description: Point your file uploads at the local disk, S3, R2, or any of 40+ Files SDK backends with one config block, and get a typed Files instance on app.storage, automatic signed URLs for private files, and direct-to-storage uploads, all without touching your collections.
 ---
 
-The **storage adapter** decides *where* your uploaded file bytes physically live, the local filesystem in development, S3 or Cloudflare R2 in production, or any other [Files SDK](https://www.npmjs.com/package/files-sdk) backend. You set it once in `questpie.config.ts`; every [upload collection](/docs/concepts/collections#uploads) and the `app.storage` handle use it without code changes. Swap local for S3 by editing one block, your collections, hooks, and the typed client stay identical.
+The **storage adapter** supplies the byte backend for the [Storage](/docs/concepts/storage) lifecycle. It can use local disk, S3, Cloudflare R2, or another [Files SDK](https://www.npmjs.com/package/files-sdk) backend while upload collections keep the same contract.
 
-> **Prerequisites:** read [Configuration](/docs/concepts/configuration) (where `storage` lives) and know how [upload collections](/docs/concepts/collections#uploads) and the [`f.upload()` field](/docs/concepts/fields#upload) work. Storage is the byte backend *behind* those features, they're taught there; this page owns where the bytes go.
+> **Prerequisites:** start with the [Storage concept](/docs/concepts/storage) for the asset model, upload flow, visibility, and direct uploads. This page covers backend configuration and operations.
 
 ## What it does
 
@@ -50,7 +50,8 @@ export default runtimeConfig({
 ```
 
 <Callout type="info" title="Drivers come from `files-sdk`, not QUESTPIE">
-QUESTPIE re-exports the `Files` class + types from [`files-sdk`](https://www.npmjs.com/package/files-sdk) (so every package shares one instance), but the actual **drivers**, `s3`, `r2`, `fs`, and ~40 others, are imported from `files-sdk` subpaths: `import { s3 } from "files-sdk/s3"`, `import { r2 } from "files-sdk/r2"`. Install `files-sdk` (it's a QUESTPIE dependency) and the provider's peer SDK (e.g. `@aws-sdk/client-s3` for `s3()`).
+  QUESTPIE re-exports the `Files` class + types from [`files-sdk`](https://www.npmjs.com/package/files-sdk) (so every package shares one instance), but the actual **drivers**, `s3`, `r2`, `fs`, and ~40 others, are imported from `files-sdk` subpaths: `import {s3} from "files-sdk/s3"`, `import {r2} from "files-sdk/r2"`.
+  Install `files-sdk` (it's a QUESTPIE dependency) and the provider's peer SDK (e.g. `@aws-sdk/client-s3` for `s3()`).
 </Callout>
 
 ## The two shapes: local vs adapter
@@ -80,7 +81,6 @@ Both shapes also accept the shared base options below.
 | `signedUrlExpiration` | `number` (seconds) | `3600` | TTL for the signed URLs QUESTPIE generates for **private** upload-collection files. |
 | `basePath` | `string` | `"/"` | Prefix for the file-serving routes (`{basePath}/:collection/files/:key`). |
 
-
 </Callout>
 
 The boot-time validator (`assertValidStorageConfig`) rejects unknown keys and rejects `adapter` + `location` together.
@@ -90,14 +90,19 @@ The boot-time validator (`assertValidStorageConfig`) rejects unknown keys and re
 With `location` (or no `storage` block at all), QUESTPIE builds a Files SDK `fs()` adapter for you and serves the bytes itself. It resolves the directory to an absolute path (relative paths are resolved against `process.cwd()`), and points file URLs at your own app:
 
 ```ts
-storage: { location: "/var/data/app-uploads" } // absolute
-storage: { location: "./uploads" }             // relative to cwd (the default)
+storage: {
+  location: "/var/data/app-uploads";
+} // absolute
+storage: {
+  location: "./uploads";
+} // relative to cwd (the default)
 ```
 
 Internally this becomes `fs({ root: <resolved>, urlBaseUrl: <app.url><basePath>/files, defaultUrlExpiresIn: signedUrlExpiration })`, so a stored file's `url` is served by QUESTPIE at `{app.url}{basePath}/files/...`. The default `basePath` of `/` collapses to an empty string, so with no `basePath` set the prefix is `<app.url>/files` (not `<app.url>//files`).
 
 <Callout type="warn" title="Local disk doesn't survive a redeploy or scale-out">
-The `fs` driver writes to the machine's disk. On ephemeral/containerized hosts (most PaaS, serverless, Cloudflare) that disk is wiped on redeploy and not shared between instances, so uploads vanish or go missing across replicas. Local storage is for **development**; use an object-storage adapter (S3/R2) in production.
+  The `fs` driver writes to the machine's disk. On ephemeral/containerized hosts (most PaaS, serverless, Cloudflare) that disk is wiped on redeploy and not shared between instances, so uploads vanish or go missing across replicas. Local storage is for **development**; use an object-storage adapter (S3/R2) in
+  production.
 </Callout>
 
 ### Object storage (`adapter`)
@@ -139,7 +144,8 @@ storage: {
 ```
 
 <Callout type="warn" title="Without `publicBaseUrl`, `url()` returns a presigned (expiring) URL">
-For both `s3()` and `r2()`, when you don't set `publicBaseUrl`, `app.storage.url(key)` returns a **presigned GetObject URL** that expires (default 1 hour, tune with `defaultUrlExpiresIn` or per-call `url(key, { expiresIn })`). Set `publicBaseUrl` (a CDN origin, public-read bucket, or custom domain) for permanent, signature-free URLs. The R2 **binding** variant (`r2({ binding })`, for Workers) has no signing primitive, `url()` throws unless `publicBaseUrl` or hybrid HTTP credentials are configured.
+  For both `s3()` and `r2()`, when you don't set `publicBaseUrl`, `app.storage.url(key)` returns a **presigned GetObject URL** that expires (default 1 hour, tune with `defaultUrlExpiresIn` or per-call `url(key, {expiresIn})`). Set `publicBaseUrl` (a CDN origin, public-read bucket, or custom domain) for permanent,
+  signature-free URLs. The R2 **binding** variant (`r2({binding})`, for Workers) has no signing primitive, `url()` throws unless `publicBaseUrl` or hybrid HTTP credentials are configured.
 </Callout>
 
 Any of the ~40 Files SDK providers works the same way, GCS (`files-sdk/gcs`), Azure (`files-sdk/azure`), Supabase (`files-sdk/supabase`), and more. Pick the subpath, pass its options, hand the result to `adapter`.
@@ -167,15 +173,14 @@ await app.storage.delete("avatars/u_42.png");
 const { items } = await app.storage.list({ prefix: "avatars/" });
 ```
 
-
-
 <Callout type="info" title="Upload collections call `app.storage` for you">
-You rarely touch `app.storage` directly for normal uploads. When you build an [upload collection](/docs/concepts/collections#uploads) with `.upload()`, its `upload()` / `uploadMany()` CRUD methods write through `app.storage`, generate the `key`, and clean up bytes on replace/delete. Reach for `app.storage` directly only for storage operations *outside* a collection (e.g. exporting a generated report). The client-side `client.collections.media.upload(file, { onProgress })` is documented in [the client SDK](/docs/client/sdk#uploads).
+  You rarely touch `app.storage` directly for normal uploads. When you build an [upload collection](/docs/concepts/collections#uploads) with `.upload()`, its `upload()` / `uploadMany()` CRUD methods write through `app.storage`, generate the `key`, and clean up bytes on replace/delete. Reach for `app.storage` directly
+  only for storage operations *outside* a collection (e.g. exporting a generated report). The client-side `client.collections.media.upload(file, {onProgress})` is documented in [the client SDK](/docs/client/sdk#uploads).
 </Callout>
 
 ## Visibility and signed URLs
 
-An upload collection's `visibility` (set via [`.upload({ visibility })`](/docs/concepts/collections#uploads)) controls how its **file bytes** are served, it does *not* gate the upload rows, which always go through the collection's [access rules](/docs/concepts/access-control).
+An upload collection's `visibility` (set via [`.upload({ visibility })`](/docs/concepts/collections#uploads)) controls how its **file bytes** are served, it does _not_ gate the upload rows, which always go through the collection's [access rules](/docs/concepts/access-control).
 
 - **`public`** (default), the file `url` is a plain, unsigned URL (the provider's public/CDN URL, or QUESTPIE's `/:collection/files/:key` route for local storage).
 - **`private`**, on read, QUESTPIE's `afterRead` hook builds a **signed URL**: it generates an HMAC-SHA256 token (`key` + `expires` + `collection`), appends it as `?token=`, and the file route verifies it before serving the bytes. The token TTL is `storage.signedUrlExpiration` (default 3600s).
@@ -189,7 +194,8 @@ asset.url; // → https://app.example.com/media/files/<key>?token=<hmac-signed>
 The signing/verification helpers are exported from `questpie/storage` if you need them directly: `generateSignedUrlToken(key, secret, expirationSeconds, collection?)`, `verifySignedUrlToken(token, secret, expectedCollection?)`, and `buildStorageFileUrl(baseUrl, basePath, collection, key, token?)`.
 
 <Callout type="warn" title="Private files need a `secret`, without it, `url` is `undefined`">
-Signing requires `app.config.secret` (resolved from `QUESTPIE_SECRET` / `BETTER_AUTH_SECRET`, or `runtimeConfig({ secret })`). If a collection is `private` and **no secret is set**, the `afterRead` hook leaves `url` as `undefined` rather than emitting an unsigned URL, failing closed instead of leaking the bytes. Always set a secret in any environment that serves private files.
+  Signing requires `app.config.secret` (resolved from `QUESTPIE_SECRET` / `BETTER_AUTH_SECRET`, or `runtimeConfig({secret})`). If a collection is `private` and **no secret is set**, the `afterRead` hook leaves `url` as `undefined` rather than emitting an unsigned URL, failing closed instead of leaking the bytes. Always
+  set a secret in any environment that serves private files.
 </Callout>
 
 <Callout type="info" title="To change *who* may fetch private bytes, use `access.serve`">
@@ -210,9 +216,9 @@ export default route()
   .handler(async ({ input, storage }) => {
     // Returns { method: "PUT" | "POST", url, ... }, POST form for S3/R2 when maxSize is set
     return storage.signedUploadUrl(input.key, {
-      expiresIn: 600,         // required: TTL in seconds
+      expiresIn: 600, // required: TTL in seconds
       contentType: "image/*", // bound into the signature where supported
-      maxSize: 10_000_000,    // STRONGLY recommended, enforces a size cap server-side
+      maxSize: 10_000_000, // STRONGLY recommended, enforces a size cap server-side
     });
   });
 ```
@@ -220,7 +226,8 @@ export default route()
 `SignUploadOptions`: `expiresIn` (required, seconds), `contentType?`, `maxSize?`, `minSize?` (default `1`). The result is a `SignedUpload`: either `{ method: "PUT", url, headers? }` or `{ method: "POST", url, fields }` (S3/R2 use the POST form when `maxSize` is set, which enforces the cap via a `content-length-range` policy).
 
 <Callout type="warn" title="Always pass `maxSize` to a presigned upload">
-Without `maxSize`, supporting adapters fall back to a presigned **PUT** with **no server-side size limit**, anyone with the URL can upload an arbitrarily large object until `expiresIn` elapses. Set `maxSize` so the adapter uses a size-enforced presigned POST. (Direct-to-storage uploads also bypass your collection's `allowedTypes`/`maxSize`, which are admin-UI hints, not server constraints, so the presigned policy is your enforcement point.)
+  Without `maxSize`, supporting adapters fall back to a presigned **PUT** with **no server-side size limit**, anyone with the URL can upload an arbitrarily large object until `expiresIn` elapses. Set `maxSize` so the adapter uses a size-enforced presigned POST. (Direct-to-storage uploads also bypass your collection's
+  `allowedTypes`/`maxSize`, which are admin-UI hints, not server constraints, so the presigned policy is your enforcement point.)
 </Callout>
 
 <Callout type="info" title="Set `Content-Disposition` for user-uploaded content">
@@ -231,18 +238,18 @@ A user-uploaded `.html` or SVG served inline executes in your domain's origin, s
 
 If you set `QUESTPIE_STORAGE_ENDPOINT` and don't pass an explicit `storage` block, QUESTPIE auto-wires an S3-compatible adapter from environment variables, the path QUESTPIE Cloud uses at deploy time:
 
-| Env var | Purpose |
-|---|---|
-| `QUESTPIE_STORAGE_ENDPOINT` | S3-compatible endpoint (presence triggers auto-wiring) |
-| `QUESTPIE_STORAGE_BUCKET` | Bucket name |
-| `QUESTPIE_STORAGE_REGION` | Region (defaults to `"auto"`) |
-| `QUESTPIE_STORAGE_ACCESS_KEY` | Access key ID |
-| `QUESTPIE_STORAGE_SECRET_KEY` | Secret access key |
+| Env var                       | Purpose                                                |
+| ----------------------------- | ------------------------------------------------------ |
+| `QUESTPIE_STORAGE_ENDPOINT`   | S3-compatible endpoint (presence triggers auto-wiring) |
+| `QUESTPIE_STORAGE_BUCKET`     | Bucket name                                            |
+| `QUESTPIE_STORAGE_REGION`     | Region (defaults to `"auto"`)                          |
+| `QUESTPIE_STORAGE_ACCESS_KEY` | Access key ID                                          |
+| `QUESTPIE_STORAGE_SECRET_KEY` | Secret access key                                      |
 
 The adapter is created with `forcePathStyle: true` and is **lazy**, the `files-sdk/s3` import (and its AWS SDK peers) loads on the first storage operation, not at boot. If the endpoint is set but bucket/keys are missing, QUESTPIE warns and falls back to local storage. An explicit `storage` block in your config always wins over the env vars.
 
 <Callout type="warn" title="The env-driven S3 path needs the AWS SDK installed">
-The lazy adapter requires `@aws-sdk/client-s3`, `@aws-sdk/lib-storage`, `@aws-sdk/s3-presigned-post`, and `@aws-sdk/s3-request-presigner` as dependencies. If they're missing, the first storage operation throws a clear install message.
+  The lazy adapter requires `@aws-sdk/client-s3`, `@aws-sdk/lib-storage`, `@aws-sdk/s3-presigned-post`, and `@aws-sdk/s3-request-presigner` as dependencies. If they're missing, the first storage operation throws a clear install message.
 </Callout>
 
 ## TypeScript
@@ -251,10 +258,10 @@ The storage config and result types are exported from `questpie/storage` (and th
 
 ```ts
 import type {
-  StorageConfig,        // the union you assign to `storage`
-  StorageLocalConfig,   // { location?, ...base }
+  StorageConfig, // the union you assign to `storage`
+  StorageLocalConfig, // { location?, ...base }
   StorageAdapterConfig, // { adapter, ...base }
-  StorageVisibility,    // "public" | "private"
+  StorageVisibility, // "public" | "private"
 } from "questpie/storage";
 
 // Files SDK types (re-exported so packages share one instance):
@@ -286,12 +293,11 @@ export default runtimeConfig({
 
 The `Adapter` type is re-exported from `questpie/storage` so you can type your implementation without a direct `files-sdk` import. Everything downstream, upload collections, `app.storage`, signed URLs for QUESTPIE-served files, works unchanged. For the full `Adapter` contract, see the [Files SDK](https://www.npmjs.com/package/files-sdk) docs.
 
-<Callout type="idea" title="Screenshot, admin media library">
-</Callout>
+<Callout type="idea" title="Screenshot, admin media library"></Callout>
 
 ## Related
 
-- [Upload collections](/docs/concepts/collections#uploads), `.upload()` makes a collection a byte store; the storage adapter is *where* those bytes go.
+- [Upload collections](/docs/concepts/collections#uploads), `.upload()` makes a collection a byte store; the storage adapter is _where_ those bytes go.
 - [`f.upload()` field](/docs/concepts/fields#upload), a typed relation from a row to an upload collection.
 - [Client SDK, uploads](/docs/client/sdk#uploads), `client.collections.media.upload(file, { onProgress })` with XHR progress.
 - [Access control](/docs/concepts/access-control), the `serve` rule that gates who may fetch file bytes.

--- a/apps/docs/content/docs/admin/collections.mdx
+++ b/apps/docs/content/docs/admin/collections.mdx
@@ -19,82 +19,81 @@ export default [adminModule] as const;
 import { collection } from "#questpie/factories";
 
 export const posts = collection("posts")
-	.fields(({ f }) => ({
-		title: f.text(255).label("Title").required(),
-		slug: f.text(120).label("Slug").required(),
-		status: f
-			.select([
-				{ value: "draft", label: "Draft" },
-				{ value: "published", label: "Published" },
-			])
-			.label("Status")
-			.default("draft"),
-		excerpt: f.textarea().label("Excerpt"),
-		body: f.richText().label("Body"),
-		cover: f.upload({ to: "assets" }).label("Cover image"),
-	}))
-	.admin(({ c }) => ({
-		label: "Posts",
-		description: "Editorial content",
-		icon: c.icon("ph:article"),
-		group: "content",
-		order: 10,
-	}))
-	.list(({ v, f }) =>
-		v.collectionTable({
-			columns: [f.title, f.status, "updatedAt"],
-			defaultSort: { field: "updatedAt", direction: "desc" },
-			searchable: [f.title],
-			filterable: [f.status],
-			realtime: true,
-		}),
-	)
-	.form(({ v, f }) =>
-		v.collectionForm({
-			sidebar: {
-				position: "right",
-				fields: [f.status, f.slug, f.cover],
-			},
-			fields: [
-				{
-					type: "section",
-					label: "Content",
-					fields: [f.title, f.excerpt, f.body],
-				},
-			],
-		}),
-	)
-	.preview({
-		enabled: true,
-		position: "right",
-		url: ({ record, locale }) =>
-			`/${locale ?? "en"}/blog/${String(record.slug)}`,
-	})
-	.actions(({ a, c }) => ({
-		builtin: [a.create(), a.save(), a.delete(), a.duplicate()],
-		custom: [
-			a.action({
-				id: "open-preview",
-				label: "Open preview",
-				icon: c.icon("ph:arrow-square-out"),
-				handler: ({ itemId }) => ({
-					type: "redirect",
-					url: `/preview/posts/${itemId}`,
-					external: true,
-				}),
-			}),
-		],
-	}));
+  .fields(({ f }) => ({
+    title: f.text(255).label("Title").required(),
+    slug: f.text(120).label("Slug").required(),
+    status: f
+      .select([
+        { value: "draft", label: "Draft" },
+        { value: "published", label: "Published" },
+      ])
+      .label("Status")
+      .default("draft"),
+    excerpt: f.textarea().label("Excerpt"),
+    body: f.richText().label("Body"),
+    cover: f.upload({ to: "assets" }).label("Cover image"),
+  }))
+  .admin(({ c }) => ({
+    label: "Posts",
+    description: "Editorial content",
+    icon: c.icon("ph:article"),
+    group: "content",
+    order: 10,
+  }))
+  .list(({ v, f }) =>
+    v.collectionTable({
+      columns: [f.title, f.status, "updatedAt"],
+      defaultSort: { field: "updatedAt", direction: "desc" },
+      searchable: [f.title],
+      filterable: [f.status],
+      realtime: true,
+    }),
+  )
+  .form(({ v, f }) =>
+    v.collectionForm({
+      sidebar: {
+        position: "right",
+        fields: [f.status, f.slug, f.cover],
+      },
+      fields: [
+        {
+          type: "section",
+          label: "Content",
+          fields: [f.title, f.excerpt, f.body],
+        },
+      ],
+    }),
+  )
+  .preview({
+    enabled: true,
+    position: "right",
+    url: ({ record, locale }) => `/${locale ?? "en"}/blog/${String(record.slug)}`,
+  })
+  .actions(({ a, c }) => ({
+    builtin: [a.create(), a.save(), a.delete(), a.duplicate()],
+    custom: [
+      a.action({
+        id: "open-preview",
+        label: "Open preview",
+        icon: c.icon("ph:arrow-square-out"),
+        handler: ({ itemId }) => ({
+          type: "redirect",
+          url: `/preview/posts/${itemId}`,
+          external: true,
+        }),
+      }),
+    ],
+  }));
 ```
 
 ## Collection methods
 
-| Method | Purpose |
-|---|---|
-| `.admin(config)` | Label, description, icon, sidebar group, sort order, visibility, and audit participation. |
-| `.list(({ v, f, a, c }) => ...)` | List view choice, columns, sorting, filters, search, grouping, realtime, and list-level actions. |
-| `.form(({ v, f }) => ...)` | Create and edit form layout, sections, tabs, sidebar fields, and form view choice. |
-| `.preview(config)` | Live preview URL builder, position, and default panel size. The URL function runs on the server. |
+| Method                           | Purpose                                                                                              |
+| -------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `.admin(config)`                 | Label, description, icon, sidebar group, sort order, visibility, and audit participation.            |
+| `.list(({ v, f, a, c }) => ...)` | List view choice, columns, sorting, filters, search, grouping, realtime, and list-level actions.     |
+| `.form(({ v, f }) => ...)`       | Create and edit form layout, sections, tabs, sidebar fields, and form view choice.                   |
+| `.preview(config)`               | Live preview URL builder, position, and default panel size. The URL function runs on the server.     |
 | `.actions(({ a, c, f }) => ...)` | Built-in actions and custom row, single-record, bulk, or header actions. Handlers run on the server. |
 
 `f` is a field-reference proxy, not a string you hand-write. Use `f.title`, `f.status`, and other registered field keys so codegen can keep the view config aligned with the collection schema.
@@ -107,34 +106,34 @@ export const posts = collection("posts")
 
 ## Globals
 
-Globals are singleton documents. They support `.admin()` and `.form()` only. There is no list page, row action, bulk action, or per-record preview for a global.
+Globals are singleton documents. Configure their admin metadata with `.admin()` and their singleton edit layout with `.form()`.
 
 ```ts title="src/questpie/server/globals/site-settings.ts"
 import { global } from "#questpie/factories";
 
 export const siteSettings = global("siteSettings")
-	.fields(({ f }) => ({
-		siteName: f.text(120).label("Site name").required(),
-		homepageTitle: f.text(180).label("Homepage title"),
-		defaultSocialImage: f.upload({ to: "assets" }).label("Default social image"),
-	}))
-	.admin(({ c }) => ({
-		label: "Site settings",
-		icon: c.icon("ph:gear-six"),
-		group: "settings",
-		order: 1,
-	}))
-	.form(({ v, f }) =>
-		v.globalForm({
-			fields: [
-				{
-					type: "section",
-					label: "General",
-					fields: [f.siteName, f.homepageTitle, f.defaultSocialImage],
-				},
-			],
-		}),
-	);
+  .fields(({ f }) => ({
+    siteName: f.text(120).label("Site name").required(),
+    homepageTitle: f.text(180).label("Homepage title"),
+    defaultSocialImage: f.upload({ to: "assets" }).label("Default social image"),
+  }))
+  .admin(({ c }) => ({
+    label: "Site settings",
+    icon: c.icon("ph:gear-six"),
+    group: "settings",
+    order: 1,
+  }))
+  .form(({ v, f }) =>
+    v.globalForm({
+      fields: [
+        {
+          type: "section",
+          label: "General",
+          fields: [f.siteName, f.homepageTitle, f.defaultSocialImage],
+        },
+      ],
+    }),
+  );
 ```
 
 ## Access and visibility
@@ -149,14 +148,14 @@ When `auditModule` is installed, collections and globals participate in audit lo
 
 ```ts
 export const imports = collection("imports")
-	.fields(({ f }) => ({
-		name: f.text(120).required(),
-		payload: f.json(),
-	}))
-	.admin({
-		label: "Imports",
-		audit: false,
-	});
+  .fields(({ f }) => ({
+    name: f.text(120).required(),
+    payload: f.json(),
+  }))
+  .admin({
+    label: "Imports",
+    audit: false,
+  });
 ```
 
 Use this for high-volume technical records where recording every mutation would add noise.

--- a/apps/docs/content/docs/client/realtime.mdx
+++ b/apps/docs/content/docs/client/realtime.mdx
@@ -24,8 +24,8 @@ import { runtimeConfig } from "questpie/app";
 import env from "./env"; // declared + validated in env.ts, see Environment
 
 export default runtimeConfig({
-	db: { url: env.DATABASE_URL },
-	realtime: true,
+  db: { url: env.DATABASE_URL },
+  realtime: true,
 });
 ```
 
@@ -35,13 +35,10 @@ Now subscribe from the client. `live()` takes your query options, a snapshot cal
 import { client } from "@/lib/client.js";
 
 // First snapshot fires immediately; then on every matching change.
-const unsubscribe = client.collections.posts.live(
-	{ where: { published: true }, orderBy: { createdAt: "desc" }, limit: 10 },
-	(snapshot) => {
-		// snapshot is the SAME shape & type as client.collections.posts.find(...)
-		console.log(snapshot.totalDocs, snapshot.docs[0]?.title);
-	},
-);
+const unsubscribe = client.collections.posts.live({ where: { published: true }, orderBy: { createdAt: "desc" }, limit: 10 }, (snapshot) => {
+  // snapshot is the SAME shape & type as client.collections.posts.find(...)
+  console.log(snapshot.totalDocs, snapshot.docs[0]?.title);
+});
 
 // Later, stop listening (e.g. on unmount):
 unsubscribe();
@@ -50,9 +47,7 @@ unsubscribe();
 That callback now re-fires with a fresh, access-filtered top-10 every time a published post changes.
 
 <Callout type="info" title="The first snapshot is your initial data">
-	You do **not** need a separate `find()` before subscribing. `live()` delivers
-	a full snapshot the moment the connection opens, then keeps it fresh. Treat
-	the first callback invocation as "data loaded".
+  You do **not** need a separate `find()` before subscribing. `live()` delivers a full snapshot the moment the connection opens, then keeps it fresh. Treat the first callback invocation as "data loaded".
 </Callout>
 
 ## Example → inferred snapshot
@@ -60,15 +55,12 @@ That callback now re-fires with a fresh, access-filtered top-10 every time a pub
 The snapshot type equals the `find()` result type for the same options, `FindResult<Row, Relations, TQuery>`. Narrow with `columns`? No: `live()` deliberately carries a **subset** of `find()` options (no `columns`), so a snapshot is always the full row plus any `with` relations you requested:
 
 ```ts
-client.collections.posts.live(
-	{ where: { published: true }, with: { author: true }, limit: 5 },
-	(snapshot) => {
-		snapshot.docs[0].author.name;
-		//         ^? string, `with: { author: true }` hydrated the relation
-		snapshot.hasNextPage;
-		//         ^? boolean, full PaginatedResult envelope, same as find()
-	},
-);
+client.collections.posts.live({ where: { published: true }, with: { author: true }, limit: 5 }, (snapshot) => {
+  snapshot.docs[0].author.name;
+  //         ^? string, `with: { author: true }` hydrated the relation
+  snapshot.hasNextPage;
+  //         ^? boolean, full PaginatedResult envelope, same as find()
+});
 ```
 
 A snapshot is a `PaginatedResult<T>` (`{ docs, totalDocs, totalPages, page, hasPrevPage, hasNextPage, prevPage, nextPage, ... }`), or, if your query uses `groupBy`… it can't, because `groupBy` isn't a live option (see below).
@@ -79,25 +71,18 @@ A snapshot is a `PaginatedResult<T>` (`{ docs, totalDocs, totalPages, page, hasP
 
 ```ts
 type LiveQueryOptions<TSelect, TRelations> = {
-	where?: Where<TSelect, TRelations>;
-	with?: With<TRelations>;
-	limit?: number;
-	offset?: number;
-	orderBy?: OrderBy<TSelect>;
-	locale?: string;
+  where?: Where<TSelect, TRelations>;
+  with?: With<TRelations>;
+  limit?: number;
+  offset?: number;
+  orderBy?: OrderBy<TSelect>;
+  locale?: string;
 };
 ```
 
-<Callout
-	type="warn"
-	title="`columns`, `groupBy`, `search`, `includeDeleted`, `stage` are not live options"
->
-	`LiveQueryOptions` intentionally **excludes** `columns`, `groupBy`, `search`,
-	`includeDeleted`, and `stage`. Realtime snapshots are the full query re-run
-	server-side from the topic fields, so column projection / grouping /
-	soft-delete-included / stage-pinned reads aren't expressed over the wire. If
-	you pass them they're simply not part of the subscription. For those, use a
-	one-shot `find()`.
+<Callout type="warn" title="`columns`, `groupBy`, `search`, `includeDeleted`, `stage` are not live options">
+  `LiveQueryOptions` intentionally **excludes** `columns`, `groupBy`, `search`, `includeDeleted`, and `stage`. Realtime snapshots are the full query re-run server-side from the topic fields, so column projection / grouping / soft-delete-included / stage-pinned reads aren't expressed over the wire. If you pass them
+  they're simply not part of the subscription. For those, use a one-shot `find()`.
 </Callout>
 
 ### `LiveSubscribeOptions`, the third argument
@@ -106,21 +91,17 @@ type LiveQueryOptions<TSelect, TRelations> = {
 
 ```ts
 type LiveSubscribeOptions = {
-	signal?: AbortSignal; // abort → auto-unsubscribe
-	onError?: (error: Error) => void; // SSE connection failed
+  signal?: AbortSignal; // abort → auto-unsubscribe
+  onError?: (error: Error) => void; // SSE connection failed
 };
 ```
 
 ```ts
 const ac = new AbortController();
-client.collections.posts.live(
-	{ where: { published: true } },
-	(snapshot) => render(snapshot),
-	{
-		signal: ac.signal,
-		onError: (err) => console.error("realtime dropped:", err),
-	},
-);
+client.collections.posts.live({ where: { published: true } }, (snapshot) => render(snapshot), {
+  signal: ac.signal,
+  onError: (err) => console.error("realtime dropped:", err),
+});
 // ac.abort() unsubscribes, equivalent to calling the returned function.
 ```
 
@@ -133,12 +114,9 @@ client.collections.posts.live(
 ```ts
 const ac = new AbortController();
 
-for await (const snapshot of client.collections.posts.liveIter(
-	{ where: { published: true }, limit: 10 },
-	{ signal: ac.signal },
-)) {
-	console.log("posts now:", snapshot.totalDocs);
-	// ac.abort() ends the loop.
+for await (const snapshot of client.collections.posts.liveIter({ where: { published: true }, limit: 10 }, { signal: ac.signal })) {
+  console.log("posts now:", snapshot.totalDocs);
+  // ac.abort() ends the loop.
 }
 ```
 
@@ -149,13 +127,10 @@ It takes only `{ signal? }`, **no `onError`** (unlike `live()`). A connection fa
 Globals are singletons, so their live API mirrors `get()` with a smaller option set. `GlobalLiveQueryOptions` is `{ with?, locale? }` only, no `where`/`limit`/`offset`/`orderBy`:
 
 ```ts
-const stop = client.globals.siteSettings.live(
-	{ with: { logo: true } },
-	(snapshot) => {
-		// snapshot is the SAME shape & type as client.globals.siteSettings.get(...)
-		document.title = snapshot.title;
-	},
-);
+const stop = client.globals.siteSettings.live({ with: { logo: true } }, (snapshot) => {
+  // snapshot is the SAME shape & type as client.globals.siteSettings.get(...)
+  document.title = snapshot.title;
+});
 ```
 
 `live()` and `liveIter()` carry the same `LiveSubscribeOptions` / `{ signal? }` semantics as collections.
@@ -170,15 +145,12 @@ import { useQuery } from "@tanstack/react-query";
 import { q } from "@/lib/query.js";
 
 function LivePosts() {
-	const { data } = useQuery(
-		// 1st arg: query options. 2nd arg: { realtime: true }.
-		q.collections.posts.find(
-			{ where: { published: true }, limit: 10 },
-			{ realtime: true },
-		),
-	);
+  const { data } = useQuery(
+    // 1st arg: query options. 2nd arg: { realtime: true }.
+    q.collections.posts.find({ where: { published: true }, limit: 10 }, { realtime: true }),
+  );
 
-	return <p>{data?.totalDocs ?? 0} published posts (live)</p>;
+  return <p>{data?.totalDocs ?? 0} published posts (live)</p>;
 }
 ```
 
@@ -192,16 +164,9 @@ Under the hood the hook uses TanStack's `experimental_streamedQuery` with `refet
 `findOne` and every mutation **reject** a `{ realtime: true }` argument at the type level, passing it is a compile error (the tests assert `@ts-expect-error`). There's no live `findOne`; subscribe with `find({ where: { id } })` (or `live()`) and read `docs[0]`.
 </Callout>
 
-<Callout
-	type="warn"
-	title="If the server has no realtime, `{ realtime: true }` errors"
->
-	The client always wires `client.realtime`, so the TanStack flag is honored
-	client-side regardless. The real prerequisite is **server-side realtime**: set
-	`realtime` in your config so `POST /realtime` exists. Without it the SSE
-	connect fails, the stream errors out (and `find()`/`get()`/`live()`'s
-	`onError` fires) rather than silently degrading to a poll. Turn `realtime` on
-	in the server config before relying on live queries.
+<Callout type="warn" title="If the server has no realtime, `{ realtime: true }` errors">
+  The client always wires `client.realtime`, so the TanStack flag is honored client-side regardless. The real prerequisite is **server-side realtime**: set `realtime` in your config so `POST /realtime` exists. Without it the SSE connect fails, the stream errors out (and `find()`/`get()`/`live()`'s `onError` fires)
+  rather than silently degrading to a poll. Turn `realtime` on in the server config before relying on live queries.
 </Callout>
 
 The TanStack realtime topic is derived purely from your read `options` via `buildCollectionTopic` / `buildGlobalTopic`, config-level `locale`/`stage` are **not** added to the topic, only `options.locale` is. Two subscriptions that differ only by `where` get distinct live streams.
@@ -213,12 +178,8 @@ Everything above is the **client** API. None of it works until you turn realtime
 The full server surface, `RealtimeConfig` options, the outbox/poll model, every transport adapter (`pgNotifyAdapter`, `redisStreamsAdapter`, `cloudflareRealtimeAdapter`), and building your own, lives on one page: see [Realtime adapter](/docs/adapters/realtime).
 
 <Callout type="info" title="One client transport, by design">
-	On the default path, `live()` / `liveIter()` calls (and the TanStack flag)
-	share a multiplexed `POST /realtime` SSE connection within the server's
-	admission caps. With Pusher/Soketi selected, the same APIs share the managed
-	provider connection. Always subscribe through the typed wrappers (or
-	`client.realtime`) so the runtime can multiplex, resume, and tear down
-	correctly.
+  On the default path, `live()` / `liveIter()` calls (and the TanStack flag) share a multiplexed `POST /realtime` SSE connection within the server's admission caps. With Pusher/Soketi selected, the same APIs share the managed provider connection. Always subscribe through the typed wrappers (or `client.realtime`) so the
+  runtime can multiplex, resume, and tear down correctly.
 </Callout>
 
 ## Raw realtime, `client.realtime`
@@ -229,34 +190,28 @@ The typed wrappers are the recommended path. If you need to subscribe to a hand-
 import { buildCollectionTopic } from "questpie/client";
 
 // Typed wrapper (preferred), TData inferred, topic built for you:
-const stop = client.collections.posts.live(
-	{ where: { published: true } },
-	onSnap,
-);
+const stop = client.collections.posts.live({ where: { published: true } }, onSnap);
 
 // Raw equivalent, you build the topic and supply TData yourself:
 const stopRaw = client.realtime.subscribe<MySnapshot>(
-	buildCollectionTopic("posts", { where: { published: true } }),
-	(data) => onSnap(data),
-	/* signal */ undefined,
-	/* customId */ undefined,
-	/* onError */ (err) => console.error(err),
+  buildCollectionTopic("posts", { where: { published: true } }),
+  (data) => onSnap(data),
+  /* signal */ undefined,
+  /* customId */ undefined,
+  /* onError */ (err) => console.error(err),
 );
 ```
 
 `RealtimeAPI` is `{ subscribe<TData>(topic, callback, signal?, customId?, onError?) => unsubscribe; stream<TData>(topic, signal?, customId?) => AsyncGenerator; destroy(); topicCount; subscriberCount }`. `subscribe` is the callback form, `stream` the async-iterable form. `destroy()` tears the multiplexer down entirely (it re-creates on the next subscribe). Prefer the typed wrappers, they infer `TData` from the query and can't drift from the topic shape.
 
-`buildCollectionTopic`, `buildGlobalTopic`, and the `RealtimeAPI` / `TopicConfig` / `TopicInput` **types** are re-exported from `questpie/client`. The multiplexer, `createRealtimeAPI`, and `sseSnapshotStream` are internal (not part of the public `questpie/client` surface), you reach them only through `client.realtime`.
+`questpie/client` exports `buildCollectionTopic`, `buildGlobalTopic`, and the `RealtimeAPI`, `TopicConfig`, and `TopicInput` types. Application subscriptions use the generated wrappers or `client.realtime`.
 
 ## Localization
 
 Pass `locale` in the live options to subscribe to a specific localized variant, it becomes part of the topic, so the `en` and `de` views of the same query are independent subscriptions:
 
 ```ts
-client.collections.posts.live(
-	{ where: { published: true }, locale: "de" },
-	onSnap,
-);
+client.collections.posts.live({ where: { published: true }, locale: "de" }, onSnap);
 ```
 
 `setLocale()` on the client mutates request headers for `find`/`create`/etc., but does **not** retarget already-open realtime subscriptions, realtime carries `locale` per topic. To switch a subscription's locale, unsubscribe and re-subscribe with the new `locale`.
@@ -273,13 +228,7 @@ client.collections.posts.live(
 The realtime option and result types come from `questpie/client`:
 
 ```ts
-import type {
-	RealtimeAPI,
-	TopicConfig,
-	TopicInput,
-	FindResult,
-	PaginatedResult,
-} from "questpie/client";
+import type { RealtimeAPI, TopicConfig, TopicInput, FindResult, PaginatedResult } from "questpie/client";
 ```
 
 `LiveQueryOptions`, `GlobalLiveQueryOptions`, and `LiveSubscribeOptions` are structural option types on the client method signatures (inferred at the call site, you rarely import them by name). The snapshot type is `FindResult<Row, Relations, TQuery>` for collections and `ApplyQuery<GlobalSelect, Relations, TQuery>` for globals, identical to `find()` / `get()`.

--- a/apps/docs/content/docs/client/sdk.mdx
+++ b/apps/docs/content/docs/client/sdk.mdx
@@ -59,7 +59,7 @@ const created = await client.collections.posts.create({
 ```
 
 <Callout type="info" title="`AppConfig` is a type, not a value">
-`createClient<AppConfig>(...)` takes the **generated** `AppConfig` (`typeof app`) as a type parameter, there is no runtime app passed to the client. Run `questpie generate` after changing your schema so `AppConfig` (and therefore every client method) stays in sync. The runtime is a `Proxy`, so any string key returns a callable surface even when the type rejects it, unknown collection/route names are compile-time errors only, not runtime guards.
+`createClient<AppConfig>(...)` takes the generated `AppConfig` as a type parameter. Run `questpie generate` after schema changes so every client method stays synchronized. Collection and route names are checked by TypeScript; runtime authorization and input validation still happen on the server.
 </Callout>
 
 ## Configuration
@@ -77,8 +77,8 @@ export type QuestpieClientConfig = {
 ```
 
 | Option | Default | What it does |
-|---|---|---|
-| `baseURL` *(required)* | none | Origin the client requests against. Combined with `basePath` to form every URL. |
+| --- | --- | --- |
+| `baseURL` _(required)_ | none | Origin the client requests against. Combined with `basePath` to form every URL. |
 | `basePath` | `"/"` | API mount path. Normalized: a leading slash is added if missing, a trailing slash stripped. **Must match** the server handler's `basePath`. |
 | `fetch` | `globalThis.fetch` | Custom fetch (e.g. an instrumented one, or a server-side polyfill). |
 | `headers` | `{}` | Default headers merged into every request. `accept-language` / `Accept-Language` here seeds the initial locale. |
@@ -89,16 +89,25 @@ export type QuestpieClientConfig = {
 ```ts
 {
   collections; // typed CRUD per collection
-  globals;     // typed get/update per global
-  routes;      // typed callers for your custom routes
-  search;      // search + reindex
-  realtime;    // low-level SSE stream API
-  setLocale; getLocale; getBasePath; // locale + base-path helpers
+  globals; // typed get/update per global
+  routes; // typed callers for your custom routes
+  search; // search + reindex
+  realtime; // low-level SSE stream API
+  setLocale;
+  getLocale;
+  getBasePath; // locale + base-path helpers
 }
 ```
 
-<Callout type="warn" title="`basePath` must match the server, and `'/'` reads back as `''`">
-The client's `basePath` and the server handler's `basePath` (`createFetchHandler({ basePath })`, `questpieNext(app, { basePath })`, …) must be identical or requests 404. Use `"/"` for a server-only API, `"/api"` for a fullstack app that also serves a frontend. `getBasePath()` returns the **normalized** path, an empty string `""` when `basePath` is `"/"`, not `"/"`.
+<Callout
+  type="warn"
+  title="`basePath` must match the server, and `'/'` reads back as `''`"
+>
+  The client's `basePath` and the server handler's `basePath`
+  (`createFetchHandler({basePath})`, `questpieNext(app, {basePath})`, …) must be
+  identical or requests 404. Use `"/"` for a server-only API, `"/api"` for a
+  fullstack app that also serves a frontend. `getBasePath()` returns the
+  **normalized** path, an empty string `""` when `basePath` is `"/"`, not `"/"`.
 </Callout>
 
 ## Collections
@@ -119,10 +128,14 @@ const result = await client.collections.posts.find({
 
 // findOne, first match or null. Optimized: a where of ONLY { id } hits GET /:id.
 const post = await client.collections.posts.findOne({ where: { id } });
-const bySlug = await client.collections.posts.findOne({ where: { slug: "hello" } });
+const bySlug = await client.collections.posts.findOne({
+  where: { slug: "hello" },
+});
 
 // count, bare number (the { count } envelope is unwrapped for you).
-const total = await client.collections.posts.count({ where: { published: true } });
+const total = await client.collections.posts.count({
+  where: { published: true },
+});
 ```
 
 `find()` serializes its options into the query string (`qs`, `skipNulls`, bracket arrays) and resolves to a `PaginatedResult`:
@@ -130,7 +143,10 @@ const total = await client.collections.posts.count({ where: { published: true } 
 ```jsonc
 // await client.collections.posts.find({ limit: 2 })
 {
-  "docs": [ { "id": "01J…", "title": "Hello", "published": true }, { "id": "01J…", "title": "World", "published": false } ],
+  "docs": [
+    { "id": "01J…", "title": "Hello", "published": true },
+    { "id": "01J…", "title": "World", "published": false },
+  ],
   "totalDocs": 2,
   "limit": 2,
   "totalPages": 1,
@@ -139,7 +155,7 @@ const total = await client.collections.posts.count({ where: { published: true } 
   "hasPrevPage": false,
   "hasNextPage": false,
   "prevPage": null,
-  "nextPage": null
+  "nextPage": null,
 }
 ```
 
@@ -200,7 +216,12 @@ const { count } = await client.collections.posts.deleteMany({
 ```
 
 <Callout type="warn" title="`updateMany` / `deleteMany` are claim-checked">
-Bulk operations lock the matching rows and re-evaluate `where` at write time, returning only the rows that won the race. `updateMany` returns the array of written rows, an **empty array means nothing matched at write time** (e.g. you lost a concurrent claim), not an error. `deleteMany`'s `count` is exactly the rows that still matched at delete time. `deleteMany` uses `POST /:collection/delete-many` (not `DELETE`) because it carries a body.
+  Bulk operations lock the matching rows and re-evaluate `where` at write time,
+  returning only the rows that won the race. `updateMany` returns the array of
+  written rows, an **empty array means nothing matched at write time** (e.g. you
+  lost a concurrent claim), not an error. `deleteMany`'s `count` is exactly the
+  rows that still matched at delete time. `deleteMany` uses `POST
+  /:collection/delete-many` (not `DELETE`) because it carries a body.
 </Callout>
 
 ### Versions and workflow
@@ -240,8 +261,17 @@ const assets = await client.collections.media.uploadMany(files, {
 });
 ```
 
-<Callout type="warn" title="Upload uses XHR, parses plain JSON, and throws `UploadError`">
-The upload path bypasses the `fetch`/SuperJSON pipeline: it sends `credentials: true` over `XMLHttpRequest`, and parses the response with plain `JSON.parse` (no SuperJSON). On failure it throws **`UploadError`**, *not* `QuestpieClientError`. `UploadError` carries `status` and `response`, with messages like `"Upload failed"`, `"Network error during upload"`, or `"Upload cancelled"`. `uploadMany` aborts between files on `signal` and short-circuits to `[]` for an empty array.
+<Callout
+  type="warn"
+  title="Upload uses XHR, parses plain JSON, and throws `UploadError`"
+>
+  The upload path bypasses the `fetch`/SuperJSON pipeline: it sends
+  `credentials: true` over `XMLHttpRequest`, and parses the response with plain
+  `JSON.parse` (no SuperJSON). On failure it throws **`UploadError`**, *not*
+  `QuestpieClientError`. `UploadError` carries `status` and `response`, with
+  messages like `"Upload failed"`, `"Network error during upload"`, or `"Upload
+  cancelled"`. `uploadMany` aborts between files on `signal` and short-circuits
+  to `[]` for an empty array.
 </Callout>
 
 ### Introspection
@@ -258,7 +288,7 @@ const schema = await client.collections.posts.schema(); // fields, relations, ac
 Every method takes an optional trailing `options` (`{ locale?, localeFallback?, stage? }`) that serializes into the query string, except the reads (which carry locale inside the query options) and `upload`/`meta`/`schema`.
 
 | Method | HTTP | Returns |
-|---|---|---|
+| --- | --- | --- |
 | `find(options?)` | `GET /:collection` | `PaginatedResult` (or `GroupedPaginatedResult` with `groupBy`) |
 | `findOne(options?)` | `GET /:collection/:id` (id-only `where`) or `find` w/ `limit:1` | row or `null` |
 | `count(options?)` | `GET /:collection/count` | `number` |
@@ -300,14 +330,20 @@ const next = await client.globals.settings.update(
 Because a global is a singleton, `update` takes the **data object as its first argument**, `update(data, options?)`, not the `{ id, data }` shape that collections use. The second argument is the query options (`with` / `locale` / `localeFallback` / `stage`). Mixing them up (`update({ id, data })`) writes a bogus `id` field.
 </Callout>
 
-<Callout type="info" title="`get()` is typed non-null, but a global can be empty">
-The client types `get()` as non-null for ergonomics, while the underlying global CRUD can return `null` before the singleton has ever been written. In practice a global resolves to its default/empty record once initialized; guard for the unwritten case if you read a global before any `update`.
+<Callout
+  type="info"
+  title="`get()` is typed non-null, but a global can be empty"
+>
+  The client types `get()` as non-null for ergonomics, while the underlying
+  global CRUD can return `null` before the singleton has ever been written. In
+  practice a global resolves to its default/empty record once initialized; guard
+  for the unwritten case if you read a global before any `update`.
 </Callout>
 
 The remaining global methods mirror collections, with the singleton shapes:
 
 | Method | HTTP | Notes |
-|---|---|---|
+| --- | --- | --- |
 | `get(options?)` | `GET /globals/:global` | `with` / `columns` / `locale` / `localeFallback` / `stage` |
 | `update(data, options?)` | `PATCH /globals/:global` | data first, options second |
 | `schema()` / `meta()` | `GET /globals/:global/schema` · `/meta` | introspection |
@@ -404,11 +440,25 @@ const unsubscribe = client.globals.settings.live({}, (snapshot) => {
 ```
 
 <Callout type="warn" title="`live()` carries a SUBSET of query options">
-Live queries only carry `where`, `with`, `limit`, `offset`, `orderBy`, and `locale` on the wire (`LiveQueryOptions`), they deliberately **exclude** `columns`, `groupBy`, `search`, `includeDeleted`, and `stage`, because each snapshot is a full query result re-run server-side from those fields. Globals carry `with` + `locale` only. Pass an unsupported option and it is dropped, not applied.
+  Live queries only carry `where`, `with`, `limit`, `offset`, `orderBy`, and
+  `locale` on the wire (`LiveQueryOptions`), they deliberately **exclude**
+  `columns`, `groupBy`, `search`, `includeDeleted`, and `stage`, because each
+  snapshot is a full query result re-run server-side from those fields. Globals
+  carry `with` + `locale` only. Pass an unsupported option and it is dropped,
+  not applied.
 </Callout>
 
-<Callout type="info" title="Always provide an unsubscribe path, and handle `onError`">
-The callback form returns an unsubscribe function; call it (or pass `opts.signal` and abort) when the component unmounts, or the SSE subscription leaks. The `onError` callback fires when the connection fails, wire it so a dropped stream surfaces instead of an infinite loading state. `liveIter()` only accepts `signal` (terminate by aborting it); it has no `onError`. Changing `setLocale()` does **not** re-key already-open subscriptions, locale is carried per-topic at subscribe time.
+<Callout
+  type="info"
+  title="Always provide an unsubscribe path, and handle `onError`"
+>
+  The callback form returns an unsubscribe function; call it (or pass
+  `opts.signal` and abort) when the component unmounts, or the SSE subscription
+  leaks. The `onError` callback fires when the connection fails, wire it so a
+  dropped stream surfaces instead of an infinite loading state. `liveIter()`
+  only accepts `signal` (terminate by aborting it); it has no `onError`.
+  Changing `setLocale()` does **not** re-key already-open subscriptions, locale
+  is carried per-topic at subscribe time.
 </Callout>
 
 ### Low-level realtime API
@@ -418,7 +468,10 @@ The callback form returns an unsubscribe function; call it (or pass `opts.signal
 ```ts
 import { buildCollectionTopic, buildGlobalTopic } from "questpie/client";
 
-const topic = buildCollectionTopic("posts", { where: { published: true }, limit: 20 });
+const topic = buildCollectionTopic("posts", {
+  where: { published: true },
+  limit: 20,
+});
 
 // subscribe<TData>(topic, callback, signal?, customId?, onError?) → unsubscribe
 const unsubscribe = client.realtime.subscribe(topic, (data) => {
@@ -426,7 +479,9 @@ const unsubscribe = client.realtime.subscribe(topic, (data) => {
 });
 
 // stream<TData>(topic, signal?, customId?) → AsyncGenerator
-for await (const snap of client.realtime.stream(topic)) { /* ... */ }
+for await (const snap of client.realtime.stream(topic)) {
+  /* ... */
+}
 
 client.realtime.destroy(); // tear down the multiplexer (re-creates lazily on next use)
 ```
@@ -434,7 +489,11 @@ client.realtime.destroy(); // tear down the multiplexer (re-creates lazily on ne
 `buildCollectionTopic(name, options?)` and `buildGlobalTopic(name, options?)` return a `TopicConfig` (`{ resourceType, resource, ...defined options }`), undefined option keys are omitted so the topic hash is stable. Both are value exports from `questpie/client`. `client.realtime` exposes `subscribe`, `stream`, `destroy`, and the `topicCount` / `subscriberCount` getters (which read `0` before the multiplexer is created).
 
 <Callout type="info" title="One SSE connection for every topic">
-The realtime API lazily creates a single `RealtimeMultiplexer` on the first `subscribe`/`stream`, and runs **all** topics over one `POST /realtime` connection, this sidesteps the browser's HTTP/1.1 six-connections-per-domain limit. The connect body is plain JSON (not SuperJSON); reconnects are debounced with exponential backoff.
+  The realtime API lazily creates a single `RealtimeMultiplexer` on the first
+  `subscribe`/`stream`, and runs **all** topics over one `POST /realtime`
+  connection, this sidesteps the browser's HTTP/1.1 six-connections-per-domain
+  limit. The connect body is plain JSON (not SuperJSON); reconnects are
+  debounced with exponential backoff.
 </Callout>
 
 ## Localization
@@ -451,8 +510,15 @@ client.setLocale(); // pass nothing to clear the locale header
 
 Per-call locale overrides go through the method `options` instead, e.g. `find({ where, locale: "de" })` or `create(data, { locale: "de" })`, which serialize into the query string and take precedence over the header for that one call.
 
-<Callout type="warn" title="`setLocale` mutates shared headers; it does not touch open SSE streams">
-`setLocale(locale)` rewrites the client's shared default headers in place, so it affects **every** subsequent collection / global / route / search request. It does **not** re-key already-open realtime subscriptions, those carry their locale per-topic from when they were opened. Re-subscribe (or pass `locale` in the live options) to change a live query's locale.
+<Callout
+  type="warn"
+  title="`setLocale` mutates shared headers; it does not touch open SSE streams"
+>
+  `setLocale(locale)` rewrites the client's shared default headers in place, so
+  it affects **every** subsequent collection / global / route / search request.
+  It does **not** re-key already-open realtime subscriptions, those carry their
+  locale per-topic from when they were opened. Re-subscribe (or pass `locale` in
+  the live options) to change a live query's locale.
 </Callout>
 
 ## Error handling
@@ -516,8 +582,7 @@ import { Elysia } from "elysia";
 import { questpieElysia } from "@questpie/elysia/server";
 import { app } from "#questpie";
 
-const server = new Elysia()
-  .use(questpieElysia(app, { basePath: "/api" }));
+const server = new Elysia().use(questpieElysia(app, { basePath: "/api" }));
 
 export default server;
 ```
@@ -564,7 +629,9 @@ To derive a specific call's argument or result type, index into your client valu
 ```ts
 import { client } from "@/lib/client.js";
 
-type PostsFindResult = Awaited<ReturnType<typeof client.collections.posts.find>>;
+type PostsFindResult = Awaited<
+  ReturnType<typeof client.collections.posts.find>
+>;
 type Post = PostsFindResult["docs"][number];
 type AppClient = typeof client; // hand the whole client to helpers
 ```

--- a/apps/docs/content/docs/client/tanstack-query.mdx
+++ b/apps/docs/content/docs/client/tanstack-query.mdx
@@ -47,47 +47,36 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { q } from "@/lib/query.js";
 
 function Posts() {
-	const queryClient = useQueryClient();
+  const queryClient = useQueryClient();
 
-	// Read: q.collections.posts.find(...) returns queryOptions()
-	const { data } = useQuery(
-		q.collections.posts.find({ where: { published: true }, limit: 10 }),
-	);
+  // Read: q.collections.posts.find(...) returns queryOptions()
+  const { data } = useQuery(q.collections.posts.find({ where: { published: true }, limit: 10 }));
 
-	// Write: q.collections.posts.create() returns mutationOptions()
-	const create = useMutation({
-		...q.collections.posts.create(),
-		onSuccess: () => {
-			// Invalidate every posts query with the top-level key helper.
-			queryClient.invalidateQueries({
-				queryKey: q.key(["collections", "posts"]),
-			});
-		},
-	});
+  // Write: q.collections.posts.create() returns mutationOptions()
+  const create = useMutation({
+    ...q.collections.posts.create(),
+    onSuccess: () => {
+      // Invalidate every posts query with the top-level key helper.
+      queryClient.invalidateQueries({
+        queryKey: q.key(["collections", "posts"]),
+      });
+    },
+  });
 
-	return (
-		<div>
-			<p>{data?.totalDocs ?? 0} published posts</p>
-			<button
-				onClick={() =>
-					create.mutate({ title: "Hello", slug: "hello", published: true })
-				}
-			>
-				Add post
-			</button>
-		</div>
-	);
+  return (
+    <div>
+      <p>{data?.totalDocs ?? 0} published posts</p>
+      <button onClick={() => create.mutate({ title: "Hello", slug: "hello", published: true })}>Add post</button>
+    </div>
+  );
 }
 ```
 
 `find()` resolves to the same **paginated envelope** the client returns, `{ docs, totalDocs, page, hasNextPage, … }`, so read your rows off `data.docs`. The mutation variables (`{ title, slug, published }`) are the collection's create input, inferred from your schema.
 
 <Callout type="info" title="Build the proxy once, not per render">
-	`createQuestpieQueryOptions(client)` is cheap, but the returned proxies are
-	stable identities, create it once at module scope (as the scaffold does) and
-	import `q` everywhere. The builders themselves are pure: calling
-	`q.collections.posts.find(opts)` only *builds* an options object; nothing
-	fetches until you hand it to `useQuery`.
+  `createQuestpieQueryOptions(client)` is cheap, but the returned proxies are stable identities, create it once at module scope (as the scaffold does) and import `q` everywhere. The builders themselves are pure: calling `q.collections.posts.find(opts)` only *builds* an options object; nothing fetches until you hand it
+  to `useQuery`.
 </Callout>
 
 ## Example → inferred types
@@ -96,8 +85,8 @@ Each builder mirrors the client method it wraps, so the inferred result is ident
 
 ```ts
 const opts = q.collections.posts.find({
-	where: { published: true },
-	limit: 10,
+  where: { published: true },
+  limit: 10,
 });
 //    ^? UseQueryOptions<FindResult<…, { docs: Post[]; totalDocs: number; … }>>
 
@@ -119,10 +108,10 @@ The selection generic is applied **per call**, `find<TQuery>(options?)` narrows 
 ```ts
 // List, paginated envelope. Optional second arg enables realtime (below).
 q.collections.posts.find({
-	where: { published: true },
-	with: { author: true },
-	orderBy: { createdAt: "desc" },
-	limit: 10,
+  where: { published: true },
+  with: { author: true },
+  orderBy: { createdAt: "desc" },
+  limit: 10,
 });
 
 // Count, number (or live total with { realtime: true }).
@@ -178,7 +167,7 @@ remove.mutate({ id: postId }); // { id } -> { success: boolean }
 
 ## Globals
 
-A global is a singleton, so `q.globals.<name>` exposes only `get`, `update`, `findVersions`, `revertToVersion`, and `transitionStage`, there is no `find` / `findOne` / `count` / `create` / `delete`.
+A global is a singleton. `q.globals.<name>` exposes `get`, `update`, `findVersions`, `revertToVersion`, and `transitionStage`.
 
 ```ts
 // Read the singleton. Non-nullable result. { realtime: true } supported.
@@ -211,9 +200,7 @@ A global always exists (it's a singleton with defaults), so `q.globals.<name>.ge
 
 ```ts
 // Read a route as a query.
-const stats = useQuery(
-	q.routes.dashboard.getStats.post.query({ period: "week" }),
-);
+const stats = useQuery(q.routes.dashboard.getStats.post.query({ period: "week" }));
 
 // Call a route as a mutation.
 const send = useMutation(q.routes.notifications.send.post.mutation());
@@ -227,17 +214,13 @@ const key = q.routes.dashboard.getStats.post.key({ period: "week" });
 - **`.mutation()`** → `mutationOptions()`. `mutate(variables)` calls the route with `variables`; if the route takes no arguments, `mutate()` calls it with none.
 - **`.key(input?)`** → the route's **query** key, for `invalidateQueries` / prefetch.
 
-<Callout type="info" title="`.key()` always builds the query key, there is no mutation-key helper">
-`q.routes.<path>.<method>.key()` returns the same key shape as `.query()` (the `'query'` segment), even when a sibling `.mutation()` exists. Mutation keys are set internally on the mutation options object; there's no helper to construct one. Use `.key()` to invalidate or prefetch a route **query**.
+<Callout type="info" title="Query keys and mutation keys">
+`q.routes.<path>.<method>.key()` builds the same query key as `.query()`, including the `"query"` segment. Use it to invalidate or prefetch route queries. Mutation options carry their mutation key directly on the returned options object.
 </Callout>
 
 <Callout type="warn" title="Unknown routes throw at fetch time, not build time">
-	The routes proxy is loose, `q.routes.a.b.c.post.query()` *builds* an options
-	object for any dot-path. The path is only resolved against `client.routes`
-	when the query runs; if it doesn't resolve to a function the fetcher throws
-	`Route not found at path: a.b.c.post`. There's no build-time check that the
-	route exists, so a typo'd path surfaces as a runtime query error, not a red
-	squiggle. The same lazy-resolution applies to unknown collection/global names.
+  The routes proxy is loose, `q.routes.a.b.c.post.query()` *builds* an options object for any dot-path. The path is only resolved against `client.routes` when the query runs; if it doesn't resolve to a function the fetcher throws `Route not found at path: a.b.c.post`. There's no build-time check that the route exists,
+  so a typo'd path surfaces as a runtime query error, not a red squiggle. The same lazy-resolution applies to unknown collection/global names.
 </Callout>
 
 ## Realtime
@@ -246,14 +229,9 @@ Three reads can become **live** by passing `{ realtime: true }` as their second 
 
 ```tsx
 function LivePosts() {
-	// Re-renders whenever a matching post changes, no manual invalidation.
-	const { data } = useQuery(
-		q.collections.posts.find(
-			{ where: { published: true } },
-			{ realtime: true },
-		),
-	);
-	return <p>{data?.totalDocs ?? 0} published posts (live)</p>;
+  // Re-renders whenever a matching post changes, no manual invalidation.
+  const { data } = useQuery(q.collections.posts.find({ where: { published: true } }, { realtime: true }));
+  return <p>{data?.totalDocs ?? 0} published posts (live)</p>;
 }
 ```
 
@@ -264,14 +242,8 @@ Under the hood a live query uses React Query's `experimental_streamedQuery` with
 </Callout>
 
 <Callout type="info" title="Realtime topic ignores some read options">
-	The live subscription's topic is derived from your read `options` via
-	`buildCollectionTopic` / `buildGlobalTopic`, which carry only `where` / `with`
-	/ `limit` / `offset` / `orderBy` / `locale` (globals: `where` / `with` /
-	`locale`). `columns`, `stage`, `includeDeleted`, and `localeFallback` are
-	**dropped from the topic**, and the config-level `locale`/`stage` are *not*
-	added to it, so live matching ignores those. Both builders are re-exported
-	from the package if you want to subscribe manually via
-	`client.realtime.subscribe`.
+  The live subscription's topic is derived from your read `options` via `buildCollectionTopic` / `buildGlobalTopic`, which carry only `where` / `with` / `limit` / `offset` / `orderBy` / `locale` (globals: `where` / `with` / `locale`). `columns`, `stage`, `includeDeleted`, and `localeFallback` are **dropped from the
+  topic**, and the config-level `locale`/`stage` are *not* added to it, so live matching ignores those. Both builders are re-exported from the package if you want to subscribe manually via `client.realtime.subscribe`.
 </Callout>
 
 ## Channel subscriptions
@@ -279,13 +251,9 @@ Under the hood a live query uses React Query's `experimental_streamedQuery` with
 Generated channels appear beside collections, globals, and routes:
 
 ```tsx
-const { data: messages = [] } = useQuery(
-	q.channels.chatRoom.subscription({ roomId }),
-);
+const { data: messages = [] } = useQuery(q.channels.chatRoom.subscription({ roomId }));
 
-const { data: members = [] } = useQuery(
-	q.channels.chatRoom.presence({ roomId }),
-);
+const { data: members = [] } = useQuery(q.channels.chatRoom.presence({ roomId }));
 ```
 
 No-param channels use `.subscription()` or `.presence()` with no argument. Parameterized channels require their exact generated params. The event query appends each typed `{ event, eventId, data }` message; the presence query replaces its value with each newest member roster. Aborting or unmounting closes the underlying iterator. See [Channels](/docs/client/channels) for definitions, authorization, publish, presence, and transport behavior.
@@ -296,10 +264,10 @@ No-param channels use `.subscription()` or `.presence()` with no argument. Param
 
 ```ts
 export const q = createQuestpieQueryOptions(client, {
-	keyPrefix: ["questpie"], // QueryKey prepended to every key. Default ['questpie'].
-	errorMap: defaultErrorMap, // (error: unknown) => unknown. Wraps every fetcher/mutator.
-	locale: undefined, // string, baked into keys AND threaded into every call.
-	stage: undefined, // string, same: keyed and threaded.
+  keyPrefix: ["questpie"], // QueryKey prepended to every key. Default ['questpie'].
+  errorMap: defaultErrorMap, // (error: unknown) => unknown. Wraps every fetcher/mutator.
+  locale: undefined, // string, baked into keys AND threaded into every call.
+  stage: undefined, // string, same: keyed and threaded.
 });
 ```
 
@@ -310,19 +278,9 @@ export const q = createQuestpieQueryOptions(client, {
 | `locale`    | `string`                      | `undefined`       | Pinned read/write locale, see the warning below.                                                   |
 | `stage`     | `string`                      | `undefined`       | Pinned workflow stage, see the warning below.                                                      |
 
-<Callout
-	type="warn"
-	title="`locale` and `stage` are global to the proxy and override per-call options for globals"
->
-	A `locale`/`stage` set in `config` is baked into **every** query key and
-	threaded into **every** read and mutation, for collections as the call's
-	options/`LocaleOptions` second argument, for globals **merged into the options
-	object**. Because they're spread *after* the caller's options, they
-	**override** any per-call `locale`/`stage` on `globals.update` /
-	`revertToVersion` / `findVersions`. If you need different locales in different
-	parts of the UI, create a second proxy with its own `config` rather than
-	fighting the override. (One asymmetry: `globals.transitionStage` merges only
-	`locale` from config, not `stage`.
+<Callout type="warn" title="`locale` and `stage` are global to the proxy and override per-call options for globals">
+  A `locale`/`stage` set in `config` is baked into **every** query key and threaded into **every** read and mutation, for collections as the call's options/`LocaleOptions` second argument, for globals **merged into the options object**. Because they're spread *after* the caller's options, they **override** any per-call
+  `locale`/`stage` on `globals.update` / `revertToVersion` / `findVersions`. If you need different locales in different parts of the UI, create a second proxy with its own `config` rather than fighting the override. (One asymmetry: `globals.transitionStage` merges only `locale` from config, not `stage`.
 </Callout>
 
 ### Custom error mapping
@@ -331,10 +289,10 @@ The default `errorMap` coerces non-`Error` throws into `Error` (passes `Error` t
 
 ```ts
 export const q = createQuestpieQueryOptions(client, {
-	errorMap: (error) => {
-		if (error instanceof MyApiError) return error;
-		return new Error("Request failed", { cause: error });
-	},
+  errorMap: (error) => {
+    if (error instanceof MyApiError) return error;
+    return new Error("Request failed", { cause: error });
+  },
 });
 ```
 
@@ -361,7 +319,7 @@ queryClient.invalidateQueries({ queryKey: q.key(["collections", "posts"]) });
 
 // Invalidate one route query exactly.
 queryClient.invalidateQueries({
-	queryKey: q.routes.dashboard.getStats.post.key({ period: "week" }),
+  queryKey: q.routes.dashboard.getStats.post.key({ period: "week" }),
 });
 
 // Or read the key straight off any builder result:
@@ -369,26 +327,13 @@ const { queryKey } = q.collections.posts.find({ where: { published: true } });
 queryClient.invalidateQueries({ queryKey });
 ```
 
-<Callout
-	type="warn"
-	title="There is no `.key()` on `q.collections.<name>` or `q.globals.<name>`"
->
-	Only **routes** have a per-leaf `.key()` builder. Collections and globals do
-	**not** expose a `key` method, to invalidate them, use the top-level
-	`q.key([...])` for partial matching, or read `.queryKey` off the options
-	object a builder returns. For an *exact* key match you'd also have to
-	replicate the `[…, locale, stage, options]` tail yourself, so partial-match
-	invalidation via `q.key(["collections", "posts"])` is almost always what you
-	want.
+<Callout type="info" title="Collection and global query keys">
+  Use top-level `q.key([...])` for partial collection or global invalidation, or read `.queryKey` from the options returned by a builder. Per-route builders also provide `.key()`. Partial invalidation with `q.key(["collections", "posts"])` covers every locale, stage, and option variant for that collection.
 </Callout>
 
 <Callout type="info" title="Functions in options are stripped from the key">
-	Key options are sanitized: function-valued properties are removed and
-	`undefined`-valued keys are dropped (`null` is kept) before they land in the
-	query key, so non-serializable values don't break React Query's structural key
-	equality. The footgun: two `find()` calls that differ **only** by a function
-	argument produce the **same** key and therefore share a cache entry. Don't
-	encode a discriminator as a function in your options.
+  Key options are sanitized: function-valued properties are removed and `undefined`-valued keys are dropped (`null` is kept) before they land in the query key, so non-serializable values don't break React Query's structural key equality. The footgun: two `find()` calls that differ **only** by a function argument
+  produce the **same** key and therefore share a cache entry. Don't encode a discriminator as a function in your options.
 </Callout>
 
 ## Custom queries & mutations
@@ -398,14 +343,14 @@ For anything the proxies don't cover, a third-party endpoint, a composed call, a
 ```ts
 // Query
 const opts = q.custom.query<DashboardData>({
-	key: ["dashboard", "summary"], // suffix only, keyPrefix is prepended for you
-	queryFn: () => fetchDashboard(),
+  key: ["dashboard", "summary"], // suffix only, keyPrefix is prepended for you
+  queryFn: () => fetchDashboard(),
 });
 
 // Mutation
 const mut = q.custom.mutation<{ id: string }, void>({
-	key: ["dashboard", "refresh"],
-	mutationFn: (vars) => refreshDashboard(vars.id),
+  key: ["dashboard", "refresh"],
+  mutationFn: (vars) => refreshDashboard(vars.id),
 });
 ```
 
@@ -417,34 +362,28 @@ The package re-exports the React Query types you'll reference, plus its own:
 
 ```ts
 import type {
-	// Re-exported from @tanstack/react-query for convenience:
-	QueryKey,
-	DefaultError,
-	UseQueryOptions,
-	UseMutationOptions,
-	// This package's types:
-	QuestpieQueryOptionsProxy, // return type of createQuestpieQueryOptions
-	QuestpieQueryOptionsConfig, // the config argument
-	QuestpieQueryErrorMap, // (error: unknown) => unknown
-	RealtimeQueryConfig, // { realtime?: boolean }
-	// Realtime topic helpers (re-exported from questpie/client):
-	TopicConfig,
-	RealtimeAPI,
+  // Re-exported from @tanstack/react-query for convenience:
+  QueryKey,
+  DefaultError,
+  UseQueryOptions,
+  UseMutationOptions,
+  // This package's types:
+  QuestpieQueryOptionsProxy, // return type of createQuestpieQueryOptions
+  QuestpieQueryOptionsConfig, // the config argument
+  QuestpieQueryErrorMap, // (error: unknown) => unknown
+  RealtimeQueryConfig, // { realtime?: boolean }
+  // Realtime topic helpers (re-exported from questpie/client):
+  TopicConfig,
+  RealtimeAPI,
 } from "@questpie/tanstack-query";
 
-import {
-	buildCollectionTopic,
-	buildGlobalTopic,
-} from "@questpie/tanstack-query";
+import { buildCollectionTopic, buildGlobalTopic } from "@questpie/tanstack-query";
 ```
 
 `QuestpieQueryOptionsProxy<TApp>` is the typed shape of `q`; you rarely name it directly because the scaffold exports `typeof q`. `buildCollectionTopic` / `buildGlobalTopic` are runtime values (re-exported from `questpie/client`) for building realtime topics manually.
 
 <Callout type="info" title="The proxies don't enumerate">
-	`q.collections`, `q.globals`, and `q.routes` are JS `Proxy` objects with a
-	get-trap only. `Object.keys(q.collections)`, spreading, or `for…in` over them
-	returns nothing useful, access builders by name (`q.collections.posts`).
-	`q.custom` and `q.key` are plain.
+  `q.collections`, `q.globals`, and `q.routes` are JS `Proxy` objects with a get-trap only. `Object.keys(q.collections)`, spreading, or `for…in` over them returns nothing useful, access builders by name (`q.collections.posts`). `q.custom` and `q.key` are plain.
 </Callout>
 
 ## Related

--- a/apps/docs/content/docs/concepts/access-control.mdx
+++ b/apps/docs/content/docs/concepts/access-control.mdx
@@ -22,37 +22,32 @@ Attach `.access({ ... })` to a collection. A boolean allows or denies outright; 
 import { collection } from "#questpie/factories";
 
 export const posts = collection("posts")
-	.fields(({ f }) => ({
-		title: f.text(255).required(),
-		body: f.richText(),
-		authorId: f.relation("user"),
-		status: f.select([
-			{ value: "draft", label: "Draft" },
-			{ value: "published", label: "Published" },
-		]),
-	}))
-	.access({
-		// Signed-in users see their own posts; everyone else sees published ones.
-		read: ({ session }) =>
-			session?.user ? { authorId: session.user.id } : { status: "published" },
-		// Must be signed in to create.
-		create: ({ session }) => !!session?.user,
-		// Only the author may edit or delete. `data` is the existing row.
-		update: ({ session, data }) => data.authorId === session?.user?.id,
-		delete: ({ session, data }) => data.authorId === session?.user?.id,
-	});
+  .fields(({ f }) => ({
+    title: f.text(255).required(),
+    body: f.richText(),
+    authorId: f.relation("user"),
+    status: f.select([
+      { value: "draft", label: "Draft" },
+      { value: "published", label: "Published" },
+    ]),
+  }))
+  .access({
+    // Signed-in users see their own posts; everyone else sees published ones.
+    read: ({ session }) => (session?.user ? { authorId: session.user.id } : { status: "published" }),
+    // Must be signed in to create.
+    create: ({ session }) => !!session?.user,
+    // Only the author may edit or delete. `data` is the existing row.
+    update: ({ session, data }) => data.authorId === session?.user?.id,
+    delete: ({ session, data }) => data.authorId === session?.user?.id,
+  });
 // Full option list and the per-operation context table are below.
 ```
 
 That single object now governs `GET/POST/PATCH/DELETE /api/posts`, every `client.collections.posts.*` call, and the admin panel for this collection.
 
 <Callout type="warn">
-	**Secure by default, collections require a session.** Leaving an operation's
-	rule out does **not** make it public: the framework requires an authenticated
-	session for it (`rule === undefined → !!session`). To make an operation public
-	you must say so explicitly with `read: true`. (Routes are the opposite, a
-	route with no `.access()` is public until you add one. See
-	[Routes](/docs/concepts/routes).)
+  **Secure by default, collections require a session.** Leaving an operation's rule out does **not** make it public: the framework requires an authenticated session for it (`rule === undefined → !!session`). To make an operation public you must say so explicitly with `read: true`. (Routes are the opposite, a route with
+  no `.access()` is public until you add one. See [Routes](/docs/concepts/routes).)
 </Callout>
 
 ## What the rule returns
@@ -116,24 +111,23 @@ To set the fallback for **every** collection and global at once, configure `acce
 import { appConfig } from "#questpie/factories";
 
 export default appConfig({
-	access: {
-		// Default for any collection/global that doesn't set its own rule.
-		read: ({ session }) => !!session,
-		create: ({ session }) => !!session,
-		update: ({ session }) => !!session,
-		delete: ({ session }) => !!session,
-	},
+  access: {
+    // Default for any collection/global that doesn't set its own rule.
+    read: ({ session }) => !!session,
+    create: ({ session }) => !!session,
+    update: ({ session }) => !!session,
+    delete: ({ session }) => !!session,
+  },
 });
 ```
 
 `appConfig({ access })` accepts `read`, `create`, `update`, `delete`, `transition`, `serve`, and `introspect`, the same operation keys as a collection, **minus `fields`** (per-field rules belong on the collection or global that owns the field). Modules can contribute a `defaultAccess` too, and they compose; the starter module ships exactly the four-CRUD-require-session shape above.
 
-<Callout type="info">
-	**There is no `.defaultAccess()` builder method.** App-wide defaults live in
-	`appConfig({ access })` (or a module's `defaultAccess`), not on a chained
-	builder. A collection's own `.access({ ... })` always wins over the app
-	default for the operations it sets, unset operations fall through to the
-	default, then to require-a-session.
+<Callout type="info" title="Configure app-wide defaults in app config">
+	Set app-wide rules with `appConfig({ access })` or a module's
+	`defaultAccess`. A collection's `.access({ ... })` overrides the app default
+	for each operation it defines; other operations fall through to the default,
+	then to the authenticated-session policy.
 </Callout>
 
 ## The per-operation context
@@ -164,12 +158,7 @@ Every rule function receives an `AccessContext`, the full app context (`db`, `se
 })
 ```
 
-<Callout type="info">
-	**`request` is only set over HTTP.** `ctx.request` is present when the
-	operation comes through an HTTP adapter, use it to tell the admin API apart
-	from the public API by URL or header. Direct server calls
-	(`app.collections.posts.find(...)`) carry no `request`.
-</Callout>
+<Callout type="info">**`request` is only set over HTTP.** `ctx.request` is present when the operation comes through an HTTP adapter, use it to tell the admin API apart from the public API by URL or header. Direct server calls (`app.collections.posts.find(...)`) carry no `request`.</Callout>
 
 ### `read` vs `update`/`delete`: where the filter lands
 
@@ -200,7 +189,7 @@ The same `AccessWhere` shape behaves differently depending on the operation:
 
 ```ts
 read: ({ session }) => ({
-	OR: [{ authorId: session?.user?.id }, { status: "published" }],
+  OR: [{ authorId: session?.user?.id }, { status: "published" }],
 });
 ```
 
@@ -259,22 +248,13 @@ Knowing the exact sequence helps you reason about which rule fires first and whe
 For an **update** it's the same shape, with `access.update` first (plus the `AccessWhere` row-match), then `beforeValidate`, validation, `access.fields[...].update`, `beforeChange`, **UPDATE**, `afterChange`, the `afterRead` hook, and finally the field read filter. **Reads** run `access.read` (producing the merged `WHERE`), the **SELECT**, then the field read filter and `afterRead`.
 
 <Callout type="info">
-	**The field read filter and `afterRead` run in opposite orders on writes vs
-	reads.** On a **write** (create/update) the `afterRead` hook fires *before*
-	the field read filter strips denied fields, so your hook sees the full row,
-	then the filter runs last on the way out. On a **read** the field read filter
-	runs *before* `afterRead`. If an `afterRead` hook depends on a field that a
-	`read` rule denies, that field is present after a write but already stripped
-	on a plain read.
+  **The field read filter and `afterRead` run in opposite orders on writes vs reads.** On a **write** (create/update) the `afterRead` hook fires *before* the field read filter strips denied fields, so your hook sees the full row, then the filter runs last on the way out. On a **read** the field read filter runs
+  *before* `afterRead`. If an `afterRead` hook depends on a field that a `read` rule denies, that field is present after a write but already stripped on a plain read.
 </Callout>
 
 <Callout type="info">
-	**Access runs before validation; field-write runs before validation too.**
-	Row-level access and field-level *write* access both gate the input **before**
-	the Zod schema sees it, so a denied write never reaches validation.
-	Field-level *read* filtering runs on the way out, after the row is loaded. See
-	[Hooks](/docs/concepts/hooks) for the full lifecycle and
-	[Validation](/docs/concepts/validation) for the schema step.
+  **Access runs before validation; field-write runs before validation too.** Row-level access and field-level *write* access both gate the input **before** the Zod schema sees it, so a denied write never reaches validation. Field-level *read* filtering runs on the way out, after the row is loaded. See
+  [Hooks](/docs/concepts/hooks) for the full lifecycle and [Validation](/docs/concepts/validation) for the schema step.
 </Callout>
 
 ## Beyond CRUD: `transition`, `serve`, `introspect`
@@ -290,12 +270,8 @@ Three more operations have their own rules, each with a deliberate fallback chai
 > Resolution: `access.serve` → collection `access.read` → app `defaultAccess.serve` → **allow**. App-level `defaultAccess.read` is deliberately _not_ in this chain: listing rows and fetching bytes by key are distinct permissions.
 
 <Callout type="warn">
-	**`serve` falls open, and private files always check the token too.** If
-	`serve`, the collection's `read`, and `defaultAccess.serve` are all undefined,
-	byte serving is **allowed**. For `visibility: "private"` uploads a
-	signed-token check always applies **in addition** to this rule, but for
-	`"public"` uploads, set `serve` explicitly if the bytes shouldn't be
-	world-readable.
+  **`serve` falls open, and private files always check the token too.** If `serve`, the collection's `read`, and `defaultAccess.serve` are all undefined, byte serving is **allowed**. For `visibility: "private"` uploads a signed-token check always applies **in addition** to this rule, but for `"public"` uploads, set
+  `serve` explicitly if the bytes shouldn't be world-readable.
 </Callout>
 
 **`introspect`**, guards the schema/meta endpoints (`GET /:collection/{schema,meta}`) that the admin UI and OpenAPI generator read.
@@ -312,24 +288,21 @@ You set it on the **context**, then pass that context to CRUD calls. Inside a se
 import { seed } from "questpie";
 
 export default seed({
-	id: "demoPosts",
-	description: "Seed demo posts with full access",
-	category: "dev",
-	async run({ collections, createContext, log }) {
-		const ctx = await createContext({
-			accessMode: "system", // bypass all access + field rules
-		});
+  id: "demoPosts",
+  description: "Seed demo posts with full access",
+  category: "dev",
+  async run({ collections, createContext, log }) {
+    const ctx = await createContext({
+      accessMode: "system", // bypass all access + field rules
+    });
 
-		// Pass ctx as the second argument to any operation.
-		const existing = await collections.posts.findOne(
-			{ where: { slug: "seeded-post" } },
-			ctx,
-		);
-		if (!existing) {
-			await collections.posts.create({ title: "Seeded post" }, ctx);
-			log("Seeded demo post");
-		}
-	},
+    // Pass ctx as the second argument to any operation.
+    const existing = await collections.posts.findOne({ where: { slug: "seeded-post" } }, ctx);
+    if (!existing) {
+      await collections.posts.create({ title: "Seeded post" }, ctx);
+      log("Seeded demo post");
+    }
+  },
 });
 ```
 
@@ -339,15 +312,12 @@ Outside a seed, build the context from the app instance, handy in server-side da
 import { app } from "#questpie";
 
 export async function createServerContext() {
-	return app.createContext({ accessMode: "system" });
+  return app.createContext({ accessMode: "system" });
 }
 ```
 
 <Callout type="warn">
-	**`system` skips everything, keep it server-only.** System mode is a complete
-	bypass of both row-level and field-level access. Never derive it from
-	user-controlled input. Direct backend calls default to system mode; the HTTP
-	adapter runs requests in `"user"` mode so the public API is always enforced.
+  **`system` skips everything, keep it server-only.** System mode is a complete bypass of both row-level and field-level access. Never derive it from user-controlled input. Direct backend calls default to system mode; the HTTP adapter runs requests in `"user"` mode so the public API is always enforced.
 </Callout>
 
 ## Globals
@@ -358,22 +328,19 @@ Globals (singletons) use the same model with a narrower surface: `.access({ read
 import { global } from "#questpie/factories";
 
 export const siteSettings = global("siteSettings")
-	.fields(({ f }) => ({
-		siteName: f.text().required(),
-		maintenanceMode: f.boolean(),
-	}))
-	.access({
-		read: true, // settings are public
-		update: ({ session }) => session?.user?.role === "admin",
-	});
+  .fields(({ f }) => ({
+    siteName: f.text().required(),
+    maintenanceMode: f.boolean(),
+  }))
+  .access({
+    read: true, // settings are public
+    update: ({ session }) => session?.user?.role === "admin",
+  });
 ```
 
 <Callout type="info">
-	**Global rules return booleans only.** With a single row there is nothing to
-	filter, so global access rules cannot return an `AccessWhere`, only `true` /
-	`false` (or a predicate that returns one). On `update`, `ctx.data` is the
-	existing record (`undefined` on the very first write) and `ctx.input` is the
-	patch. The same `transition` / `introspect` fallback chains apply.
+  **Global rules return booleans only.** With a single row there is nothing to filter, so global access rules cannot return an `AccessWhere`, only `true` / `false` (or a predicate that returns one). On `update`, `ctx.data` is the existing record (`undefined` on the very first write) and `ctx.input` is the patch. The
+  same `transition` / `introspect` fallback chains apply.
 </Callout>
 
 ## Throwing your own errors
@@ -430,7 +397,7 @@ For **shared helpers** in routes, services, jobs, or scripts, import the generat
 import type { AccessRuleContext } from "#questpie";
 
 export function isOwner(ctx: AccessRuleContext<"posts">) {
-	return ctx.data?.authorId === ctx.session?.user?.id; // ctx.collections typed too
+  return ctx.data?.authorId === ctx.session?.user?.id; // ctx.collections typed too
 }
 ```
 
@@ -446,12 +413,7 @@ export function isOwner(ctx: AccessRuleContext<"posts">) {
 The full set of access types, `CollectionAccess`, `AccessRule`, `RowAccessRule`, `AccessContext`, `AccessWhere`, `FieldAccess`, `FieldAccessRule`, `FieldAccessRuleContext`, `GlobalAccess`, `GlobalAccessRule`, `GlobalAccessContext`, `AccessMode`, is exported from `questpie/types`.
 
 ```ts
-import type {
-	CollectionAccess,
-	AccessRule,
-	AccessWhere,
-	AccessMode,
-} from "questpie/types";
+import type { CollectionAccess, AccessRule, AccessWhere, AccessMode } from "questpie/types";
 ```
 
 ## Related

--- a/apps/docs/content/docs/concepts/blocks.mdx
+++ b/apps/docs/content/docs/concepts/blocks.mdx
@@ -26,7 +26,11 @@ export const heroBlock = block("hero")
   .admin(({ c }) => ({
     label: { en: "Hero Section", sk: "Hero sekcia" },
     icon: c.icon("ph:image"),
-    category: { label: { en: "Sections" }, icon: c.icon("ph:layout"), order: 1 },
+    category: {
+      label: { en: "Sections" },
+      icon: c.icon("ph:layout"),
+      order: 1,
+    },
     order: 1,
   }))
   .fields(({ f }) => ({
@@ -62,7 +66,8 @@ questpie push       # adds the jsonb content column to the pages table
 That gives you a `pages.content` field that renders the block editor in the admin, validates each block against its declared fields, and returns a `BlocksDocument` your frontend can render.
 
 <Callout type="warn" title="Blocks require the admin module">
-`f.blocks()` and the `block()` factory only exist when `adminModule` is registered in `src/questpie/server/modules.ts`. The admin module registers the `blocks` (and `richText`) field types, and codegen discovers your `blocks/` files and wires `f.blocks()` onto the generated `f`. Without it, `f.blocks()` is not on the field proxy.
+  `f.blocks()` and the `block()` factory only exist when `adminModule` is registered in `src/questpie/server/modules.ts`. The admin module registers the `blocks` (and `richText`) field types, and codegen discovers your `blocks/` files and wires `f.blocks()` onto the generated `f`. Without it, `f.blocks()` is not on the
+  field proxy.
 </Callout>
 
 ## Example → stored shape
@@ -89,19 +94,17 @@ The TypeScript shape is `BlocksDocument`:
 
 ```ts
 interface BlocksDocument {
-  _tree: BlockNode[];                                  // hierarchy: order + nesting
-  _values: Record<string, BlockValues>;                // blockId → field values
-  _data?: Record<string, Record<string, {}>>;          // blockId → prefetched data
+  _tree: BlockNode[]; // hierarchy: order + nesting
+  _values: Record<string, BlockValues>; // blockId → field values
+  _data?: Record<string, Record<string, {}>>; // blockId → prefetched data
 }
 
 interface BlockNode {
   id: string;
-  type: string;            // block type name, e.g. "hero"
-  children: BlockNode[];   // nested blocks (layout blocks)
+  type: string; // block type name, e.g. "hero"
+  children: BlockNode[]; // nested blocks (layout blocks)
 }
 ```
-
-
 
 <Callout type="info" title="Structure and content are split on purpose">
 `_tree` holds **structure**, `_values` holds **content**, both keyed by `BlockNode.id`. They are separated so reordering or nesting a block never rewrites its values, and child blocks live in `BlockNode.children`, not inside `_values`. The persisted Zod schema validates `{ _tree, _values }`; `_data` is added by the read hook, not stored.
@@ -111,28 +114,26 @@ interface BlockNode {
 
 `block(name)` returns a chainable builder. Every method returns a new builder, so order them top to bottom and end the chain with your export. The block type **name** is the first argument and must match the `type` stored in the tree (it's also the key under `admin.blocks` and the renderer lookup key).
 
-| Method | Purpose |
-|---|---|
-| `.admin(config \| (ctx) => config)` | Label, icon, description, category, order, and visibility in the block picker. |
-| `.fields(({ f }) => ({ ... }))` | The block's fields, same `f` proxy as collections (builtins + `richText` / `blocks`). |
-| `.form(({ f }) => ({ fields }))` | Lay the fields out in the editor with sections / tabs / grid. |
-| `.allowChildren(max?)` | Make this a layout block that can contain other blocks (optionally capped). |
-| `.prefetch(fn \| { with, loader? })` | Fetch related data on read; the result is attached to `_data[blockId]`. |
-
-
+| Method                               | Purpose                                                                               |
+| ------------------------------------ | ------------------------------------------------------------------------------------- |
+| `.admin(config \| (ctx) => config)`  | Label, icon, description, category, order, and visibility in the block picker.        |
+| `.fields(({ f }) => ({ ... }))`      | The block's fields, same `f` proxy as collections (builtins + `richText` / `blocks`). |
+| `.form(({ f }) => ({ fields }))`     | Lay the fields out in the editor with sections / tabs / grid.                         |
+| `.allowChildren(max?)`               | Make this a layout block that can contain other blocks (optionally capped).           |
+| `.prefetch(fn \| { with, loader? })` | Fetch related data on read; the result is attached to `_data[blockId]`.               |
 
 ### `.admin()`, picker metadata
 
 `.admin()` takes a config object or a function receiving `{ c }`, the component-reference proxy (`c.icon("ph:…")`). The shape is `AdminBlockConfig`:
 
-| Option | Type | Effect |
-|---|---|---|
-| `label` | `I18nText` | Display name in the picker. `I18nText` = `string \| Record<locale, string>`. |
-| `description` | `I18nText` | Tooltip / help text. |
-| `icon` | `ComponentReference` | Icon, e.g. `c.icon("ph:image")`. |
-| `category` | `BlockCategoryConfig` | Groups the block: `{ label: I18nText; icon?; order? }`. |
-| `order` | `number` | Order within its category (lower = first). |
-| `hidden` | `boolean` | Hide from the picker. |
+| Option        | Type                  | Effect                                                                       |
+| ------------- | --------------------- | ---------------------------------------------------------------------------- |
+| `label`       | `I18nText`            | Display name in the picker. `I18nText` = `string \| Record<locale, string>`. |
+| `description` | `I18nText`            | Tooltip / help text.                                                         |
+| `icon`        | `ComponentReference`  | Icon, e.g. `c.icon("ph:image")`.                                             |
+| `category`    | `BlockCategoryConfig` | Groups the block: `{ label: I18nText; icon?; order? }`.                      |
+| `order`       | `number`              | Order within its category (lower = first).                                   |
+| `hidden`      | `boolean`             | Hide from the picker.                                                        |
 
 ```ts
 .admin(({ c }) => ({
@@ -142,8 +143,6 @@ interface BlockNode {
   order: 1,
 }))
 ```
-
-
 
 <Callout type="info" title="Reuse one category across blocks">
 Export a helper that returns a `BlockCategoryConfig` so every block in a group shares one label/icon/order. Type it with `AdminConfigContext` and `BlockCategoryConfig` from `@questpie/admin/factories`:
@@ -159,6 +158,7 @@ export const sections = (c: AdminConfigContext["c"]): BlockCategoryConfig => ({
 ```
 
 Then `category: sections(c)` in each block's `.admin()`.
+
 </Callout>
 
 ### `.fields()`, the block's data
@@ -192,8 +192,6 @@ Field values are validated against the block's generated Zod schema and stored u
 }))
 ```
 
-
-
 ### `.allowChildren()`, layout blocks
 
 Call `.allowChildren()` to let a block contain other blocks, that is what `BlockNode.children` is for. Pass a number to cap the count.
@@ -203,12 +201,14 @@ import { block } from "#questpie/factories";
 
 export const columnsBlock = block("columns")
   .admin(({ c }) => ({ label: "Columns", icon: c.icon("ph:columns") }))
-  .allowChildren()        // or .allowChildren(4) for at most 4 children
+  .allowChildren() // or .allowChildren(4) for at most 4 children
   .fields(({ f }) => ({
-    columns: f.select([
-      { value: "2", label: "2" },
-      { value: "3", label: "3" },
-    ]).default("2"),
+    columns: f
+      .select([
+        { value: "2", label: "2" },
+        { value: "3", label: "3" },
+      ])
+      .default("2"),
   }));
 ```
 
@@ -263,7 +263,8 @@ Combine the two: expand fields with `with`, then run a `loader` that receives th
 On key conflicts, loader/function data wins over expanded data (it is merged on top).
 
 <Callout type="warn" title="Prefetch runs in afterRead, keep it outside an open transaction">
-Prefetch runs in the blocks field's `afterRead` hook. Heavy reads inside an **already-open transaction** can deadlock Bun SQL, because the context-inherited tx connection blocks while you query. Keep block hydration (and any field `afterRead`) outside an open `tx`. See the framework invariant in `CLAUDE.md` (`feedback_save_inside_tx`).
+  Prefetch runs in the blocks field's `afterRead` hook. Heavy reads inside an **already-open transaction** can deadlock Bun SQL, because the context-inherited tx connection blocks while you query. Keep block hydration (and any field `afterRead`) outside an open `tx`. See the framework invariant in `CLAUDE.md`
+  (`feedback_save_inside_tx`).
 </Callout>
 
 <Callout type="info" title="Prefetch is best-effort and access-aware">
@@ -281,9 +282,9 @@ import { BlockRenderer, type BlockContent } from "@questpie/admin/client";
 export function PageRenderer({ page }: { page: { content: BlockContent } }) {
   return (
     <BlockRenderer
-      content={page.content}                 // _tree + _values
-      renderers={admin.blocks}               // block type → component
-      data={page.content._data}              // prefetched data, keyed by block id
+      content={page.content} // _tree + _values
+      renderers={admin.blocks} // block type → component
+      data={page.content._data} // prefetched data, keyed by block id
     />
   );
 }
@@ -291,13 +292,13 @@ export function PageRenderer({ page }: { page: { content: BlockContent } }) {
 
 `BlockRenderer` walks `content._tree`, looks up each node's renderer by `type` (falling back from `kebab-case` to `camelCase`), and renders nothing for an unknown type (with a dev-only console warning). Its props (`BlockRendererComponentProps`):
 
-| Prop | Type | Purpose |
-|---|---|---|
-| `content` | `BlockContent` | The stored `{ _tree, _values, _data? }`. |
-| `renderers` | `Record<string, (props) => ReactNode>` | Block type → component, e.g. the generated `admin.blocks`. |
-| `data` | `Record<string, unknown>` | Prefetched `_data`, keyed by block id (optional; for SSR). |
-| `className` | `string` | Container class. |
-| `selectedBlockId`, `onBlockClick`, `onBlockInsert` | none | Editor / live-preview wiring (select + insert affordances). |
+| Prop                                               | Type                                   | Purpose                                                     |
+| -------------------------------------------------- | -------------------------------------- | ----------------------------------------------------------- |
+| `content`                                          | `BlockContent`                         | The stored `{ _tree, _values, _data? }`.                    |
+| `renderers`                                        | `Record<string, (props) => ReactNode>` | Block type → component, e.g. the generated `admin.blocks`.  |
+| `data`                                             | `Record<string, unknown>`              | Prefetched `_data`, keyed by block id (optional; for SSR).  |
+| `className`                                        | `string`                               | Container class.                                            |
+| `selectedBlockId`, `onBlockClick`, `onBlockInsert` | none                                   | Editor / live-preview wiring (select + insert affordances). |
 
 Each renderer receives the block's `id`, typed `values`, prefetched `data`, and rendered `children`:
 
@@ -310,7 +311,7 @@ export function HeroRenderer({ values, data, children }: BlockProps<"hero">) {
     <section style={{ backgroundImage: bgUrl ? `url(${bgUrl})` : undefined }}>
       <h1>{values.title}</h1>
       {values.subtitle && <p>{values.subtitle}</p>}
-      {children}              {/* nested blocks, for layout blocks */}
+      {children} {/* nested blocks, for layout blocks */}
     </section>
   );
 }
@@ -319,23 +320,24 @@ export function HeroRenderer({ values, data, children }: BlockProps<"hero">) {
 `values` is typed from the block's `.fields()`; `data` is typed from its `.prefetch()`. Layout blocks (`.allowChildren()`) render their nested blocks through `children`. The runnable [TanStack barbershop example](https://github.com/questpie/questpie/tree/main/examples/tanstack-barbershop) shows a complete page renderer paired with admin block components.
 
 <Callout type="info" title="What `BlockRenderer` actually passes each renderer">
-At runtime, `BlockRenderer` passes each renderer component `id`, `type` (the block type name, an extra prop the typed shape below omits), `values`, `data`, and the rendered `children`, and nothing else. The `isSelected` / `isPreview` fields in the renderer-props type are **reserved and not wired by `BlockRenderer`**: they are always `undefined` here, so don't build rendering logic on them (selection state lives on the editor wrapper, not the renderer). Stick to `values`, `data`, and `children`.
+  At runtime, `BlockRenderer` passes each renderer component `id`, `type` (the block type name, an extra prop the typed shape below omits), `values`, `data`, and the rendered `children`, and nothing else. The `isSelected` / `isPreview` fields in the renderer-props type are **reserved and not wired by `BlockRenderer`**:
+  they are always `undefined` here, so don't build rendering logic on them (selection state lives on the editor wrapper, not the renderer). Stick to `values`, `data`, and `children`.
 </Callout>
 
 <Callout type="info" title="Same renderers power live preview">
-Wrap fields in `PreviewField` to make them inline-editable in live preview, and forward `selectedBlockId` / `onBlockClick` / `onBlockInsert` from `useCollectionPreview()`, `BlockRenderer` then adds click-to-select and insert affordances in preview mode while rendering the exact same components in production.
+  Wrap fields in `PreviewField` to make them inline-editable in live preview, and forward `selectedBlockId` / `onBlockClick` / `onBlockInsert` from `useCollectionPreview()`, `BlockRenderer` then adds click-to-select and insert affordances in preview mode while rendering the exact same components in production.
 </Callout>
 
 ## Querying blocks fields
 
 The blocks field ships custom operators so you can filter on block **content**, not just presence. They are available on the `where` clause for a blocks field.
 
-| Operator | Value | Matches |
-|---|---|---|
-| `hasBlockType` | `string` | Documents whose tree contains a block of that type. |
-| `blockCount` | `{ op: "gte" \| "lte" \| "eq"; count: number }` | Documents by root-level block count. |
-| `isEmpty` / `isNotEmpty` | none | Documents with no / at least one root block. |
-| `isNull` / `isNotNull` | none | Documents where the field is / isn't null. |
+| Operator                 | Value                                           | Matches                                             |
+| ------------------------ | ----------------------------------------------- | --------------------------------------------------- |
+| `hasBlockType`           | `string`                                        | Documents whose tree contains a block of that type. |
+| `blockCount`             | `{ op: "gte" \| "lte" \| "eq"; count: number }` | Documents by root-level block count.                |
+| `isEmpty` / `isNotEmpty` | none                                            | Documents with no / at least one root block.        |
+| `isNull` / `isNotNull`   | none                                            | Documents where the field is / isn't null.          |
 
 ```ts
 // Pages that contain a CTA block:
@@ -363,7 +365,7 @@ type HeroProps = BlockProps<"hero">;
 // values inferred from .fields(), data inferred from .prefetch()
 ```
 
-`BlockProps<T>` resolves to `BlockRendererProps<InferBlockValues<...>, InferBlockData<...>>` (the per-renderer props type, distinct from the `<BlockRenderer>` component's `BlockRendererComponentProps`), so `values` comes from the block's `.fields()` and `data` from its `.prefetch()`. The renderer props themselves are `{ id, values, data?, children?, isSelected?, isPreview? }`, destructure what you need (`values`, `data`, and `children` are the ones `BlockRenderer` populates; `isSelected` / `isPreview` are reserved and unwired, see the [Rendering](#rendering-on-the-frontend) note). The document and node types come from `@questpie/admin/fields`:
+`BlockProps<T>` resolves renderer props from the block definition: `values` comes from `.fields()`, `data` comes from `.prefetch()`, and `children` carries nested rendering when applicable. The document and node types come from `@questpie/admin/fields`:
 
 ```ts
 import type { BlocksDocument, BlockNode } from "@questpie/admin/fields";
@@ -372,7 +374,7 @@ import type { BlocksDocument, BlockNode } from "@questpie/admin/fields";
 If you build blocks programmatically (a plugin), `block`, `BlockBuilder`, `AdminBlockConfig`, `BlockCategoryConfig`, `AdminConfigContext`, `BlockPrefetchContext`, and the inference helpers `InferBlockValues` / `InferBlockData` are exported from `@questpie/admin/factories` (and `@questpie/admin/server`); `BlockRenderer`, `BlockRendererProps`, `BlockContent`, `BlockNode`, and `isBlockContent` from `@questpie/admin/client`.
 
 <Callout type="info" title="Import `block` from `#questpie/factories`, not `@questpie/admin/server`">
-In app code, always import `block` from `#questpie/factories`. The generated factory wraps the field proxy with your enabled modules so `f.richText()` / `f.blocks()` are available inside a block's `.fields()`; the bare `block()` from `@questpie/admin/server` only sees builtin fields.
+  In app code, always import `block` from `#questpie/factories`. The generated factory wraps the field proxy with your enabled modules so `f.richText()` / `f.blocks()` are available inside a block's `.fields()`; the bare `block()` from `@questpie/admin/server` only sees builtin fields.
 </Callout>
 
 ## Related

--- a/apps/docs/content/docs/concepts/collections.mdx
+++ b/apps/docs/content/docs/concepts/collections.mdx
@@ -12,7 +12,7 @@ A **collection** is one database table you define in code. You declare its field
 - **Lifecycle built in.** Opt into `timestamps`, `softDelete`, and `versioning` (with an optional draft → published `workflow`) per collection through one `.options()` call.
 - **Rules co-located.** Attach `.access()` (row-level rules that can return a `where` to filter) and `.hooks()` (functions around each operation) right on the definition.
 - **Relations and uploads as fields.** `f.relation("author")` adds a typed FK, admin picker, and `with: { author: true }` hydration; `.upload()` turns the collection into a media store. Covered in [Relations](/docs/concepts/relations) and below.
-- **Auto-discovered.** Drop a file in `collections/`, run codegen, and it's registered. There is no central registry to edit.
+- **Auto-discovered.** Add a file to `collections/`, run codegen, and it joins the generated registry.
 
 ## Quick start
 
@@ -41,18 +41,21 @@ questpie push       # creates the table in your dev database
 ```
 
 <Callout type="info" title="Import from `#questpie/factories`, not `questpie`">
-The bare `collection()` exported from `questpie` only sees **builtin** field types. The generated `#questpie/factories` factory calls `CollectionBuilder.create(name, fieldDefs)` under the hood with your merged builtins + module fields, so module types (`richText`, `blocks`, …) show up on `f`. Always import `collection` from `#questpie/factories` in app code.
+  The bare `collection()` exported from `questpie` only sees **builtin** field types. The generated `#questpie/factories` factory calls `CollectionBuilder.create(name, fieldDefs)` under the hood with your merged builtins + module fields, so module types (`richText`, `blocks`, …) show up on `f`. Always import
+  `collection` from `#questpie/factories` in app code.
 </Callout>
 
 That one file now gives you:
 
 ```ts
 // Typed CRUD, server-side:
-const { docs } = await app.collections.posts.find({ where: { published: true } });
+const { docs } = await app.collections.posts.find({
+  where: { published: true },
+});
 const post = await app.collections.posts.create({
-	title: "Hello",
-	slug: "hello",
-	published: true,
+  title: "Hello",
+  slug: "hello",
+  published: true,
 });
 
 // REST, out of the box (mounted under /api):
@@ -97,7 +100,7 @@ collection("articles").fields(({ f }) => ({
     { value: "draft", label: "Draft" },
     { value: "live", label: "Live" },
   ]),
-  author: f.relation("users"),   // typed FK + admin picker + with: { author: true }
+  author: f.relation("users"), // typed FK + admin picker + with: { author: true }
   coverImage: f.upload({ to: "assets" }), // a RELATION to the "assets" upload collection
 }));
 ```
@@ -128,7 +131,7 @@ collection("posts").options({
 });
 ```
 
-`CollectionOptions` is `{ schema?, timestamps?, softDelete?, versioning? }`. There is no `singleton` option, singletons are [Globals](/docs/concepts/globals).
+`CollectionOptions` is `{ schema?, timestamps?, softDelete?, versioning? }`. Model singleton data with [Globals](/docs/concepts/globals).
 
 ### `timestamps`
 
@@ -185,7 +188,7 @@ Workflow stages create version snapshots, so workflow lives **under** `versionin
 
 ## Access control
 
-`.access()` declares who may read, create, update, delete (and, with workflow, transition) rows. Each rule is `boolean` or a function of the request context; for `read`, `update`, `delete`, and `transition` a function may return a **`where` object** to *filter* rows rather than allow-or-deny.
+`.access()` declares who may read, create, update, delete (and, with workflow, transition) rows. Each rule is `boolean` or a function of the request context; for `read`, `update`, `delete`, and `transition` a function may return a **`where` object** to _filter_ rows rather than allow-or-deny.
 
 ```ts
 collection("posts").access({
@@ -199,21 +202,21 @@ collection("posts").access({
 
 The rule context spreads the full `AppContext` (`db`, `session`, `kv`, `queue`, `collections`, `app`, …) plus `{ data?, input?, locale?, request? }`. Its shape differs by operation:
 
-| Rule | `data` (existing row) | `input` (incoming) | May return a `where` filter? |
-|---|---|---|---|
-| `read` | none | none | yes (narrows results) |
-| `create` | none | the insert payload | no |
-| `update` | the existing row | the patch | yes |
-| `delete` / `transition` | the existing row | none | yes |
+| Rule                    | `data` (existing row) | `input` (incoming) | May return a `where` filter? |
+| ----------------------- | --------------------- | ------------------ | ---------------------------- |
+| `read`                  | none                  | none               | yes (narrows results)        |
+| `create`                | none                  | the insert payload | no                           |
+| `update`                | the existing row      | the patch          | yes                          |
+| `delete` / `transition` | the existing row      | none               | yes                          |
 
-A rule that returns an `AccessWhere` object grants *filtered* access, rows are narrowed by that condition. A rule function that **throws** denies with a reason. Beyond CRUD, two extra rules exist: `serve` (upload-byte access, resolves `serve` → `read` → `defaultAccess.serve` → allow) and `introspect` (admin schema visibility, visible iff any CRUD op is allowed). Field-level rules go under `access.fields` and can only allow/deny (no filtering); their context is slim (`{ req?, user?, doc?, operation }`), not the full `AppContext`.
+A rule that returns an `AccessWhere` object grants _filtered_ access, rows are narrowed by that condition. A rule function that **throws** denies with a reason. Beyond CRUD, two extra rules exist: `serve` (upload-byte access, resolves `serve` → `read` → `defaultAccess.serve` → allow) and `introspect` (admin schema visibility, visible iff any CRUD op is allowed). Field-level rules go under `access.fields` and can only allow/deny (no filtering); their context is slim (`{ req?, user?, doc?, operation }`), not the full `AppContext`.
 
 <Callout type="warn" title="Secure by default">
-An **undefined** access rule is not "open", it requires a session. Leave `read` unset and anonymous reads are rejected. Set `read: true` to make a collection public on purpose.
+  An **undefined** access rule is not "open", it requires a session. Leave `read` unset and anonymous reads are rejected. Set `read: true` to make a collection public on purpose.
 </Callout>
 
 <Callout type="info" title="`.access()` replaces; `.merge()` shallow-merges">
-On a single builder, each `.access()` call **replaces** the previous one (last call wins), unlike `.hooks()`, which merges. When you `.merge()` two builders, access objects are shallow-merged with the *other* builder winning per key.
+  On a single builder, each `.access()` call **replaces** the previous one (last call wins), unlike `.hooks()`, which merges. When you `.merge()` two builders, access objects are shallow-merged with the *other* builder winning per key.
 </Callout>
 
 Access is enforced only when you ask for it. CRUD calls default to `accessMode: "system"` (backend; rules bypassed). Pass `{ accessMode: "user", session }` as the **second argument** to run the rules. The full model, `AccessWhere` shape, the `serve`/`introspect` chains, field-level rules, is in [Access control](/docs/concepts/access-control).
@@ -240,14 +243,14 @@ collection("posts").hooks({
 
 The fire order per operation:
 
-- **create / update:** `beforeOperation` → `beforeValidate` → `beforeChange` → *[DB write]* → `afterChange` → `afterRead`
-- **delete:** `beforeOperation` → `beforeDelete` → *[DB write]* → `afterDelete` → `afterRead`
-- **read:** `beforeOperation` → `beforeRead` → *[DB read]* → `afterRead`
+- **create / update:** `beforeOperation` → `beforeValidate` → `beforeChange` → _[DB write]_ → `afterChange` → `afterRead`
+- **delete:** `beforeOperation` → `beforeDelete` → _[DB write]_ → `afterDelete` → `afterRead`
+- **read:** `beforeOperation` → `beforeRead` → _[DB read]_ → `afterRead`
 
 `beforeValidate` / `beforeChange` receive the mutable input (`TInsert` on create, `TUpdate` on update); `afterChange` / `afterRead` receive the full selected row plus `original` (only on update). Workflow adds `beforeTransition` / `afterTransition`, which use a `TransitionHookContext` (`{ data, recordId, fromStage, toStage, scheduledAt? }`), throw in `beforeTransition` to abort. Every hook context spreads the full `AppContext`.
 
 <Callout type="warn" title="Fire jobs and emails from `onAfterCommit`, never inline">
-If a hook runs inside an open transaction, doing extra reads (blocks, upload `afterRead`) or queuing work from the hook body can deadlock or fire on data that later rolls back. Use `onAfterCommit(cb)`, it runs after the tx commits (or immediately if there is no tx), so jobs/emails/search only fire on durable data.
+  If a hook runs inside an open transaction, doing extra reads (blocks, upload `afterRead`) or queuing work from the hook body can deadlock or fire on data that later rolls back. Use `onAfterCommit(cb)`, it runs after the tx commits (or immediately if there is no tx), so jobs/emails/search only fire on durable data.
 </Callout>
 
 Hooks **merge** (collections accumulate; globals replace, a deliberate asymmetry). See [Hooks](/docs/concepts/hooks) for each stage's exact signature and the transaction lifecycle.
@@ -283,7 +286,7 @@ export const media = collection("media")
 The `key`/`filename`/`mimeType`/`size` columns are nullable (a row can exist before its blob); `visibility` is `notNull` default `"public"`.
 
 <Callout type="info" title="`visibility` gates bytes, not rows">
-`visibility` only controls who can fetch the **file bytes**. Reading and listing the upload **rows** still goes through the normal `.access()` chain. To override just the byte-serving rule, set `access.serve`.
+  `visibility` only controls who can fetch the **file bytes**. Reading and listing the upload **rows** still goes through the normal `.access()` chain. To override just the byte-serving rule, set `access.serve`.
 </Callout>
 
 Store files at runtime with the CRUD methods (only present on `.upload()` collections):
@@ -318,20 +321,20 @@ A `FacetFieldConfig` is `true | { type: "array" } | { type: "range"; buckets } |
 
 `collection(name)` returns a `CollectionBuilder` whose methods chain and return the builder. Codegen calls `.build()` for you. The common methods:
 
-| Method | Purpose | Merge behavior |
-|---|---|---|
-| `.fields(({ f }) => …)` | Declare columns (the source of truth for all types). | cumulative, override by key |
-| `.title(({ f }) => f.x)` | Field name that labels a row (`_title`). | replaces |
-| `.options(opts)` | Lifecycle: `timestamps`, `softDelete`, `versioning`, `schema`. | replaces |
-| `.access(rules)` | Read/create/update/delete/transition/serve/introspect rules. | replaces |
-| `.hooks(hooks)` | Functions around each operation. | merges into arrays |
-| `.searchable(config)` | Search indexing (or `false` to disable). | replaces |
-| `.indexes(({ table }) => […])` | Drizzle indexes / unique constraints. | replaces (lazy callback) |
-| `.validation(opts)` | Tune the generated Zod schemas (`exclude` / `refine`). | replaces |
-| `.upload(opts)` | Make it a media collection. | none |
-| `.set(key, value)` | Attach arbitrary state (extension seam). | none |
-| `.merge(other)` | Combine with another builder of the same name. | see below |
-| `.build()` | Resolve relations and materialize the `Collection`. | none |
+| Method                         | Purpose                                                        | Merge behavior              |
+| ------------------------------ | -------------------------------------------------------------- | --------------------------- |
+| `.fields(({ f }) => …)`        | Declare columns (the source of truth for all types).           | cumulative, override by key |
+| `.title(({ f }) => f.x)`       | Field name that labels a row (`_title`).                       | replaces                    |
+| `.options(opts)`               | Lifecycle: `timestamps`, `softDelete`, `versioning`, `schema`. | replaces                    |
+| `.access(rules)`               | Read/create/update/delete/transition/serve/introspect rules.   | replaces                    |
+| `.hooks(hooks)`                | Functions around each operation.                               | merges into arrays          |
+| `.searchable(config)`          | Search indexing (or `false` to disable).                       | replaces                    |
+| `.indexes(({ table }) => […])` | Drizzle indexes / unique constraints.                          | replaces (lazy callback)    |
+| `.validation(opts)`            | Tune the generated Zod schemas (`exclude` / `refine`).         | replaces                    |
+| `.upload(opts)`                | Make it a media collection.                                    | none                        |
+| `.set(key, value)`             | Attach arbitrary state (extension seam).                       | none                        |
+| `.merge(other)`                | Combine with another builder of the same name.                 | see below                   |
+| `.build()`                     | Resolve relations and materialize the `Collection`.            | none                        |
 
 The **admin** methods, `.admin()`, `.list()`, `.form()`, `.actions()`, `.preview()`, are contributed by the `@questpie/admin` module via codegen (they appear on the builder once admin is enabled, attached through `.set()`). They configure the panel UI and are documented in the admin docs.
 
@@ -342,40 +345,37 @@ The **admin** methods, `.admin()`, `.list()`, `.form()`, `.actions()`, `.preview
 ```ts
 import { uniqueIndex } from "questpie/drizzle-pg-core";
 
-collection("posts").indexes(({ table }) => [
-  uniqueIndex("posts_slug_idx").on(table.slug),
-]);
+collection("posts").indexes(({ table }) => [uniqueIndex("posts_slug_idx").on(table.slug)]);
 ```
-
-
 
 ### Merging builders
 
 `.merge(other)` combines two builders of the **same name**, fields, virtuals, relations, indexes, hooks, access, options, and output. The other builder's `title` / `searchable` / `upload` / `validation` win; hooks combine into arrays; access is shallow-merged (other wins). This is the mechanism behind extending a module-provided collection.
 
 <Callout type="info" title="`.merge()` preserves admin config">
-`.merge()` spreads the full state first so the admin extension keys (`admin`, `adminList`, `adminForm`, `adminActions`, `adminPreview`) survive before explicit keys are overridden, this is a framework invariant. Pending (unresolved) relations are merged by field name; a field the other side redefines drops this side's pending entry.
+  `.merge()` spreads the full state first so the admin extension keys (`admin`, `adminList`, `adminForm`, `adminActions`, `adminPreview`) survive before explicit keys are overridden, this is a framework invariant. Pending (unresolved) relations are merged by field name; a field the other side redefines drops this
+  side's pending entry.
 </Callout>
 
 ## CRUD reference
 
 The built collection produces `app.collections.<name>` (and `ctx.collections.<name>` inside hooks, routes, jobs, and seeds), a typed CRUD object. One vocabulary across all collections:
 
-| Method | Use |
-|---|---|
-| `find(opts)` | List rows. Returns a paginated envelope (`{ docs, totalDocs, … }`). |
-| `findOne(opts)` | First match or `null`. |
-| `count(opts)` | Count matching rows (`where`, `includeDeleted`). |
-| `create(data)` | Insert one row (supports nested relation mutations). |
-| `updateById({ id, data })` | Update one row by id. |
-| `updateMany({ where, data })` | Bulk update by filter (claim-checked). |
-| `updateBatch({ updates })` | Per-record updates (`[{ id, data }]`) in one transaction. |
-| `deleteById({ id })` | Delete (soft if enabled) by id. |
-| `restoreById({ id })` | Restore a soft-deleted row (soft-delete collections only). |
-| `deleteMany({ where })` | Bulk delete by filter (claim-checked). |
-| `findVersions(opts)` / `revertToVersion(opts)` | History (versioning on). |
-| `transitionStage({ id, stage })` | Move a row's workflow stage (workflow on). |
-| `upload(file)` / `uploadMany(files)` | Store files (`.upload()` collections only). |
+| Method                                         | Use                                                                 |
+| ---------------------------------------------- | ------------------------------------------------------------------- |
+| `find(opts)`                                   | List rows. Returns a paginated envelope (`{ docs, totalDocs, … }`). |
+| `findOne(opts)`                                | First match or `null`.                                              |
+| `count(opts)`                                  | Count matching rows (`where`, `includeDeleted`).                    |
+| `create(data)`                                 | Insert one row (supports nested relation mutations).                |
+| `updateById({ id, data })`                     | Update one row by id.                                               |
+| `updateMany({ where, data })`                  | Bulk update by filter (claim-checked).                              |
+| `updateBatch({ updates })`                     | Per-record updates (`[{ id, data }]`) in one transaction.           |
+| `deleteById({ id })`                           | Delete (soft if enabled) by id.                                     |
+| `restoreById({ id })`                          | Restore a soft-deleted row (soft-delete collections only).          |
+| `deleteMany({ where })`                        | Bulk delete by filter (claim-checked).                              |
+| `findVersions(opts)` / `revertToVersion(opts)` | History (versioning on).                                            |
+| `transitionStage({ id, stage })`               | Move a row's workflow stage (workflow on).                          |
+| `upload(file)` / `uploadMany(files)`           | Store files (`.upload()` collections only).                         |
 
 Every method takes a `CRUDContext` as its **second** argument, pass `{ accessMode: "user", session }` to enforce access, `{ locale }` to read/write a localized variant, `{ stage }` to target a workflow stage. The context type is index-signature-free on purpose: a typo'd key is a compile error, not a silent fallback to `accessMode: "system"`.
 
@@ -389,24 +389,24 @@ Bulk operations lock the matching rows and re-evaluate the `where` inside the tr
 
 Every collection is also served over HTTP, mounted under your handler's `basePath` (default `/api`). The routes are real file-convention routes the core module ships:
 
-| Method | Path | Maps to |
-|---|---|---|
-| `GET` | `/api/:collection` | `find` (paginated) |
-| `POST` | `/api/:collection` | `create` |
-| `PATCH` | `/api/:collection` | `updateMany` |
-| `GET` | `/api/:collection/:id` | `findOne` |
-| `PATCH` | `/api/:collection/:id` | `updateById` |
-| `DELETE` | `/api/:collection/:id` | `deleteById` |
-| `GET` | `/api/:collection/count` | `count` |
-| `POST` | `/api/:collection/delete-many` | `deleteMany` |
-| `POST` | `/api/:collection/update-batch` | `updateBatch` |
-| `POST` | `/api/:collection/:id/restore` | `restoreById` (soft-delete) |
-| `GET` | `/api/:collection/:id/versions` | `findVersions` (versioning) |
-| `POST` | `/api/:collection/:id/revert` | `revertToVersion` (versioning) |
-| `POST` | `/api/:collection/:id/transition` | `transitionStage` (workflow) |
-| `POST` | `/api/:collection/upload` | `upload` (`.upload()` collections) |
-| `GET` | `/api/:collection/files/*key` | serve file bytes |
-| `GET` | `/api/:collection/schema` · `/meta` | introspection (admin) |
+| Method   | Path                                | Maps to                            |
+| -------- | ----------------------------------- | ---------------------------------- |
+| `GET`    | `/api/:collection`                  | `find` (paginated)                 |
+| `POST`   | `/api/:collection`                  | `create`                           |
+| `PATCH`  | `/api/:collection`                  | `updateMany`                       |
+| `GET`    | `/api/:collection/:id`              | `findOne`                          |
+| `PATCH`  | `/api/:collection/:id`              | `updateById`                       |
+| `DELETE` | `/api/:collection/:id`              | `deleteById`                       |
+| `GET`    | `/api/:collection/count`            | `count`                            |
+| `POST`   | `/api/:collection/delete-many`      | `deleteMany`                       |
+| `POST`   | `/api/:collection/update-batch`     | `updateBatch`                      |
+| `POST`   | `/api/:collection/:id/restore`      | `restoreById` (soft-delete)        |
+| `GET`    | `/api/:collection/:id/versions`     | `findVersions` (versioning)        |
+| `POST`   | `/api/:collection/:id/revert`       | `revertToVersion` (versioning)     |
+| `POST`   | `/api/:collection/:id/transition`   | `transitionStage` (workflow)       |
+| `POST`   | `/api/:collection/upload`           | `upload` (`.upload()` collections) |
+| `GET`    | `/api/:collection/files/*key`       | serve file bytes                   |
+| `GET`    | `/api/:collection/schema` · `/meta` | introspection (admin)              |
 
 The same operations are reachable through the [typed client](/docs/client/sdk) and appear in the OpenAPI/Scalar reference at `/api/docs`.
 
@@ -414,18 +414,18 @@ The same operations are reachable through the [typed client](/docs/client/sdk) a
 
 Codegen discovers collections by scanning the `collections/` directory. Two rules:
 
-- **The `collection("…")` argument is the key.** The string you pass to `collection()` (kebab → camelCased) is what registers on `app.collections`, `collection("blog-posts")` keys as `blogPosts`, regardless of the file name. Keep the file name matching the argument (`collections/blog-posts.ts`) so the two never drift, and keep one collection per file. The file name is only a **fallback**: a *default* export with no string argument keys off the file name; a *named* export with no argument keys off the export name. So `export const foo = collection("articles")` in `posts.ts` registers as `articles`, not `posts`.
+- **The `collection("…")` argument is the key.** The string you pass to `collection()` (kebab → camelCased) is what registers on `app.collections`, `collection("blog-posts")` keys as `blogPosts`, regardless of the file name. Keep the file name matching the argument (`collections/blog-posts.ts`) so the two never drift, and keep one collection per file. The file name is only a **fallback**: a _default_ export with no string argument keys off the file name; a _named_ export with no argument keys off the export name. So `export const foo = collection("articles")` in `posts.ts` registers as `articles`, not `posts`.
 - **Default or named export both work.** `export const posts = collection("posts")…` and `export default collection("posts")…` are both picked up.
 
 After adding or renaming a file, run `questpie generate` (or `questpie dev`, which watches) to regenerate `.generated/`, that's what wires the new collection into `app.collections.*`, the admin, REST, OpenAPI, and the client. Then `questpie push` (dev) or `questpie migrate:create` (production) to materialize the table.
 
 <Callout type="idea" title="Scaffold it">
-`questpie add collection my-thing` creates the file with the right boilerplate and runs codegen for you. Run `questpie add --list` to see every scaffold type.
+  `questpie add collection my-thing` creates the file with the right boilerplate and runs codegen for you. Run `questpie add --list` to see every scaffold type.
 </Callout>
 
 ## Extending: custom field types
 
-`f.*` is open. A collection can use any field a module registers, including your own. A custom field is a `field()` definition that declares how it maps to a column, validates, and exposes query operators; once a module contributes it, it appears on `f` in `.fields(({ f }) => …)` exactly like a builtin. The contract (`toColumn` / `toZodSchema` / `getOperators` / `getMetadata`) and the publishing loop are covered in [Fields → custom field types](/docs/concepts/fields) and the Extend section. This is the QUESTPIE principle in action: **core, modules, and your own code reach the same builder through one seam**, there are no privileged internal field APIs.
+`f.*` is extensible. A collection can use any field a module registers, including your own. A custom `field()` definition declares its column mapping, validation, metadata, and query operators; after module registration it appears in `.fields(({ f }) => …)` beside the built-ins. See [Fields → custom field types](/docs/concepts/fields) and the Extend section for the contract and publishing flow.
 
 ## TypeScript
 

--- a/apps/docs/content/docs/concepts/configuration.mdx
+++ b/apps/docs/content/docs/concepts/configuration.mdx
@@ -26,10 +26,10 @@ import env from "./env"; // declared + validated in env.ts, see Environment
 
 // Runtime infrastructure + codegen plugins only, no entities here.
 export default runtimeConfig({
-	app: { url: env.APP_URL },
-	db: { url: env.DATABASE_URL },
-	secret: env.BETTER_AUTH_SECRET,
-	email: { adapter: new ConsoleAdapter() },
+  app: { url: env.APP_URL },
+  db: { url: env.DATABASE_URL },
+  secret: env.BETTER_AUTH_SECRET,
+  email: { adapter: new ConsoleAdapter() },
 });
 ```
 
@@ -38,13 +38,13 @@ import { appConfig } from "questpie/app";
 
 // Discovered as config/app.ts → AppStateConfig.app.
 export default appConfig({
-	locale: {
-		locales: [
-			{ code: "en", label: "English", fallback: true },
-			{ code: "sk", label: "Slovenčina" },
-		],
-		defaultLocale: "en",
-	},
+  locale: {
+    locales: [
+      { code: "en", label: "English", fallback: true },
+      { code: "sk", label: "Slovenčina" },
+    ],
+    defaultLocale: "en",
+  },
 });
 ```
 
@@ -53,7 +53,7 @@ import { authConfig } from "questpie/app";
 
 // Discovered as config/auth.ts → AppStateConfig.auth (Better Auth options).
 export default authConfig({
-	emailAndPassword: { enabled: true, requireEmailVerification: false },
+  emailAndPassword: { enabled: true, requireEmailVerification: false },
 });
 ```
 
@@ -72,14 +72,8 @@ Then regenerate the typed app:
 questpie generate   # discovers every config file, merges modules, emits .generated/index.ts
 ```
 
-<Callout
-	type="info"
-	title="Import the factories from `questpie/app` (or `questpie`)"
->
-	`runtimeConfig`, `module`, `appConfig`, and `authConfig` are all exported from
-	both `questpie` and the lighter `questpie/app` barrel. The starter templates
-	and examples use `questpie/app`. The CLI factories, `config()` and
-	`packageConfig()`, live in `questpie/cli` instead.
+<Callout type="info" title="Import the factories from `questpie/app` (or `questpie`)">
+  `runtimeConfig`, `module`, `appConfig`, and `authConfig` are all exported from both `questpie` and the lighter `questpie/app` barrel. The starter templates and examples use `questpie/app`. The CLI factories, `config()` and `packageConfig()`, live in `questpie/cli` instead.
 </Callout>
 
 ## How the files connect
@@ -102,15 +96,8 @@ questpie generate   # one shot: pre-pass modules.ts, discover all files, emit .g
 questpie dev        # the same, in watch mode, regenerates on file add/remove
 ```
 
-<Callout
-	type="warn"
-	title="`questpie.config.ts` needs `.generated/index.ts` to exist"
->
-	The CLI's `questpie.config.ts` is in the "new format", it carries `app.url`
-	but is **not** itself a built app. On a CLI command it auto-resolves
-	`.generated/index.ts` for the real app instance, and errors with *"Run
-	`questpie generate` first"* if that file is missing. Generate before you
-	migrate, seed, or push.
+<Callout type="warn" title="`questpie.config.ts` needs `.generated/index.ts` to exist">
+  The CLI's `questpie.config.ts` is in the "new format", it carries `app.url` but is **not** itself a built app. On a CLI command it auto-resolves `.generated/index.ts` for the real app instance, and errors with *"Run `questpie generate` first"* if that file is missing. Generate before you migrate, seed, or push.
 </Callout>
 
 ## `runtimeConfig`, runtime infrastructure
@@ -126,13 +113,13 @@ import { messages } from "@/questpie/server/i18n";
 import env from "./env";
 
 export default runtimeConfig({
-	app: { url: env.APP_URL },
-	db: { url: env.DATABASE_URL },
-	secret: env.BETTER_AUTH_SECRET,
-	storage: { basePath: "/api" },
-	translations: { messages },
-	email: { adapter: new ConsoleAdapter({ logHtml: false }) },
-	queue: { adapter: pgBossAdapter({ connectionString: env.DATABASE_URL }) },
+  app: { url: env.APP_URL },
+  db: { url: env.DATABASE_URL },
+  secret: env.BETTER_AUTH_SECRET,
+  storage: { basePath: "/api" },
+  translations: { messages },
+  email: { adapter: new ConsoleAdapter({ logHtml: false }) },
+  queue: { adapter: pgBossAdapter({ connectionString: env.DATABASE_URL }) },
 });
 ```
 
@@ -151,16 +138,14 @@ So on QUESTPIE Cloud the whole file can collapse to just your plugins:
 
 ```ts
 export default runtimeConfig({
-	plugins: [], // app/db/secret/storage all auto-resolved from QUESTPIE_* env
+  plugins: [], // app/db/secret/storage all auto-resolved from QUESTPIE_* env
 });
 ```
 
 When `QUESTPIE_STORAGE_ENDPOINT`, `QUESTPIE_STORAGE_BUCKET`, `QUESTPIE_STORAGE_ACCESS_KEY`, and `QUESTPIE_STORAGE_SECRET_KEY` are all set, an S3-compatible Files SDK adapter is auto-configured. The adapter is lazy, the AWS SDK import is deferred to the first storage operation, so you must install all four peer deps: `@aws-sdk/client-s3`, `@aws-sdk/lib-storage`, `@aws-sdk/s3-presigned-post`, and `@aws-sdk/s3-request-presigner`.
 
 <Callout type="warn" title="`db` must resolve from somewhere">
-	`app.url` falls back to `http://localhost:3000`, but `db.url` has no default,
-	if it can't be resolved from your value, `QUESTPIE_DB`, or `DATABASE_URL`,
-	`runtimeConfig()` throws at construction. Always provide a database.
+  `app.url` falls back to `http://localhost:3000`, but `db.url` has no default, if it can't be resolved from your value, `QUESTPIE_DB`, or `DATABASE_URL`, `runtimeConfig()` throws at construction. Always provide a database.
 </Callout>
 
 ### Options reference
@@ -189,11 +174,8 @@ Everything below `app`/`db` is optional. The full `RuntimeConfigInput` shape:
 The input type is `RuntimeConfigInput`, defined as `Partial<Pick<RuntimeConfig, "app" | "db">> & Omit<RuntimeConfig, "app" | "db">`: the resolved `RuntimeConfig` interface with `app` and `db` made optional. `DbConfig` itself is a union, `{ url }`, `{ pglite }`, `{ drizzle }` (a pre-built client, for Neon / Vercel Postgres / Hyperdrive), or `{ create }` (a lazy factory, preferred for Cloudflare Workers).
 
 <Callout type="info" title="`plugins` is for codegen plugins, not modules">
-	`runtimeConfig({plugins})` registers **codegen plugins** (the thing that adds
-	file-convention discovery and generated output). Module *dependencies* go in
-	`modules.ts` instead, and a module can carry its own codegen plugin, so most
-	apps never touch `plugins` directly. The adapters (queue, search, KV, …) each
-	have their own page under Infrastructure.
+  `runtimeConfig({plugins})` registers **codegen plugins** (the thing that adds file-convention discovery and generated output). Module *dependencies* go in `modules.ts` instead, and a module can carry its own codegen plugin, so most apps never touch `plugins` directly. The adapters (queue, search, KV, …) each have
+  their own page under Infrastructure.
 </Callout>
 
 The adapter and storage wiring (`StorageConfig`, the queue/search/realtime/kv/executor adapters) each have a dedicated page; this page covers the config _file_, not every adapter.
@@ -206,17 +188,17 @@ The adapter and storage wiring (`StorageConfig`, the queue/search/realtime/kv/ex
 import { appConfig } from "questpie/app";
 
 export default appConfig({
-	locale: {
-		locales: [
-			{ code: "en", label: "English", fallback: true, flagCountryCode: "us" },
-			{ code: "sk", label: "Slovenčina" },
-		],
-		defaultLocale: "en",
-	},
-	access: { read: true }, // app-wide default; collections can override
-	context: async ({ request, session }) => ({
-		role: session?.user?.role ?? "guest",
-	}),
+  locale: {
+    locales: [
+      { code: "en", label: "English", fallback: true, flagCountryCode: "us" },
+      { code: "sk", label: "Slovenčina" },
+    ],
+    defaultLocale: "en",
+  },
+  access: { read: true }, // app-wide default; collections can override
+  context: async ({ request, session }) => ({
+    role: session?.user?.role ?? "guest",
+  }),
 });
 ```
 
@@ -251,12 +233,8 @@ access: {
 ```
 
 <Callout type="warn" title="The app-level access context is a leaner seam">
-	The function context here is `ResolvedAppDefaultAccessContext` (db, session,
-	collections, …), **not** the fully augmented `AccessContext` that
-	per-collection `.access()` rules get. This is deliberate: routing app-level
-	rules through the full augmented context would create a type cycle in the
-	generated app. Use collection-level `.access()` when you need the richest
-	typed context.
+  The function context here is `ResolvedAppDefaultAccessContext` (db, session, collections, …), **not** the fully augmented `AccessContext` that per-collection `.access()` rules get. This is deliberate: routing app-level rules through the full augmented context would create a type cycle in the generated app. Use
+  collection-level `.access()` when you need the richest typed context.
 </Callout>
 
 ### `hooks`, global hooks
@@ -275,10 +253,10 @@ hooks: {
 }
 ```
 
-The shape is `GlobalHooksInput`, `{ collections?: GlobalCollectionHookEntry; globals?: GlobalGlobalHookEntry }`. Each value is a **single** hook-entry object (not an array): `GlobalCollectionHookEntry` is `{ include?, exclude?, beforeChange?, afterChange?, beforeDelete?, afterDelete?, beforeTransition?, afterTransition? }`, and `include`/`exclude` scope it to specific slugs. The framework concatenates these entries across modules internally. Per-entity hooks still live on the collection/global builder, see [Hooks](/docs/concepts/hooks).
+The shape is `GlobalHooksInput`, `{ collections?: GlobalCollectionHookEntry; globals?: GlobalGlobalHookEntry }`. Each value is one hook-entry object. `GlobalCollectionHookEntry` contains `include`, `exclude`, and lifecycle callbacks; `include` and `exclude` scope it to specific slugs. Per-entity hooks live on collection and global builders; see [Hooks](/docs/concepts/hooks).
 
-<Callout type="warn" title="`collections` / `globals` each take one entry object, not an array">
-A natural mistake is `collections: [{ afterChange }]`, but the public `GlobalHooksInput` type rejects an array; `collections` is a single `GlobalCollectionHookEntry`. The array form (`{ collections: GlobalCollectionHookEntry[] }`) is the framework's internal accumulator (`GlobalHooksState`), never the input. To register several hooks, put multiple lifecycle keys on the one object (`{ beforeChange, afterChange, afterDelete }`).
+<Callout type="info" title="Group lifecycle callbacks in one entry">
+`collections` and `globals` each accept one hook-entry object. Put several lifecycle callbacks on that object, such as `{ beforeChange, afterChange, afterDelete }`.
 </Callout>
 
 ### `context`, the per-request context resolver
@@ -306,16 +284,9 @@ The resolver receives `{ request, session, db }` plus the full system-mode servi
 The resolver's **return type** is what drives the typed context extension downstream, so it must resolve to an object. `appConfig()` rejects a resolver that returns *only* a primitive (`async () => "x"`) or *only* `null` (`async () => null`) at the call site. The common `session ? { role } : null` shape passes because it has an object arm. Because the return type is load-bearing, prefer returning an explicit object literal over an inferred-then-narrowed value.
 </Callout>
 
-<Callout
-	type="info"
-	title="Why `access` and `hooks` vanish from `appConfig()`'s return type"
->
-	`appConfig()` is identity at runtime, but its **return type** erases `access`
-	and `hooks` to opaque storage and keeps only `locale` and `context`. That's
-	intentional: their function parameter types embed the merged `AppContext`, and
-	riding them back into the generated index would collapse the whole
-	augmentation (TS2456). Both are still fully typed *at the call site*, you just
-	can't read them back off `typeof appConfigFile`.
+<Callout type="info" title="Why `access` and `hooks` vanish from `appConfig()`'s return type">
+  `appConfig()` is identity at runtime, but its **return type** erases `access` and `hooks` to opaque storage and keeps only `locale` and `context`. That's intentional: their function parameter types embed the merged `AppContext`, and riding them back into the generated index would collapse the whole augmentation
+  (TS2456). Both are still fully typed *at the call site*, you just can't read them back off `typeof appConfigFile`.
 </Callout>
 
 ## `config/auth.ts`, authentication
@@ -326,13 +297,13 @@ The resolver's **return type** is what drives the typed context extension downst
 import { authConfig } from "questpie/app";
 
 export default authConfig({
-	emailAndPassword: { enabled: true, requireEmailVerification: false },
-	socialProviders: {
-		google: {
-			clientId: process.env.GOOGLE_CLIENT_ID!,
-			clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
-		},
-	},
+  emailAndPassword: { enabled: true, requireEmailVerification: false },
+  socialProviders: {
+    google: {
+      clientId: process.env.GOOGLE_CLIENT_ID!,
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
+    },
+  },
 });
 ```
 
@@ -357,8 +328,8 @@ import { admin, bearer } from "better-auth/plugins";
 import { authConfig } from "questpie/app";
 
 export default authConfig({
-	plugins: [admin(), bearer()],
-	emailAndPassword: { enabled: true, requireEmailVerification: false },
+  plugins: [admin(), bearer()],
+  emailAndPassword: { enabled: true, requireEmailVerification: false },
 });
 ```
 
@@ -383,17 +354,16 @@ discover: {
 ```ts
 // in your plugin's types, make the key typed and discoverable
 declare module "questpie" {
-	interface AppStateConfig {
-		myPlugin?: MyPluginConfig;
-	}
+  interface AppStateConfig {
+    myPlugin?: MyPluginConfig;
+  }
 }
 ```
 
 Now users add `config/my-plugin.ts` (default-exporting your config), codegen folds it into `config.myPlugin`, and modules contributing the same key are merged per sub-key. `AppStateConfig` is `{ app?, auth? }` at the core; everything else is augmentation.
 
 <Callout type="info" title="Use `configKey` for config files">
-	A discover pattern's `configKey` emits the **whole file** as one entry under
-	the config bucket: one file maps to one config key.
+  A discover pattern's `configKey` emits the **whole file** as one entry under the config bucket: one file maps to one config key.
 </Callout>
 
 ## `modules.ts`, module dependencies
@@ -423,14 +393,8 @@ export const blogModule = module({
 });
 ```
 
-<Callout
-	type="info"
-	title="A module's `plugin` is codegen-only, never merged at runtime"
->
-	The `plugin` key on a module is extracted by codegen and **excluded** from the
-	runtime module merge. That's how a module package (`@questpie/admin`,
-	`@questpie/openapi`) ships its file conventions without you registering
-	anything in `questpie.config.ts`, adding the module to `modules.ts` is enough.
+<Callout type="info" title="A module's `plugin` is codegen-only, never merged at runtime">
+  The `plugin` key on a module is extracted by codegen and **excluded** from the runtime module merge. That's how a module package (`@questpie/admin`, `@questpie/openapi`) ships its file conventions without you registering anything in `questpie.config.ts`, adding the module to `modules.ts` is enough.
 </Callout>
 
 The full module surface (`ModuleDefinition`), how modules contribute each category, and the depth-first merge are covered in [Extend → Modules](/docs/extend/modules).
@@ -447,10 +411,7 @@ export { default } from "./src/questpie/server/questpie.config";
 `create-questpie` scaffolds this shape. CLI settings such as migration and [seed](/docs/concepts/seeds) directories live in the server config when you need to override the defaults.
 
 <Callout type="warn" title="Importing `questpie/cli` must not run a command">
-	The CLI program is side-effect-free on import, command parsing is guarded by
-	`import.meta.main`. This matters because package config files import
-	`questpie/cli` for `packageConfig`, and a stray src-vs-dist double instance
-	running a command could corrupt `.generated/`.
+  The CLI program is side-effect-free on import, command parsing is guarded by `import.meta.main`. This matters because package config files import `questpie/cli` for `packageConfig`, and a stray src-vs-dist double instance running a command could corrupt `.generated/`.
 </Callout>
 
 ## The static-module pattern (`packageConfig`)
@@ -462,15 +423,15 @@ import { packageConfig } from "questpie/cli";
 import { myPlugin } from "./src/server/plugin.js";
 
 export default packageConfig({
-	modulesDir: "src/server/modules", // each subdir → one module
-	modulePrefix: "questpie", // dir "admin" → module "questpie-admin"
-	plugins: [myPlugin()], // codegen plugins shared across all modules
+  modulesDir: "src/server/modules", // each subdir → one module
+  modulePrefix: "questpie", // dir "admin" → module "questpie-admin"
+  plugins: [myPlugin()], // codegen plugins shared across all modules
 });
 ```
 
 In package mode, `questpie generate` scans `modulesDir/*`, derives each module's name as `${modulePrefix}-${dirName}`, and runs codegen in **module mode** per subdirectory (emitting `.generated/module.ts`, plus `registries.ts` when there are type augmentations). `PackageConfig` is `{ modulesDir, modulePrefix?, plugins? }` (`modulePrefix` defaults from `package.json` name).
 
-This is the foundation of the QUESTPIE extensibility principle: **the framework's own built-in modules use the exact same `packageConfig` + `config/*.ts` conventions a userland module would**, there are no privileged internal APIs. The core itself is configured with `packageConfig({ modulesDir: "src/server/modules", modulePrefix: "questpie" })`. Building a publishable module + plugin is covered in the Extend → Build a plugin section.
+Built-in and published modules use the same `packageConfig` and `config/*.ts` conventions. Core uses `packageConfig({ modulesDir: "src/server/modules", modulePrefix: "questpie" })`. See Extend → Build a plugin to package your own module.
 
 ## CLI commands
 
@@ -484,20 +445,14 @@ The configuration files only do something once codegen reads them. The relevant 
 | `questpie migrate:create` | Generate a migration from the current schema (production path).                                                    |
 
 <Callout type="warn" title="Production uses migrations, never push">
-	`questpie push` and `bun run db:push` are local-development tools. Never run
-	them against production or in deployment automation, even with `--force`.
-	Production changes must use a reviewed, committed `questpie migrate:create`
-	output followed by `questpie migrate` during deployment.
+  `questpie push` and `bun run db:push` are local-development tools. Never run them against production or in deployment automation, even with `--force`. Production changes must use a reviewed, committed `questpie migrate:create` output followed by `questpie migrate` during deployment.
 </Callout>
 
 `questpie generate` auto-detects the config mode from the file shape (root-app vs module vs `packageConfig`) and sets `QUESTPIE_SKIP_ENV_VALIDATION=1` while it imports your code (codegen must run without a populated env).
 
 <Callout type="idea" title="Watch mode regenerates on structural change only">
-	`questpie dev` only re-runs codegen when a file is **added or removed** (or a
-	config file changes), editing the *contents* of an existing collection/config
-	file is skipped, because the generated app references it by `typeof
-	import(...)`, which is stable. If a change isn't picked up, it's structural:
-	add/rename/delete is what triggers a regen.
+  `questpie dev` only re-runs codegen when a file is **added or removed** (or a config file changes), editing the *contents* of an existing collection/config file is skipped, because the generated app references it by `typeof import(...)`, which is stable. If a change isn't picked up, it's structural: add/rename/delete
+  is what triggers a regen.
 </Callout>
 
 ## TypeScript
@@ -506,13 +461,13 @@ The config factories give you typed access to every config shape, import them fr
 
 ```ts
 import type {
-	RuntimeConfig, // resolved questpie.config.ts shape
-	RuntimeConfigInput, // its input (app/db optional)
-	AppConfigInput, // config/app.ts input ({ locale, access, hooks, context })
-	AppStateConfig, // the plugin-extensible config bucket
-	ContextResolver, // the appConfig({ context }) function type
-	LocaleConfig,
-	ModuleDefinition,
+  RuntimeConfig, // resolved questpie.config.ts shape
+  RuntimeConfigInput, // its input (app/db optional)
+  AppConfigInput, // config/app.ts input ({ locale, access, hooks, context })
+  AppStateConfig, // the plugin-extensible config bucket
+  ContextResolver, // the appConfig({ context }) function type
+  LocaleConfig,
+  ModuleDefinition,
 } from "questpie";
 
 import type { TypedAuthConfig } from "questpie/app"; // authConfig() return

--- a/apps/docs/content/docs/concepts/emails.mdx
+++ b/apps/docs/content/docs/concepts/emails.mdx
@@ -50,10 +50,7 @@ import env from "./env";
 export default runtimeConfig({
   // ...app, db, secret, etc.
   email: {
-    adapter:
-      env.NODE_ENV === "production"
-        ? new SmtpAdapter({ transport: env.SMTP_URL })
-        : new ConsoleAdapter(),
+    adapter: env.NODE_ENV === "production" ? new SmtpAdapter({ transport: env.SMTP_URL }) : new ConsoleAdapter(),
     defaults: { from: "QUESTPIE <noreply@example.com>" },
   },
 });
@@ -69,7 +66,10 @@ questpie generate   # collects emails/*.ts into the templates registry
 // inside a hook, route, job, or service, ctx.email is the MailerService
 await ctx.email.sendTemplate({
   template: "welcome",
-  input: { name: "Ada", activationLink: "https://app.example.com/activate/abc" },
+  input: {
+    name: "Ada",
+    activationLink: "https://app.example.com/activate/abc",
+  },
   to: "ada@example.com",
 });
 ```
@@ -79,7 +79,8 @@ A default-exported `email(...)` in `emails/welcome.ts` is registered under the c
 </Callout>
 
 <Callout type="warn" title="You must set an adapter, even in dev">
-The core email service throws at app build if `email.adapter` is missing: `"QUESTPIE: 'email.adapter' is required."`. The mailer does have a `ConsoleAdapter` fallback for when no adapter is configured, but the core service never reaches it, it constructs `MailerService` only after asserting your adapter exists. So always set `adapter`; use `new ConsoleAdapter()` explicitly for local development rather than relying on a fallback.
+  The core email service throws at app build if `email.adapter` is missing: `"QUESTPIE: 'email.adapter' is required."`. The mailer does have a `ConsoleAdapter` fallback for when no adapter is configured, but the core service never reaches it, it constructs `MailerService` only after asserting your adapter exists. So
+  always set `adapter`; use `new ConsoleAdapter()` explicitly for local development rather than relying on a fallback.
 </Callout>
 
 ## Example → real output
@@ -107,8 +108,6 @@ Two things happened for free during serialization:
 - **`from` was filled** from `defaults.from`, you didn't pass one in the send call.
 - **`text` was derived** from your `html` via `html-to-text`, because the handler returned only `html`.
 
-
-
 The `input` argument is inferred straight from the template's Zod schema, so a wrong shape is a compile error before it can ever be a runtime one:
 
 ```ts
@@ -130,11 +129,11 @@ import { email } from "questpie/services";
 
 The definition has exactly three fields:
 
-| Field | Type | Notes |
-|---|---|---|
-| `name` | `string` | A stable identifier for the template. Convention is to match the filename. |
-| `schema` | `z.ZodSchema<TInput>` | Validates `input` on every render/send. The inferred input type flows into `sendTemplate`/`renderTemplate`. |
-| `handler` | `(args) => EmailResult \| Promise<EmailResult>` | Builds the email. Sync or async. |
+| Field     | Type                                            | Notes                                                                                                       |
+| --------- | ----------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `name`    | `string`                                        | A stable identifier for the template. Convention is to match the filename.                                  |
+| `schema`  | `z.ZodSchema<TInput>`                           | Validates `input` on every render/send. The inferred input type flows into `sendTemplate`/`renderTemplate`. |
+| `handler` | `(args) => EmailResult \| Promise<EmailResult>` | Builds the email. Sync or async.                                                                            |
 
 The handler receives `EmailHandlerArgs<TInput>`, the **full `AppContext` spread in**, plus `input` and an optional `locale`. That means you can fetch from the database while rendering:
 
@@ -165,16 +164,17 @@ The handler must return an `EmailResult`:
 
 ```ts
 interface EmailResult {
-  subject: string;   // required, render throws if falsy
-  html: string;      // required, render throws if falsy
-  text?: string;     // optional, auto-derived from html if omitted
+  subject: string; // required, render throws if falsy
+  html: string; // required, render throws if falsy
+  text?: string; // optional, auto-derived from html if omitted
 }
 ```
 
 `renderTemplate` throws `Email handler for "X" must return a subject` / `... must return html` if either is falsy, so you can't accidentally ship a blank email.
 
 <Callout type="warn" title="App context is only populated inside a request or job scope">
-The handler's `db`, `collections`, and other services are resolved from the active request/job context (AsyncLocalStorage). When you render or send **inside** a hook, route, job, or service, they're fully populated. If you call `renderTemplate`/`sendTemplate` from a bare script with no surrounding scope, those services resolve to an empty `{}`, only `input` and `locale` are guaranteed. Send from within a handler, or wrap standalone calls in an app context.
+  The handler's `db`, `collections`, and other services are resolved from the active request/job context (AsyncLocalStorage). When you render or send **inside** a hook, route, job, or service, they're fully populated. If you call `renderTemplate`/`sendTemplate` from a bare script with no surrounding scope, those
+  services resolve to an empty `{}`, only `input` and `locale` are guaranteed. Send from within a handler, or wrap standalone calls in an app context.
 </Callout>
 
 ## Sending: `send` vs `sendTemplate`
@@ -187,23 +187,23 @@ Use this for anything you've defined as a template. It renders the template (val
 
 ```ts
 await ctx.email.sendTemplate({
-  template: "welcome",                          // a known template key (autocompletes)
-  input: { name: "Ada", activationLink: "…" },  // typed from that template's schema
-  to: "ada@example.com",                        // string | string[]
+  template: "welcome", // a known template key (autocompletes)
+  input: { name: "Ada", activationLink: "…" }, // typed from that template's schema
+  to: "ada@example.com", // string | string[]
   // subject?, defaults to the rendered subject if omitted
   // from?, cc?, bcc?, locale?, all optional
 });
 ```
 
-| Option | Type | Notes |
-|---|---|---|
-| `template` | `keyof TTemplates` | Required. The template key (camelCased filename). |
-| `input` | inferred from template schema | Required. Validated by the template's Zod schema. |
-| `to` | `string \| string[]` | Required. |
-| `subject` | `string` | Optional. Falls back to the template's rendered `subject`. |
-| `from` | `string` | Optional. Falls back to `defaults.from`. |
-| `cc` / `bcc` | `string \| string[]` | Optional. |
-| `locale` | `string` | Optional. Passed to the handler as `args.locale`. |
+| Option       | Type                          | Notes                                                      |
+| ------------ | ----------------------------- | ---------------------------------------------------------- |
+| `template`   | `keyof TTemplates`            | Required. The template key (camelCased filename).          |
+| `input`      | inferred from template schema | Required. Validated by the template's Zod schema.          |
+| `to`         | `string \| string[]`          | Required.                                                  |
+| `subject`    | `string`                      | Optional. Falls back to the template's rendered `subject`. |
+| `from`       | `string`                      | Optional. Falls back to `defaults.from`.                   |
+| `cc` / `bcc` | `string \| string[]`          | Optional.                                                  |
+| `locale`     | `string`                      | Optional. Passed to the handler as `args.locale`.          |
 
 <Callout type="info" title="sendTemplate is the narrower surface">
 `sendTemplate` does **not** accept `attachments`, `headers`, or `replyTo`, only `send` does. If you need those alongside a template, call `renderTemplate` to get `{ subject, html, text }`, then pass it to `send` with your extras.
@@ -216,30 +216,28 @@ Use this for messages that don't have a template, or when you need attachments, 
 ```ts
 await ctx.email.send({
   to: "ada@example.com",
-  subject: "Your export is ready",   // required for send()
+  subject: "Your export is ready", // required for send()
   html: "<p>Download it <a href='…'>here</a>.</p>",
-  attachments: [
-    { filename: "report.csv", content: csvBuffer, contentType: "text/csv" },
-  ],
+  attachments: [{ filename: "report.csv", content: csvBuffer, contentType: "text/csv" }],
 });
 ```
 
 `send` takes the full `MailOptions`:
 
-| Option | Type | Notes |
-|---|---|---|
-| `to` | `string \| string[]` | Required. |
-| `subject` | `string` | Required (unlike `sendTemplate`, where it's optional). |
-| `html` | `string` | At least one of `html` / `text` must be present. |
-| `text` | `string` | Auto-derived from `html` if omitted. |
-| `from` | `string` | Optional. Falls back to `defaults.from`, then `"noreply@example.com"`. |
-| `cc` / `bcc` | `string \| string[]` | Optional. |
-| `replyTo` | `string` | Optional. |
-| `attachments` | `Array<{ filename; content: Buffer \| string; contentType? }>` | Optional. |
-| `headers` | `Record<string, string>` | Optional. |
+| Option        | Type                                                           | Notes                                                                  |
+| ------------- | -------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| `to`          | `string \| string[]`                                           | Required.                                                              |
+| `subject`     | `string`                                                       | Required (unlike `sendTemplate`, where it's optional).                 |
+| `html`        | `string`                                                       | At least one of `html` / `text` must be present.                       |
+| `text`        | `string`                                                       | Auto-derived from `html` if omitted.                                   |
+| `from`        | `string`                                                       | Optional. Falls back to `defaults.from`, then `"noreply@example.com"`. |
+| `cc` / `bcc`  | `string \| string[]`                                           | Optional.                                                              |
+| `replyTo`     | `string`                                                       | Optional.                                                              |
+| `attachments` | `Array<{ filename; content: Buffer \| string; contentType? }>` | Optional.                                                              |
+| `headers`     | `Record<string, string>`                                       | Optional.                                                              |
 
 <Callout type="warn" title="send needs a body and a subject">
-`send` throws `"No text or html provided"` if both `html` and `text` are empty, and `subject` is required on the type. For templates, prefer `sendTemplate` so the rendered subject is your fallback.
+  `send` throws `"No text or html provided"` if both `html` and `text` are empty, and `subject` is required on the type. For templates, prefer `sendTemplate` so the rendered subject is your fallback.
 </Callout>
 
 ### `renderTemplate(options)`, render without sending
@@ -275,7 +273,7 @@ afterChange: ({ data, operation, onAfterCommit, email }) => {
 ```
 
 <Callout type="warn" title="Don't send inside an open transaction">
-Send from `onAfterCommit`, not directly in `beforeChange`/`afterChange`. A template handler that reads the database while a write transaction is still open can deadlock, and mail sent before commit will be wrong if the transaction rolls back. See [Hooks](/docs/concepts/hooks) for the commit lifecycle.
+  Send from `onAfterCommit`, not directly in `beforeChange`/`afterChange`. A template handler that reads the database while a write transaction is still open can deadlock, and mail sent before commit will be wrong if the transaction rolls back. See [Hooks](/docs/concepts/hooks) for the commit lifecycle.
 </Callout>
 
 ## Configuration
@@ -284,9 +282,9 @@ The `email` key on `runtimeConfig({ ... })` is a `MailerConfig`:
 
 ```ts
 interface MailerConfig {
-  adapter?: MailAdapter | Promise<MailAdapter>;         // required in practice (see gotcha above)
-  defaults?: { from?: string };                         // default 'from' for every message
-  templates?: Record<string, EmailTemplateDefinition>;  // populated by codegen, don't hand-write
+  adapter?: MailAdapter | Promise<MailAdapter>; // required in practice (see gotcha above)
+  defaults?: { from?: string }; // default 'from' for every message
+  templates?: Record<string, EmailTemplateDefinition>; // populated by codegen, don't hand-write
 }
 ```
 
@@ -294,14 +292,13 @@ interface MailerConfig {
 - **`defaults.from`**, used whenever a `send`/`sendTemplate` call omits `from`. If neither is set, the serializer falls back to `"noreply@example.com"`.
 - **`templates`**, collected automatically from `emails/*.ts` by codegen. You normally never write this by hand.
 
-
-
 ## Adapters
 
 An adapter is the delivery backend. All four extend `MailAdapter` (one abstract method, `send(options: SerializableMailOptions)`) and each lives on its own import path. Pick one; your templates and send calls don't change.
 
 <Callout type="info" title="Adapters import from their own subpath">
-The concrete adapters are **not** re-exported from the root `questpie` barrel, only the abstract `MailAdapter` base and the mailer types are (via `questpie/mailer`). Import each adapter from its dedicated subpath: `questpie/adapters/console`, `questpie/adapters/smtp`, `questpie/adapters/resend`, `questpie/adapters/plunk`.
+  The concrete adapters are **not** re-exported from the root `questpie` barrel, only the abstract `MailAdapter` base and the mailer types are (via `questpie/mailer`). Import each adapter from its dedicated subpath: `questpie/adapters/console`, `questpie/adapters/smtp`, `questpie/adapters/resend`,
+  `questpie/adapters/plunk`.
 </Callout>
 
 ### Console, `questpie/adapters/console`
@@ -311,15 +308,13 @@ Logs the message to your logger instead of sending. Use it in development and te
 ```ts
 import { ConsoleAdapter } from "questpie/adapters/console";
 
-new ConsoleAdapter({ logHtml: false });  // both options optional
+new ConsoleAdapter({ logHtml: false }); // both options optional
 ```
 
-| Option | Type | Default | Notes |
-|---|---|---|---|
-| `logHtml` | `boolean` | `false` | When `false`, the HTML body is suppressed with a hint instead of printed. |
-| `logger` | `(message: string) => void` | `console.log` | Where the formatted email is written. |
-
-
+| Option    | Type                        | Default       | Notes                                                                     |
+| --------- | --------------------------- | ------------- | ------------------------------------------------------------------------- |
+| `logHtml` | `boolean`                   | `false`       | When `false`, the HTML body is suppressed with a hint instead of printed. |
+| `logger`  | `(message: string) => void` | `console.log` | Where the formatted email is written.                                     |
 
 ### SMTP, `questpie/adapters/smtp`
 
@@ -339,10 +334,10 @@ new SmtpAdapter({
 // or: new SmtpAdapter({ transport: "smtp://user:pass@smtp.example.com:587" })
 ```
 
-| Option | Type | Notes |
-|---|---|---|
-| `transport` | `SMTPTransport \| SMTPTransport.Options \| string` | Passed to `nodemailer.createTransport`. |
-| `afterSendCallback` | `(info) => void \| Promise<void>` | Optional. Runs after each send, handy for logging. |
+| Option              | Type                                               | Notes                                              |
+| ------------------- | -------------------------------------------------- | -------------------------------------------------- |
+| `transport`         | `SMTPTransport \| SMTPTransport.Options \| string` | Passed to `nodemailer.createTransport`.            |
+| `afterSendCallback` | `(info) => void \| Promise<void>`                  | Optional. Runs after each send, handy for logging. |
 
 `SmtpAdapter` also has `verify(): Promise<boolean>` (proxies the nodemailer connection check).
 
@@ -360,14 +355,14 @@ import { resendAdapter } from "questpie/adapters/resend";
 resendAdapter({ apiKey: process.env.RESEND_API_KEY! });
 ```
 
-| Option | Type | Default | Notes |
-|---|---|---|---|
-| `apiKey` | `string` | none | Required. |
-| `baseUrl` | `string` | `"https://api.resend.com"` | Point at a Resend-compatible endpoint; trailing slashes are stripped. |
-| `idempotencyKey` | `string \| (options) => string \| undefined` | none | Sets the `Idempotency-Key` header, static or computed per email. |
-| `fetch` | `typeof fetch` | global `fetch` | Override for tests / non-standard runtimes. |
-| `userAgent` | `string` | `"questpie-resend-adapter"` | Resend requires this for direct HTTP calls. |
-| `afterSendCallback` | `(response, options) => void \| Promise<void>` | none | Receives the parsed Resend response (`{ id? }`). |
+| Option              | Type                                           | Default                     | Notes                                                                 |
+| ------------------- | ---------------------------------------------- | --------------------------- | --------------------------------------------------------------------- |
+| `apiKey`            | `string`                                       | none                        | Required.                                                             |
+| `baseUrl`           | `string`                                       | `"https://api.resend.com"`  | Point at a Resend-compatible endpoint; trailing slashes are stripped. |
+| `idempotencyKey`    | `string \| (options) => string \| undefined`   | none                        | Sets the `Idempotency-Key` header, static or computed per email.      |
+| `fetch`             | `typeof fetch`                                 | global `fetch`              | Override for tests / non-standard runtimes.                           |
+| `userAgent`         | `string`                                       | `"questpie-resend-adapter"` | Resend requires this for direct HTTP calls.                           |
+| `afterSendCallback` | `(response, options) => void \| Promise<void>` | none                        | Receives the parsed Resend response (`{ id? }`).                      |
 
 Throws `Resend API error (status statusText): body` on a non-2xx response.
 
@@ -381,22 +376,22 @@ import { plunkAdapter } from "questpie/adapters/plunk";
 plunkAdapter({ apiKey: process.env.PLUNK_SECRET_KEY! });
 ```
 
-| Option | Type | Default | Notes |
-|---|---|---|---|
-| `apiKey` | `string` | none | Required, must be a **secret** key (public keys only track events). |
-| `baseUrl` | `string` | `"https://next-api.useplunk.com"` | Override for self-hosted Plunk. |
-| `fromName` | `string` | none | Applied only when `from` is a bare email with no display name. |
-| `subscribed` | `boolean` | none | Toggles Plunk's marketing-subscribe flag; leave unset for transactional mail. |
-| `fetch` | `typeof fetch` | global `fetch` | Override for tests. |
-| `afterSendCallback` | `(response, options) => void \| Promise<void>` | none | Receives the parsed Plunk response. |
+| Option              | Type                                           | Default                           | Notes                                                                         |
+| ------------------- | ---------------------------------------------- | --------------------------------- | ----------------------------------------------------------------------------- |
+| `apiKey`            | `string`                                       | none                              | Required, must be a **secret** key (public keys only track events).           |
+| `baseUrl`           | `string`                                       | `"https://next-api.useplunk.com"` | Override for self-hosted Plunk.                                               |
+| `fromName`          | `string`                                       | none                              | Applied only when `from` is a bare email with no display name.                |
+| `subscribed`        | `boolean`                                      | none                              | Toggles Plunk's marketing-subscribe flag; leave unset for transactional mail. |
+| `fetch`             | `typeof fetch`                                 | global `fetch`                    | Override for tests.                                                           |
+| `afterSendCallback` | `(response, options) => void \| Promise<void>` | none                              | Receives the parsed Plunk response.                                           |
 
 <Callout type="warn" title="Plunk rejects cc/bcc">
-The Plunk adapter throws if a message sets `cc` or `bcc`, Plunk's transactional API doesn't document them. It also treats a `success: false` body as an error even on an HTTP 2xx. If you need cc/bcc, use SMTP or Resend.
+  The Plunk adapter throws if a message sets `cc` or `bcc`, Plunk's transactional API doesn't document them. It also treats a `success: false` body as an error even on an HTTP 2xx. If you need cc/bcc, use SMTP or Resend.
 </Callout>
 
 ### Custom adapter
 
-Adapters are an extension point: any class extending `MailAdapter` works, and the framework's own four adapters use that exact same base class, there's no privileged internal API. Implement the single `send(options: SerializableMailOptions)` method. By the time it's called, `from`, `text`, and `html` are guaranteed non-empty strings (the mailer serializes before handing off), so you don't re-derive plain text or default the sender.
+Any class extending `MailAdapter` can provide delivery; built-in and custom adapters share this contract. Implement `send(options: SerializableMailOptions)`. The mailer passes non-empty `from`, `text`, and `html` strings, so the adapter can focus on provider delivery.
 
 ```ts
 import { MailAdapter } from "questpie/mailer";
@@ -433,15 +428,15 @@ The full set of exported types (all from `questpie/mailer`, most also from `ques
 
 ```ts
 import type {
-  EmailTemplateDefinition,   // the { name, schema, handler } shape
-  EmailResult,               // { subject, html, text? }
-  EmailHandlerArgs,          // AppContext & { input; locale? }
-  EmailTemplateNames,        // keyof a templates record
-  GetEmailTemplate,          // index a templates record by name
-  MailOptions,               // the argument to send()
-  SerializableMailOptions,   // the post-serialize shape every adapter receives
-  MailerConfig,              // the email config object
-  InferEmailTemplateInput,   // extract a template's input type
+  EmailTemplateDefinition, // the { name, schema, handler } shape
+  EmailResult, // { subject, html, text? }
+  EmailHandlerArgs, // AppContext & { input; locale? }
+  EmailTemplateNames, // keyof a templates record
+  GetEmailTemplate, // index a templates record by name
+  MailOptions, // the argument to send()
+  SerializableMailOptions, // the post-serialize shape every adapter receives
+  MailerConfig, // the email config object
+  InferEmailTemplateInput, // extract a template's input type
 } from "questpie/mailer";
 ```
 

--- a/apps/docs/content/docs/concepts/environment.mdx
+++ b/apps/docs/content/docs/concepts/environment.mdx
@@ -9,7 +9,7 @@ Your app needs `DATABASE_URL`, an auth secret, an app URL, and some of those val
 
 ## What it does
 
-- **Validate at boot, fail fast.** `env()` runs your schemas the moment `env.ts` is evaluated, and the generated app imports `env.ts` *before* the runtime config. A missing or malformed var throws before `new Questpie()`, before any adapter, auth, or DB connection.
+- **Validate at boot, fail fast.** `env()` runs your schemas the moment `env.ts` is evaluated, and the generated app imports `env.ts` _before_ the runtime config. A missing or malformed var throws before `new Questpie()`, before any adapter, auth, or DB connection.
 - **Typed `env.*` end to end.** Each schema's output type flows into the returned object. `env.DATABASE_URL` is `string`, `env.SMTP_PORT` is `number`, typos and wrong types are compile errors.
 - **Server / client split that the type system enforces.** Server secrets live in `env.ts`; public vars live in `env.client.ts`. Declaring a server var with a public prefix (`NEXT_PUBLIC_`, `VITE_`, …) is a **compile error**.
 - **One definition, every bundler.** `clientEnv({ consumers: ["next", "vite", "expo"] })` and codegen emits a `.generated/env.client.<consumer>.ts` per consumer, each inlining the physical prefixed var the bundler understands.
@@ -62,7 +62,7 @@ That's it. Server code reads the validated `env` (default export of `env.ts`); b
 // Server (env.ts is server-only):
 import env from "./env";
 env.DATABASE_URL; // string
-env.APP_URL;      // string, client vars are validated server-side too
+env.APP_URL; // string, client vars are validated server-side too
 
 // Browser (never import env.ts, import the generated module):
 import { env } from "./.generated/env.client.vite";
@@ -70,7 +70,8 @@ env.APP_URL; // string, inlined from import.meta.env.VITE_APP_URL at build time
 ```
 
 <Callout type="info" title="Two files, two factories, one source of truth">
-`env.ts` → `env()` (server, validated at boot). `env.client.ts` → `clientEnv()` (a pure definition, no validation, no env reads). The client vars are declared **once** in `env.client.ts` and consumed in both places: the server validates them under their unprefixed name, and the browser gets them through the generated module under their prefixed name. You never write the prefix yourself.
+  `env.ts` → `env()` (server, validated at boot). `env.client.ts` → `clientEnv()` (a pure definition, no validation, no env reads). The client vars are declared **once** in `env.client.ts` and consumed in both places: the server validates them under their unprefixed name, and the browser gets them through the generated
+  module under their prefixed name. You never write the prefix yourself.
 </Callout>
 
 ## Example → real output
@@ -86,9 +87,13 @@ import _envClient from "../env.client";
 import { resolveClientEnv } from "questpie/env-client";
 
 /** Typed client env for the vite consumer, server keys are physically absent. */
-export const env = resolveClientEnv(_envClient, {
-  APP_URL: import.meta.env.VITE_APP_URL,
-}, "vite");
+export const env = resolveClientEnv(
+  _envClient,
+  {
+    APP_URL: import.meta.env.VITE_APP_URL,
+  },
+  "vite",
+);
 export type ClientEnv = typeof env;
 ```
 
@@ -115,16 +120,17 @@ The two sides read the same logical vars from different places, by design, so a 
 - A **server** var is read by its exact name only (`DATABASE_URL`).
 - A **client** var is read by its unprefixed name first, then each consumer's prefixed spelling as a fallback, **unprefixed wins**. With `consumers: ["vite"]`, `APP_URL` resolves as `APP_URL ?? VITE_APP_URL`. This is why a single dev `.env` with `APP_URL=…` satisfies both server and browser.
 
-**Browser (generated module):** the generated `env.client.<consumer>.ts` reads **only** the physical prefixed literal (`import.meta.env.VITE_APP_URL`) so the bundler inlines it, then validates via `resolveClientEnv()`. There is no unprefixed fallback in the browser, the value must be present, with its public prefix, in the build environment.
+**Browser (generated module):** the generated `env.client.<consumer>.ts` reads the physical prefixed literal (`import.meta.env.VITE_APP_URL`) so the bundler can inline it, then validates through `resolveClientEnv()`. Provide the public-prefixed value in the build environment.
 
 <Callout type="warn" title="In production, prefix your client vars">
-The unprefixed fallback only helps on the server. A browser bundle can only see vars the bundler inlined, which means the **prefixed** name. Ship `VITE_APP_URL` / `NEXT_PUBLIC_APP_URL` / `EXPO_PUBLIC_APP_URL` in your production environment (e.g. EAS, Vercel, your CI), not bare `APP_URL`. If it's missing, `resolveClientEnv()` throws at import of the generated module, and its error names the **physical** var (`VITE_APP_URL`) so the fix is obvious.
+  The unprefixed fallback only helps on the server. A browser bundle can only see vars the bundler inlined, which means the **prefixed** name. Ship `VITE_APP_URL` / `NEXT_PUBLIC_APP_URL` / `EXPO_PUBLIC_APP_URL` in your production environment (e.g. EAS, Vercel, your CI), not bare `APP_URL`. If it's missing,
+  `resolveClientEnv()` throws at import of the generated module, and its error names the **physical** var (`VITE_APP_URL`) so the fix is obvious.
 </Callout>
 
 ## `env()`, server API
 
 ```ts
-function env<TServer, TClient>(options: EnvOptions<TServer, TClient>): ResolvedEnv<TServer, TClient>
+function env<TServer, TClient>(options: EnvOptions<TServer, TClient>): ResolvedEnv<TServer, TClient>;
 ```
 
 Import from `questpie/env`. Call it as the **default export** of `env.ts`. It validates at call time (= when `env.ts` is evaluated) and returns a frozen, typed object.
@@ -144,7 +150,8 @@ server: {
 ```
 
 <Callout type="warn" title="A server var with a public prefix is a compile error">
-`env.ts` is server-only, so a key named `NEXT_PUBLIC_API_KEY` (or `VITE_*`, `EXPO_PUBLIC_*`, `PUBLIC_*`) under `server` is almost certainly a mistake, it reads like a secret but would be inlined into client bundles. The `ValidateServerKeys` mapped type turns any such key into `["server var must not use a client prefix", K]`, so the schema no longer type-checks. Public vars belong in `env.client.ts`.
+  `env.ts` is server-only, so a key named `NEXT_PUBLIC_API_KEY` (or `VITE_*`, `EXPO_PUBLIC_*`, `PUBLIC_*`) under `server` is almost certainly a mistake, it reads like a secret but would be inlined into client bundles. The `ValidateServerKeys` mapped type turns any such key into `["server var must not use a client
+  prefix", K]`, so the schema no longer type-checks. Public vars belong in `env.client.ts`.
 </Callout>
 
 ### `client`
@@ -160,13 +167,10 @@ env({
   client,
   server: { BETTER_AUTH_SECRET: z.string().min(32) },
   refine: (e) => {
-    if (e.NODE_ENV === "production" && e.BETTER_AUTH_SECRET === "dev-secret")
-      return "BETTER_AUTH_SECRET must not be the dev default in production";
+    if (e.NODE_ENV === "production" && e.BETTER_AUTH_SECRET === "dev-secret") return "BETTER_AUTH_SECRET must not be the dev default in production";
   },
 });
 ```
-
-
 
 ### `skipValidation`
 
@@ -185,7 +189,7 @@ env({
 </Callout>
 
 <Callout type="warn" title="Schemas must be synchronous">
-Validation is synchronous. If any schema's `validate` returns a `Promise` (an async refinement), `env()` throws a clear error naming the var. Keep `env.ts` schemas sync.
+  Validation is synchronous. If any schema's `validate` returns a `Promise` (an async refinement), `env()` throws a clear error naming the var. Keep `env.ts` schemas sync.
 </Callout>
 
 ### The framework base preset
@@ -205,13 +209,13 @@ server: {
 Your `server` keys and client `vars` win over base keys with the same name (the base key is omitted from the result type where you override it).
 
 <Callout type="info" title="Why the base vars are all optional">
-Presence varies by deployment, Cloud injects `QUESTPIE_DB`, self-host uses `DATABASE_URL`, an explicit `db: { url }` in config needs neither. So the base schema can't statically require any of them; the **runtime resolvers** enforce what they actually need. Re-declare a var in `server` when *your* app requires it.
+  Presence varies by deployment, Cloud injects `QUESTPIE_DB`, self-host uses `DATABASE_URL`, an explicit `db: {url}` in config needs neither. So the base schema can't statically require any of them; the **runtime resolvers** enforce what they actually need. Re-declare a var in `server` when *your* app requires it.
 </Callout>
 
 ## `clientEnv()`, client definition API
 
 ```ts
-function clientEnv<TVars, TConsumers>(def: { consumers: TConsumers; vars: TVars }): ClientEnvDefinition<TVars, TConsumers>
+function clientEnv<TVars, TConsumers>(def: { consumers: TConsumers; vars: TVars }): ClientEnvDefinition<TVars, TConsumers>;
 ```
 
 Import from `questpie/env`. Default-export it from `env.client.ts`. It's a **pure, frozen definition**, it performs no validation and reads no env. Its only runtime behavior is to fail fast on a typo'd preset name (it resolves each consumer at definition time).
@@ -220,20 +224,18 @@ Import from `questpie/env`. Default-export it from `env.client.ts`. It's a **pur
 - **`consumers`**, `readonly ClientConsumer[]`. One generated module is emitted per consumer. A consumer is either a built-in preset **name** or an explicit config object.
 
 <Callout type="warn" title="`env.client.ts` must stay a client-safe leaf">
-This file is imported by the browser (transitively, via the generated module), so it may import **only** `questpie/env` and a Standard Schema validator (Zod, etc.), nothing server-side, no secrets, no Node APIs. Keep it tiny.
+  This file is imported by the browser (transitively, via the generated module), so it may import **only** `questpie/env` and a Standard Schema validator (Zod, etc.), nothing server-side, no secrets, no Node APIs. Keep it tiny.
 </Callout>
 
 ### Consumer presets
 
 The three built-in presets map a logical var to the physical prefix + the env object your bundler inlines:
 
-| Preset | Prefix | Inlined from | Typical bundler |
-|---|---|---|---|
-| `next` | `NEXT_PUBLIC_` | `process.env` | Next.js |
-| `vite` | `VITE_` | `import.meta.env` | Vite / TanStack Start |
-| `expo` | `EXPO_PUBLIC_` | `process.env` | Expo / React Native (Metro) |
-
-
+| Preset | Prefix         | Inlined from      | Typical bundler             |
+| ------ | -------------- | ----------------- | --------------------------- |
+| `next` | `NEXT_PUBLIC_` | `process.env`     | Next.js                     |
+| `vite` | `VITE_`        | `import.meta.env` | Vite / TanStack Start       |
+| `expo` | `EXPO_PUBLIC_` | `process.env`     | Expo / React Native (Metro) |
 
 ```ts
 clientEnv({
@@ -243,7 +245,8 @@ clientEnv({
 ```
 
 <Callout type="info" title="`PUBLIC_` is a guarded prefix, not a preset">
-The compile-time guard rejects four public prefixes on server vars, `EXPO_PUBLIC_`, `VITE_`, `NEXT_PUBLIC_`, and `PUBLIC_`, but only three have built-in presets. `PUBLIC_` (the SvelteKit-style spelling) is reserved so it can't slip into `server`, but there's no built-in `"public"` consumer; supply a custom consumer config (below) if you need it.
+  The compile-time guard rejects four public prefixes on server vars, `EXPO_PUBLIC_`, `VITE_`, `NEXT_PUBLIC_`, and `PUBLIC_`, but only three have built-in presets. `PUBLIC_` (the SvelteKit-style spelling) is reserved so it can't slip into `server`, but there's no built-in `"public"` consumer; supply a custom consumer
+  config (below) if you need it.
 </Callout>
 
 ### Custom bundlers, a `ClientConsumerConfig`
@@ -252,10 +255,7 @@ For any bundler without a built-in preset, pass an explicit config instead of a 
 
 ```ts
 clientEnv({
-  consumers: [
-    "vite",
-    { name: "sveltekit", prefix: "PUBLIC_", envObject: "import.meta.env" },
-  ],
+  consumers: ["vite", { name: "sveltekit", prefix: "PUBLIC_", envObject: "import.meta.env" }],
   vars: { APP_URL: z.string().url() },
 });
 // emits env.client.vite.ts AND env.client.sveltekit.ts
@@ -264,8 +264,6 @@ clientEnv({
 - **`name`**, becomes the generated file suffix (`env.client.<name>.ts`) and the consumer label.
 - **`prefix`**, the physical prefix the bundler inlines (`"PUBLIC_"`).
 - **`envObject`**, `"process.env"` or `"import.meta.env"`, the object the bundler statically replaces member expressions on.
-
-
 
 <Callout type="warn" title="An unknown preset name throws at definition time">
 Pass a string consumer that isn't `expo` / `vite` / `next` and `clientEnv()` throws immediately, `Unknown client env consumer "…"`, listing the built-in names and telling you to pass a `{ name, prefix, envObject }` config for a custom bundler. The error fires when `env.client.ts` is evaluated, so you catch it at codegen, not at runtime.
@@ -282,7 +280,7 @@ QUESTPIE_SKIP_ENV_VALIDATION=1 questpie generate
 `questpie generate` and friends set this for you; reach for it manually only in your own build/CI scripts.
 
 <Callout type="warn" title="The skip flag only reaches the server `env()`">
-`QUESTPIE_SKIP_ENV_VALIDATION` is read at `env()` call time on the server. The **generated client module** validates unconditionally at import, skip flags can't be read after the bundler has inlined the values, so there's no way (and no reason) to skip client validation.
+  `QUESTPIE_SKIP_ENV_VALIDATION` is read at `env()` call time on the server. The **generated client module** validates unconditionally at import, skip flags can't be read after the bundler has inlined the values, so there's no way (and no reason) to skip client validation.
 </Callout>
 
 ## TypeScript
@@ -297,7 +295,7 @@ import type {
   ClientConsumer,
   ClientConsumerConfig,
   ClientConsumerPreset, // "expo" | "vite" | "next"
-  PublicVarPrefix,       // "EXPO_PUBLIC_" | "VITE_" | "NEXT_PUBLIC_" | "PUBLIC_"
+  PublicVarPrefix, // "EXPO_PUBLIC_" | "VITE_" | "NEXT_PUBLIC_" | "PUBLIC_"
   InferShape,
   StandardSchemaV1,
 } from "questpie/env";

--- a/apps/docs/content/docs/concepts/fields.mdx
+++ b/apps/docs/content/docs/concepts/fields.mdx
@@ -35,9 +35,7 @@ export const posts = collection("posts").fields(({ f }) => ({
 
 That gives you a `posts` table with the right columns, a validation schema, typed filters, and an admin form, no migrations to hand-write, no types to declare.
 
-<Callout type="info">
-  `f` is a proxy over the registered field types. Accessing an unknown type throws at build time, `Unknown field type: "x". Available types: …`, so typos surface immediately.
-</Callout>
+<Callout type="info">`f` is a proxy over the registered field types. Accessing an unknown type throws at build time, `Unknown field type: "x". Available types: …`, so typos surface immediately.</Callout>
 
 ## Example → inferred types
 
@@ -45,10 +43,10 @@ Each field flows into the generated collection types. A `notNull` field with no 
 
 ```ts
 const posts = collection("posts").fields(({ f }) => ({
-  title: f.text(255).required(),       // required on insert, string on read
-  views: f.number().default(0),         // optional on insert (has default)
+  title: f.text(255).required(), // required on insert, string on read
+  views: f.number().default(0), // optional on insert (has default)
   slug: f.text(255).required().inputOptional(), // NOT NULL column, optional input
-  author: f.relation("user").required(),// FK column, required id string
+  author: f.relation("user").required(), // FK column, required id string
 }));
 
 // After `questpie generate`, the typed client returns rows shaped like:
@@ -66,36 +64,36 @@ The public `ExtractInputType`, `ExtractSelectType`, and `ExtractWhereType` helpe
 
 ## Field types
 
-Every type below is reached as `f.<type>(…)`. The **constructor arg** is positional, there is no options-object constructor. Refine each field with the [shared methods](#shared-methods) plus the type-specific methods listed here.
+Every type below is reached as `f.<type>(…)`. Each constructor has its documented positional argument, then shared and type-specific builder methods refine the field.
 
 Each type has its own page with the full constructor, type-specific methods, operator set, and gotchas. This hub is the overview; follow a link for the detail.
 
-| Field | What it stores |
-|---|---|
-| [`f.text()`](/docs/concepts/fields/text) | Single-line string, a `varchar` (or unbounded `text`) with length, pattern, and string filtering. |
-| [`f.textarea()`](/docs/concepts/fields/textarea) | Unbounded multi-line string, a `text` column rendered as a multiline editor. |
-| [`f.email()`](/docs/concepts/fields/email) | String validated as an email address, with domain-aware filters. |
-| [`f.url()`](/docs/concepts/fields/url) | Web address, a `varchar(2048)` with URL-format validation and host/protocol filters. |
-| [`f.number()`](/docs/concepts/fields/number) | Numeric, integer, smallint, bigint, real, double, or fixed-precision decimal, with value bounds. |
-| [`f.boolean()`](/docs/concepts/fields/boolean) | True/false, a `boolean` column with equality / null filtering. |
-| [`f.date()`](/docs/concepts/fields/date) | Calendar date (no time) as an ISO date string, with auto-now stamping. |
-| [`f.datetime()`](/docs/concepts/fields/datetime) | Instant in time, a `timestamp` reading back as a JS `Date`, with precision and timezone. |
-| [`f.time()`](/docs/concepts/fields/time) | Time of day (`HH:MM:SS`) in a `time` column. |
-| [`f.select()`](/docs/concepts/fields/select) | Enumerated string, read type narrows to the literal union of the option values. |
-| [`f.upload()`](/docs/concepts/fields/upload) | Typed relation to an upload collection, single file, gallery, or inline asset IDs. |
-| [`f.object()`](/docs/concepts/fields/object) | Fixed, typed nested shape in one `jsonb` column. |
-| [`.array()`](/docs/concepts/fields/array) | Wraps any field into a list stored as `jsonb`, with length bounds. |
-| [`f.json()`](/docs/concepts/fields/json) | Schema-less `jsonb` (or `json`) for free-form data you narrow and validate yourself. |
-| [`f.richText()`](/docs/concepts/fields/rich-text) | TipTap WYSIWYG stored as structured JSONB (or markdown). Admin module only. |
+| Field                                             | What it stores                                                                                    |
+| ------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| [`f.text()`](/docs/concepts/fields/text)          | Single-line string, a `varchar` (or unbounded `text`) with length, pattern, and string filtering. |
+| [`f.textarea()`](/docs/concepts/fields/textarea)  | Unbounded multi-line string, a `text` column rendered as a multiline editor.                      |
+| [`f.email()`](/docs/concepts/fields/email)        | String validated as an email address, with domain-aware filters.                                  |
+| [`f.url()`](/docs/concepts/fields/url)            | Web address, a `varchar(2048)` with URL-format validation and host/protocol filters.              |
+| [`f.number()`](/docs/concepts/fields/number)      | Numeric, integer, smallint, bigint, real, double, or fixed-precision decimal, with value bounds.  |
+| [`f.boolean()`](/docs/concepts/fields/boolean)    | True/false, a `boolean` column with equality / null filtering.                                    |
+| [`f.date()`](/docs/concepts/fields/date)          | Calendar date (no time) as an ISO date string, with auto-now stamping.                            |
+| [`f.datetime()`](/docs/concepts/fields/datetime)  | Instant in time, a `timestamp` reading back as a JS `Date`, with precision and timezone.          |
+| [`f.time()`](/docs/concepts/fields/time)          | Time of day (`HH:MM:SS`) in a `time` column.                                                      |
+| [`f.select()`](/docs/concepts/fields/select)      | Enumerated string, read type narrows to the literal union of the option values.                   |
+| [`f.upload()`](/docs/concepts/fields/upload)      | Typed relation to an upload collection, single file, gallery, or inline asset IDs.                |
+| [`f.object()`](/docs/concepts/fields/object)      | Fixed, typed nested shape in one `jsonb` column.                                                  |
+| [`.array()`](/docs/concepts/fields/array)         | Wraps any field into a list stored as `jsonb`, with length bounds.                                |
+| [`f.json()`](/docs/concepts/fields/json)          | Schema-less `jsonb` (or `json`) for free-form data you narrow and validate yourself.              |
+| [`f.richText()`](/docs/concepts/fields/rich-text) | TipTap WYSIWYG stored as structured JSONB (or markdown). Admin module only.                       |
 
 ### Text & string
 
-| Field | Constructor | Column | Read type | Type-specific methods |
-|---|---|---|---|---|
-| `f.text(maxLength?)` | `maxLength` number (default `255`) **or** `{ mode: "text" }` for unbounded | `varchar(255)`, or `text` in `{ mode: "text" }` | `string` | `.pattern(re)` `.trim()` `.lowercase()` `.uppercase()` `.min(n)` `.max(n)` |
-| `f.textarea()` | none | `text` (unbounded) | `string` | `.min(n)` `.max(n)` |
-| `f.email(maxLength?)` | `maxLength` number (default `255`) | `varchar(maxLength)` | `string` | `.min(n)` `.max(n)` |
-| `f.url(maxLength?)` | `maxLength` number (default `2048`) | `varchar(maxLength)` | `string` | `.min(n)` `.max(n)` |
+| Field                 | Constructor                                                                | Column                                          | Read type | Type-specific methods                                                      |
+| --------------------- | -------------------------------------------------------------------------- | ----------------------------------------------- | --------- | -------------------------------------------------------------------------- |
+| `f.text(maxLength?)`  | `maxLength` number (default `255`) **or** `{ mode: "text" }` for unbounded | `varchar(255)`, or `text` in `{ mode: "text" }` | `string`  | `.pattern(re)` `.trim()` `.lowercase()` `.uppercase()` `.min(n)` `.max(n)` |
+| `f.textarea()`        | none                                                                       | `text` (unbounded)                              | `string`  | `.min(n)` `.max(n)`                                                        |
+| `f.email(maxLength?)` | `maxLength` number (default `255`)                                         | `varchar(maxLength)`                            | `string`  | `.min(n)` `.max(n)`                                                        |
+| `f.url(maxLength?)`   | `maxLength` number (default `2048`)                                        | `varchar(maxLength)`                            | `string`  | `.min(n)` `.max(n)`                                                        |
 
 ```ts
 title: f.text(255).required(),
@@ -108,14 +106,15 @@ website: f.url(),                          // validated z.string().url(), len 20
 For `text`/`textarea`/`email`/`url`, `.min(n)` / `.max(n)` constrain **string length** (they map to `minLength` / `maxLength`). `email` and `url` add `.email()` / `.url()` format validation automatically.
 
 <Callout type="warn">
-  `.trim()`, `.lowercase()`, and `.uppercase()` set runtime state but are **not currently applied to the Zod schema**, `derive-schema.ts` only emits `maxLength` / `minLength` / `pattern` for strings, so these three do not transform or validate the value yet. To normalize input, use a `.zod()` refinement or a field hook instead.
+  `.trim()`, `.lowercase()`, and `.uppercase()` set runtime state but are **not currently applied to the Zod schema**, `derive-schema.ts` only emits `maxLength` / `minLength` / `pattern` for strings, so these three do not transform or validate the value yet. To normalize input, use a `.zod()` refinement or a field hook
+  instead.
 </Callout>
 
 ### Number
 
-| Field | Constructor | Column | Read type | Type-specific methods |
-|---|---|---|---|---|
-| `f.number(mode?)` | `mode`: `"integer"` (default) `\| "smallint" \| "bigint" \| "real" \| "double"`, **or** `{ mode: "decimal"; precision?; scale? }` | `integer` / `smallint` / `bigint` / `real` / `doublePrecision` / `numeric(10, 2)` | `number` | `.min(n)` `.max(n)` `.positive()` `.int()` `.step(n)` |
+| Field             | Constructor                                                                                                                       | Column                                                                            | Read type | Type-specific methods                                 |
+| ----------------- | --------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- | --------- | ----------------------------------------------------- |
+| `f.number(mode?)` | `mode`: `"integer"` (default) `\| "smallint" \| "bigint" \| "real" \| "double"`, **or** `{ mode: "decimal"; precision?; scale? }` | `integer` / `smallint` / `bigint` / `real` / `doublePrecision` / `numeric(10, 2)` | `number`  | `.min(n)` `.max(n)` `.positive()` `.int()` `.step(n)` |
 
 ```ts
 quantity: f.number().required(),                       // integer (default mode)
@@ -128,9 +127,9 @@ Default mode is `"integer"`. `bigint` and `decimal` use Drizzle's `mode: "number
 
 ### Boolean
 
-| Field | Constructor | Column | Read type | Type-specific methods |
-|---|---|---|---|---|
-| `f.boolean()` | none | `boolean` | `boolean` | none |
+| Field         | Constructor | Column    | Read type | Type-specific methods |
+| ------------- | ----------- | --------- | --------- | --------------------- |
+| `f.boolean()` | none        | `boolean` | `boolean` | none                  |
 
 ```ts
 isActive: f.boolean().default(true).required(),
@@ -140,11 +139,11 @@ No type-specific methods, refine with the shared methods only.
 
 ### Date & time
 
-| Field | Constructor | Column | Read type | Type-specific methods |
-|---|---|---|---|---|
-| `f.date()` | none | `date` (`mode: "string"`) | `string` (ISO date) | `.autoNow()` `.autoNowUpdate()` |
-| `f.datetime(config?)` | `{ precision?: 0-6; withTimezone?: boolean }` | `timestamp` (precision `3`, `withTimezone: true`) | `Date` | `.autoNow()` `.autoNowUpdate()` |
-| `f.time(config?)` | `{ precision?: 0-6; withSeconds?: boolean }` | `time` (precision `0`) | `string` (`HH:MM:SS`) | none |
+| Field                 | Constructor                                   | Column                                            | Read type             | Type-specific methods           |
+| --------------------- | --------------------------------------------- | ------------------------------------------------- | --------------------- | ------------------------------- |
+| `f.date()`            | none                                          | `date` (`mode: "string"`)                         | `string` (ISO date)   | `.autoNow()` `.autoNowUpdate()` |
+| `f.datetime(config?)` | `{ precision?: 0-6; withTimezone?: boolean }` | `timestamp` (precision `3`, `withTimezone: true`) | `Date`                | `.autoNow()` `.autoNowUpdate()` |
+| `f.time(config?)`     | `{ precision?: 0-6; withSeconds?: boolean }`  | `time` (precision `0`)                            | `string` (`HH:MM:SS`) | none                            |
 
 ```ts
 createdAt: f.datetime().autoNow().inputFalse(),       // set once on create
@@ -157,9 +156,9 @@ opensAt: f.time(),                                     // "09:00:00"
 
 ### Select
 
-| Field | Constructor | Column | Read type | Type-specific methods |
-|---|---|---|---|---|
-| `f.select(options)` | `readonly SelectOption[]` (static) **or** an `OptionsConfig` (dynamic) | `varchar` (sized to the longest value, min `50`; `255` for dynamic) | literal union of values (static) / `string` (dynamic) | `.enum(name)` |
+| Field               | Constructor                                                            | Column                                                              | Read type                                             | Type-specific methods |
+| ------------------- | ---------------------------------------------------------------------- | ------------------------------------------------------------------- | ----------------------------------------------------- | --------------------- |
+| `f.select(options)` | `readonly SelectOption[]` (static) **or** an `OptionsConfig` (dynamic) | `varchar` (sized to the longest value, min `50`; `255` for dynamic) | literal union of values (static) / `string` (dynamic) | `.enum(name)`         |
 
 A `SelectOption` is `{ value: string \| number; label: I18nText; description?; disabled?; icon?; className? }`.
 
@@ -178,12 +177,12 @@ tags: f.select([
 ]).array(),
 ```
 
-Passing static options narrows the field's read type to the **literal union** of those values. Multi-select is `.array()`, there is no separate multi factory. Dynamic, server-driven options (search + pagination) use an `OptionsConfig` `{ handler, deps? }`; the read type then widens to `string`. `.enum(name)` creates a fresh `pgEnum` from the option values.
+Passing static options narrows the field's read type to their literal union. Chain `.array()` for multi-select. Dynamic server-driven options use `OptionsConfig { handler, deps? }`, whose read type is `string`. `.enum(name)` creates a `pgEnum` from static option values.
 
 ### Relation
 
-| Field | Constructor | Default column | Read type | Transition methods |
-|---|---|---|---|---|
+| Field                | Constructor                                                                                                | Default column               | Read type                 | Transition methods                                                                       |
+| -------------------- | ---------------------------------------------------------------------------------------------------------- | ---------------------------- | ------------------------- | ---------------------------------------------------------------------------------------- |
 | `f.relation(target)` | collection name `"user"`, lazy `() => ({ name })`, or polymorphic map `{ users: "users", posts: "posts" }` | `varchar(36)` FK (belongsTo) | `string` (the related id) | `.hasMany()` `.manyToMany()` `.multiple()` `.onDelete()` `.onUpdate()` `.relationName()` |
 
 ```ts
@@ -211,15 +210,13 @@ The default form is **belongsTo**: it owns a `varchar(36)` foreign-key column an
 
 The `target` collection name is checked against your registry once codegen runs, so a typo'd target fails to type-check.
 
-<Callout type="info">
-  `.hasMany()`, `.manyToMany()`, `.multiple()` are **transition** methods, they re-shape the field's type state. Chain them early; the order-preserving `.onDelete()` / `.onUpdate()` / `.relationName()` keep whatever state you have accumulated.
-</Callout>
+<Callout type="info">`.hasMany()`, `.manyToMany()`, `.multiple()` are **transition** methods, they re-shape the field's type state. Chain them early; the order-preserving `.onDelete()` / `.onUpdate()` / `.relationName()` keep whatever state you have accumulated.</Callout>
 
 ### Upload
 
-| Field | Constructor | Default column | Read type | Type-specific methods |
-|---|---|---|---|---|
-| `f.upload(config?)` | `{ to?; mimeTypes?; maxSize?; through?; sourceField?; targetField? }` | `varchar(36)` FK to the upload collection (default `"assets"`) | `string` (asset id) | `.multiple()` |
+| Field               | Constructor                                                           | Default column                                                 | Read type           | Type-specific methods |
+| ------------------- | --------------------------------------------------------------------- | -------------------------------------------------------------- | ------------------- | --------------------- |
+| `f.upload(config?)` | `{ to?; mimeTypes?; maxSize?; through?; sourceField?; targetField? }` | `varchar(36)` FK to the upload collection (default `"assets"`) | `string` (asset id) | `.multiple()`         |
 
 ```ts
 avatar: f.upload({ to: "assets", mimeTypes: ["image/*"], maxSize: 5_000_000 }),
@@ -229,17 +226,15 @@ gallery: f.upload({ to: "assets" }).multiple(),  // inline jsonb array of asset 
 
 `upload` is a relation specialised for files, by default it owns a `varchar(36)` FK to the `assets` collection and the admin renders an upload widget (not a relation picker). Setting `through` makes it many-to-many (virtual); `.multiple()` stores an inline `jsonb` array of asset ids.
 
-<Callout type="warn">
-  `mimeTypes` and `maxSize` are captured as admin metadata, **not** enforced as column constraints. They guide the upload UI; enforce hard limits in your storage adapter or a field hook.
-</Callout>
+<Callout type="warn">`mimeTypes` and `maxSize` are captured as admin metadata, **not** enforced as column constraints. They guide the upload UI; enforce hard limits in your storage adapter or a field hook.</Callout>
 
 ### Structured
 
-| Field | Constructor | Column | Read type | Notes |
-|---|---|---|---|---|
-| `f.object(fields)` | `Record<string, Field>` of nested fields | `jsonb` | inferred object from the nested fields | nested `outputFalse()`/virtual fields drop out of the shape |
-| `f.json(config?)` | `{ mode?: "jsonb" \| "json" }` | `jsonb` (default) or `json` | `JsonValue` (narrow with `.$type<T>()`) | schema-less |
-| `<field>.array()` | none (chain method) | `jsonb` | `T[]` of the inner read type | combine with `.minItems()` / `.maxItems()` |
+| Field              | Constructor                              | Column                      | Read type                               | Notes                                                       |
+| ------------------ | ---------------------------------------- | --------------------------- | --------------------------------------- | ----------------------------------------------------------- |
+| `f.object(fields)` | `Record<string, Field>` of nested fields | `jsonb`                     | inferred object from the nested fields  | nested `outputFalse()`/virtual fields drop out of the shape |
+| `f.json(config?)`  | `{ mode?: "jsonb" \| "json" }`           | `jsonb` (default) or `json` | `JsonValue` (narrow with `.$type<T>()`) | schema-less                                                 |
+| `<field>.array()`  | none (chain method)                      | `jsonb`                     | `T[]` of the inner read type            | combine with `.minItems()` / `.maxItems()`                  |
 
 ```ts
 // object, typed nested shape stored as one jsonb column:
@@ -265,23 +260,19 @@ Keep the QUESTPIE field type and use `.drizzle()` when the field needs column-le
 ```ts
 import { sql } from "drizzle-orm";
 
-const externalId = f
-  .text(255)
-  .drizzle((column) => column.$type<`ext_${string}`>());
+const externalId = f.text(255).drizzle((column) => column.$type<`ext_${string}`>());
 
-const createdAt = f
-  .datetime()
-  .drizzle((column) => column.default(sql`now()`));
+const createdAt = f.datetime().drizzle((column) => column.default(sql`now()`));
 ```
 
 Use `.drizzle()` for column builder details such as SQL defaults, Drizzle `$type<T>()`, or a Drizzle option that belongs to the generated column. If the field needs a new storage model, metadata shape, or operator set, create a custom field type with `field()` / `fieldType()` instead.
 
 ### Rich text & blocks (admin module)
 
-| Field | Constructor | Column | Read type |
-|---|---|---|---|
+| Field                  | Constructor                                          | Column                              | Read type                                     |
+| ---------------------- | ---------------------------------------------------- | ----------------------------------- | --------------------------------------------- |
 | `f.richText(options?)` | `{ mode?: "json" \| "markdown" }` (default `"json"`) | `jsonb` (json) or `text` (markdown) | `TipTapDocument` (json) / `string` (markdown) |
-| `f.blocks()` | none | `jsonb` | `BlocksDocument` |
+| `f.blocks()`           | none                                                 | `jsonb`                             | `BlocksDocument`                              |
 
 ```ts
 bio: f.richText().localized(),            // TipTap JSON document
@@ -291,9 +282,7 @@ body: f.blocks(),                          // block-based page builder
 
 These two are contributed by `@questpie/admin` and are only on `f` when the admin module is active. `richText` defaults to a TipTap JSON document (`mode: "markdown"` stores a markdown string instead). `blocks` stores a block tree built from your `block(name)` declarations.
 
-<Callout type="info">
-  `f.richText()` and `f.blocks()` exist only when the admin module is registered, they ride in on the generated `f` alongside the 15 core types. Without the admin module, accessing them throws the "Unknown field type" error.
-</Callout>
+<Callout type="info">`f.richText()` and `f.blocks()` exist only when the admin module is registered, they ride in on the generated `f` alongside the 15 core types. Without the admin module, accessing them throws the "Unknown field type" error.</Callout>
 
 ## Shared methods
 
@@ -301,12 +290,12 @@ These chain methods are available on **every** field type. Each returns a new im
 
 ### Schema & nullability
 
-| Method | Effect |
-|---|---|
-| `.required()` | `NOT NULL` column + required on input (unless it has a default or is `inputOptional`). |
+| Method            | Effect                                                                                                                            |
+| ----------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `.required()`     | `NOT NULL` column + required on input (unless it has a default or is `inputOptional`).                                            |
 | `.default(value)` | Column default, literal, a `() => value` factory, or raw `SQL`. Makes input optional. Type-checked against the field's data type. |
-| `.zod(fn)` | Transform the auto-derived Zod schema (`.refine()`, or replace it). Returning a concrete output narrows the field's value type. |
-| `.$type<T>()` | Type-level only (no runtime effect), pin the value type, mainly for `f.json()`. Pair with `.zod()` for runtime validation. |
+| `.zod(fn)`        | Transform the auto-derived Zod schema (`.refine()`, or replace it). Returning a concrete output narrows the field's value type.   |
+| `.$type<T>()`     | Type-level only (no runtime effect), pin the value type, mainly for `f.json()`. Pair with `.zod()` for runtime validation.        |
 
 ```ts
 email: f.email().required(),
@@ -321,16 +310,16 @@ metadata: f.json<{ flags: string[] }>(),
 
 ### Input/output shaping
 
-| Method | Effect |
-|---|---|
-| `.inputFalse()` | Read-only, excluded from the insert/update input type. |
-| `.inputOptional()` | Always optional on input, even if the column is `NOT NULL`. |
-| `.inputTrue()` | Force into the input type even if the field is virtual. |
-| `.outputFalse()` | Write-only, dropped from the select/output type (e.g. a password). |
-| `.virtual(expr?)` | No DB column; optional `SQL` expression for a computed value. |
-| `.localized()` | Store per-locale values in the i18n side-table. |
-| `.array()` | Wrap the value as an array (stored as `jsonb`). For `select`, this is multi-select. |
-| `.minItems(n)` / `.maxItems(n)` | Array length bounds, only meaningful after `.array()`. |
+| Method                          | Effect                                                                              |
+| ------------------------------- | ----------------------------------------------------------------------------------- |
+| `.inputFalse()`                 | Read-only, excluded from the insert/update input type.                              |
+| `.inputOptional()`              | Always optional on input, even if the column is `NOT NULL`.                         |
+| `.inputTrue()`                  | Force into the input type even if the field is virtual.                             |
+| `.outputFalse()`                | Write-only, dropped from the select/output type (e.g. a password).                  |
+| `.virtual(expr?)`               | No DB column; optional `SQL` expression for a computed value.                       |
+| `.localized()`                  | Store per-locale values in the i18n side-table.                                     |
+| `.array()`                      | Wrap the value as an array (stored as `jsonb`). For `select`, this is multi-select. |
+| `.minItems(n)` / `.maxItems(n)` | Array length bounds, only meaningful after `.array()`.                              |
 
 ```ts
 createdAt: f.datetime().autoNow().inputFalse(),
@@ -343,13 +332,13 @@ tags: f.text().array().maxItems(10),
 
 ### Behaviour & access
 
-| Method | Effect |
-|---|---|
-| `.label(text)` / `.description(text)` | Admin label/help text. `I18nText` = `string \| Record<locale, string>`. |
-| `.hooks(hooks)` | Per-field `beforeChange` / `afterRead` / `validate` / `beforeCreate` / `beforeUpdate`. Each transforms the value (same type in, same type out). |
-| `.access(rules)` | Per-field `read` / `create` / `update` access, `boolean` or `(ctx) => boolean \| Promise<boolean>`. |
-| `.operators(ops)` | Override the WHERE operator set for this field. |
-| `.admin(config)` | Per-field admin UI config (component, placeholder, layout, …). Admin module only. |
+| Method                                | Effect                                                                                                                                          |
+| ------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `.label(text)` / `.description(text)` | Admin label/help text. `I18nText` = `string \| Record<locale, string>`.                                                                         |
+| `.hooks(hooks)`                       | Per-field `beforeChange` / `afterRead` / `validate` / `beforeCreate` / `beforeUpdate`. Each transforms the value (same type in, same type out). |
+| `.access(rules)`                      | Per-field `read` / `create` / `update` access, `boolean` or `(ctx) => boolean \| Promise<boolean>`.                                             |
+| `.operators(ops)`                     | Override the WHERE operator set for this field.                                                                                                 |
+| `.admin(config)`                      | Per-field admin UI config (component, placeholder, layout, …). Admin module only.                                                               |
 
 ```ts
 price: f.number({ mode: "decimal" }).label({ en: "Price", sk: "Cena" }),
@@ -359,16 +348,17 @@ phone: f.text(50).admin({ placeholder: "+1 (555) 000-0000" }),
 ```
 
 <Callout type="warn">
-  Field `afterRead` hooks (and `f.blocks()`'s built-in afterRead) run output processing that can deadlock Bun SQL if executed inside an already-open transaction, the context-inherited tx connection blocks. Keep heavy afterRead/block hydration outside an open `tx`. See the framework invariant in `CLAUDE.md` (`feedback_save_inside_tx`).
+  Field `afterRead` hooks (and `f.blocks()`'s built-in afterRead) run output processing that can deadlock Bun SQL if executed inside an already-open transaction, the context-inherited tx connection blocks. Keep heavy afterRead/block hydration outside an open `tx`. See the framework invariant in `CLAUDE.md`
+  (`feedback_save_inside_tx`).
 </Callout>
 
 ### Low-level escape hatches
 
-| Method | Effect |
-|---|---|
-| `.drizzle(fn)` | Customize the underlying Drizzle column builder (``.default(sql`...`)``, `.$type<T>()`). Applied last when building the column. |
-| `.fromDb(fn)` / `.toDb(fn)` | Pure value mappers at the DB boundary (no type change). |
-| `.set(key, value)` | Generic plugin-extension setter (what `.admin()` / `.form()` use under the hood). |
+| Method                      | Effect                                                                                                                          |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `.drizzle(fn)`              | Customize the underlying Drizzle column builder (``.default(sql`...`)``, `.$type<T>()`). Applied last when building the column. |
+| `.fromDb(fn)` / `.toDb(fn)` | Pure value mappers at the DB boundary (no type change).                                                                         |
+| `.set(key, value)`          | Generic plugin-extension setter (what `.admin()` / `.form()` use under the hood).                                               |
 
 ```ts
 createdAt: f.datetime().drizzle((c) => c.default(sql`now()`)),
@@ -386,10 +376,6 @@ The shared methods above are available on every registered field type.
 
 A new field type is declared with `fieldType(name, { create, methods })`, the declarative way to add a type with its own chain methods. Every built-in exports a matching `<name>FieldType` (`textFieldType`, `numberFieldType`, `relationFieldType`, …) that codegen discovers from your `fields/` directories.
 
-### Custom operator sets
-
-`.operators(ops)` overrides the WHERE operators for a field. Build a set with `operator<TValue>((col, value, ctx) => SQL)` / `operatorSet(...)`. Built-in field types register their corresponding string, number, boolean, date, select, and relation operator sets automatically.
-
 ## TypeScript
 
 Fields are the single origin of your collection's read/insert/where types, you rarely touch field types directly. After `questpie generate`, import the projected collection types:
@@ -397,15 +383,13 @@ Fields are the single origin of your collection's read/insert/where types, you r
 ```ts
 import type { CollectionDoc, CollectionWhere } from "#questpie/types";
 
-type Post = CollectionDoc<"posts">;          // the read shape
-type PostFilter = CollectionWhere<"posts">;  // the typed where clause
+type Post = CollectionDoc<"posts">; // the read shape
+type PostFilter = CollectionWhere<"posts">; // the typed where clause
 ```
 
 If you need the field primitives themselves (building a plugin or a custom field type), they are exported from `questpie` and `questpie/builders`: `Field`, `field`, `fieldType`, `FieldState`, `FieldWithMethods`, the `Extract*Type` helpers, and the reactive types. Admin's `richText` / `blocks` and their state/document types come from `@questpie/admin/fields`.
 
-<Callout type="info">
-  You don't import the field factories (`text`, `relation`, …) directly in app code, they ride in on the destructured `f` inside `.fields()`. Direct factory imports are for library/plugin authors building custom `f` proxies via `createFieldBuilder`.
-</Callout>
+<Callout type="info">You don't import the field factories (`text`, `relation`, …) directly in app code, they ride in on the destructured `f` inside `.fields()`. Direct factory imports are for library/plugin authors building custom `f` proxies via `createFieldBuilder`.</Callout>
 
 ## Related
 

--- a/apps/docs/content/docs/concepts/fields/array.mdx
+++ b/apps/docs/content/docs/concepts/fields/array.mdx
@@ -7,8 +7,8 @@ description: .array() wraps any field type into a list stored as a single jsonb 
 
 > **Prerequisites:** read [Fields](/docs/concepts/fields) first, this page covers only the `.array()` modifier. The `f` proxy, the chain-modifier model, and the other shared modifiers (`.required()` / `.default()` / `.localized()`) are taught there.
 
-<Callout type="info" title="There is no `f.array()` factory">
-`.array()` is a **chain modifier**, not a field type, you never call `f.array()`. You build the element field first, then wrap it: `f.text(40).array()`. It is one of the [shared modifiers](/docs/concepts/fields#shared-methods) every field carries.
+<Callout type="info" title="Arrays start from the element field">
+  Build the element field, then wrap it with the `.array()` chain modifier: `f.text(40).array()`. It is one of the [shared modifiers](/docs/concepts/fields#shared-methods) available on field definitions.
 </Callout>
 
 ## What it does
@@ -42,28 +42,28 @@ That gives `posts` a `tags` column typed `string[] | null` on read and a non-nul
 
 `.array()` rewrites four things on the field state.
 
-| Aspect | Before `.array()` | After `.array()` |
-|---|---|---|
-| **Data type** | `T` (the inner field's data) | `T[]` |
-| **Column** | the inner column (e.g. `varchar(40)`) | `jsonb` (always) |
-| **Schema** | the inner Zod schema | `z.array(inner)` |
-| **Operators** | the inner set (e.g. `stringOps`) | `selectMultiOps` (membership) |
-| **`getType()`** | the inner type (`"text"`) | `"array"` |
+| Aspect          | Before `.array()`                     | After `.array()`              |
+| --------------- | ------------------------------------- | ----------------------------- |
+| **Data type**   | `T` (the inner field's data)          | `T[]`                         |
+| **Column**      | the inner column (e.g. `varchar(40)`) | `jsonb` (always)              |
+| **Schema**      | the inner Zod schema                  | `z.array(inner)`              |
+| **Operators**   | the inner set (e.g. `stringOps`)      | `selectMultiOps` (membership) |
+| **`getType()`** | the inner type (`"text"`)             | `"array"`                     |
 
-The inner field is preserved on the state (`innerField` / `innerState`), so per-element validation still runs, `f.text(40).array()` rejects an element longer than 40 characters, and `f.email().array()` rejects a non-email element. The array itself is stored verbatim as a single JSONB value; there is no separate table or row-per-item.
+Per-element validation remains active: `f.text(40).array()` rejects strings longer than 40 characters, and `f.email().array()` validates every email. The array is stored as one JSONB value. Use a related collection when items need independent rows or lifecycle.
 
 <Callout type="info" title="Order doesn't matter for length, but `.minItems()` / `.maxItems()` only apply after `.array()`">
-`.minItems(n)` and `.maxItems(n)` are no-ops unless the field is an array, they refine the `z.array(...)` schema (`arraySchema.min(n)` / `.max(n)`). On a non-array field they set state that nothing reads.
+  `.minItems(n)` and `.maxItems(n)` are no-ops unless the field is an array, they refine the `z.array(...)` schema (`arraySchema.min(n)` / `.max(n)`). On a non-array field they set state that nothing reads.
 </Callout>
 
 ## Chained methods
 
 `.array()` itself takes no arguments. The two modifiers that only make sense on an array are:
 
-| Method | Effect |
-|---|---|
+| Method         | Effect                                                             |
+| -------------- | ------------------------------------------------------------------ |
 | `.minItems(n)` | Array must have **at least** `n` elements (`z.array(...).min(n)`). |
-| `.maxItems(n)` | Array may have **at most** `n` elements (`z.array(...).max(n)`). |
+| `.maxItems(n)` | Array may have **at most** `n` elements (`z.array(...).max(n)`).   |
 
 Everything else is a [shared modifier](/docs/concepts/fields#shared-methods) and applies to the array as a whole:
 
@@ -83,15 +83,15 @@ collection("recipes").fields(({ f }) => ({
 
 An array field uses the **multi-value operator set** (`selectMultiOps`). Every operand element is typed to the inner field's filter value, a `number[]` filters on `number`, a `f.select([...]).array()` filters on its literal union.
 
-| Operator | Operand | Matches |
-|---|---|---|
-| `containsAll` | `Item[]` | Array contains **every** listed value (JSONB `@>`). |
-| `containsAny` | `Item[]` | Array contains **at least one** listed value (JSONB `?\|`). |
-| `eq` | `Item[]` | Array equals the given array **exactly** (same elements, same order). |
-| `length` | `number` | Array has exactly this many elements (`jsonb_array_length`). |
-| `isEmpty` | `boolean` | Array is `[]` **or** `null`. |
-| `isNotEmpty` | `boolean` | Array is non-empty and not null. |
-| `isNull` / `isNotNull` | `boolean` | Column is (not) null. Pass `true` to assert, `false` to invert. |
+| Operator               | Operand   | Matches                                                               |
+| ---------------------- | --------- | --------------------------------------------------------------------- |
+| `containsAll`          | `Item[]`  | Array contains **every** listed value (JSONB `@>`).                   |
+| `containsAny`          | `Item[]`  | Array contains **at least one** listed value (JSONB `?\|`).           |
+| `eq`                   | `Item[]`  | Array equals the given array **exactly** (same elements, same order). |
+| `length`               | `number`  | Array has exactly this many elements (`jsonb_array_length`).          |
+| `isEmpty`              | `boolean` | Array is `[]` **or** `null`.                                          |
+| `isNotEmpty`           | `boolean` | Array is non-empty and not null.                                      |
+| `isNull` / `isNotNull` | `boolean` | Column is (not) null. Pass `true` to assert, `false` to invert.       |
 
 ```ts
 // Posts tagged with BOTH "ts" and "cms"
@@ -136,8 +136,8 @@ type Post = typeof posts.$infer.select;
 ```ts
 import type { CollectionDoc, CollectionWhere } from "#questpie";
 
-type Post = CollectionDoc<"posts">;          // { tags: string[] | null; ratings: number[]; ... }
-type PostFilter = CollectionWhere<"posts">;  // { tags?: { containsAll?: string[]; ... } }
+type Post = CollectionDoc<"posts">; // { tags: string[] | null; ratings: number[]; ... }
+type PostFilter = CollectionWhere<"posts">; // { tags?: { containsAll?: string[]; ... } }
 ```
 
 `.required()` makes the array non-null and required on insert; without it the column is nullable (`Item[] | null`) and the insert field optional. `.minItems()` / `.maxItems()` add length validation to the derived `z.array(...)` schema but have no type-level effect. See [Fields → inferred types](/docs/concepts/fields#example--inferred-types) for how modifiers flow into the generated types.

--- a/apps/docs/content/docs/concepts/fields/boolean.mdx
+++ b/apps/docs/content/docs/concepts/fields/boolean.mdx
@@ -16,14 +16,14 @@ description: f.boolean() is a true/false field backed by a Postgres boolean colu
 
 ## Quick start
 
-Use `f.boolean()` inside a `.fields()` callback. There is no constructor argument; chain the shared modifiers to refine it.
+Use `f.boolean()` inside a `.fields()` callback, then chain shared modifiers to refine it.
 
 ```ts title="src/questpie/server/collections/posts.ts"
 import { collection } from "#questpie/factories";
 
 export const posts = collection("posts").fields(({ f }) => ({
   published: f.boolean().label("Published").default(false).required(), // NOT NULL, defaults to false
-  featured: f.boolean(),                                               // nullable boolean
+  featured: f.boolean(), // nullable boolean
 }));
 ```
 
@@ -33,22 +33,18 @@ That gives `posts` a `published` column typed `boolean` on read, required on ins
 
 `f.boolean()` takes **no arguments**. It always produces a `boolean` column with a `z.boolean()` schema.
 
-| Call | Column | Schema |
-|---|---|---|
+| Call          | Column    | Schema        |
+| ------------- | --------- | ------------- |
 | `f.boolean()` | `boolean` | `z.boolean()` |
 
 ## Chained methods
 
-`f.boolean()` has **no type-specific methods**, it returns a plain `Field`, not a `FieldWithMethods` wrapper, because there is nothing boolean-specific to refine. Shape it with the [shared modifiers](/docs/concepts/fields#shared-methods) every field carries (`.required()`, `.default()`, `.label()`, `.description()`, `.localized()`, `.array()`, `.access()`, `.hooks()`, …).
+`f.boolean()` uses the common `Field` builder. Shape it with shared modifiers such as `.required()`, `.default()`, `.label()`, `.description()`, `.localized()`, `.array()`, `.access()`, and `.hooks()`.
 
 ```ts
 collection("settings").fields(({ f }) => ({
   // Common pattern: a non-null flag with an explicit default.
-  emailNotifications: f
-    .boolean()
-    .label("Email notifications")
-    .default(true)
-    .required(),
+  emailNotifications: f.boolean().label("Email notifications").default(true).required(),
 }));
 ```
 
@@ -60,9 +56,9 @@ collection("settings").fields(({ f }) => ({
 
 `boolean` uses the **boolean operator set** (`booleanOps`), so every boolean field is filterable with these in a `where` clause. The operand is typed `boolean`.
 
-| Operator | Operand | Matches |
-|---|---|---|
-| `eq` / `ne` | `boolean` | Exact equal / not equal. |
+| Operator               | Operand   | Matches                                                                          |
+| ---------------------- | --------- | -------------------------------------------------------------------------------- |
+| `eq` / `ne`            | `boolean` | Exact equal / not equal.                                                         |
 | `isNull` / `isNotNull` | `boolean` | Column is (not) null. Pass `true` to assert the condition, `false` to invert it. |
 
 ```ts
@@ -77,7 +73,7 @@ const { docs: unset } = await app.collections.posts.find({
 });
 ```
 
-There are no `gt` / `lt` / `in` style operators, for a tri-state value (true / false / unknown), keep the column nullable and filter `isNull` / `isNotNull` alongside `eq`.
+Boolean filters use `eq`, `ne`, `isNull`, and `isNotNull`. Keep the column nullable to model a tri-state value of true, false, or unknown.
 
 For the full query language, combining field filters with `AND` / `OR` / `NOT`, pagination, and `orderBy`, see the [query reference](/docs/concepts/relations).
 
@@ -108,7 +104,7 @@ type Post = typeof posts.$infer.select;
 ```ts
 import type { CollectionDoc, CollectionWhere } from "#questpie/types";
 
-type Post = CollectionDoc<"posts">;        // { published: boolean; ... }
+type Post = CollectionDoc<"posts">; // { published: boolean; ... }
 type PostFilter = CollectionWhere<"posts">; // { published?: { eq?: boolean; ... } }
 ```
 

--- a/apps/docs/content/docs/concepts/fields/date.mdx
+++ b/apps/docs/content/docs/concepts/fields/date.mdx
@@ -9,7 +9,7 @@ description: f.date() stores a calendar date (no time) as an ISO date string, ba
 
 ## What it does
 
-- **Stores a date-only value**, a Postgres `date` column (`mode: "string"`), so there is no time-of-day or timezone component to reason about.
+- **Stores a date-only value** in a Postgres `date` column with `mode: "string"`, independent of time and timezone.
 - **Reads and writes as an ISO date string**, the value type is `string` (`"YYYY-MM-DD"`), not a `Date`. Validated by `z.string().date()`, which rejects `Date` objects and full date-time strings.
 - **Auto-stamps on write**, `.autoNow()` defaults the field on create; `.autoNowUpdate()` refreshes it on every write.
 - **Filters with comparison operators**, `eq`, `ne`, `gt`, `gte`, `lt`, `lte`, `in`, `notIn`, `isNull`, `isNotNull`, all typed against `string`.
@@ -24,7 +24,7 @@ import { collection } from "#questpie/factories";
 
 export const announcements = collection("announcements").fields(({ f }) => ({
   validFrom: f.date().label("Valid From").required(), // ISO date, NOT NULL
-  validTo: f.date().label("Valid Until"),             // nullable
+  validTo: f.date().label("Valid Until"), // nullable
 }));
 ```
 
@@ -32,29 +32,30 @@ That gives `announcements` two `date` columns typed `string` on read, one requir
 
 ## Constructor argument
 
-`f.date()` takes **no arguments**. There is no precision or timezone knob, a calendar date has neither. It always produces a `date` column in Drizzle's `mode: "string"`, so the field data is `string` and the derived schema is `z.string().date()`.
+`f.date()` produces a calendar-date column in Drizzle's `mode: "string"`. Field data is a `YYYY-MM-DD` string validated by `z.string().date()`.
 
 If you need a timestamp (a moment in time, with timezone) use [`f.datetime()`](/docs/concepts/fields/datetime); for a time of day with no date use [`f.time()`](/docs/concepts/fields/time).
 
 <Callout type="info" title="The value is a string, not a `Date`">
-A `date` field's data type is `string`, an ISO date like `"2024-01-31"`. Its schema (`z.string().date()`) rejects both `Date` objects and full ISO date-time strings (e.g. `"2024-01-31T00:00:00Z"`). Pass the bare date string when you create or update, and expect a string when you read. This is the deliberate difference from `f.datetime()`, whose data *is* a `Date`.
+  A `date` field's data type is `string`, an ISO date like `"2024-01-31"`. Its schema (`z.string().date()`) rejects both `Date` objects and full ISO date-time strings (e.g. `"2024-01-31T00:00:00Z"`). Pass the bare date string when you create or update, and expect a string when you read. This is the deliberate
+  difference from `f.datetime()`, whose data *is* a `Date`.
 </Callout>
 
 ## Chained methods
 
 These two methods are specific to `date` (on top of the [shared modifiers](/docs/concepts/fields#shared-methods) every field has). Each returns a new immutable field, so they chain in any order.
 
-| Method | Effect |
-|---|---|
-| `.autoNow()` | Sets a default of the current time on **create**, `hasDefault: true`, `defaultValue: () => new Date()`. Makes the input optional. |
-| `.autoNowUpdate()` | Adds a `beforeChange` hook that returns the current time on **every write** (create and update), merged with any existing hooks. |
+| Method             | Effect                                                                                                                            |
+| ------------------ | --------------------------------------------------------------------------------------------------------------------------------- |
+| `.autoNow()`       | Sets a default of the current time on **create**, `hasDefault: true`, `defaultValue: () => new Date()`. Makes the input optional. |
+| `.autoNowUpdate()` | Adds a `beforeChange` hook that returns the current time on **every write** (create and update), merged with any existing hooks.  |
 
 The common pattern is to pair either method with [`.inputFalse()`](/docs/concepts/fields#input-output-shaping) so the field is system-managed and never accepted from the client:
 
 ```ts
 collection("posts").fields(({ f }) => ({
-  publishedOn: f.date().autoNow().inputFalse(),     // stamped once, on create
-  reviewedOn:  f.date().autoNowUpdate().inputFalse(), // re-stamped on every write
+  publishedOn: f.date().autoNow().inputFalse(), // stamped once, on create
+  reviewedOn: f.date().autoNowUpdate().inputFalse(), // re-stamped on every write
 }));
 ```
 
@@ -66,13 +67,13 @@ Both helpers use `() => new Date()` as the value, a full timestamp, even though 
 
 `date` uses the **date-string operator set** (`dateStringOps`), so every date field is filterable with these in a `where` clause. The operand is typed `string` (or `string[]` for `in` / `notIn`), pass ISO date strings, not `Date` objects.
 
-| Operator | Operand | Matches |
-|---|---|---|
-| `eq` / `ne` | `string` | Exact equal / not equal. |
-| `gt` / `gte` | `string` | After / on-or-after the given date. |
-| `lt` / `lte` | `string` | Before / on-or-before the given date. |
-| `in` / `notIn` | `string[]` | Date is (not) in the list. |
-| `isNull` / `isNotNull` | `boolean` | Column is (not) null. |
+| Operator               | Operand    | Matches                               |
+| ---------------------- | ---------- | ------------------------------------- |
+| `eq` / `ne`            | `string`   | Exact equal / not equal.              |
+| `gt` / `gte`           | `string`   | After / on-or-after the given date.   |
+| `lt` / `lte`           | `string`   | Before / on-or-before the given date. |
+| `in` / `notIn`         | `string[]` | Date is (not) in the list.            |
+| `isNull` / `isNotNull` | `boolean`  | Column is (not) null.                 |
 
 ```ts
 // Announcements valid as of today:
@@ -85,7 +86,7 @@ const { docs } = await app.collections.announcements.find({
 });
 ```
 
-ISO date strings sort lexicographically the same way they sort chronologically, so range filters (`gte` / `lte`) and `orderBy` behave as you expect. The runtime comparison is identical to [`f.datetime()`](/docs/concepts/fields/datetime)'s; only the operand *type* differs, `date` narrows it to `string`. To combine a date filter with a [relation filter](/docs/concepts/relations) (e.g. only announcements whose `author` is active), nest both in the same `where` clause.
+ISO date strings sort lexicographically the same way they sort chronologically, so range filters (`gte` / `lte`) and `orderBy` behave as you expect. The runtime comparison is identical to [`f.datetime()`](/docs/concepts/fields/datetime)'s; only the operand _type_ differs, `date` narrows it to `string`. To combine a date filter with a [relation filter](/docs/concepts/relations) (e.g. only announcements whose `author` is active), nest both in the same `where` clause.
 
 ## When to use it
 
@@ -113,8 +114,8 @@ type Announcement = typeof announcements.$infer.select;
 ```ts
 import type { CollectionDoc, CollectionWhere } from "#questpie/types";
 
-type Announcement = CollectionDoc<"announcements">;          // { validFrom: string; ... }
-type AnnouncementFilter = CollectionWhere<"announcements">;  // { validFrom?: { gte?: string; ... } }
+type Announcement = CollectionDoc<"announcements">; // { validFrom: string; ... }
+type AnnouncementFilter = CollectionWhere<"announcements">; // { validFrom?: { gte?: string; ... } }
 ```
 
 `.required()` makes the field non-null and required on insert; without it the column is nullable and the insert field optional. `.default("2024-01-01")` (or `.autoNow()`) makes the input optional and is type-checked against `string`. See [Fields → inferred types](/docs/concepts/fields#example--inferred-types) for how modifiers flow into the generated types.

--- a/apps/docs/content/docs/concepts/fields/json.mdx
+++ b/apps/docs/content/docs/concepts/fields/json.mdx
@@ -22,8 +22,8 @@ Use `f.json()` inside a `.fields()` callback. It takes an optional config object
 import { collection } from "#questpie/factories";
 
 export const posts = collection("posts").fields(({ f }) => ({
-  metadata: f.json(),                                  // jsonb, any JSON value
-  settings: f.json<{ theme: "light" | "dark" }>(),     // typed, schema-less
+  metadata: f.json(), // jsonb, any JSON value
+  settings: f.json<{ theme: "light" | "dark" }>(), // typed, schema-less
 }));
 ```
 
@@ -33,11 +33,11 @@ That gives `posts` a `metadata` column that accepts any JSON value, and a `setti
 
 `f.json()` takes a single optional config object.
 
-| Call | Column | Schema |
-|---|---|---|
-| `f.json()` | `jsonb` | recursive `jsonValueSchema` |
+| Call                        | Column  | Schema                      |
+| --------------------------- | ------- | --------------------------- |
+| `f.json()`                  | `jsonb` | recursive `jsonValueSchema` |
 | `f.json({ mode: "jsonb" })` | `jsonb` | recursive `jsonValueSchema` |
-| `f.json({ mode: "json" })` | `json` | recursive `jsonValueSchema` |
+| `f.json({ mode: "json" })`  | `json`  | recursive `jsonValueSchema` |
 
 The `mode` selects the underlying Postgres column type. **`jsonb` (the default) is what you want**, it is stored in a decomposed binary format, supports indexing, and is faster to query; the `json` mode stores the exact input text (preserving key order and whitespace) and is rarely needed. The derived schema is the same in both modes.
 
@@ -47,12 +47,12 @@ The `mode` selects the underlying Postgres column type. **`jsonb` (the default) 
 
 ## Chained methods
 
-`f.json()` has **no type-specific methods**, it returns a plain `Field` (no `FieldWithMethods` wrapper), because there is nothing json-specific to refine. You shape it entirely with the [shared modifiers](/docs/concepts/fields#shared-methods) every field carries. Two of them are central to working with JSON.
+`f.json()` uses the common `Field` builder. Shape it with the [shared modifiers](/docs/concepts/fields#shared-methods); the following two are especially useful for JSON values.
 
-| Modifier | Effect on a JSON field |
-|---|---|
-| `.$type<T>()` | **Type-level only**, no runtime effect, pin the read/write value type to `T`. The primary way to type a JSON field.
-| `.zod(fn)` | Replace or refine the auto-derived schema to **actually validate** that shape at runtime.
+| Modifier      | Effect on a JSON field                                                                                              |
+| ------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `.$type<T>()` | **Type-level only**, no runtime effect, pin the read/write value type to `T`. The primary way to type a JSON field. |
+| `.zod(fn)`    | Replace or refine the auto-derived schema to **actually validate** that shape at runtime.                           |
 
 The type argument on `f.json<T>()` is shorthand for `.$type<T>()`, both are type-only. For runtime safety, pair the type with `.zod()`:
 
@@ -79,13 +79,13 @@ collection("users").fields(({ f }) => ({
 
 ## Filtering, operators
 
-`json` uses the **basic operator set** (`basicOps`), equality, membership, and null checks. There are no `gt` / `lt` / `contains` / path operators; a JSON field is filtered as a whole value. The operand is typed against the JSON value (or your narrowed shape via `JsonWhereInput<T>`), not `unknown`.
+`json` uses `basicOps`: equality, membership, and null checks over the whole JSON value. The operand is typed against the JSON value or your narrowed `JsonWhereInput<T>` shape. Use `f.object()` or a custom operator set for path-oriented queries.
 
-| Operator | Operand | Matches |
-|---|---|---|
-| `eq` / `ne` | the JSON value | Whole-value equal / not equal. |
-| `in` / `notIn` | array of JSON values | Whole value is (not) in the list. |
-| `isNull` / `isNotNull` | `boolean` | Column is (not) null. Pass `true` to assert, `false` to invert. |
+| Operator               | Operand              | Matches                                                         |
+| ---------------------- | -------------------- | --------------------------------------------------------------- |
+| `eq` / `ne`            | the JSON value       | Whole-value equal / not equal.                                  |
+| `in` / `notIn`         | array of JSON values | Whole value is (not) in the list.                               |
+| `isNull` / `isNotNull` | `boolean`            | Column is (not) null. Pass `true` to assert, `false` to invert. |
 
 ```ts
 // Rows whose settings exactly match this value
@@ -99,14 +99,14 @@ const { docs: unset } = await app.collections.posts.find({
 });
 ```
 
-The operators compare the value as a whole, there is no built-in filtering *inside* the JSON (by a nested key). When you need to query individual keys, model them as real fields (`f.object()` or top-level columns) instead, or add a custom operator set with `.operators()` (see [Fields → custom operator sets](/docs/concepts/fields#custom-operator-sets)).
+The built-in operators compare the JSON value as a whole. For nested-key queries, model known keys with `f.object()` or top-level columns, or add a custom operator set with `.operators()` (see [Fields → custom operator sets](/docs/concepts/fields#custom-operator-sets)).
 
 For the full query language, combining field filters with `AND` / `OR` / `NOT`, pagination, and `orderBy`, see [Fields → filtering](/docs/concepts/fields). Relation filters and hydration are covered in [Relations](/docs/concepts/relations).
 
 ## When to use it
 
 - **`f.json()`**, free-form or open-ended data with no fixed shape: a settings/preferences blob, a captured third-party webhook payload, feature-flag bags, denormalized snapshots.
-- **`f.json<T>()` + `.zod()`**, data that *does* have a shape but is more naturally one value than separate columns (and you still want type safety + validation).
+- **`f.json<T>()` + `.zod()`**, data that _does_ have a shape but is more naturally one value than separate columns (and you still want type safety + validation).
 - **Reach for [`f.object()`](/docs/concepts/fields#structured) instead** when the nested shape is fixed and you want per-key validation and admin form fields generated automatically, `f.object()` also stores `jsonb`, but each key is its own typed, validated field. Use `f.json()` only when the data is genuinely schema-less.
 - **Need to filter by a nested key?** That's a sign the data should be structured (`f.object()` or separate fields), since the JSON operators match the value as a whole.
 
@@ -119,7 +119,7 @@ tags: f.json<string[]>(),                  // a JSON array, one jsonb column
 events: f.json<Array<{ at: string; type: string }>>(),
 ```
 
-`.array()` is a [shared modifier](/docs/concepts/fields#shared-methods) for making *any field type* repeat, it isn't needed here, since the JSON value can already be an array.
+`.array()` is a [shared modifier](/docs/concepts/fields#shared-methods) for making _any field type_ repeat, it isn't needed here, since the JSON value can already be an array.
 
 ## TypeScript
 
@@ -138,8 +138,8 @@ type Post = typeof posts.$infer.select;
 ```ts
 import type { CollectionDoc, CollectionWhere } from "#questpie/types";
 
-type Post = CollectionDoc<"posts">;          // { settings: { theme: "light" | "dark" } | null; ... }
-type PostFilter = CollectionWhere<"posts">;  // { settings?: { eq?: { theme: "light" | "dark" }; ... } }
+type Post = CollectionDoc<"posts">; // { settings: { theme: "light" | "dark" } | null; ... }
+type PostFilter = CollectionWhere<"posts">; // { settings?: { eq?: { theme: "light" | "dark" }; ... } }
 ```
 
 `.required()` makes the column non-null and the input required; without it the column is nullable and the insert field optional. The `JsonValue` type is exported from `questpie` if you need it directly. See [Fields → inferred types](/docs/concepts/fields#example--inferred-types) for how modifiers flow into the generated types.

--- a/apps/docs/content/docs/concepts/fields/number.mdx
+++ b/apps/docs/content/docs/concepts/fields/number.mdx
@@ -11,7 +11,7 @@ description: f.number() is a numeric field that maps to any Postgres number colu
 
 - **Stores a number in any Postgres numeric type**, `integer` by default; switch to `smallint`, `bigint`, `real`, `double`, or fixed-precision `decimal` with one argument.
 - **Reads back as a JS `number`**, every mode (including `bigint` and `decimal`) uses Drizzle's `mode: "number"`, so you never deal with `bigint`/string values on read.
-- **Validates the value**, integer modes auto-enforce `z.number().int()`; add `.min(n)` / `.max(n)` for range bounds, `.positive()` for `> 0`, and `.step(n)` for a "multiple of n" check. Unlike text's no-op modifiers, every number method *is* wired into the schema.
+- **Validates the value**, integer modes auto-enforce `z.number().int()`; add `.min(n)` / `.max(n)` for range bounds, `.positive()` for `> 0`, and `.step(n)` for a "multiple of n" check. Unlike text's no-op modifiers, every number method _is_ wired into the schema.
 - **Filters with comparison operators**, `eq`, `ne`, `gt`, `gte`, `lt`, `lte`, `in`, `notIn`, `isNull`, `isNotNull`, all typed against `number`.
 - **Renders a number input** in the admin form.
 
@@ -23,8 +23,8 @@ Use `f.number()` inside a `.fields()` callback. The optional argument selects th
 import { collection } from "#questpie/factories";
 
 export const products = collection("products").fields(({ f }) => ({
-  stock: f.number().required(),                          // integer, NOT NULL
-  rating: f.number("smallint").min(1).max(5),            // smallint, 1..5
+  stock: f.number().required(), // integer, NOT NULL
+  rating: f.number("smallint").min(1).max(5), // smallint, 1..5
   price: f.number({ mode: "decimal", precision: 10, scale: 2 }), // numeric(10,2)
 }));
 ```
@@ -33,59 +33,60 @@ That gives `products` a `stock` column typed `number` on read, required on inser
 
 ## Constructor argument
 
-`f.number()` has three call signatures. The argument selects the **storage mode** (it is positional, there is no general options object).
+`f.number()` has three call signatures. Its positional argument selects the storage mode.
 
-| Call | Column | Read type | Notes |
-|---|---|---|---|
-| `f.number()` | `integer` | `number` | Default. Mode is `"integer"`; schema is `z.number().int()`. |
-| `f.number("smallint")` | `smallint` | `number` | 16-bit integer; also `z.number().int()`. |
-| `f.number("bigint")` | `bigint` (`mode: "number"`) | `number` | 64-bit; reads as JS `number`, **not** `bigint`. |
-| `f.number("real")` | `real` | `number` | 32-bit float. No `.int()`. |
-| `f.number("double")` | `doublePrecision` | `number` | 64-bit float. No `.int()`. |
-| `f.number({ mode: "decimal", precision?, scale? })` | `numeric(precision, scale)` (`mode: "number"`) | `number` | Fixed precision. Defaults: `precision: 10`, `scale: 2`. Reads as JS `number`. |
+| Call                                                | Column                                         | Read type | Notes                                                                         |
+| --------------------------------------------------- | ---------------------------------------------- | --------- | ----------------------------------------------------------------------------- |
+| `f.number()`                                        | `integer`                                      | `number`  | Default. Mode is `"integer"`; schema is `z.number().int()`.                   |
+| `f.number("smallint")`                              | `smallint`                                     | `number`  | 16-bit integer; also `z.number().int()`.                                      |
+| `f.number("bigint")`                                | `bigint` (`mode: "number"`)                    | `number`  | 64-bit; reads as JS `number`, **not** `bigint`.                               |
+| `f.number("real")`                                  | `real`                                         | `number`  | 32-bit float. No `.int()`.                                                    |
+| `f.number("double")`                                | `doublePrecision`                              | `number`  | 64-bit float. No `.int()`.                                                    |
+| `f.number({ mode: "decimal", precision?, scale? })` | `numeric(precision, scale)` (`mode: "number"`) | `number`  | Fixed precision. Defaults: `precision: 10`, `scale: 2`. Reads as JS `number`. |
 
 The resulting field data is always `number`. The derived Zod schema is `z.number()`, with `.int()` added automatically for the **integer** and **smallint** modes (`isInt` flag). The float modes (`real`, `double`) and `decimal` accept fractional values.
 
 <Callout type="info" title="`bigint` and `decimal` read back as JS `number`">
-Both use Drizzle's `mode: "number"`, so the value type on read/insert/update is a plain JS `number`. That keeps the API uniform, but a `number` only holds integers exactly up to `Number.MAX_SAFE_INTEGER` (2^53 − 1) and `decimal` arithmetic goes through floating point. For money or IDs beyond that range, store an exact string value with `f.text()` and validate the format with `.zod()`, or create a dedicated custom field type.
+  Both use Drizzle's `mode: "number"`, so the value type on read/insert/update is a plain JS `number`. That keeps the API uniform, but a `number` only holds integers exactly up to `Number.MAX_SAFE_INTEGER` (2^53 − 1) and `decimal` arithmetic goes through floating point. For money or IDs beyond that range, store an
+  exact string value with `f.text()` and validate the format with `.zod()`, or create a dedicated custom field type.
 </Callout>
 
 ## Chained methods
 
 These methods are specific to `number` (on top of the [shared modifiers](/docs/concepts/fields#shared-methods) every field has). Each returns a new immutable field, so they chain in any order.
 
-| Method | Effect | Schema |
-|---|---|---|
-| `.min(n)` | Minimum **value** (inclusive). | `z.number().min(n)` |
-| `.max(n)` | Maximum **value** (inclusive). | `z.number().max(n)` |
-| `.positive()` | Value must be `> 0`. | `z.number().positive()` |
-| `.int()` | Value must be an integer (already implied by `integer`/`smallint` modes). | `z.number().int()` |
-| `.step(n)` | Value must be a multiple of `n`, adds a `value % n === 0` refinement. | `.refine(v => v % n === 0)` |
+| Method        | Effect                                                                    | Schema                      |
+| ------------- | ------------------------------------------------------------------------- | --------------------------- |
+| `.min(n)`     | Minimum **value** (inclusive).                                            | `z.number().min(n)`         |
+| `.max(n)`     | Maximum **value** (inclusive).                                            | `z.number().max(n)`         |
+| `.positive()` | Value must be `> 0`.                                                      | `z.number().positive()`     |
+| `.int()`      | Value must be an integer (already implied by `integer`/`smallint` modes). | `z.number().int()`          |
+| `.step(n)`    | Value must be a multiple of `n`, adds a `value % n === 0` refinement.     | `.refine(v => v % n === 0)` |
 
 ```ts
 collection("orders").fields(({ f }) => ({
-  quantity: f.number().required().min(1).step(1),   // ≥ 1, whole units
-  discount: f.number("real").min(0).max(100),       // percentage 0..100
+  quantity: f.number().required().min(1).step(1), // ≥ 1, whole units
+  discount: f.number("real").min(0).max(100), // percentage 0..100
 }));
 ```
 
 All five refinements are applied to the derived Zod schema during create and update validation.
 
 <Callout type="info" title="`.min()` / `.max()` here are VALUE bounds, not string length">
-On a number field, `.min(n)` / `.max(n)` constrain the numeric **value**. On [`f.text()`](/docs/concepts/fields/text) the same method names constrain **string length** (they map to `minLength` / `maxLength`). Same names, different meaning, sized by the field's type.
+  On a number field, `.min(n)` / `.max(n)` constrain the numeric **value**. On [`f.text()`](/docs/concepts/fields/text) the same method names constrain **string length** (they map to `minLength` / `maxLength`). Same names, different meaning, sized by the field's type.
 </Callout>
 
 ## Filtering, operators
 
 `number` uses the **number operator set** (`numberOps`), so every number field is filterable with these in a `where` clause. The operand is typed `number` (or `number[]` for `in` / `notIn`).
 
-| Operator | Operand | Matches |
-|---|---|---|
-| `eq` / `ne` | `number` | Exact equal / not equal. |
-| `gt` / `gte` | `number` | Greater than / greater-or-equal. |
-| `lt` / `lte` | `number` | Less than / less-or-equal. |
-| `in` / `notIn` | `number[]` | Value is (not) in the list. |
-| `isNull` / `isNotNull` | `boolean` | Column is (not) null. |
+| Operator               | Operand    | Matches                          |
+| ---------------------- | ---------- | -------------------------------- |
+| `eq` / `ne`            | `number`   | Exact equal / not equal.         |
+| `gt` / `gte`           | `number`   | Greater than / greater-or-equal. |
+| `lt` / `lte`           | `number`   | Less than / less-or-equal.       |
+| `in` / `notIn`         | `number[]` | Value is (not) in the list.      |
+| `isNull` / `isNotNull` | `boolean`  | Column is (not) null.            |
 
 ```ts
 // In-stock products priced between 10 and 50:
@@ -127,7 +128,7 @@ type Product = typeof products.$infer.select;
 ```ts
 import type { CollectionDoc, CollectionWhere } from "#questpie/types";
 
-type Product = CollectionDoc<"products">;        // { stock: number; ... }
+type Product = CollectionDoc<"products">; // { stock: number; ... }
 type ProductFilter = CollectionWhere<"products">; // { stock?: { gt?: number; ... } }
 ```
 

--- a/apps/docs/content/docs/concepts/fields/object.mdx
+++ b/apps/docs/content/docs/concepts/fields/object.mdx
@@ -37,14 +37,14 @@ That gives `users` an `address` column typed `{ street: string; city: string; zi
 
 `f.object(fields)` takes one positional argument: a `Record<string, Field>` of nested field definitions.
 
-| Argument | Type | Notes |
-|---|---|---|
+| Argument | Type                    | Notes                                                                                |
+| -------- | ----------------------- | ------------------------------------------------------------------------------------ |
 | `fields` | `Record<string, Field>` | The nested shape. Each value is a field built from `f` (and chained like any other). |
 
 The column is always `jsonb`. The schema is built by calling `.toZodSchema()` on each nested field and wrapping the result in `z.object({...})`, so each key validates with its own field's rules. The object's read type is **inferred** from the nested fields' select types, declare `f.text().required()` and that key is `string`; leave it optional and it is `string | null`.
 
 <Callout type="info" title="Nested fields are real fields">
-Each value in the record is a full field, chain `.required()`, `.default()`, `.label()`, even nest another `f.object({...})`. The nested field's Zod schema and its nullability both flow into the parent object's schema and inferred type. There is no separate "object sub-field" type; you compose the same `f.*` factories.
+Each value is a full field: chain `.required()`, `.default()`, `.label()`, or nest another `f.object({...})`. Nested Zod schemas and nullability flow into the parent schema and inferred type through the same `f.*` factories.
 </Callout>
 
 ## Chained methods
@@ -64,24 +64,24 @@ seo: f
 
 The two shared modifiers worth calling out for objects:
 
-- **`.array()`**, turns the field into a *list of objects* (`T[]`), still stored as one `jsonb` column. Bound the length with `.minItems(n)` / `.maxItems(n)`. See [Repeated objects](#repeated-objects) below.
+- **`.array()`**, turns the field into a _list of objects_ (`T[]`), still stored as one `jsonb` column. Bound the length with `.minItems(n)` / `.maxItems(n)`. See [Repeated objects](#repeated-objects) below.
 - **`.required()`**, makes the column `NOT NULL` and the whole object required on insert. Without it the object is nullable (`T | null`) and optional on input.
 
 ## Filtering, operators
 
-`object` uses the **object operator set** (`objectOps`), built on structural JSONB operations. The whole set is JSONB-path aware: the same operators work on a top-level object field and on a key *inside* a nested object.
+`object` uses the **object operator set** (`objectOps`), built on structural JSONB operations. The whole set is JSONB-path aware: the same operators work on a top-level object field and on a key _inside_ a nested object.
 
-| Operator | Operand | Matches (Postgres) |
-|---|---|---|
-| `contains` | a partial object | JSON contains (`@>`), the stored value contains this subtree. |
-| `containedBy` | an object | JSON contained by (`<@`), the stored value is a subtree of this. |
-| `hasKey` | `string` | The object has this top-level key (`?`). |
-| `hasKeys` | `string[]` | The object has **all** of these keys (`?&`). |
-| `hasAnyKeys` | `string[]` | The object has **any** of these keys (`?\|`). |
-| `pathEquals` | `{ path: string[]; val }` | The value at `path` equals `val` (JSONB path navigation). |
-| `jsonPath` | `string` | Matches a Postgres `jsonpath` expression (`@@`). |
-| `isEmpty` / `isNotEmpty` | `boolean` | The object is (not) `{}` / null. |
-| `isNull` / `isNotNull` | `boolean` | The column is (not) `null`. |
+| Operator                 | Operand                   | Matches (Postgres)                                               |
+| ------------------------ | ------------------------- | ---------------------------------------------------------------- |
+| `contains`               | a partial object          | JSON contains (`@>`), the stored value contains this subtree.    |
+| `containedBy`            | an object                 | JSON contained by (`<@`), the stored value is a subtree of this. |
+| `hasKey`                 | `string`                  | The object has this top-level key (`?`).                         |
+| `hasKeys`                | `string[]`                | The object has **all** of these keys (`?&`).                     |
+| `hasAnyKeys`             | `string[]`                | The object has **any** of these keys (`?\|`).                    |
+| `pathEquals`             | `{ path: string[]; val }` | The value at `path` equals `val` (JSONB path navigation).        |
+| `jsonPath`               | `string`                  | Matches a Postgres `jsonpath` expression (`@@`).                 |
+| `isEmpty` / `isNotEmpty` | `boolean`                 | The object is (not) `{}` / null.                                 |
+| `isNull` / `isNotNull`   | `boolean`                 | The column is (not) `null`.                                      |
 
 ```ts
 // Find users in a given city using a nested-path match:
@@ -98,7 +98,7 @@ await app.collections.users.find({
 ```
 
 <Callout type="info" title="`pathEquals` / `contains` over per-field columns">
-There is no relational filter on a sub-key (an object is one `jsonb` value, not joined rows). To filter by a nested value, use `pathEquals` (exact value at a path) or `contains` (a subtree must be present). If you find yourself querying deep object paths constantly, that data may belong in its own [collection](/docs/concepts/collections) with a [relation](/docs/concepts/relations).
+  An object is one `jsonb` value. Use `pathEquals` for an exact nested value or `contains` for a required subtree. Data that needs relational filters, frequent deep queries, or independent lifecycle belongs in its own [collection](/docs/concepts/collections) with a [relation](/docs/concepts/relations).
 </Callout>
 
 For the full query language, combining filters with `AND` / `OR` / `NOT`, pagination, and `orderBy`, see the [query reference](/docs/concepts/relations).
@@ -107,7 +107,7 @@ For the full query language, combining filters with `AND` / `OR` / `NOT`, pagina
 
 - **`f.object()`**, a **fixed, known** nested shape you want validated key by key: an address, an SEO block, a coordinate pair, a settings group. The keys and their types are part of your schema.
 - **[`f.json()`](/docs/concepts/fields/json)**, **free-form** or externally-shaped data with no fixed keys (a raw webhook payload, arbitrary metadata). It is schema-less; narrow the type with `.$type<T>()` and add runtime validation with `.zod()` only if you want it.
-- **A separate [collection](/docs/concepts/collections) + [relation](/docs/concepts/relations)**, when the nested data needs its own rows, its own queries, or its own access rules. An object is the right call only while the data is genuinely *owned by and embedded in* the parent row.
+- **A separate [collection](/docs/concepts/collections) + [relation](/docs/concepts/relations)**, when the nested data needs its own rows, its own queries, or its own access rules. An object is the right call only while the data is genuinely _owned by and embedded in_ the parent row.
 
 ## Repeated objects
 
@@ -126,17 +126,19 @@ links: f
 ```
 
 <Callout type="info" title="Object array vs blocks">
-`f.object().array()` is for a **homogeneous** list, every item has the same shape. When items can be *different* types chosen from a palette (a page builder), use [`f.blocks()`](/docs/concepts/blocks) instead. (For arranging an object's keys into sections/tabs in the admin form, an object field also accepts a field-level `.form()` layout config, contributed by the admin module.)
+  `f.object().array()` is for a **homogeneous** list, every item has the same shape. When items can be *different* types chosen from a palette (a page builder), use [`f.blocks()`](/docs/concepts/blocks) instead. (For arranging an object's keys into sections/tabs in the admin form, an object field also accepts a
+  field-level `.form()` layout config, contributed by the admin module.)
 </Callout>
 
 ## Gotchas
 
 <Callout type="warn" title="Nested write-only fields drop out of the object shape">
-A nested field marked `.outputFalse()` (write-only) resolves to `never` and is **dropped from the inferred object data type**, mirroring how the same field is dropped from a top-level row. The key still validates on input (its Zod schema is in the composed `z.object`), but it won't appear in the read shape. A *virtual* nested field is different: it keeps its data type in the read shape (a nested to-many `f.relation()`, for instance, infers as `string[] | null`).
+  A nested field marked `.outputFalse()` (write-only) resolves to `never` and is **dropped from the inferred object data type**, mirroring how the same field is dropped from a top-level row. The key still validates on input (its Zod schema is in the composed `z.object`), but it won't appear in the read shape. A
+  *virtual* nested field is different: it keeps its data type in the read shape (a nested to-many `f.relation()`, for instance, infers as `string[] | null`).
 </Callout>
 
 <Callout type="warn" title="The object is stored as one JSONB value">
-The whole object is a single `jsonb` column, there are no per-key columns, indexes, or foreign keys inside it. Nested `f.relation()` fields don't create real FKs, and you can't `orderBy` a nested key or hydrate it with `with:`. If a nested value needs to be a real, query-first relationship, model it as its own collection.
+  The whole object is stored in one `jsonb` column. Nested keys do not create independent columns, indexes, or foreign keys, and they are not hydrated through `with`. Model query-first relationships as their own collections.
 </Callout>
 
 ## TypeScript
@@ -155,6 +157,6 @@ type User = typeof users.$infer.select;
 
 - [Fields](/docs/concepts/fields), the `f` proxy, the chain-modifier model, and the shared modifiers (`.required()`, `.array()`, `.localized()`, `.default()`, …).
 - [`f.json()`](/docs/concepts/fields/json), the schema-less sibling for free-form data with no fixed keys.
-- [Blocks](/docs/concepts/blocks), for *heterogeneous* repeatable content (a page builder) rather than a homogeneous object array.
+- [Blocks](/docs/concepts/blocks), for _heterogeneous_ repeatable content (a page builder) rather than a homogeneous object array.
 - [Collections](/docs/concepts/collections) / [Relations](/docs/concepts/relations), when nested data should be its own rows with real queries and relationships.
 - [Validation](/docs/concepts/validation), the auto-derived Zod schema and the `.zod()` escape hatch.

--- a/apps/docs/content/docs/concepts/fields/rich-text.mdx
+++ b/apps/docs/content/docs/concepts/fields/rich-text.mdx
@@ -8,7 +8,8 @@ description: f.richText() is a TipTap-backed WYSIWYG field, stored as structured
 > **Prerequisites:** read [Fields](/docs/concepts/fields) first, this page covers only the `richText` type. The `f` proxy, the chain-modifier model, and shared modifiers like `.required()` / `.localized()` / `.label()` are taught there.
 
 <Callout type="info" title="Admin-only field, needs the `@questpie/admin` module">
-`f.richText()` is contributed by `@questpie/admin`, not by the core builtins. It appears on `f` (alongside `f.blocks()`) only when the admin module is enabled and you import `collection` from `#questpie/factories`. Without the admin module, `f.richText` is not a registered type and `f.richText()` throws `Unknown field type`.
+  `f.richText()` is contributed by `@questpie/admin`, not by the core builtins. It appears on `f` (alongside `f.blocks()`) only when the admin module is enabled and you import `collection` from `#questpie/factories`. Without the admin module, `f.richText` is not a registered type and `f.richText()` throws `Unknown
+  field type`.
 </Callout>
 
 ## What it does
@@ -49,15 +50,20 @@ A stored value is the TipTap JSON tree:
 {
   "type": "doc",
   "content": [
-    { "type": "heading", "attrs": { "level": 2 },
-      "content": [{ "type": "text", "text": "Hello" }] },
-    { "type": "paragraph",
+    {
+      "type": "heading",
+      "attrs": { "level": 2 },
+      "content": [{ "type": "text", "text": "Hello" }],
+    },
+    {
+      "type": "paragraph",
       "content": [
         { "type": "text", "text": "A " },
         { "type": "text", "marks": [{ "type": "bold" }], "text": "formatted" },
-        { "type": "text", "text": " paragraph." }
-      ] }
-  ]
+        { "type": "text", "text": " paragraph." },
+      ],
+    },
+  ],
 }
 ```
 
@@ -67,16 +73,17 @@ A stored value is the TipTap JSON tree:
 
 `f.richText()` has two call signatures. The only option is the storage `mode`.
 
-| Call | Column | Data type | Schema |
-|---|---|---|---|
-| `f.richText()` | `jsonb` | `TipTapDocument` | recursive TipTap-node Zod schema |
-| `f.richText({ mode: "json" })` | `jsonb` | `TipTapDocument` | recursive TipTap-node Zod schema |
-| `f.richText({ mode: "markdown" })` | `text` | `string` | `z.string()` |
+| Call                               | Column  | Data type        | Schema                           |
+| ---------------------------------- | ------- | ---------------- | -------------------------------- |
+| `f.richText()`                     | `jsonb` | `TipTapDocument` | recursive TipTap-node Zod schema |
+| `f.richText({ mode: "json" })`     | `jsonb` | `TipTapDocument` | recursive TipTap-node Zod schema |
+| `f.richText({ mode: "markdown" })` | `text`  | `string`         | `z.string()`                     |
 
 `mode` defaults to `"json"`. In json mode the derived Zod schema validates the `{ type: "doc", content?: TipTapNode[] }` shape recursively; in markdown mode it is a plain `z.string()`. The chosen mode is recorded on the field metadata as `outputMode`, which the editor reads to decide whether to emit JSON or a markdown string.
 
 <Callout type="info" title="Pick `json` unless you specifically need markdown">
-The default `json` mode preserves the full document structure (marks, nodes, attributes) and is what the editor, the JSON operators, and any structured rendering expect. Reach for `markdown` only when you need a portable plain-text representation, e.g. feeding the body to an external markdown renderer or a system that doesn't understand TipTap JSON.
+  The default `json` mode preserves the full document structure (marks, nodes, attributes) and is what the editor, the JSON operators, and any structured rendering expect. Reach for `markdown` only when you need a portable plain-text representation, e.g. feeding the body to an external markdown renderer or a system
+  that doesn't understand TipTap JSON.
 </Callout>
 
 ## Chained methods
@@ -85,13 +92,13 @@ The default `json` mode preserves the full document structure (marks, nodes, att
 
 The ones you'll reach for most:
 
-| Modifier | Effect |
-|---|---|
-| `.required()` | `NOT NULL` column; required on insert. |
-| `.localized()` | Stores a separate document per locale (moves to the i18n side-table). |
-| `.label(text)` / `.description(text)` | Admin form label / helper text. |
-| `.default(doc)` | Default document (json) or string (markdown). |
-| `.admin(config)` | Tune the editor, toolbar, preset, features (see [Admin config](#configuring-the-editor-admin)). |
+| Modifier                              | Effect                                                                                          |
+| ------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `.required()`                         | `NOT NULL` column; required on insert.                                                          |
+| `.localized()`                        | Stores a separate document per locale (moves to the i18n side-table).                           |
+| `.label(text)` / `.description(text)` | Admin form label / helper text.                                                                 |
+| `.default(doc)`                       | Default document (json) or string (markdown).                                                   |
+| `.admin(config)`                      | Tune the editor, toolbar, preset, features (see [Admin config](#configuring-the-editor-admin)). |
 
 ```ts
 collection("articles").fields(({ f }) => ({
@@ -104,13 +111,13 @@ collection("articles").fields(({ f }) => ({
 
 `richText` ships a small, content-aware operator set. The operators are the same names in both modes, but the implementation differs: json mode searches the text inside the JSON tree; markdown mode runs `ILIKE` on the text column.
 
-| Operator | Operand | Matches |
-|---|---|---|
-| `contains` | `string` | Substring match against the document's **text content** (case-insensitive). |
-| `isEmpty` | `boolean` | Document is null, an empty `doc`, or only whitespace. |
-| `isNotEmpty` | `boolean` | Document has non-whitespace text. |
-| `isNull` | `boolean` | Column is `NULL`. |
-| `isNotNull` | `boolean` | Column is not `NULL`. |
+| Operator     | Operand   | Matches                                                                     |
+| ------------ | --------- | --------------------------------------------------------------------------- |
+| `contains`   | `string`  | Substring match against the document's **text content** (case-insensitive). |
+| `isEmpty`    | `boolean` | Document is null, an empty `doc`, or only whitespace.                       |
+| `isNotEmpty` | `boolean` | Document has non-whitespace text.                                           |
+| `isNull`     | `boolean` | Column is `NULL`.                                                           |
+| `isNotNull`  | `boolean` | Column is not `NULL`.                                                       |
 
 ```ts
 // Posts whose body mentions "changelog", excluding empty drafts
@@ -126,7 +133,8 @@ Unlike text / number / select fields, a `richText` field's `where` slot is **not
 </Callout>
 
 <Callout type="info" title="`contains` matches rendered text, not JSON keys">
-In json mode, `contains` walks the document with `jsonb_path_query_array(col, '$..text')` and matches inside the extracted text nodes, so it searches the words an editor sees, not node types or attribute values. To filter on whether a *block type* exists, that's the [`f.blocks()`](/docs/concepts/blocks) field, which has `hasBlockType` / `blockCount` operators.
+  In json mode, `contains` walks the document with `jsonb_path_query_array(col, '$..text')` and matches inside the extracted text nodes, so it searches the words an editor sees, not node types or attribute values. To filter on whether a *block type* exists, that's the [`f.blocks()`](/docs/concepts/blocks) field, which
+  has `hasBlockType` / `blockCount` operators.
 </Callout>
 
 For the full query language, combining field filters with `AND` / `OR` / `NOT`, pagination, and `orderBy`, see the querying reference (the canonical home of the query language).
@@ -152,11 +160,13 @@ content: f.richText().label("Content").admin({
 ```
 
 <Callout type="warn" title="Field `.admin()` config is loosely typed">
-The field-level `.admin()` accepts `unknown`, it does not type-check the editor props for you, so a misspelled key is silent. Cross-check the available toggles against `RichTextFeatures` / `RichTextEditorProps`. The full admin-config model (how `.admin()` flows into component props, and the `RichTextFieldMeta` augmentation point) is covered in the admin docs.
+  The field-level `.admin()` accepts `unknown`, it does not type-check the editor props for you, so a misspelled key is silent. Cross-check the available toggles against `RichTextFeatures` / `RichTextEditorProps`. The full admin-config model (how `.admin()` flows into component props, and the `RichTextFieldMeta`
+  augmentation point) is covered in the admin docs.
 </Callout>
 
 <Callout type="warn" title="Markdown mode round-trips through the markdown extension">
-A `markdown`-mode field stores a plain markdown string. The editor loads and saves it via the `tiptap-markdown` extension, which is wired up from the field's `outputMode`. If you author a custom editor or drop the extension, the body can render empty and autosave an empty string over your content. Stick with the built-in editor for markdown fields.
+  A `markdown`-mode field stores a plain markdown string. The editor loads and saves it via the `tiptap-markdown` extension, which is wired up from the field's `outputMode`. If you author a custom editor or drop the extension, the body can render empty and autosave an empty string over your content. Stick with the
+  built-in editor for markdown fields.
 </Callout>
 
 ## TypeScript
@@ -170,7 +180,7 @@ type Post = typeof posts.$infer.select;
 //   ^? { ...; content: TipTapDocument }
 ```
 
-Also public from `@questpie/admin/fields`: `richText`, `richTextFieldType`, `RichTextFieldState`, `RichTextFeature`, and the augmentable `RichTextFieldMeta`. (The `RichTextMode` / `RichTextOptions` types are internal, they back the `{ mode }` argument but aren't re-exported from the public entry.) See [Fields → inferred types](/docs/concepts/fields) for how modifiers flow into the generated types.
+`@questpie/admin/fields` exports `richText`, `richTextFieldType`, `RichTextFieldState`, `RichTextFeature`, and the augmentable `RichTextFieldMeta`. See [Fields → inferred types](/docs/concepts/fields) for how modifiers flow into generated types.
 
 ## Related
 

--- a/apps/docs/content/docs/concepts/fields/select.mdx
+++ b/apps/docs/content/docs/concepts/fields/select.mdx
@@ -39,12 +39,12 @@ That gives `posts` a `status` column whose read type is `"draft" | "published" |
 
 ## Constructor argument
 
-`f.select()` takes one argument, either a **static options array** or a dynamic **`OptionsConfig`**. There is no options-object constructor.
+`f.select()` takes one argument: either a static options array or a dynamic `OptionsConfig`.
 
-| Call | Stored value | Read type | Column |
-|---|---|---|---|
-| `f.select([...options])` | one option `value` (as string) | **literal union** of the values | `varchar(n)`, where `n` = the longest value's length, minimum `50` |
-| `f.select(optionsConfig)` | any string the handler returns | `string` | `varchar(255)` |
+| Call                      | Stored value                   | Read type                       | Column                                                             |
+| ------------------------- | ------------------------------ | ------------------------------- | ------------------------------------------------------------------ |
+| `f.select([...options])`  | one option `value` (as string) | **literal union** of the values | `varchar(n)`, where `n` = the longest value's length, minimum `50` |
+| `f.select(optionsConfig)` | any string the handler returns | `string`                        | `varchar(255)`                                                     |
 
 For static options, the field data is the **literal union** of the option values, the read/insert/update/`where` types all narrow to `"draft" | "published" | …`. The derived schema is `z.enum(values)`. For a dynamic `OptionsConfig`, the data widens to `string`, the schema is `z.string()`, and the introspection metadata ships an empty options array (the admin fetches them at runtime).
 
@@ -56,14 +56,14 @@ The narrowing comes from the `<const T extends readonly SelectOption[]>` overloa
 
 Each option is a `SelectOption`. Only `value` and `label` are required; the rest drive the admin UI.
 
-| Key | Type | Purpose |
-|---|---|---|
-| `value` | `string \| number` | The stored value. A `number` is coerced to a string for the `varchar` column and the `z.enum` (`String(value)`). |
-| `label` | `I18nText` | What the dropdown shows. `I18nText` = `string \| Record<locale, string>`. |
-| `description?` | `I18nText` | Secondary help text shown under the option. |
-| `disabled?` | `boolean` | Renders the option non-selectable. |
-| `icon?` | `ComponentReference` | An icon next to the option, built with the `c` proxy, e.g. `c.icon("ph:check-circle")`. |
-| `className?` | `string` | Tailwind/utility classes for the option's badge/row (tonal styling). |
+| Key            | Type                 | Purpose                                                                                                          |
+| -------------- | -------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `value`        | `string \| number`   | The stored value. A `number` is coerced to a string for the `varchar` column and the `z.enum` (`String(value)`). |
+| `label`        | `I18nText`           | What the dropdown shows. `I18nText` = `string \| Record<locale, string>`.                                        |
+| `description?` | `I18nText`           | Secondary help text shown under the option.                                                                      |
+| `disabled?`    | `boolean`            | Renders the option non-selectable.                                                                               |
+| `icon?`        | `ComponentReference` | An icon next to the option, built with the `c` proxy, e.g. `c.icon("ph:check-circle")`.                          |
+| `className?`   | `string`             | Tailwind/utility classes for the option's badge/row (tonal styling).                                             |
 
 `value`, `label`, `description`, `disabled`, `icon`, and `className` are all serialized into the admin introspection metadata, so the dropdown and table cells render consistently without any per-project component override.
 
@@ -91,8 +91,8 @@ export const deployments = collection("deployments").fields(({ f, c }) => ({
 
 `.enum(name)` is the only method specific to `select`, on top of the [shared modifiers](/docs/concepts/fields#shared-methods) every field has and `.array()` for multi-select (below).
 
-| Method | Effect |
-|---|---|
+| Method        | Effect                                                                                   |
+| ------------- | ---------------------------------------------------------------------------------------- |
 | `.enum(name)` | Back the column with a native Postgres `enum` type named `name`, instead of a `varchar`. |
 
 Without `.enum()`, a select is stored as a `varchar` and the option set lives only in your schema and the Zod validator, the database itself accepts any string of the right length. `.enum("post_status")` swaps the column for a real `pgEnum` built from the option values, so the **database** enforces the value set too:
@@ -108,12 +108,12 @@ status: f
 ```
 
 <Callout type="warn" title="`.enum()` builds a fresh `pgEnum` from the *static* values">
-`.enum(name)` reads the option values it has at call time and creates a brand-new `pgEnum(name, values)` each call, there is no shared cache, so the same `name` used twice creates two distinct definitions. Call it **after** your options are set. On a select with **no** static options (a dynamic `OptionsConfig`) it only flags `enumType`/`enumName` and leaves the column a `varchar`, since there are no values to build the enum from. Changing the option set later is a Postgres enum migration (add/rename a value), not a free edit.
+  `.enum(name)` creates a new `pgEnum(name, values)` from the static values available at call time. Call it after defining the options and use each enum name for one definition. Dynamic `OptionsConfig` selects remain `varchar` because their values are resolved at runtime. Changing a Postgres enum requires a migration.
 </Callout>
 
 ## Multi-select
 
-There is no separate multi-select factory, chain the shared [`.array()`](/docs/concepts/fields/array) modifier and the field stores a list of option values in a single `jsonb` column. The read type becomes the value union as an array (`("news" | "guide")[]`), and the operator set switches to the **multi-select** operators. Bound the list length with `.minItems(n)` / `.maxItems(n)`:
+Chain the shared [`.array()`](/docs/concepts/fields/array) modifier for multi-select. The field stores option values in one `jsonb` column, returns the value union as an array (`("news" | "guide")[]`), and uses multi-select operators. Bound list length with `.minItems(n)` and `.maxItems(n)`:
 
 ```ts
 tags: f
@@ -131,11 +131,11 @@ tags: f
 
 A single (non-array) select uses the **single-select operator set** (`selectSingleOps`), equality and membership against the value union.
 
-| Operator | Operand | Matches |
-|---|---|---|
-| `eq` / `ne` | a value | Exact equal / not equal. |
-| `in` / `notIn` | value array | Value is (not) in the list. |
-| `isNull` / `isNotNull` | `boolean` | Column is (not) null. |
+| Operator               | Operand     | Matches                     |
+| ---------------------- | ----------- | --------------------------- |
+| `eq` / `ne`            | a value     | Exact equal / not equal.    |
+| `in` / `notIn`         | value array | Value is (not) in the list. |
+| `isNull` / `isNotNull` | `boolean`   | Column is (not) null.       |
 
 ```ts
 // Published or archived posts:
@@ -146,14 +146,14 @@ const { docs } = await app.collections.posts.find({
 
 A **multi-select** (`.array()`) uses `selectMultiOps` instead, the value is a `jsonb` array, so the operators are structural.
 
-| Operator | Operand | Matches |
-|---|---|---|
-| `containsAll` | value array | The stored list contains **all** of these. |
-| `containsAny` | value array | The stored list contains **any** of these. |
-| `eq` | value array | The stored list equals this array exactly. |
-| `length` | `number` | The stored list has exactly this many items. |
-| `isEmpty` / `isNotEmpty` | `boolean` | List is empty (`[]` or null) / non-empty. |
-| `isNull` / `isNotNull` | `boolean` | Column is (not) null. |
+| Operator                 | Operand     | Matches                                      |
+| ------------------------ | ----------- | -------------------------------------------- |
+| `containsAll`            | value array | The stored list contains **all** of these.   |
+| `containsAny`            | value array | The stored list contains **any** of these.   |
+| `eq`                     | value array | The stored list equals this array exactly.   |
+| `length`                 | `number`    | The stored list has exactly this many items. |
+| `isEmpty` / `isNotEmpty` | `boolean`   | List is empty (`[]` or null) / non-empty.    |
+| `isNull` / `isNotNull`   | `boolean`   | Column is (not) null.                        |
 
 ```ts
 // Posts tagged with both "news" and "release":
@@ -200,19 +200,21 @@ export const addresses = collection("addresses").fields(({ f }) => ({
 
 `OptionsConfig` is `{ handler, deps? }`:
 
-| Key | Type | Purpose |
-|---|---|---|
-| `handler` | `(ctx: OptionsContext) => OptionsResult \| Promise<OptionsResult>` | Returns the options for the current form `data` / `search` / `page`. |
-| `deps?` | `string[] \| ((ctx) => any[])` | Sibling field values whose changes refetch the options. Auto-tracked from the handler if omitted. |
+| Key       | Type                                                               | Purpose                                                                                           |
+| --------- | ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------- |
+| `handler` | `(ctx: OptionsContext) => OptionsResult \| Promise<OptionsResult>` | Returns the options for the current form `data` / `search` / `page`.                              |
+| `deps?`   | `string[] \| ((ctx) => any[])`                                     | Sibling field values whose changes refetch the options. Auto-tracked from the handler if omitted. |
 
 The handler's `ctx` (`OptionsContext`) carries `{ data, sibling, search, page, limit, ctx }`, the current form `data`, the `sibling` field values, the `search` string the user typed, the `page`/`limit` for pagination, and the server `ctx` (`{ db, user, req, locale }`). It returns an `OptionsResult`: `{ options: { value, label }[]; hasMore?; total? }`.
 
 <Callout type="info" title="The server `ctx.db` is untyped here">
-Inside an options handler the server context `ctx.ctx.db` is typed `unknown` (`ReactiveServerContext`), so it carries no per-collection autocomplete. To load options from your own tables, query through a typed handle you bring into scope (e.g. an imported `app`), not `ctx.ctx.db.collections.*`. If what you want is a typed reference to another collection's rows, use [`f.relation()`](/docs/concepts/relations) instead.
+  Inside an options handler the server context `ctx.ctx.db` is typed `unknown` (`ReactiveServerContext`), so it carries no per-collection autocomplete. To load options from your own tables, query through a typed handle you bring into scope (e.g. an imported `app`), not `ctx.ctx.db.collections.*`. If what you want is a
+  typed reference to another collection's rows, use [`f.relation()`](/docs/concepts/relations) instead.
 </Callout>
 
 <Callout type="info" title="Dynamic select stores a plain `string`">
-With an `OptionsConfig`, the value isn't known at compile time, so the field's read type is `string` (not a literal union) and the schema is `z.string()`. Use a static options array whenever the set is fixed and known, you get the narrowed type and `z.enum` validation for free. For a typed reference to another collection's rows, reach for [`f.relation()`](/docs/concepts/relations) instead, which gives a real FK and `with:` hydration.
+  With an `OptionsConfig`, the value isn't known at compile time, so the field's read type is `string` (not a literal union) and the schema is `z.string()`. Use a static options array whenever the set is fixed and known, you get the narrowed type and `z.enum` validation for free. For a typed reference to another
+  collection's rows, reach for [`f.relation()`](/docs/concepts/relations) instead, which gives a real FK and `with:` hydration.
 </Callout>
 
 ## When to use it
@@ -220,7 +222,7 @@ With an `OptionsConfig`, the value isn't known at compile time, so the field's r
 - **Static `f.select([...])`**, a small, fixed set of values: a status, a priority, a category, a role. This is the common case; you get the literal union type and `z.enum` validation.
 - **`.enum(name)`**, add it when you want the database to enforce the value set too (a real Postgres `enum`), accepting that changing the set later is an enum migration.
 - **`.array()`**, pick several from the set: tags, feature flags, days of the week.
-- **Dynamic `OptionsConfig`**, the choices are data-driven *but the field still stores a plain string* (e.g. a value pulled from another table you don't want a hard FK to). If you want a typed foreign key with hydration, use [`f.relation()`](/docs/concepts/relations) instead.
+- **Dynamic `OptionsConfig`**, the choices are data-driven _but the field still stores a plain string_ (e.g. a value pulled from another table you don't want a hard FK to). If you want a typed foreign key with hydration, use [`f.relation()`](/docs/concepts/relations) instead.
 
 ## TypeScript
 
@@ -234,8 +236,8 @@ type Post = typeof posts.$infer.select;
 ```ts
 import type { CollectionDoc, CollectionWhere } from "#questpie/types";
 
-type Post = CollectionDoc<"posts">;          // { status: "draft" | "published" | "archived"; ... }
-type PostFilter = CollectionWhere<"posts">;  // { status?: { eq?: "draft" | "published" | "archived"; in?: (...)[]; ... } }
+type Post = CollectionDoc<"posts">; // { status: "draft" | "published" | "archived"; ... }
+type PostFilter = CollectionWhere<"posts">; // { status?: { eq?: "draft" | "published" | "archived"; in?: (...)[]; ... } }
 ```
 
 `.required()` makes the field non-null and required on insert; `.default("draft")` makes the input optional and is type-checked against the value union (`f.select([...]).default("nope")` won't compile). A dynamic `OptionsConfig` widens the type to `string`. See [Fields → inferred types](/docs/concepts/fields#example--inferred-types) for how modifiers flow into the generated types.

--- a/apps/docs/content/docs/concepts/fields/time.mdx
+++ b/apps/docs/content/docs/concepts/fields/time.mdx
@@ -24,7 +24,7 @@ import { collection } from "#questpie/factories";
 
 export const businesses = collection("businesses").fields(({ f }) => ({
   name: f.text().required(),
-  opensAt: f.time().required(),  // time column, NOT NULL, "HH:MM:SS"
+  opensAt: f.time().required(), // time column, NOT NULL, "HH:MM:SS"
   closesAt: f.time().required(),
 }));
 ```
@@ -33,9 +33,9 @@ That gives `businesses` two `time` columns, required on insert, validated agains
 
 ```ts
 await app.collections.businesses.create({
-	name: "Cafe",
-	opensAt: "08:00:00",
-	closesAt: "17:30:00",
+  name: "Cafe",
+  opensAt: "08:00:00",
+  closesAt: "17:30:00",
 });
 ```
 
@@ -43,10 +43,10 @@ await app.collections.businesses.create({
 
 `f.time(config?)` takes one optional config object.
 
-| Option | Type | Default | Effect |
-|---|---|---|---|
-| `precision` | `0 \| 1 \| 2 \| 3 \| 4 \| 5 \| 6` | `0` | Fractional-second precision of the `time` column. `0` = whole seconds; `3` = milliseconds. |
-| `withSeconds` | `boolean` | `true` | When `true`, the schema requires `HH:MM:SS` (with optional `.ms`). When `false`, it requires `HH:MM`. |
+| Option        | Type                              | Default | Effect                                                                                                |
+| ------------- | --------------------------------- | ------- | ----------------------------------------------------------------------------------------------------- |
+| `precision`   | `0 \| 1 \| 2 \| 3 \| 4 \| 5 \| 6` | `0`     | Fractional-second precision of the `time` column. `0` = whole seconds; `3` = milliseconds.            |
+| `withSeconds` | `boolean`                         | `true`  | When `true`, the schema requires `HH:MM:SS` (with optional `.ms`). When `false`, it requires `HH:MM`. |
 
 ```ts
 startTime: f.time(),                         // time(0), validates "HH:MM:SS"
@@ -61,7 +61,7 @@ The resulting field data is always a `string`. The derived Zod schema is a `z.st
 </Callout>
 
 <Callout type="warn" title="The value is a STRING, not a Date">
-A time field's data is an `"HH:MM:SS"` **string**, there is no date or timezone attached. Don't pass a `Date`; pass the formatted string (`"09:30:00"`). This differs from [`f.datetime()`](/docs/concepts/fields/datetime), whose value is a real `Date`.
+  A time field stores an `"HH:MM:SS"` string representing time of day. Pass a formatted string such as `"09:30:00"`. Use [`f.datetime()`](/docs/concepts/fields/datetime) when the value needs a calendar date or instant.
 </Callout>
 
 ## Chained methods
@@ -71,26 +71,26 @@ A time field's data is an `"HH:MM:SS"` **string**, there is no date or timezone 
 ```ts
 collection("schedules").fields(({ f }) => ({
   startTime: f.time().required().label("Start"),
-  endTime:   f.time().required().label("End"),
-  reminders: f.time().array(),                  // string[] stored as jsonb
+  endTime: f.time().required().label("End"),
+  reminders: f.time().array(), // string[] stored as jsonb
 }));
 ```
 
 <Callout type="info" title="No `autoNow()` on time fields">
-`.autoNow()` and `.autoNowUpdate()` are [`f.datetime()`](/docs/concepts/fields/datetime) methods (they set the column to the current `Date`). They do **not** exist on `f.time()`. For a literal default time use the shared `.default("09:00:00")` modifier.
+  `.autoNow()` and `.autoNowUpdate()` are [`f.datetime()`](/docs/concepts/fields/datetime) methods (they set the column to the current `Date`). They do **not** exist on `f.time()`. For a literal default time use the shared `.default("09:00:00")` modifier.
 </Callout>
 
 ## Filtering, operators
 
 `time` uses the **date operator set** (`dateOps`), the same set as [`f.datetime()`](/docs/concepts/fields/datetime). Every time field is filterable with these in a `where` clause. The operand is typed `DateInput` (`Date | string`), pass the time string, e.g. `"12:00:00"`.
 
-| Operator | Operand | Matches |
-|---|---|---|
-| `eq` / `ne` | `Date \| string` | Exact equal / not equal. |
-| `gt` / `gte` | `Date \| string` | After / at-or-after the given time. |
-| `lt` / `lte` | `Date \| string` | Before / at-or-before the given time. |
-| `in` / `notIn` | `(Date \| string)[]` | Value is (not) in the list. |
-| `isNull` / `isNotNull` | `boolean` | Column is (not) null. |
+| Operator               | Operand              | Matches                               |
+| ---------------------- | -------------------- | ------------------------------------- |
+| `eq` / `ne`            | `Date \| string`     | Exact equal / not equal.              |
+| `gt` / `gte`           | `Date \| string`     | After / at-or-after the given time.   |
+| `lt` / `lte`           | `Date \| string`     | Before / at-or-before the given time. |
+| `in` / `notIn`         | `(Date \| string)[]` | Value is (not) in the list.           |
+| `isNull` / `isNotNull` | `boolean`            | Column is (not) null.                 |
 
 ```ts
 // Businesses open at or before noon:
@@ -130,8 +130,8 @@ type Business = typeof businesses.$infer.select;
 ```ts
 import type { CollectionDoc, CollectionWhere } from "#questpie/types";
 
-type Business = CollectionDoc<"businesses">;          // { opensAt: string; ... }
-type BusinessFilter = CollectionWhere<"businesses">;  // { opensAt?: { gt?: Date | string; ... } }
+type Business = CollectionDoc<"businesses">; // { opensAt: string; ... }
+type BusinessFilter = CollectionWhere<"businesses">; // { opensAt?: { gt?: Date | string; ... } }
 ```
 
 `.required()` makes the field non-null and required on insert; without it the column is nullable and the insert field optional. `.default("09:00:00")` makes the input optional and is type-checked against `string`. See [Fields → inferred types](/docs/concepts/fields#example--inferred-types) for how modifiers flow into the generated types.

--- a/apps/docs/content/docs/concepts/fields/upload.mdx
+++ b/apps/docs/content/docs/concepts/fields/upload.mdx
@@ -3,7 +3,7 @@ title: Upload field
 description: f.upload() is a typed relation from a row to a separate upload collection (default "assets"), store a single file reference, a many-to-many gallery, or an inline list of asset IDs, and the admin renders a file picker instead of a relation dropdown.
 ---
 
-`f.upload()` links a row to a file stored in a *separate* upload collection, by default the built-in `"assets"` collection. In its single form it's a typed `varchar(36)` foreign key holding one asset ID; the admin renders it as a file picker (upload + browse the media library), not a relation dropdown. Switch it to many-to-many or an inline array when a row needs several files. Reach for it whenever a row references uploaded bytes, a cover image, an attachment, a gallery.
+`f.upload()` links a row to a file stored in a _separate_ upload collection, by default the built-in `"assets"` collection. In its single form it's a typed `varchar(36)` foreign key holding one asset ID; the admin renders it as a file picker (upload + browse the media library), not a relation dropdown. Switch it to many-to-many or an inline array when a row needs several files. Reach for it whenever a row references uploaded bytes, a cover image, an attachment, a gallery.
 
 > **Prerequisites:** read [Fields](/docs/concepts/fields) first, this page covers only the `upload` type. The `f` proxy, the chain-modifier model, and shared modifiers like `.required()` / `.localized()` / `.label()` are taught there.
 
@@ -24,34 +24,35 @@ import { collection } from "#questpie/factories";
 
 export const posts = collection("posts").fields(({ f }) => ({
   title: f.text().required(),
-  coverImage: f.upload(),                          // FK to "assets", optional
-  attachment: f.upload({ to: "documents" }),       // FK to a "documents" upload collection
+  coverImage: f.upload(), // FK to "assets", optional
+  attachment: f.upload({ to: "documents" }), // FK to a "documents" upload collection
 }));
 ```
 
 That gives `posts` a `coverImage` column typed `string` on read (the asset ID), nullable until you add `.required()`, rendered as a file picker in the admin form, and filterable with the belongsTo operators, no junction table or relation wiring written by hand.
 
 <Callout type="info" title="`f.upload()` references a collection, it isn't the byte store">
-The `f.upload()` *field* is a relation **to** an upload collection; the bytes live in that target collection (default `"assets"`). Turning a collection *itself* into the byte store (storage adapter, URL generation, signed URLs, direct-to-storage uploads) is a different concern with the same name. See [Storage adapters](/docs/adapters/storage) for where bytes are persisted and served.
+  The `f.upload()` *field* is a relation **to** an upload collection; the bytes live in that target collection (default `"assets"`). Turning a collection *itself* into the byte store (storage adapter, URL generation, signed URLs, direct-to-storage uploads) is a different concern with the same name. See [Storage
+  adapters](/docs/adapters/storage) for where bytes are persisted and served.
 </Callout>
 
 ## Constructor argument
 
 `f.upload()` takes a single optional config object. Every key is optional.
 
-| Option | Type | Default | Effect |
-|---|---|---|---|
-| `to` | `string` | `"assets"` | Target upload collection the FK points at. Narrows the field's typed target. |
-| `mimeTypes` | `string[]` | none | Accepted by the config but **currently ignored**, no effect anywhere (see gotcha). Use `.admin({ accept })` to constrain the picker. |
-| `maxSize` | `number` | none | Accepted by the config but **currently ignored**, no effect anywhere (see gotcha). Use `.admin({ maxSize })` to constrain the picker. |
-| `through` | `string` | none | Junction collection name. Setting it makes the field **many-to-many** (see below). |
-| `sourceField` | `string` | none | Name of the source FK column on the junction (M2M only). |
-| `targetField` | `string` | none | Name of the target FK column on the junction (M2M only). |
+| Option        | Type       | Default    | Effect                                                                             |
+| ------------- | ---------- | ---------- | ---------------------------------------------------------------------------------- |
+| `to`          | `string`   | `"assets"` | Target upload collection the FK points at. Narrows the field's typed target.       |
+| `mimeTypes`   | `string[]` | none       | Reserved config key. Set picker constraints with `.admin({ accept })`.             |
+| `maxSize`     | `number`   | none       | Reserved config key. Set picker constraints with `.admin({ maxSize })`.            |
+| `through`     | `string`   | none       | Junction collection name. Setting it makes the field **many-to-many** (see below). |
+| `sourceField` | `string`   | none       | Name of the source FK column on the junction (M2M only).                           |
+| `targetField` | `string`   | none       | Name of the target FK column on the junction (M2M only).                           |
 
 The single-upload field is always `varchar(36)`, data `string`, schema `z.string().uuid()`.
 
-<Callout type="warn" title="`mimeTypes` / `maxSize` are accepted but currently ignored">
-`mimeTypes` and `maxSize` are destructured from the config and then never used, they reach **no** part of the field. They are not applied to the column, not to the derived Zod schema, and not to the field's metadata (the `metadataFactory` emits no `mimeTypes`/`maxSize`, and `RelationFieldMetadata` has no such keys), so they have no admin-picker effect either. Today they are dead config. To actually constrain the admin file picker, set them on the **field's admin config** instead, `f.upload().admin({ accept: "image/*", maxSize: 5_000_000 })`, which flows to the picker's `accept` / `maxSize` props. Enforce real upload limits on the target upload collection / storage adapter.
+<Callout type="warn" title="Configure upload constraints at both layers">
+Use `f.upload().admin({ accept: "image/*", maxSize: 5_000_000 })` to constrain the admin picker. Enforce authoritative MIME and size limits on the target upload collection with `.upload({ allowedTypes, maxSize })`.
 </Callout>
 
 ## Variants, single, many-to-many, inline array
@@ -76,22 +77,23 @@ gallery: f.upload({ through: "post_assets" }), // M2M gallery via a junction col
 
 ### Inline array, `.multiple()`
 
-Several assets stored *inline* as a JSONB array of IDs on this row (no junction). `.multiple()` switches the field to a virtual JSONB column with a runtime schema of `z.array(z.string().uuid())`, the value you write/read back is `string[]`. Uses the **multiple** operator set.
+Several assets stored _inline_ as a JSONB array of IDs on this row (no junction). `.multiple()` switches the field to a virtual JSONB column with a runtime schema of `z.array(z.string().uuid())`, the value you write/read back is `string[]`. Uses the **multiple** operator set.
 
 ```ts
 images: f.upload().multiple(),   // string[] of asset IDs, stored inline as jsonb
 ```
 
 <Callout type="info" title="M2M vs `.multiple()`, junction table or inline array">
-Both hold many assets. **`through`** stores the links in a separate junction collection (queryable, supports the `some` / `none` / `every` quantifiers). **`.multiple()`** stores the IDs inline as a JSONB array on the row (no extra table, queried with array operators like `contains`). Use `through` when the relationship itself needs rows (ordering, pivot data); use `.multiple()` for a simple ordered list of files.
+  Both hold many assets. **`through`** stores the links in a separate junction collection (queryable, supports the `some` / `none` / `every` quantifiers). **`.multiple()`** stores the IDs inline as a JSONB array on the row (no extra table, queried with array operators like `contains`). Use `through` when the
+  relationship itself needs rows (ordering, pivot data); use `.multiple()` for a simple ordered list of files.
 </Callout>
 
 ## Chained methods
 
 This method is specific to `upload` (on top of the [shared modifiers](/docs/concepts/fields) every field has). It returns a new immutable field.
 
-| Method | Effect |
-|---|---|
+| Method        | Effect                                                                                  |
+| ------------- | --------------------------------------------------------------------------------------- |
 | `.multiple()` | Switch to an inline JSONB array of asset IDs (runtime value `string[]`, `multipleOps`). |
 
 ```ts
@@ -104,12 +106,12 @@ Which operators a `where: { <field>: { … } }` accepts depends on the variant. 
 
 **Single upload**, the **belongsTo** operator set (`belongsToOps`).
 
-| Operator | Operand | Matches |
-|---|---|---|
-| `eq` / `ne` | `string` | Asset ID equal / not equal. |
-| `in` / `notIn` | `string[]` | Asset ID is (not) in the list. |
-| `isNull` / `isNotNull` | `boolean` | The FK is (not) set. |
-| `is` / `isNot` | related `where` | Filter on the *target* asset's fields (e.g. its `mimeType`). |
+| Operator               | Operand         | Matches                                                      |
+| ---------------------- | --------------- | ------------------------------------------------------------ |
+| `eq` / `ne`            | `string`        | Asset ID equal / not equal.                                  |
+| `in` / `notIn`         | `string[]`      | Asset ID is (not) in the list.                               |
+| `isNull` / `isNotNull` | `boolean`       | The FK is (not) set.                                         |
+| `is` / `isNot`         | related `where` | Filter on the _target_ asset's fields (e.g. its `mimeType`). |
 
 ```ts
 // Posts whose cover image is a specific asset
@@ -125,23 +127,23 @@ const missing = await app.collections.posts.find({
 
 **Many-to-many (`through`)**, the **toMany** operator set (`toManyOps`): the relation quantifiers.
 
-| Operator | Operand | Matches |
-|---|---|---|
-| `some` | related `where` | At least one linked asset matches. |
-| `none` | related `where` | No linked asset matches. |
-| `every` | related `where` | Every linked asset matches. |
-| `count` | `number` | Number of linked assets equals the value. |
+| Operator | Operand         | Matches                                   |
+| -------- | --------------- | ----------------------------------------- |
+| `some`   | related `where` | At least one linked asset matches.        |
+| `none`   | related `where` | No linked asset matches.                  |
+| `every`  | related `where` | Every linked asset matches.               |
+| `count`  | `number`        | Number of linked assets equals the value. |
 
 **Inline array (`.multiple()`)**, the **multiple** operator set (`multipleOps`), querying the JSONB array.
 
-| Operator | Operand | Matches |
-|---|---|---|
-| `contains` | `string` | Array contains the asset ID. |
-| `containsAll` | `string[]` | Array contains all listed IDs. |
-| `containsAny` | `string[]` | Array contains at least one listed ID. |
-| `isEmpty` / `isNotEmpty` | `boolean` | Array is empty / non-empty (treats `null` as empty). |
-| `count` | `number` | Array length equals the value. |
-| `isNull` / `isNotNull` | `boolean` | The JSONB column is (not) null. |
+| Operator                 | Operand    | Matches                                              |
+| ------------------------ | ---------- | ---------------------------------------------------- |
+| `contains`               | `string`   | Array contains the asset ID.                         |
+| `containsAll`            | `string[]` | Array contains all listed IDs.                       |
+| `containsAny`            | `string[]` | Array contains at least one listed ID.               |
+| `isEmpty` / `isNotEmpty` | `boolean`  | Array is empty / non-empty (treats `null` as empty). |
+| `count`                  | `number`   | Array length equals the value.                       |
+| `isNull` / `isNotNull`   | `boolean`  | The JSONB column is (not) null.                      |
 
 ```ts
 // Posts whose inline image list includes a given asset
@@ -155,8 +157,8 @@ For the full query language, combining field filters with `AND` / `OR` / `NOT`, 
 ## When to use it
 
 - **`f.upload()`**, any field that references an uploaded file: a cover image, an avatar, a downloadable attachment. You get a typed asset-ID FK and a file picker in the admin, instead of a free-form string.
-- **`f.upload({ through })` / `f.upload().multiple()`**, when a row holds *several* files: a gallery, a set of attachments. Choose `through` for a junction-backed relation, `.multiple()` for a simple inline list.
-- For a relation to a *non-upload* collection (an author, a category), use [`f.relation()`](/docs/concepts/relations) instead, same FK mechanics, but the admin renders a record picker, not an upload control.
+- **`f.upload({ through })` / `f.upload().multiple()`**, when a row holds _several_ files: a gallery, a set of attachments. Choose `through` for a junction-backed relation, `.multiple()` for a simple inline list.
+- For a relation to a _non-upload_ collection (an author, a category), use [`f.relation()`](/docs/concepts/relations) instead, same FK mechanics, but the admin renders a record picker, not an upload control.
 
 <Callout type="info" title="Hydrate the asset with `with:`">
 A single upload stores only the asset **ID**. To read the asset record itself (its `url`, filename, metadata) alongside the row, hydrate the relation with `with: { coverImage: true }`, exactly like any belongsTo relation (see [Relations → hydration with `with`](/docs/concepts/relations)). The resolved `url` and serving the bytes are covered in [Storage adapters](/docs/adapters/storage).

--- a/apps/docs/content/docs/concepts/globals.mdx
+++ b/apps/docs/content/docs/concepts/globals.mdx
@@ -3,19 +3,19 @@ title: Globals
 description: Globals are single-row data models, site settings, a homepage, a footer, built with the same fields, hooks, and access rules as collections, but with get/update instead of full CRUD.
 ---
 
-A global is a **singleton**: one record, not a table of many. Use it for the thing your app has exactly one of, site settings, SEO defaults, a homepage layout, a footer. You declare it in a file with the same field, hook, and access builders you use for a [collection](/docs/concepts/collections), run codegen, and get a typed `app.globals.<name>` surface with `get()` and `update()`, no `create`, no `find`, no `delete`, and a single edit screen in the admin instead of a list.
+A global is a **singleton**. Use it for data your app has exactly one of: site settings, SEO defaults, a homepage layout, or a footer. It uses the collection field, hook, and access builders, then generates typed `get()` and `update()` methods plus one admin edit screen.
 
 ## What it does
 
-- **Gives you one always-addressable record.** No ids to track, no "create first", you `get()` it and `update()` it.
+- **Gives you one always-addressable record.** Read it with `get()` and create or patch its row with `update()`.
 - **Reuses the entire field builder.** `f.text()`, `f.object().array()`, `f.upload()`, `f.select()`, relations, and `.localized()` all work exactly as in collections.
 - **Generates a typed `get()`/`update()` API** on `app.globals.<name>` (server) and on the typed client (over HTTP), with the row type inferred from your fields.
-- **Renders a single admin form** via `.admin()` + `.form()`, no list view, because there is nothing to list.
+- **Renders a single admin form** configured with `.admin()` and `.form()`.
 - **Snapshots history with `versioning`**, and adds draft → published stages with a nested `workflow`.
 - **Scopes per tenant with `scoped`**, one row per city, property, or tenant from the same definition.
 
-<Callout type="info" title="Global or collection, the one-line rule">
-If you could ever have *two* of them, it's a [collection](/docs/concepts/collections). If there's exactly one, settings, homepage, footer, it's a global. Globals have no `find`, `create`, `delete`, or list view.
+<Callout type="info" title="Global or collection">
+  Use a [collection](/docs/concepts/collections) for a set of records. Use a global for one settings document, homepage, footer, or other singleton.
 </Callout>
 
 ## Quick start
@@ -54,7 +54,7 @@ questpie push       # create the table (dev), or migrate:create for prod
 ```
 
 <Callout type="info" title="Import from `#questpie/factories`, not `questpie`">
-Import `global` from **`#questpie/factories`**, not from `questpie` directly. The generated factory injects your module field types (`richText`, `blocks`, …) into `f`. A plain `global()` from the package only sees builtin field types.
+  Import `global` from **`#questpie/factories`**, not from `questpie` directly. The generated factory injects your module field types (`richText`, `blocks`, …) into `f`. A plain `global()` from the package only sees builtin field types.
 </Callout>
 
 ## Reading and writing
@@ -83,10 +83,10 @@ const settings = await app.globals.siteSettings.get(
 );
 ```
 
-`GlobalGetOptions` accepts exactly: `with` (relations), `columns` (partial selection), `locale`, `localeFallback`, and `stage` (workflow). There is no `where`, `limit`, `offset`, or `orderBy`, a singleton has nothing to filter or paginate.
+`GlobalGetOptions` accepts `with` for relations, `columns` for partial selection, `locale`, `localeFallback`, and workflow `stage`. Singleton reads return that one scoped row, so filtering and pagination options belong to collection queries.
 
 <Callout type="warn" title="`get()` returns `null` until the row exists, and `.default()` does not change that">
-A global has no row until something writes it: a seed, an admin save, or an `update()`. Field `.default(...)` values describe the **admin form's initial state**, not a database default, they are *not* auto-inserted on first read. Always handle `null` on the first read (or seed the global at boot).
+  A global has no row until something writes it: a seed, an admin save, or an `update()`. Field `.default(...)` values describe the **admin form's initial state**, not a database default, they are *not* auto-inserted on first read. Always handle `null` on the first read (or seed the global at boot).
 </Callout>
 
 ### update(data, context?, options?)
@@ -105,20 +105,14 @@ const updated = await app.globals.siteSettings.update({
 `update()` is an **upsert** of the single row: it creates the row on the first call and patches it thereafter. It returns the updated record (never `null`). The patch is validated against the field schema before the write, and `beforeChange`/`afterChange` (and `beforeUpdate`/`afterUpdate`) hooks run around it.
 
 <Callout type="warn" title="Argument order differs from collections">
-On the server, `update(data, context, options)` takes the patch **first**, then the `CRUDContext`, then options, there is no id to address, so the context is the *second* argument. Collections use `updateById({ id, data }, context)`.
+On the server, `update(data, context, options)` takes the patch **first**, then the `CRUDContext`, then options. Collections address a record with `updateById({ id, data }, context)`.
 </Callout>
 
 To write per-locale content, pass a locale-bound context (or the `locale` option) and call `update()` once per locale:
 
 ```ts
-await app.globals.siteSettings.update(
-  { tagline: "Sharp cuts, every time" },
-  { accessMode: "system", locale: "en" },
-);
-await app.globals.siteSettings.update(
-  { tagline: "Ostré strihy, vždy" },
-  { accessMode: "system", locale: "sk" },
-);
+await app.globals.siteSettings.update({ tagline: "Sharp cuts, every time" }, { accessMode: "system", locale: "en" });
+await app.globals.siteSettings.update({ tagline: "Ostré strihy, vždy" }, { accessMode: "system", locale: "sk" });
 ```
 
 ### Versions and workflow
@@ -139,22 +133,19 @@ await app.globals.siteSettings.transitionStage({ stage: "published" });
 `transitionStage()` exists only on workflow-enabled globals; its `scheduledAt` param schedules the transition for a future date instead of running it now (`GlobalTransitionStageParams`). `revertToVersion()` accepts `{ version }`, `{ versionId }`, or `{ id }` (`GlobalRevertVersionOptions`).
 
 <Callout type="info" title="`GlobalVersionRecord` has no `versionStage`">
-A collection's version record carries the workflow stage; a global's does not, read the current stage via the `stage` option on `get()` instead.
+  A collection's version record carries the workflow stage; a global's does not, read the current stage via the `stage` option on `get()` instead.
 </Callout>
 
 ### From the typed client
 
-The typed client exposes the same global over HTTP at `client.globals.<name>`, with one signature difference: there is no `context` argument, the request carries the session via cookies, so access runs in `user` mode automatically.
+The typed client exposes the same global over HTTP at `client.globals.<name>`. Client calls carry the session through cookies, so access runs in `user` mode automatically and the signature contains only data and query options.
 
 ```ts
 // update(data, options?), NO context arg on the client
-const settings = await client.globals.siteSettings.update(
-  { siteName: "QUESTPIE" },
-  { with: { logo: true } },
-);
+const settings = await client.globals.siteSettings.update({ siteName: "QUESTPIE" }, { with: { logo: true } });
 
 const schema = await client.globals.siteSettings.schema(); // full introspection
-const meta = await client.globals.siteSettings.meta();     // timestamps/versioning/localized
+const meta = await client.globals.siteSettings.meta(); // timestamps/versioning/localized
 ```
 
 The `GlobalAPI` client surface is `get`, `update`, `schema`, `meta`, `findVersions`, `revertToVersion`, and `transitionStage`. Live subscriptions (`live()`) are available when the realtime adapter is configured.
@@ -164,7 +155,7 @@ The `GlobalAPI` client surface is `get`, `update`, `schema`, `meta`, `findVersio
 `global(name)` returns a `GlobalBuilder`. Every method returns the builder, so you chain them and export the result, **codegen calls `.build()` for you**; you never call it yourself in app code.
 
 <Callout type="info" title="Method order does not matter">
-`.fields()`, `.options()`, `.access()`, `.hooks()`, `.admin()`, and `.form()` can appear in any order. The barbershop example places `.options()` and `.access()` last; the quick start places them first. Both are valid.
+  `.fields()`, `.options()`, `.access()`, `.hooks()`, `.admin()`, and `.form()` can appear in any order. The barbershop example places `.options()` and `.access()` last; the quick start places them first. Both are valid.
 </Callout>
 
 ### `.fields(({ f }) => ({ ... }))`
@@ -175,14 +166,14 @@ Define the global's fields with the field builder. **Cumulative + override-by-ke
 global("site_settings").fields(({ f }) => ({
   siteName: f.text().required(),
   contactEmail: f.email(),
-  tagline: f.text().localized(),                 // per-locale value
-  logo: f.upload({ to: "assets" }),              // relation to an upload collection
+  tagline: f.text().localized(), // per-locale value
+  logo: f.upload({ to: "assets" }), // relation to an upload collection
   navigation: f
     .object({
       label: f.text().required(),
       href: f.text().required(),
     })
-    .array(),                                    // repeatable nested objects
+    .array(), // repeatable nested objects
 }));
 ```
 
@@ -203,18 +194,18 @@ Mark a field `.localized()` and QUESTPIE generates a `<name>_i18n` table behind 
 
 `GlobalOptions` is a strict, four-key shape:
 
-| Option | Type | Default | Effect |
-|---|---|---|---|
-| `timestamps` | `boolean` | `true` | Adds `createdAt` + `updatedAt`. Set `false` to drop them. |
-| `schema` | `string` | `public` | Places all tables in a Postgres schema; migrations emit `CREATE SCHEMA IF NOT EXISTS`. |
-| `versioning` | `boolean \| { enabled?, maxVersions?, workflow? }` | `false` | Snapshots into `<name>_versions`; enables `findVersions` / `revertToVersion`. |
-| `scoped` | `(ctx) => string \| null \| undefined` | none | Multi-tenant: each scope gets its own row (see [below](#multi-tenant-globals-with-scoped)). |
+| Option       | Type                                               | Default  | Effect                                                                                      |
+| ------------ | -------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------- |
+| `timestamps` | `boolean`                                          | `true`   | Adds `createdAt` + `updatedAt`. Set `false` to drop them.                                   |
+| `schema`     | `string`                                           | `public` | Places all tables in a Postgres schema; migrations emit `CREATE SCHEMA IF NOT EXISTS`.      |
+| `versioning` | `boolean \| { enabled?, maxVersions?, workflow? }` | `false`  | Snapshots into `<name>_versions`; enables `findVersions` / `revertToVersion`.               |
+| `scoped`     | `(ctx) => string \| null \| undefined`             | none     | Multi-tenant: each scope gets its own row (see [below](#multi-tenant-globals-with-scoped)). |
 
 There is **no `softDelete`** option, a singleton is never deleted. (Note: `.options()` replaces the whole options object on the builder; it does not deep-merge across multiple `.options()` calls.)
 
 ### `.access({ read, update, transition, introspect, fields })`
 
-Control who can read and write the global. A rule is a `boolean` or a function returning `boolean` (or a promise of one). Because a global is a single row, rules **cannot return a where-filter** the way [collection access rules](/docs/concepts/access-control) can, there is nothing to filter.
+Control who can read and write the global. A rule is a `boolean` or a function returning `boolean` (or a promise of one). Collection access rules can additionally return a row filter because they operate on a set of records.
 
 ```ts
 .access({
@@ -226,13 +217,13 @@ Control who can read and write the global. A rule is a `boolean` or a function r
 
 `GlobalAccess` supports:
 
-| Rule | When it runs | `ctx.data` |
-|---|---|---|
-| `read` | before reading | not loaded |
-| `update` | before writing | the existing record (`undefined` on first write); `ctx.input` is the patch |
-| `transition` | before a stage change | the existing record, falls back to `update` if omitted |
-| `introspect` | admin schema visibility | none visible if `read` **or** `update` is allowed |
-| `fields` | per-field allow/deny | `{ read?, update? }` per field name (no filtering, only allow/deny) |
+| Rule         | When it runs            | `ctx.data`                                                                 |
+| ------------ | ----------------------- | -------------------------------------------------------------------------- |
+| `read`       | before reading          | not loaded                                                                 |
+| `update`     | before writing          | the existing record (`undefined` on first write); `ctx.input` is the patch |
+| `transition` | before a stage change   | the existing record, falls back to `update` if omitted                     |
+| `introspect` | admin schema visibility | none visible if `read` **or** `update` is allowed                          |
+| `fields`     | per-field allow/deny    | `{ read?, update? }` per field name (no filtering, only allow/deny)        |
 
 The rule context (`GlobalAccessContext`) spreads the full `AppContext` (`db`, `session`, `kv`, `queue`, `globals`, …) plus `{ data?, input?, locale? }`.
 
@@ -260,7 +251,7 @@ Calling `.hooks()` twice on a global keeps only the **last** call's hooks (the b
 
 ### .admin() and .form()
 
-Globals support exactly **two** admin methods, `.admin()` (label, description, icon, group, ordering) and `.form()` (the edit-form layout). They have **no** `.list()`, `.preview()`, or `.actions()`, because there is no list of records. These methods are declaration-merged onto the builder by `@questpie/admin`; install it to make them available.
+Globals use `.admin()` for label, description, icon, group, and ordering, and `.form()` for the singleton edit layout. `@questpie/admin` adds both methods to the global builder.
 
 ```ts
 .admin(({ c }) => ({
@@ -322,21 +313,19 @@ const propertySettings = global("property_settings")
 Behind the scenes a nullable `scope_id` column and a unique `<name>_scope_idx` index are added (and `scope_id` is carried into the versions table too). `get()` and `update()` then read and write the row for whatever scope the context resolves to, you call them exactly as before; **the scope is selected from context, not passed as an argument**. Wiring `ctx.propertyId` is covered under multi-tenancy.
 
 <Callout type="info" title="The resolver may return `null`/`undefined`">
-When it does, the global resolves the unscoped (null-scope) row, useful for a shared default across tenants. The resolver runs per request, so it sees the same context your hooks and access rules see.
+  When it does, the global resolves the unscoped (null-scope) row, useful for a shared default across tenants. The resolver runs per request, so it sees the same context your hooks and access rules see.
 </Callout>
 
 ### What gets generated
 
 A built global produces up to four Drizzle tables, mirroring collections (minus the title column):
 
-| Table | When | Notes |
-|---|---|---|
-| `<name>` | always | main row: `id` + your main fields (+ `scope_id` if scoped, + timestamps unless disabled) |
-| `<name>_i18n` | any `.localized()` field | per-locale values, unique on `(parent_id, locale)` |
-| `<name>_versions` | `versioning` enabled | snapshots; indexed on `(id, version_number)` and `(id, version_stage, version_number)` |
-| `<name>_i18n_versions` | versioning **and** localized | per-locale snapshot values |
-
-
+| Table                  | When                         | Notes                                                                                    |
+| ---------------------- | ---------------------------- | ---------------------------------------------------------------------------------------- |
+| `<name>`               | always                       | main row: `id` + your main fields (+ `scope_id` if scoped, + timestamps unless disabled) |
+| `<name>_i18n`          | any `.localized()` field     | per-locale values, unique on `(parent_id, locale)`                                       |
+| `<name>_versions`      | `versioning` enabled         | snapshots; indexed on `(id, version_number)` and `(id, version_stage, version_number)`   |
+| `<name>_i18n_versions` | versioning **and** localized | per-locale snapshot values                                                               |
 
 ## TypeScript
 

--- a/apps/docs/content/docs/concepts/hooks.mdx
+++ b/apps/docs/content/docs/concepts/hooks.mdx
@@ -3,7 +3,7 @@ title: Hooks
 description: Run your code at each stage of a collection's create, update, read, and delete lifecycle, to transform input, derive fields, enforce rules, and fire side effects only after the write commits.
 ---
 
-Hooks let you run logic at precise points in a collection's lifecycle: mutate input before it's validated, compute derived fields right before the write, react to a completed change with the full saved record, and fire jobs or emails only after the row is durable. You declare them once with `.hooks({ ... })`, and they run on **every** operation against that collection, REST, the typed client, the admin UI, and internal server code alike. There is no separate "API hook" vs "admin hook"; one declaration governs them all.
+Hooks run logic at precise points in a collection lifecycle: transform input before validation, compute fields before a write, react to the saved record, and schedule side effects after commit. One `.hooks({ ... })` declaration governs REST, typed client, admin, and internal operations.
 
 ## What it does
 
@@ -23,45 +23,42 @@ Add a `.hooks({ ... })` block to any collection. This one generates a slug befor
 import { collection } from "#questpie/factories";
 
 function slugify(input: string): string {
-	return input
-		.toLowerCase()
-		.replace(/[^a-z0-9]+/g, "-")
-		.replace(/^-|-$/g, "");
+  return input
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
 }
 
 export const posts = collection("posts")
-	.fields(({ f }) => ({
-		title: f.text(255).required(),
-		slug: f.text(255),
-		body: f.richText(),
-	}))
-	.hooks({
-		// Runs after validation, before the INSERT/UPDATE. Mutate `data` in place.
-		beforeChange: ({ data, operation }) => {
-			if (operation === "create" && data.title && !data.slug) {
-				data.slug = slugify(data.title);
-			}
-		},
+  .fields(({ f }) => ({
+    title: f.text(255).required(),
+    slug: f.text(255),
+    body: f.richText(),
+  }))
+  .hooks({
+    // Runs after validation, before the INSERT/UPDATE. Mutate `data` in place.
+    beforeChange: ({ data, operation }) => {
+      if (operation === "create" && data.title && !data.slug) {
+        data.slug = slugify(data.title);
+      }
+    },
 
-		// Runs after the write, INSIDE the CRUD transaction.
-		// Defer the side effect so it only fires once the data is durable.
-		afterChange: ({ data, operation, onAfterCommit, queue }) => {
-			if (operation !== "create") return;
-			onAfterCommit(async () => {
-				await queue.notifyPost.publish({ postId: data.id });
-			});
-		},
-	});
+    // Runs after the write, INSIDE the CRUD transaction.
+    // Defer the side effect so it only fires once the data is durable.
+    afterChange: ({ data, operation, onAfterCommit, queue }) => {
+      if (operation !== "create") return;
+      onAfterCommit(async () => {
+        await queue.notifyPost.publish({ postId: data.id });
+      });
+    },
+  });
 ```
 
 That's the whole surface for most collections: one or two `before*` hooks to shape data, one `afterChange` to react. Every stage and every `ctx` property is in [Full API](#full-api) below.
 
 <Callout type="info">
-	**Hooks merge across calls.** Each call to `.hooks()` *appends* to the existing
-	handlers per stage, it never replaces them. Calling `.hooks()` twice, or
-	composing a collection from modules, accumulates handlers for each stage and
-	runs them in registration order. (Contrast with `.access()`, which overwrites
-	the whole access object on each call.)
+  **Hooks merge across calls.** Each call to `.hooks()` *appends* to the existing handlers per stage, it never replaces them. Calling `.hooks()` twice, or composing a collection from modules, accumulates handlers for each stage and runs them in registration order. (Contrast with `.access()`, which overwrites the whole
+  access object on each call.)
 </Callout>
 
 ## Example: what each hook receives
@@ -101,11 +98,12 @@ Written **inline** on `.hooks({ ... })`, `data` / `original` / `operation` are a
 	the non-update operations. Always branch on `ctx.operation === "update"` before
 	reading it.
 
-	On every *other* hook (`beforeOperation`, the `before*` write/read/delete
-	hooks, and `afterDelete`) `ctx.original` is `never`-typed, you can't read it
-	without a cast. (At runtime the delete path does pass the deleted row into
-	`ctx.original` for `beforeDelete` / `afterDelete`, but the type contract hides
-	it; read `ctx.data` for the deleted record instead.)
+    On every *other* hook (`beforeOperation`, the `before*` write/read/delete
+    hooks, and `afterDelete`) `ctx.original` is `never`-typed, you can't read it
+    without a cast. (At runtime the delete path does pass the deleted row into
+    `ctx.original` for `beforeDelete` / `afterDelete`, but the type contract hides
+    it; read `ctx.data` for the deleted record instead.)
+
 </Callout>
 
 ## Full API
@@ -114,18 +112,18 @@ Written **inline** on `.hooks({ ... })`, `data` / `original` / `operation` are a
 
 Declare any subset of these on `.hooks({ ... })`. Each value is a **single function or an array of functions**, see [Arrays and composition](#arrays-and-composition).
 
-| Stage | Fires on | `ctx.data` | `ctx.original` | Throw aborts? |
-|---|---|---|---|---|
-| `beforeOperation` | create, update, read, delete | input (type depends on op) | none | yes |
-| `beforeValidate` | create, update | **mutable** input | none | yes |
-| `beforeChange` | create, update | **validated** input | none | yes |
-| `afterChange` | create, update | the saved record | record (update only) | **on create only**, propagates + rolls back; on update it's caught + logged |
-| `beforeRead` | read | query options | none | yes |
-| `afterRead` | create, update, read, delete | the record | record (update only) | **yes**, propagates to the caller |
-| `beforeDelete` | delete | record to be deleted | none | yes |
-| `afterDelete` | delete | the deleted record | none | no, caught + logged |
-| `beforeTransition` | workflow transition | the record | none | yes |
-| `afterTransition` | workflow transition | the record | none | no, caught + logged |
+| Stage              | Fires on                     | `ctx.data`                 | `ctx.original`       | Throw aborts?                                                               |
+| ------------------ | ---------------------------- | -------------------------- | -------------------- | --------------------------------------------------------------------------- |
+| `beforeOperation`  | create, update, read, delete | input (type depends on op) | none                 | yes                                                                         |
+| `beforeValidate`   | create, update               | **mutable** input          | none                 | yes                                                                         |
+| `beforeChange`     | create, update               | **validated** input        | none                 | yes                                                                         |
+| `afterChange`      | create, update               | the saved record           | record (update only) | **on create only**, propagates + rolls back; on update it's caught + logged |
+| `beforeRead`       | read                         | query options              | none                 | yes                                                                         |
+| `afterRead`        | create, update, read, delete | the record                 | record (update only) | **yes**, propagates to the caller                                           |
+| `beforeDelete`     | delete                       | record to be deleted       | none                 | yes                                                                         |
+| `afterDelete`      | delete                       | the deleted record         | none                 | no, caught + logged                                                         |
+| `beforeTransition` | workflow transition          | the record                 | none                 | yes                                                                         |
+| `afterTransition`  | workflow transition          | the record                 | none                 | no, caught + logged                                                         |
 
 `beforeTransition` / `afterTransition` fire only on workflow stage transitions and carry a different context, see [Transition hooks](#transition-hooks). The "Throw aborts?" column is subtle for the `after*` hooks, see [Aborting an operation](#aborting-an-operation) for exactly which ones swallow errors and which propagate.
 
@@ -140,18 +138,15 @@ Read    →  beforeOperation → beforeRead     → [SELECT] → afterRead
 
 `afterRead` is the only output hook that fires after **all four** operations, branch on `ctx.operation` to discriminate inside it. (The upload feature auto-injects an `afterRead` hook to generate file URLs, and an `afterDelete` hook to remove stored bytes, your hooks run alongside these.)
 
-<Callout type="info">
-	**There is no `beforeCreate` / `beforeUpdate`.** Create and update share the
-	same `beforeValidate` / `beforeChange` / `afterChange` stages, branch on
-	`ctx.operation === "create"` to distinguish them. (Globals are different: they
-	use `beforeUpdate` / `afterUpdate`. See [Globals](#related).)
+<Callout type="info" title="Create and update share change hooks">
+  Use `beforeValidate`, `beforeChange`, and `afterChange` for both operations, then branch on `ctx.operation === "create"` when behavior differs. Globals use `beforeUpdate` and `afterUpdate`. See [Globals](#related).
 </Callout>
 
 ### What each stage is for
 
 - **`beforeOperation`**, runs first for **every** operation, including read and delete. Use for logging, rate limiting, or early checks. `ctx.data` is the input (type depends on the operation), `ctx.original` is not available.
 - **`beforeValidate`**, transform, normalize, and default the **mutable** input before the Zod schema runs. Mutate `ctx.data` in place. Create and update only.
-- **`beforeChange`**, business logic on **validated** input: slug generation, derived fields, complex cross-field validation. The last point at which you can change what gets written. Create and update only; `ctx.original` is *not* available here, diff in `afterChange` instead.
+- **`beforeChange`**, business logic on **validated** input: slug generation, derived fields, complex cross-field validation. The last point at which you can change what gets written. Create and update only; `ctx.original` is _not_ available here, diff in `afterChange` instead.
 - **`afterChange`**, react to a completed write with the full record. Has `ctx.original` on update for diffing. Runs **inside** the transaction, defer durable side effects with [`onAfterCommit`](#side-effects-onaftercommit).
 - **`beforeRead`**, modify query options / add filters. Here `ctx.data` is the query context, not a row.
 - **`afterRead`**, transform output, add computed fields, format values. Fires after create, update, delete, and read.
@@ -164,48 +159,47 @@ Every hook receives one argument, the `HookContext`. It is your `AppContext` (al
 
 ```ts
 type HookContext = AppContext & {
-	data: TData;              // see the stage table for what this is
-	original: TOriginal;      // CollectionDoc<K> | undefined on afterChange/afterRead (set only on update); never-typed elsewhere
-	operation: "create" | "update" | "delete" | "read";
-	locale?: string;
-	accessMode?: "user" | "system";
-	onAfterCommit: (callback: () => Promise<void>) => void;
+  data: TData; // see the stage table for what this is
+  original: TOriginal; // CollectionDoc<K> | undefined on afterChange/afterRead (set only on update); never-typed elsewhere
+  operation: "create" | "update" | "delete" | "read";
+  locale?: string;
+  accessMode?: "user" | "system";
+  onAfterCommit: (callback: () => Promise<void>) => void;
 
-	// Bulk metadata, present only inside updateMany / deleteMany:
-	isBatch?: boolean;
-	recordIds?: (string | number)[];
-	records?: TData[];
-	count?: number;
+  // Bulk metadata, present only inside updateMany / deleteMany:
+  isBatch?: boolean;
+  recordIds?: (string | number)[];
+  records?: TData[];
+  count?: number;
 };
 ```
 
-| `ctx` property | What you get |
-|---|---|
-| `data` | The lifecycle payload for this stage (input for `before*`; the record for `afterChange` / `afterRead` / delete hooks). |
-| `original` | The pre-update record. Typed `CollectionDoc<K> \| undefined` on `afterChange` / `afterRead` (populated only on `update`, `undefined` on the other operations); `never`-typed on every other hook. |
-| `operation` | `"create"` \| `"update"` \| `"delete"` \| `"read"`, narrowed per stage. |
-| `locale` | The active locale for this operation, when set. |
-| `accessMode` | `"user"` (normal) or `"system"` (internal/seed/job code, bypasses access control). |
-| `onAfterCommit` | Queue a callback to run after the outermost transaction commits. See [Side effects](#side-effects-onaftercommit). |
-| `db`, `collections`, `globals` | Database handle and typed access to other collections/globals. |
-| `queue`, `email`, `search`, `realtime`, `kv`, `storage` | Adapter services: queue jobs, email, search index, realtime, KV, file storage. |
-| `session`, `services`, `logger` | The current session, your registered services, and the logger. |
-| `isBatch`, `recordIds`, `records`, `count` | Bulk metadata, present only in `updateMany` / `deleteMany`. See [Bulk operations](#bulk-operations). |
+| `ctx` property                                          | What you get                                                                                                                                                                                      |
+| ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `data`                                                  | The lifecycle payload for this stage (input for `before*`; the record for `afterChange` / `afterRead` / delete hooks).                                                                            |
+| `original`                                              | The pre-update record. Typed `CollectionDoc<K> \| undefined` on `afterChange` / `afterRead` (populated only on `update`, `undefined` on the other operations); `never`-typed on every other hook. |
+| `operation`                                             | `"create"` \| `"update"` \| `"delete"` \| `"read"`, narrowed per stage.                                                                                                                           |
+| `locale`                                                | The active locale for this operation, when set.                                                                                                                                                   |
+| `accessMode`                                            | `"user"` (normal) or `"system"` (internal/seed/job code, bypasses access control).                                                                                                                |
+| `onAfterCommit`                                         | Queue a callback to run after the outermost transaction commits. See [Side effects](#side-effects-onaftercommit).                                                                                 |
+| `db`, `collections`, `globals`                          | Database handle and typed access to other collections/globals.                                                                                                                                    |
+| `queue`, `email`, `search`, `realtime`, `kv`, `storage` | Adapter services: queue jobs, email, search index, realtime, KV, file storage.                                                                                                                    |
+| `session`, `services`, `logger`                         | The current session, your registered services, and the logger.                                                                                                                                    |
+| `isBatch`, `recordIds`, `records`, `count`              | Bulk metadata, present only in `updateMany` / `deleteMany`. See [Bulk operations](#bulk-operations).                                                                                              |
 
 `AppContext` is assembled from your registered adapters and services, so `ctx.session` and `ctx.services` are typed by your app's codegen. The same flat service surface is injected into access rules, routes, and jobs, once you know it in a hook, you know it everywhere.
 
 <Callout type="info">
 	**The email service is `ctx.email`, and you send with `sendTemplate`.** Reach
-	for `ctx.email.sendTemplate({ template, input, to })`, `template` is one of
-	your generated email keys and `input` is its typed props. There is no
-	`ctx.mailer`.
+	for `ctx.email.sendTemplate({ template, input, to })`; `template` is one of
+	your generated email keys and `input` is its typed props.
 </Callout>
 
 ## Advanced
 
 ### Side effects (`onAfterCommit`)
 
-`afterChange`, `afterDelete`, and `afterTransition` run **inside** the CRUD transaction. If you dispatch a job, send an email, or index a document directly from one of them and the transaction later rolls back, you've fired a side effect for data that never landed. (`afterRead` runs *after* the transaction closes, but the same rule applies, keep durable side effects out of hook bodies.)
+`afterChange`, `afterDelete`, and `afterTransition` run **inside** the CRUD transaction. If you dispatch a job, send an email, or index a document directly from one of them and the transaction later rolls back, you've fired a side effect for data that never landed. (`afterRead` runs _after_ the transaction closes, but the same rule applies, keep durable side effects out of hook bodies.)
 
 Use `ctx.onAfterCommit(cb)` to defer the side effect until the **outermost** transaction commits:
 
@@ -229,12 +223,8 @@ Use `ctx.onAfterCommit(cb)` to defer the side effect until the **outermost** tra
 This is exactly how the framework's own realtime and search hooks are written, both subscribe to `afterChange` / `afterDelete` and wrap their broadcast/indexing in `ctx.onAfterCommit`, so events fire only on durable data.
 
 <Callout type="warn">
-	**Don't write to the DB or dispatch directly from an `after*` hook.** Inside
-	an `after*` hook you are already in the CRUD transaction. Dispatching a job,
-	calling `realtime.notify`, or running a second write directly can fire on data
-	that rolls back, and on a single-connection database (PGlite in dev) a
-	context-inherited write can **deadlock** against the open outer transaction.
-	Always wrap durable side effects in `onAfterCommit`.
+  **Don't write to the DB or dispatch directly from an `after*` hook.** Inside an `after*` hook you are already in the CRUD transaction. Dispatching a job, calling `realtime.notify`, or running a second write directly can fire on data that rolls back, and on a single-connection database (PGlite in dev) a
+  context-inherited write can **deadlock** against the open outer transaction. Always wrap durable side effects in `onAfterCommit`.
 </Callout>
 
 ### Aborting an operation
@@ -261,19 +251,20 @@ import { ApiError } from "questpie/errors";
 	three places: **`afterChange` on update** (single and bulk), **`afterDelete`**,
 	and **`afterTransition`**. The operation still succeeds there.
 
-	But two cases **do propagate** a thrown error, and they will surface to the
-	caller:
+    But two cases **do propagate** a thrown error, and they will surface to the
+    caller:
 
-	- **`afterChange` on *create*** runs inside the create transaction with no
-	  catch, a throw **rolls the insert back** and fails the request.
-	- **`afterRead` on *every* operation** (create, update, delete, read) runs with
-	  no catch, a throw propagates to the caller, even though the write itself
-	  already committed (so you can get a failed response for data that landed).
+    - **`afterChange` on *create*** runs inside the create transaction with no
+      catch, a throw **rolls the insert back** and fails the request.
+    - **`afterRead` on *every* operation** (create, update, delete, read) runs with
+      no catch, a throw propagates to the caller, even though the write itself
+      already committed (so you can get a failed response for data that landed).
 
-	If you need a hook that can never affect the response, use one of the three
-	non-fatal `after*` cases, or, better, do the veto-able work in a `before*`
-	stage and defer everything else with [`onAfterCommit`](#side-effects-onaftercommit),
-	whose callbacks are always non-fatal.
+    If you need a hook that can never affect the response, use one of the three
+    non-fatal `after*` cases, or, better, do the veto-able work in a `before*`
+    stage and defer everything else with [`onAfterCommit`](#side-effects-onaftercommit),
+    whose callbacks are always non-fatal.
+
 </Callout>
 
 ### Bulk operations
@@ -298,18 +289,13 @@ import { ApiError } from "questpie/errors";
 - `recordIds` / `records` / `count` describe the whole batch. `records` semantics: **post-image** on update, **pre-image** on delete.
 
 <Callout type="warn">
-	**Bulk `before*` hooks are *intent*, bulk `afterChange` is *fact*.** In a
-	conditional (`where`-based) `updateMany`, `beforeValidate` and `beforeChange`
-	run on the *pre-image* of every candidate row, they may fire for rows that
-	then lose a concurrent write-time claim and are never actually written.
-	`afterChange` (and the returned records) fire for the **winners only**. So put
-	validation/transform that's safe to run speculatively in `before*`, and
-	anything that must reflect a real committed change in `afterChange`.
+  **Bulk `before*` hooks are *intent*, bulk `afterChange` is *fact*.** In a conditional (`where`-based) `updateMany`, `beforeValidate` and `beforeChange` run on the *pre-image* of every candidate row, they may fire for rows that then lose a concurrent write-time claim and are never actually written. `afterChange` (and
+  the returned records) fire for the **winners only**. So put validation/transform that's safe to run speculatively in `before*`, and anything that must reflect a real committed change in `afterChange`.
 </Callout>
 
 ### Transition hooks
 
-If a collection has versioning + a workflow enabled, `beforeTransition` and `afterTransition` fire when a record moves between workflow stages (via `transitionStage`). They receive a **different context** from the CRUD hooks, there is no `data` / `original` / `operation` triple; instead you get the stage move:
+With versioning and workflow enabled, `beforeTransition` and `afterTransition` fire around `transitionStage`. Their context describes the stage move with transition-specific fields:
 
 ```ts title="src/questpie/server/collections/posts.ts"
 .hooks({
@@ -342,8 +328,8 @@ Because `.hooks()` **merges** per stage, you can split hooks across calls or con
 
 ```ts
 collection("posts")
-	.hooks({ beforeChange: normalizeTitle })   // e.g. module A
-	.hooks({ beforeChange: computeSlug });      // e.g. module B
+  .hooks({ beforeChange: normalizeTitle }) // e.g. module A
+  .hooks({ beforeChange: computeSlug }); // e.g. module B
 // → both run on every change, in order
 ```
 
@@ -361,20 +347,17 @@ For **shared helpers** in separate files, import the generated `HookRuleContext<
 import type { HookRuleContext } from "#questpie";
 
 export function stampSlug(ctx: HookRuleContext<"posts">) {
-	if (ctx.operation === "create" && ctx.data.title && !ctx.data.slug) {
-		ctx.data.slug = ctx.data.title.toLowerCase().replace(/\s+/g, "-");
-	}
+  if (ctx.operation === "create" && ctx.data.title && !ctx.data.slug) {
+    ctx.data.slug = ctx.data.title.toLowerCase().replace(/\s+/g, "-");
+  }
 }
 ```
 
 `HookRuleContext<K>` is generated into `src/questpie/server/.generated/index.ts` and aliases the package-level `HookContext`, resolving `data` to `CollectionDoc<K>` and typing `ctx.session` / `ctx.collections` through your app's `AppContext`.
 
 <Callout type="warn">
-	**Cycle rule for the generated context aliases.** Import `HookRuleContext` /
-	`AccessRuleContext` **only** from files that are *not* imported by a collection
-	(routes, services, jobs, scripts). A helper that a collection imports must take
-	the package-level `HookContext` / `AccessContext` from `questpie` instead, importing the generated `#questpie` barrel from a collection creates a codegen
-	cycle.
+  **Cycle rule for the generated context aliases.** Import `HookRuleContext` / `AccessRuleContext` **only** from files that are *not* imported by a collection (routes, services, jobs, scripts). A helper that a collection imports must take the package-level `HookContext` / `AccessContext` from `questpie` instead,
+  importing the generated `#questpie` barrel from a collection creates a codegen cycle.
 </Callout>
 
 The raw types live in the `questpie` package if you need them directly:
@@ -387,7 +370,7 @@ import type { HookContext, HookFunction } from "questpie";
 
 ## Related
 
-- **[Access control](/docs/concepts/access-control)**, authorize reads/writes and filter rows; field-level access for hiding columns. Use access for *who*, hooks for *what happens*.
+- **[Access control](/docs/concepts/access-control)**, authorize reads/writes and filter rows; field-level access for hiding columns. Use access for _who_, hooks for _what happens_.
 - **[Validation](/docs/concepts/validation)**, the Zod schema that runs between `beforeValidate` and `beforeChange`; `exclude` / `refine` and field-level `.zod()`; the full `ApiError` surface you throw from `before*` hooks.
 - **[Collections](/docs/concepts/collections)**, where `.hooks()` lives, alongside fields, indexes, access, and admin config.
 - **[Globals](/docs/concepts/globals)**, singletons with their own `beforeUpdate` / `afterUpdate` hook stages.

--- a/apps/docs/content/docs/concepts/jobs.mdx
+++ b/apps/docs/content/docs/concepts/jobs.mdx
@@ -29,7 +29,9 @@ export default job({
   }),
   // `payload` is z.infer<typeof schema>; everything else is your full AppContext.
   handler: async ({ payload, collections, email }) => {
-    const user = await collections.user.findOne({ where: { id: payload.userId } });
+    const user = await collections.user.findOne({
+      where: { id: payload.userId },
+    });
     if (!user) return;
 
     await email.send({
@@ -81,11 +83,12 @@ collection("user").hooks({
 That's the whole loop: define → wire an adapter → publish. A worker drains the queue (see [Running a worker](#running-a-worker)), and the full options surface follows below.
 
 <Callout type="info" title="Import `job` from `questpie`, not `#questpie/factories`">
-Unlike `collection()`, `job()` takes no generated field types, so there's no `#questpie/factories` variant. `job` is exported from the `questpie` package root and, equivalently, from `questpie/queue` and `questpie/services`, `import { job } from "questpie"` is correct everywhere.
+  Unlike `collection()`, `job()` takes no generated field types, so there's no `#questpie/factories` variant. `job` is exported from the `questpie` package root and, equivalently, from `questpie/queue` and `questpie/services`, `import {job} from "questpie"` is correct everywhere.
 </Callout>
 
 <Callout type="warn" title="Don't dispatch directly from an after* hook">
-`afterChange` runs **inside** the CRUD transaction. If you call `queue.x.publish(...)` directly and the transaction later rolls back, you've enqueued work for a row that never landed, and on a single-connection database (PGlite in dev) it can deadlock against the open transaction. Wrap the dispatch in `onAfterCommit(...)` so it fires only after the write is durable. See [Hooks](/docs/concepts/hooks).
+  `afterChange` runs **inside** the CRUD transaction. If you call `queue.x.publish(...)` directly and the transaction later rolls back, you've enqueued work for a row that never landed, and on a single-connection database (PGlite in dev) it can deadlock against the open transaction. Wrap the dispatch in
+  `onAfterCommit(...)` so it fires only after the write is durable. See [Hooks](/docs/concepts/hooks).
 </Callout>
 
 ## Example → what you get
@@ -111,7 +114,7 @@ await app.queue.sendWelcomeEmail.publish({ userId: 123 });
 A job declares a **durable name** (the string the queue backend stores), but you dispatch it through a **camelCase registration key** that codegen derives from the file/name:
 
 ```ts
-job({ name: "send-welcome-email", /* ... */ });
+job({ name: "send-welcome-email" /* ... */ });
 //          └── durable name (what the adapter stores)
 
 queue.sendWelcomeEmail.publish({ userId });
@@ -134,9 +137,14 @@ The handler receives **one** argument: the validated `payload` plus your full ap
 
 ```ts
 handler: async ({
-  payload,                                          // schema-validated, Zod-parsed payload
-  locale,                                           // locale resolved for this run, when set
-  db, collections, globals, queue, email, search,   // ...the rest is your AppContext, realtime, kv, storage, services, logger, t, app,  // the same services a route or hook gets
+  payload, // schema-validated, Zod-parsed payload
+  locale, // locale resolved for this run, when set
+  db,
+  collections,
+  globals,
+  queue,
+  email,
+  search, // ...the rest is your AppContext, realtime, kv, storage, services, logger, t, app,  // the same services a route or hook gets
 }) => {
   // ...
 };
@@ -147,7 +155,7 @@ handler: async ({
 - Everything else is the flat `AppContext`, `db`, `collections`, `globals`, `queue`, `email`, `search`, `realtime`, `kv`, `storage`, `services`, `logger`, `t`, `app`, `session`. Because the handler gets the **same** `queue` client, a job can enqueue other jobs (fan out, chain, or re-queue).
 
 <Callout type="info" title="`schema` is required, and the payload is validated twice">
-Every job **must** carry a Zod `schema`; it isn't optional. The payload is parsed at **dispatch** time (`publish`/`schedule` throw if it fails) and the framework re-validates the raw job data again before invoking your handler. So inside the handler, `payload` is always well-formed.
+  Every job **must** carry a Zod `schema`; it isn't optional. The payload is parsed at **dispatch** time (`publish`/`schedule` throw if it fails) and the framework re-validates the raw job data again before invoking your handler. So inside the handler, `payload` is always well-formed.
 </Callout>
 
 ## Dispatching
@@ -196,22 +204,20 @@ Throws on adapters without scheduling support.
 
 ```ts
 interface JobDefinition<TPayload, TResult = void, TName extends string = string> {
-  name: TName;                                  // durable job name (use a string literal)
-  schema: z.ZodSchema<TPayload>;                // required, validates the payload
+  name: TName; // durable job name (use a string literal)
+  schema: z.ZodSchema<TPayload>; // required, validates the payload
   handler: (args: JobHandlerArgs<TPayload>) => Promise<TResult>;
   options?: {
-    priority?: number;        // higher = more important
-    retryLimit?: number;      // number of retry attempts
-    retryDelay?: number;      // seconds between retries
-    retryBackoff?: boolean;   // exponential backoff
+    priority?: number; // higher = more important
+    retryLimit?: number; // number of retry attempts
+    retryDelay?: number; // seconds between retries
+    retryBackoff?: boolean; // exponential backoff
     expireInSeconds?: number; // job expiration (seconds)
     startAfter?: number | string | Date; // delay the first run
-    cron?: string;            // recurring schedule (declarative)
+    cron?: string; // recurring schedule (declarative)
   };
 }
 ```
-
-
 
 `job()` itself is an **identity function** at runtime, it returns the definition object unchanged. All typing and validation live in the `JobDefinition` type and in the queue client at dispatch time.
 
@@ -219,20 +225,20 @@ interface JobDefinition<TPayload, TResult = void, TName extends string = string>
 
 These are the **defaults** baked into the job. Each is optional. At dispatch time they're merged with [`PublishOptions`](#publishoptions) via `{ ...jobDef.options, ...publishOptions }`, so call-time options win.
 
-| Option | Type | Effect |
-|---|---|---|
-| `priority` | `number` | Higher values run before lower ones. |
-| `retryLimit` | `number` | How many times to retry a failed run. |
-| `retryDelay` | `number` | **Seconds** to wait between retries. |
-| `retryBackoff` | `boolean` | Use exponential backoff between retries. |
-| `expireInSeconds` | `number` | Drop the job if it hasn't run within this window. |
-| `startAfter` | `number \| string \| Date` | Delay the first run (seconds / ISO string / Date). |
-| `cron` | `string` | Register the job as recurring, see [Recurring jobs](#recurring-jobs). |
+| Option            | Type                       | Effect                                                                |
+| ----------------- | -------------------------- | --------------------------------------------------------------------- |
+| `priority`        | `number`                   | Higher values run before lower ones.                                  |
+| `retryLimit`      | `number`                   | How many times to retry a failed run.                                 |
+| `retryDelay`      | `number`                   | **Seconds** to wait between retries.                                  |
+| `retryBackoff`    | `boolean`                  | Use exponential backoff between retries.                              |
+| `expireInSeconds` | `number`                   | Drop the job if it hasn't run within this window.                     |
+| `startAfter`      | `number \| string \| Date` | Delay the first run (seconds / ISO string / Date).                    |
+| `cron`            | `string`                   | Register the job as recurring, see [Recurring jobs](#recurring-jobs). |
 
 Adapter support varies, see the [adapter comparison](#adapters).
 
 <Callout type="warn" title="`retryDelay` is in seconds, not milliseconds">
-`retryDelay`, `expireInSeconds`, and the numeric form of `startAfter` are all in **seconds**. `retryDelay: 30` means thirty seconds between retries, not thirty milliseconds. The BullMQ adapter multiplies `retryDelay` by 1000 internally; you still pass seconds.
+  `retryDelay`, `expireInSeconds`, and the numeric form of `startAfter` are all in **seconds**. `retryDelay: 30` means thirty seconds between retries, not thirty milliseconds. The BullMQ adapter multiplies `retryDelay` by 1000 internally; you still pass seconds.
 </Callout>
 
 ### `PublishOptions`
@@ -243,9 +249,9 @@ The per-call override surface for `publish()`. It's a superset of `options` minu
 interface PublishOptions {
   priority?: number;
   startAfter?: number | string | Date;
-  singletonKey?: string;     // dedup, only one queued job may carry this key
+  singletonKey?: string; // dedup, only one queued job may carry this key
   retryLimit?: number;
-  retryDelay?: number;       // seconds
+  retryDelay?: number; // seconds
   retryBackoff?: boolean;
   expireInSeconds?: number;
 }
@@ -278,11 +284,11 @@ export default job({
 When a worker starts (`queue.listen()`), it calls `registerSchedules()`, which reads every job's `options.cron` and registers it as a recurring schedule.
 
 <Callout type="warn" title="A cron job's schema must accept an empty payload">
-`registerSchedules()` registers cron jobs by calling `schema.parse({})`, recurring runs carry **no** payload. If your schema requires fields, it throws *"Job &lt;name&gt; has cron schedule but schema does not accept an empty payload."* Use `z.object({})`, or make every field optional or defaulted.
+  `registerSchedules()` registers cron jobs by calling `schema.parse({})`, recurring runs carry **no** payload. If your schema requires fields, it throws *"Job &lt;name&gt; has cron schedule but schema does not accept an empty payload."* Use `z.object({})`, or make every field optional or defaulted.
 </Callout>
 
 <Callout type="info" title="`startAfter` is ignored for cron jobs">
-When a job is registered via `options.cron`, its `cron` and `startAfter` are stripped from the options handed to the adapter, `startAfter` has no meaning for a recurring schedule.
+  When a job is registered via `options.cron`, its `cron` and `startAfter` are stripped from the options handed to the adapter, `startAfter` has no meaning for a recurring schedule.
 </Callout>
 
 Choose `options.cron` (declarative, auto-registered by the worker) for fixed schedules baked into your app. Reach for [`queue.<name>.schedule(payload, cron)`](#schedulepayload-cron-options) only when you need to register a schedule **with a payload** or set one up dynamically at runtime.
@@ -291,8 +297,8 @@ Choose `options.cron` (declarative, auto-registered by the worker) for fixed sch
 
 Defining a job and dispatching it only **enqueues** work, something has to **drain** the queue. QUESTPIE picks the runtime model from the adapter's capabilities, and you start the worker **programmatically** by importing your built app.
 
-<Callout type="warn" title="There is no `questpie worker` CLI command">
-Workers run programmatically, not via the CLI. The `questpie` CLI has commands for codegen, migrations, seeding, and deploy, but nothing for queues. Write a small entrypoint script (below) and run it with your runtime.
+<Callout type="info" title="Workers start from application entrypoints">
+  Write a small entrypoint that imports the built app, selects a consumer model, and runs with your application runtime.
 </Callout>
 
 ### Long-running worker (Node / Bun)
@@ -303,7 +309,7 @@ For a persistent worker process, write an entrypoint that calls `app.queue.liste
 import { app } from "#questpie";
 
 await app.queue.listen({
-  teamSize: 5,  // max concurrent jobs (pg-boss teamSize / BullMQ concurrency)
+  teamSize: 5, // max concurrent jobs (pg-boss teamSize / BullMQ concurrency)
   batchSize: 3, // jobs fetched per poll
 });
 
@@ -352,20 +358,18 @@ export default {
 `createPushConsumer()` throws on pg-boss / BullMQ (they're poll-based, not push).
 
 <Callout type="info" title="Detect capabilities before calling listen / runOnce / schedule">
-Each adapter advertises what it supports via `app.queue.capabilities`, `longRunningConsumer`, `runOnceConsumer`, `pushConsumer`, `scheduling`, `singleton`. If you target multiple runtimes from one codebase, check the relevant flag before calling a method; that's cheaper than catching the throw.
+  Each adapter advertises what it supports via `app.queue.capabilities`, `longRunningConsumer`, `runOnceConsumer`, `pushConsumer`, `scheduling`, `singleton`. If you target multiple runtimes from one codebase, check the relevant flag before calling a method; that's cheaper than catching the throw.
 </Callout>
 
 ## Adapters
 
 You pick the queue backend by passing an adapter to `.build({ queue: { adapter } })`. Each adapter lives in its own subpath so its driver stays out of your bundle unless you import it.
 
-| Adapter | Import | Backed by | Long-running | Run-once | Push | Scheduling | Singleton |
-|---|---|---|---|---|---|---|---|
-| **pg-boss** | `questpie/adapters/pg-boss` | Postgres | yes | yes | no | yes | yes |
-| **BullMQ** | `questpie/adapters/bullmq` | Redis | yes | yes | no | yes | yes |
-| **Cloudflare Queues** | `questpie/adapters/cloudflare-queues` | CF Queues | no | no | yes | no | no |
-
-
+| Adapter               | Import                                | Backed by | Long-running | Run-once | Push | Scheduling | Singleton |
+| --------------------- | ------------------------------------- | --------- | ------------ | -------- | ---- | ---------- | --------- |
+| **pg-boss**           | `questpie/adapters/pg-boss`           | Postgres  | yes          | yes      | no   | yes        | yes       |
+| **BullMQ**            | `questpie/adapters/bullmq`            | Redis     | yes          | yes      | no   | yes        | yes       |
+| **Cloudflare Queues** | `questpie/adapters/cloudflare-queues` | CF Queues | no           | no       | yes  | no         | no        |
 
 ### pg-boss (Postgres)
 
@@ -429,21 +433,39 @@ class MyAdapter implements QueueAdapter {
     singleton: false,
   };
 
-  async start() { /* connect */ }
-  async stop() { /* disconnect */ }
-  async publish(jobName, payload, options) { /* enqueue */ return "job-id"; }
-  async schedule(jobName, cron, payload, options) { /* register cron */ }
-  async unschedule(jobName) { /* cancel cron */ }
-  on(event, handler) { /* "error" listener */ }
+  async start() {
+    /* connect */
+  }
+  async stop() {
+    /* disconnect */
+  }
+  async publish(jobName, payload, options) {
+    /* enqueue */ return "job-id";
+  }
+  async schedule(jobName, cron, payload, options) {
+    /* register cron */
+  }
+  async unschedule(jobName) {
+    /* cancel cron */
+  }
+  on(event, handler) {
+    /* "error" listener */
+  }
 
   // Optional, presence drives capability fallbacks:
-  async listen(handlers, options) { /* long-running consumer */ }
-  async runOnce(handlers, options) { return { processed: 0 }; }
-  createPushConsumer(args) { return async (batch) => {}; }
+  async listen(handlers, options) {
+    /* long-running consumer */
+  }
+  async runOnce(handlers, options) {
+    return { processed: 0 };
+  }
+  createPushConsumer(args) {
+    return async (batch) => {};
+  }
 }
 ```
 
-`start` / `stop` / `publish` / `schedule` / `unschedule` / `on` are **required**; `listen` / `runOnce` / `createPushConsumer` are **optional**, whether you implement each one drives the corresponding capability flag when `capabilities` leaves it unset. Each handler in the `QueueHandlerMap` is keyed by the **durable job name** and receives `{ id, data }`; the framework re-validates `data` against the job's Zod schema before your user handler runs. This is the QUESTPIE principle in action: **the three built-in adapters use the exact same `QueueAdapter` seam your custom adapter does**, there is no privileged internal queue API.
+`start` / `stop` / `publish` / `schedule` / `unschedule` / `on` are **required**; `listen` / `runOnce` / `createPushConsumer` are **optional** and drive their capability flags when `capabilities` leaves them unset. Each `QueueHandlerMap` entry is keyed by the durable job name and receives `{ id, data }`; QUESTPIE validates `data` against the job's Zod schema before the handler runs. Built-in and custom backends implement the same `QueueAdapter` contract.
 
 ## Built-in job: `index-records`
 

--- a/apps/docs/content/docs/concepts/kv.mdx
+++ b/apps/docs/content/docs/concepts/kv.mdx
@@ -1,0 +1,75 @@
+---
+title: Key-value storage
+description: Use the QUESTPIE key-value service for caches, TTL-backed data, namespaces, and tag invalidation while keeping durable application state in collections.
+---
+
+The key-value service provides a small cache-oriented API on `ctx.kv` and `app.kv`. Application code uses one contract while an adapter selects in-memory, Redis, Cloudflare KV, or a custom backend.
+
+## When to use KV
+
+KV fits derived or short-lived data:
+
+- cached API responses,
+- feature configuration,
+- rate-limit buckets,
+- expiring verification state,
+- rendered fragments invalidated by tags.
+
+Collections and globals remain the durable source of truth for relational data, workflows, access rules, and records that require transactional updates.
+
+## Core API
+
+```ts
+await ctx.kv.set("weather:bratislava", forecast, 300);
+
+const cached = await ctx.kv.get<Forecast>("weather:bratislava");
+const exists = await ctx.kv.has("weather:bratislava");
+
+await ctx.kv.delete("weather:bratislava");
+await ctx.kv.clear();
+```
+
+TTL values use seconds. `get` returns `null` after expiry or when the key is absent.
+
+## Namespaces
+
+Use an adapter `keyPrefix` when several applications share one backend. Prefixes isolate keys and scope destructive operations such as `clear()`.
+
+Choose stable, readable keys that describe the owner and identity:
+
+```ts
+const key = `catalog:product:${productId}:summary`;
+```
+
+## Tag invalidation
+
+Built-in adapters support optional tag methods for invalidating groups of related keys:
+
+```ts
+await adapter.setWithTags?.(
+	`page:/posts/${slug}`,
+	html,
+	[`post:${postId}`],
+	3600,
+);
+
+await adapter.invalidateByTag?.(`post:${postId}`);
+```
+
+Keep a reference to the configured adapter when application code needs tag capabilities. The core `KVService` stays focused on `get`, `set`, `has`, `delete`, and `clear`.
+
+## Consistency
+
+Backend semantics matter. In-memory state is process-local. Redis provides shared state with immediate reads. Cloudflare KV is globally distributed and eventually consistent.
+
+Pick the backend from the consistency and durability requirements of the cached value, then keep the application API unchanged.
+
+## Choose a backend
+
+See [KV adapters](/docs/adapters/kv) for Redis clients, Cloudflare bindings, prefixes, tag indexes, clearing behavior, and custom adapter contracts.
+
+## Related
+
+- [Services](/docs/concepts/services), how `ctx.kv` enters application context.
+- [KV adapters](/docs/adapters/kv), backend configuration and capabilities.
+- [Hooks](/docs/concepts/hooks), invalidate derived data after committed writes.

--- a/apps/docs/content/docs/concepts/meta.json
+++ b/apps/docs/content/docs/concepts/meta.json
@@ -1,20 +1,4 @@
 {
-	"title": "Concepts",
-	"pages": [
-		"collections",
-		"globals",
-		"fields",
-		"relations",
-		"blocks",
-		"access-control",
-		"hooks",
-		"validation",
-		"routes",
-		"jobs",
-		"seeds",
-		"services",
-		"emails",
-		"configuration",
-		"environment"
-	]
+  "title": "Concepts",
+  "pages": ["collections", "globals", "fields", "relations", "blocks", "access-control", "hooks", "validation", "routes", "jobs", "seeds", "services", "emails", "search", "realtime", "storage", "kv", "sandboxed-code", "configuration", "environment"]
 }

--- a/apps/docs/content/docs/concepts/realtime.mdx
+++ b/apps/docs/content/docs/concepts/realtime.mdx
@@ -1,0 +1,87 @@
+---
+title: Realtime
+description: Understand live queries, channels, the durable outbox, cross-instance delivery, presence, and the consistency model behind QUESTPIE realtime applications.
+---
+
+Realtime keeps connected clients synchronized after committed application changes. QUESTPIE separates the application contract from delivery, so the same live-query and channel APIs work across local SSE and managed transports.
+
+## Two realtime primitives
+
+Use the primitive that matches the data:
+
+| Primitive  | Carries                               | Best for                                  |
+| ---------- | ------------------------------------- | ----------------------------------------- |
+| Live query | A fresh collection or global snapshot | Lists, detail views, counters, dashboards |
+| Channel    | A typed application event             | Progress, typing, notifications, presence |
+
+Live queries re-run a normal read after invalidation. Channels deliver schema-validated events and keep transient state separate from persisted records.
+
+## Change flow
+
+A collection or global write follows this live-query path:
+
+1. QUESTPIE writes the data change and its realtime outbox row in one transaction.
+2. The transaction commits both records together.
+3. The broker wakes every application instance that serves subscribers.
+4. Each instance refreshes affected live queries under each subscriber's access rules.
+5. The client updates the matching subscription.
+
+The durable outbox closes the gap between database commit and delivery. Broker messages act as wake-ups; application rows remain in the database.
+
+## Live queries
+
+The client subscribes with the same query shape used for a normal read:
+
+```ts
+const unsubscribe = client.collections.posts.live(
+	{ where: { status: "published" }, orderBy: { createdAt: "desc" } },
+	(snapshot) => render(snapshot.docs),
+);
+```
+
+The first callback receives the current snapshot. Later invalidations refresh only subscriptions affected by the changed collection, global, locale, stage, and query scope.
+
+See [Client realtime](/docs/client/realtime) for `live()`, `liveIter()`, lifecycle options, and TanStack Query integration.
+
+## Channels
+
+Channels define typed event streams in `channels/`. Codegen adds publish and subscribe methods to server context and the generated client.
+
+```ts title="channels/progress.ts"
+import { channel } from "questpie/channels";
+import { z } from "zod";
+
+export default channel("progress-[jobId]").events({
+	updated: z.object({ percent: z.number().min(0).max(100) }),
+});
+```
+
+Publishing a channel event validates it, authorizes the caller, and appends it to the bounded delivery ledger before transport fan-out. Use persisted collections for history that users must retrieve later. Use channels for transient events.
+
+See [Channels](/docs/client/channels) for authorization, publishing, subscriptions, presence, and replay behavior.
+
+## Connections and scaling
+
+Clients multiplex subscriptions over a shared connection. A broker distributes invalidations across app instances; a transport carries updates to browsers.
+
+Single-instance development can use the built-in path. Multi-instance deployments choose a shared broker or managed transport that matches their topology.
+
+## Consistency and delivery
+
+Realtime is a synchronization layer over committed state. Clients reconnect, resume from the supported cursor, and reconcile from the database when delivery is interrupted.
+
+Design handlers to tolerate duplicate wake-ups. Persist business facts before publishing events, and derive durable UI state from collections or globals.
+
+## Choose a transport
+
+The realtime configuration selects polling, Postgres notifications, Redis Streams, Pusher/Soketi, or Cloudflare delivery without changing application subscriptions.
+
+See [Realtime adapters](/docs/adapters/realtime) for topology, admission, outbox settings, transport configuration, and custom contracts.
+
+## Related
+
+- [Client realtime](/docs/client/realtime), live collection and global snapshots.
+- [Channels](/docs/client/channels), typed application events and presence.
+- [Reactive apps](/docs/client/reactive-apps), subscription sizing and React performance.
+- [Realtime adapters](/docs/adapters/realtime), server transport and broker selection.
+- [Realtime v2 migration](/docs/adapters/realtime-v2-migration), canary rollout and rollback.

--- a/apps/docs/content/docs/concepts/relations.mdx
+++ b/apps/docs/content/docs/concepts/relations.mdx
@@ -45,7 +45,9 @@ By default a relation reads back as the related **id**, not the related row. Hyd
 
 ```ts
 // Without `with`, relations are ids:
-const appt = await client.collections.appointments.findOne({ where: { id: "…" } });
+const appt = await client.collections.appointments.findOne({
+  where: { id: "…" },
+});
 // {
 //   id: string;
 //   customer: string;   // the related user id
@@ -76,11 +78,11 @@ A belongsTo FK is a single `string` in the read shape; under `with` the FK key i
 
 The positional argument to `f.relation(...)` takes three shapes.
 
-| Form | Example | Result |
-|---|---|---|
-| **Collection name** (string) | `f.relation("user")` | belongsTo to the `user` collection, the common case. |
-| **Lazy ref** (function) | `f.relation(() => barbers)` | Same as the string form, but defers the reference, use it to dodge circular imports between two collection files. The function returns the collection (the factory reads `.name` off it). |
-| **Polymorphic map** (object) | `f.relation({ users: "users", posts: "posts" })` | morphTo, stores a `type` + `id` pair so the field can point at *any* listed collection. |
+| Form                         | Example                                          | Result                                                                                                                                                                                    |
+| ---------------------------- | ------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Collection name** (string) | `f.relation("user")`                             | belongsTo to the `user` collection, the common case.                                                                                                                                      |
+| **Lazy ref** (function)      | `f.relation(() => barbers)`                      | Same as the string form, but defers the reference, use it to dodge circular imports between two collection files. The function returns the collection (the factory reads `.name` off it). |
+| **Polymorphic map** (object) | `f.relation({ users: "users", posts: "posts" })` | morphTo, stores a `type` + `id` pair so the field can point at _any_ listed collection.                                                                                                   |
 
 ```ts
 // Collection name (default belongsTo)
@@ -104,7 +106,7 @@ The default form is **belongsTo**: it owns a `varchar(36)` foreign-key column on
 
 ### `.hasMany({ foreignKey, onDelete?, relationName? })`
 
-One-to-many. The field becomes **virtual**, it owns no column on this table; the FK lives on the *target* table, named by `foreignKey`. It is absent from the base read shape and populated (as `string[]`, or full rows under `with`) only when queried.
+One-to-many. The field becomes **virtual**, it owns no column on this table; the FK lives on the _target_ table, named by `foreignKey`. It is absent from the base read shape and populated (as `string[]`, or full rows under `with`) only when queried.
 
 ```ts
 // On `barbers`: a barber has many appointments.
@@ -131,14 +133,20 @@ The junction itself is a normal collection of two belongsTo relations:
 
 ```ts title="src/questpie/server/collections/barber-services.ts"
 export const barberServices = collection("barber_services").fields(({ f }) => ({
-  barber: f.relation(() => barbers).required().onDelete("cascade"),
-  service: f.relation(() => services).required().onDelete("cascade"),
+  barber: f
+    .relation(() => barbers)
+    .required()
+    .onDelete("cascade"),
+  service: f
+    .relation(() => services)
+    .required()
+    .onDelete("cascade"),
 }));
 ```
 
 ### `.multiple()`
 
-An inline list of ids. **Unlike `hasMany` / `manyToMany`, this is not virtual**, it owns a single `jsonb` column holding an array of FK uuids on *this* row. Reads back as `string[]`. Reach for it when the set is small and you want it stored on the record itself rather than via a junction table.
+An inline list of ids. **Unlike `hasMany` / `manyToMany`, this is not virtual**, it owns a single `jsonb` column holding an array of FK uuids on _this_ row. Reads back as `string[]`. Reach for it when the set is small and you want it stored on the record itself rather than via a junction table.
 
 ```ts
 // A small inline set of ids stored on this row, here a barber's handful of
@@ -159,12 +167,12 @@ These modifiers preserve the field's accumulated state, so they compose in any o
 
 Set the referential action for the relation. `action` is one of:
 
-| Action | Effect when the referenced row is deleted/updated |
-|---|---|
-| `"cascade"` | Delete/update this row too. |
-| `"set null"` | Null out the FK on this row. |
-| `"restrict"` | Block the operation while this row still references it. |
-| `"no action"` | Defer the check (Postgres default). |
+| Action        | Effect when the referenced row is deleted/updated       |
+| ------------- | ------------------------------------------------------- |
+| `"cascade"`   | Delete/update this row too.                             |
+| `"set null"`  | Null out the FK on this row.                            |
+| `"restrict"`  | Block the operation while this row still references it. |
+| `"no action"` | Defer the check (Postgres default).                     |
 
 ```ts
 // When the parent barber is deleted, delete its barber_services rows too.
@@ -172,7 +180,8 @@ barber: f.relation(() => barbers).required().onDelete("cascade"),
 ```
 
 <Callout type="info">
-  The action flows into the relation graph and is **enforced on the QUESTPIE CRUD path**: `cascade` / `hasMany` cascade-deletes run through `deleteById`, and `restrict` throws a `409 Conflict` ("Cannot delete: related records exist…") when dependents remain. It needs a `relationName` (or an inferred reverse relation) to find the dependents.
+  The action flows into the relation graph and is **enforced on the QUESTPIE CRUD path**: `cascade` / `hasMany` cascade-deletes run through `deleteById`, and `restrict` throws a `409 Conflict` ("Cannot delete: related records exist…") when dependents remain. It needs a `relationName` (or an inferred reverse relation)
+  to find the dependents.
 </Callout>
 
 ### `.relationName(name)`
@@ -194,7 +203,7 @@ const review = await client.collections.reviews.findOne({
   where: { id: "…" },
   with: {
     customer: { columns: { id: true, email: true } }, // partial select on the related row
-    barber: true,                                       // whole row
+    barber: true, // whole row
   },
 });
 
@@ -226,7 +235,8 @@ const barber = await client.collections.barbers.findOne({
 ```
 
 <Callout type="info">
-  Relations are **not** hydrated unless you ask. A field you didn't list in `with` comes back as its id (belongsTo → a single `string`; `multiple` → the raw `string[]` array stored in its column) or is absent entirely (hasMany / manyToMany have no column here). This keeps the default read one query and one row, opt into joins only where you need them. Hydration depth is capped by the type system to keep inference finite, so very deep nested `with` chains stop resolving past the cap.
+  Relations are **not** hydrated unless you ask. A field you didn't list in `with` comes back as its id (belongsTo → a single `string`; `multiple` → the raw `string[]` array stored in its column) or is absent entirely (hasMany / manyToMany have no column here). This keeps the default read one query and one row, opt
+  into joins only where you need them. Hydration depth is capped by the type system to keep inference finite, so very deep nested `with` chains stop resolving past the cap.
 </Callout>
 
 ## Filtering by relation
@@ -239,7 +249,9 @@ A belongsTo field accepts three forms in `where`:
 
 ```ts
 // 1. Match the FK directly (eq / ne / in / notIn / isNull / isNotNull)
-await client.collections.appointments.find({ where: { barber: { eq: barberId } } });
+await client.collections.appointments.find({
+  where: { barber: { eq: barberId } },
+});
 
 // 2. Bare FK shorthand, pass the id value directly
 await client.collections.appointments.find({ where: { barber: barberId } });
@@ -283,7 +295,7 @@ await client.collections.barbers.find({
 ```
 
 <Callout type="warning">
-  The to-many quantifiers are `some` / `none` / `every`, there is no `count` operator you can put in a relation `where`. To count related rows, use `with: { rel: { _count: true } }` on the query instead.
+  Use `some`, `none`, and `every` to filter to-many relations. Request related counts with `with: { rel: { _count: true } }`.
 </Callout>
 
 ## Writing relations (nested create / update)
@@ -339,20 +351,21 @@ The nested mutation supports `connect` (link existing), `create` (insert new), `
 ## Gotchas
 
 <Callout type="warning">
-  **Transition methods reset the chain, order matters.** Put `.hasMany()` / `.manyToMany()` / `.multiple()` first, then refine. They flip the field from the belongsTo type-state to a to-many one; the state-preserving modifiers (`.required()`, `.onDelete()`, `.onUpdate()`, `.relationName()`) carry forward, but a transition applied *after* them is the one that defines the final kind.
+  **Transition methods reset the chain, order matters.** Put `.hasMany()` / `.manyToMany()` / `.multiple()` first, then refine. They flip the field from the belongsTo type-state to a to-many one; the state-preserving modifiers (`.required()`, `.onDelete()`, `.onUpdate()`, `.relationName()`) carry forward, but a
+  transition applied *after* them is the one that defines the final kind.
 </Callout>
 
 <Callout type="warning">
-  **`hasMany` / `manyToMany` are virtual, no column here.** The FK lives on the target table (`hasMany`) or the junction (`manyToMany`), so these fields never appear in this collection's base read shape or insert type, and you never write them by setting a column on this row, you write them with a nested mutation (`connect` / `create` / `set`). `.multiple()` is the exception: it owns a real `jsonb` array column on this table.
+  **`hasMany` / `manyToMany` are virtual, no column here.** The FK lives on the target table (`hasMany`) or the junction (`manyToMany`), so these fields never appear in this collection's base read shape or insert type, and you never write them by setting a column on this row, you write them with a nested mutation
+  (`connect` / `create` / `set`). `.multiple()` is the exception: it owns a real `jsonb` array column on this table.
 </Callout>
 
 <Callout type="warning">
-  **`upload` is the file relation, use it for assets.** `f.upload(...)` is a relation specialised for files: it owns a `varchar(36)` FK to the `assets` collection and the admin renders an upload widget instead of a relation picker. Don't model file links with a raw `f.relation("assets")`, reach for `f.upload()`. See [Fields](/docs/concepts/fields).
+  **`upload` is the file relation, use it for assets.** `f.upload(...)` is a relation specialised for files: it owns a `varchar(36)` FK to the `assets` collection and the admin renders an upload widget instead of a relation picker. Don't model file links with a raw `f.relation("assets")`, reach for `f.upload()`. See
+  [Fields](/docs/concepts/fields).
 </Callout>
 
-<Callout type="info">
-  **`onDelete` / `restrict` enforcement needs a resolvable reverse relation.** Cascade and restrict run on the QUESTPIE CRUD path and walk the relation graph to find dependents; when two relations target the same collection, set `.relationName(...)` so the reverse relation resolves.
-</Callout>
+<Callout type="info">**`onDelete` / `restrict` enforcement needs a resolvable reverse relation.** Cascade and restrict run on the QUESTPIE CRUD path and walk the relation graph to find dependents; when two relations target the same collection, set `.relationName(...)` so the reverse relation resolves.</Callout>
 
 ## TypeScript
 
@@ -361,17 +374,17 @@ You rarely touch relation types directly, they flow into the generated collectio
 ```ts
 import type { CollectionDoc, CollectionWhere } from "#questpie";
 
-type Appointment = CollectionDoc<"appointments">;   // `barber`/`customer` are `string` ids
-type ApptFilter = CollectionWhere<"appointments">;  // typed where, incl. relation filters
+type Appointment = CollectionDoc<"appointments">; // `barber`/`customer` are `string` ids
+type ApptFilter = CollectionWhere<"appointments">; // typed where, incl. relation filters
 ```
 
 `CollectionDoc<"appointments">` resolves the belongsTo fields to ids; passing `with` to a query widens the result to include the populated rows (this happens at the call site, you don't annotate it). `CollectionWhere<"appointments">` types the relation filters above (`is`/`isNot`, `some`/`none`/`every`).
 
-If you are building a plugin or a custom field type and need the relation primitives themselves, four are exported from `questpie`: the `relation` factory, its `RelationFieldState` / `RelationFieldMethods` type-state, and the `RelationFieldMetadata` introspection shape. The other internal symbols (`ToManyRelationFieldState`, `MultipleRelationFieldState`, `MorphToFieldState`, `relationFieldType`, `ReferentialAction`, `InferredRelationType`) are not re-exported from the package entry, reach for them via the `fieldType()` recipe below rather than importing them directly.
+Plugin authors can import the `relation` factory, `RelationFieldState`, `RelationFieldMethods`, and `RelationFieldMetadata` from `questpie`. Generated application types remain the preferred surface for ordinary collection code.
 
 ## Extending
 
-`relation` is itself built on the public `fieldType()` declaration API, its transition methods (`.hasMany()`, `.multiple()`, …) are defined in `relationFieldType.methods`, the same mechanism you use to add your own field type with chain methods. If you need a relation variant the builtins don't cover (a custom referential strategy, a different column layout), you build a new field type the same way the framework builds this one, no internal hooks. See [Fields → custom field types](/docs/concepts/fields) for the `fieldType()` recipe (`create`, `methods`, `toColumn` / `toZodSchema` / `getOperators` / `getMetadata`).
+`relation` uses the public `fieldType()` declaration API, and its transition methods such as `.hasMany()` and `.multiple()` are field-type methods. See [Fields → custom field types](/docs/concepts/fields) for the `fieldType()` recipe.
 
 ## Related
 

--- a/apps/docs/content/docs/concepts/routes.mdx
+++ b/apps/docs/content/docs/concepts/routes.mdx
@@ -3,12 +3,12 @@ title: Routes
 description: Custom HTTP endpoints declared as files, chain a builder to get a typed handler, automatic input validation, access control, a nested typed client method, and OpenAPI/MCP metadata, all from one file.
 ---
 
-A **route** is one HTTP endpoint you declare as a file. You default-export a `route()` builder and chain a method, an optional input schema, an access rule, and a handler. From that single file QUESTPIE gives you a validated, typed `input`, the full app context inside the handler (`collections`, `db`, `session`, `queue`, …), a typed client method at `client.routes.*`, and an entry your OpenAPI and MCP integrations can read. Drop the file, run codegen, and the endpoint is live, there is no router to register and nothing to import.
+A **route** is one HTTP endpoint declared as a file. Default-export a `route()` builder and chain a method, optional input schema, access rule, and handler. Codegen registers the endpoint, gives the handler validated input and application context, emits a typed `client.routes.*` method, and exposes metadata to OpenAPI and MCP integrations.
 
 ## What it does
 
 - **Turns a file into an endpoint.** A `route()` export under `routes/` (or `functions/`) becomes a live HTTP route after codegen, no registration, no central router.
-- **Validates input before your handler.** `.schema(z…)` parses the request body with Zod *before* access control and *before* the handler; a bad payload throws a `400` and never reaches your code.
+- **Validates input before your handler.** `.schema(z…)` parses the request body with Zod _before_ access control and _before_ the handler; a bad payload throws a `400` and never reaches your code.
 - **Hands your handler the full context.** Destructure `input` and `params` alongside `collections`, `globals`, `db`, `session`, `queue`, `kv`, `storage`, and the rest, everything arrives through the argument.
 - **Generates a nested typed client method.** `routes/create-booking.post.ts` becomes `client.routes.createBooking.post(input)`, with input and return type inferred end to end; nested folders nest the proxy (`routes/admin/stats.get.ts` → `client.routes.admin.stats.get`).
 - **Gates access, public by default.** `.access(rule)` accepts a boolean or a predicate over the request context. With no rule, the route is public, the inverse of collections.
@@ -69,7 +69,7 @@ A route with **no** `.access()` is reachable by anyone, the framework adds no au
 </Callout>
 
 <Callout type="info" title="Re-run codegen after adding or removing a route file">
-A new route only enters the typed runtime and the client once `questpie generate` / `questpie dev` regenerates `.generated/`. Editing the *body* of an existing route does not need a regen.
+  A new route only enters the typed runtime and the client once `questpie generate` / `questpie dev` regenerates `.generated/`. Editing the *body* of an existing route does not need a regen.
 </Callout>
 
 ## Where route files live
@@ -80,18 +80,19 @@ Codegen scans two directories, `routes/` and `functions/`, recursively, with the
 
 The filename drives three things at once. A route file maps to a per-segment camelCase **key** (the client path and the registry entry), a kebab-case **URL pattern** mounted under your API base path (`/api` in the default scaffold), and the typed client method leaf:
 
-| File | Client method | HTTP path |
-| --- | --- | --- |
-| `routes/create-booking.post.ts` | `client.routes.createBooking.post` | `POST /api/create-booking` |
-| `routes/revenue-stats.get.ts` | `client.routes.revenueStats.get` | `GET /api/revenue-stats` |
-| `routes/admin/stats.get.ts` | `client.routes.admin.stats.get` | `GET /api/admin/stats` |
-| `routes/posts/[id].get.ts` | `client.routes.posts["[id]"].get` (literal key) | `GET /api/posts/:id` |
-| `routes/files/[...path].get.ts` | `client.routes.files["[...path]"].get` (literal key) | `GET /api/files/*path` |
+| File                            | Client method                                        | HTTP path                  |
+| ------------------------------- | ---------------------------------------------------- | -------------------------- |
+| `routes/create-booking.post.ts` | `client.routes.createBooking.post`                   | `POST /api/create-booking` |
+| `routes/revenue-stats.get.ts`   | `client.routes.revenueStats.get`                     | `GET /api/revenue-stats`   |
+| `routes/admin/stats.get.ts`     | `client.routes.admin.stats.get`                      | `GET /api/admin/stats`     |
+| `routes/posts/[id].get.ts`      | `client.routes.posts["[id]"].get` (literal key)      | `GET /api/posts/:id`       |
+| `routes/files/[...path].get.ts` | `client.routes.files["[...path]"].get` (literal key) | `GET /api/files/*path`     |
 
-Folders nest into both the URL path and the client proxy: `routes/admin/stats.get.ts` is reachable as `client.routes.admin.stats.get(input)`, not `client.routes.adminStats.get`. A `[param]` segment becomes a dynamic `:param` in the URL; a `[...slug]` segment becomes a catch-all `*slug`. On the **typed** client, though, a `[param]` segment is **not** a value-substitutable index, it stays a **literal bracketed property key**. The client's `ExpandKey` type only splits route keys on `/` and `:`, so `routes/posts/[id].get.ts` is typed as `client.routes.posts["[id]"].get`, the literal string `"[id]"`, not a slot you fill with `"p_1"`. There is no value-substitution anywhere in the proxy (it only camelCases→kebab-cases each segment and joins with `/`).
+Folders nest in both the URL and client proxy: `routes/admin/stats.get.ts` becomes `client.routes.admin.stats.get(input)`. A `[param]` segment maps to dynamic `:param` in the URL and remains the literal bracketed key on the typed client, such as `client.routes.posts["[id]"].get`. Pass the parameter through the route input schema.
 
 <Callout type="warn" title="The typed client has no value-substitution form for dynamic routes">
-A `[param]` route is reachable on the typed client only as its **literal** key plus method leaf (`client.routes.posts["[id]"].get`), which builds the URL `/api/posts/[id]` verbatim, not a real `:id` lookup. To call a dynamic route with an actual id, hit it over HTTP yourself (`fetch("/api/posts/p_1")`) or build the URL manually; the typed client does not splice the value in. The route's **server** handler still reads the resolved value through `params` (see below), it's only the client *call* surface that has no first-class dynamic form.
+  A `[param]` route is reachable on the typed client only as its **literal** key plus method leaf (`client.routes.posts["[id]"].get`), which builds the URL `/api/posts/[id]` verbatim, not a real `:id` lookup. To call a dynamic route with an actual id, hit it over HTTP yourself (`fetch("/api/posts/p_1")`) or build the
+  URL manually; the typed client does not splice the value in. The route's **server** handler still reads the resolved value through `params` (see below), it's only the client *call* surface that has no first-class dynamic form.
 </Callout>
 
 ## Path params
@@ -136,7 +137,8 @@ export default route()
 The access context (`RouteAccessContext`) is the full app context (`session`, `db`, `collections`, …) plus `locale`, `request`, and `params`. You can also pass the object form `{ execute: rule }`, routes have a single `execute` operation, with none of the read/create/update/delete split that collections have.
 
 <Callout type="warn" title="A thrown error in the access rule is treated as deny">
-The rule runs inside a `try/catch`; **any** exception is swallowed and resolves to `false` (denied), it is **not** propagated to the client. If you need a specific status or message, return `false` for a generic `403` and throw your `ApiError` from inside the **handler** instead. A denied route throws `ApiError.forbidden` (HTTP `403`) before the handler runs.
+  The rule runs inside a `try/catch`; **any** exception is swallowed and resolves to `false` (denied), it is **not** propagated to the client. If you need a specific status or message, return `false` for a generic `403` and throw your `ApiError` from inside the **handler** instead. A denied route throws
+  `ApiError.forbidden` (HTTP `403`) before the handler runs.
 </Callout>
 
 ## Validation and output
@@ -161,7 +163,8 @@ export default route()
 - **Output**, when present, `outputSchema.parse(result)` validates and coerces the handler's return at the end. The schema type also **becomes** the route's output type and constrains what the handler may return.
 
 <Callout type="info" title="`.schema()` alone gives you a typed return, `.outputSchema()` is optional">
-For a schema route without an output schema, the handler's inferred return type is threaded into the route's output type (and into the client), so you only reach for `.outputSchema()` when you want **runtime** response validation/coercion on top of the inferred type. An `.outputSchema()`-only chain (no `.schema()`) is still a JSON route, its `input` is `unknown`, never raw.
+  For a schema route without an output schema, the handler's inferred return type is threaded into the route's output type (and into the client), so you only reach for `.outputSchema()` when you want **runtime** response validation/coercion on top of the inferred type. An `.outputSchema()`-only chain (no `.schema()`)
+  is still a JSON route, its `input` is `unknown`, never raw.
 </Callout>
 
 ## Metadata: OpenAPI and MCP
@@ -191,7 +194,10 @@ export default route()
   .handler(async ({ input, collections }) => {
     const { docs } = await collections.appointments.find({
       where: {
-        scheduledAt: { gte: new Date(input.startDate), lte: new Date(input.endDate) },
+        scheduledAt: {
+          gte: new Date(input.startDate),
+          lte: new Date(input.endDate),
+        },
         ...(input.completedOnly ? { status: "completed" } : {}),
       },
       with: { service: true },
@@ -204,8 +210,8 @@ export default route()
 
 `RouteMeta` is `{ title?, description?, tags?, mcp?, [key]: unknown }`, the open index signature lets you add arbitrary serializable keys (e.g. extra OpenAPI hints). `RouteMcpMeta` is `{ expose?, name?, title?, description?, annotations?, [key]: unknown }`, where `annotations` carries the standard MCP tool hints (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`).
 
-<Callout type="info" title="`meta` must be serializable, and there is no `openapi` field">
-OpenAPI reads the top-level `title`, `description`, and `tags` (plus any extra keys you add). Only `mcp` is a dedicated structural sub-object, there is no `openapi` key. The MCP shape is kept structural on purpose so the framework carries **no** MCP SDK dependency.
+<Callout type="info" title="Serializable route metadata">
+  OpenAPI reads top-level `title`, `description`, and `tags`, plus additional serializable keys. MCP metadata lives in the dedicated `mcp` sub-object, whose structural shape keeps route definitions independent of the MCP SDK.
 </Callout>
 
 ## Raw routes
@@ -227,7 +233,8 @@ export default route()
 ```
 
 <Callout type="warn" title="`.raw()` and `.schema()` are mutually exclusive">
-`.raw()` clears any schema and output schema and switches the handler to the `Request → Response` signature; `.schema()` switches back to a typed JSON route. The builder's type-state makes the two chains mutually exclusive, pick one per route. Raw handlers get **no** input parsing and **no** output validation; `request` is **required** on the handler args (unlike JSON handlers, where it is optional).
+  `.raw()` clears any schema and output schema and switches the handler to the `Request → Response` signature; `.schema()` switches back to a typed JSON route. The builder's type-state makes the two chains mutually exclusive, pick one per route. Raw handlers get **no** input parsing and **no** output validation;
+  `request` is **required** on the handler args (unlike JSON handlers, where it is optional).
 </Callout>
 
 ## Multiple methods
@@ -243,17 +250,11 @@ export async function handleWebhook({ request }: RawRouteHandlerArgs) {
 ```
 
 ```ts title="src/questpie/server/routes/webhook/[id].get.ts"
-export default route()
-  .get()
-  .raw()
-  .handler(handleWebhook);
+export default route().get().raw().handler(handleWebhook);
 ```
 
 ```ts title="src/questpie/server/routes/webhook/[id].post.ts"
-export default route()
-  .post()
-  .raw()
-  .handler(handleWebhook);
+export default route().post().raw().handler(handleWebhook);
 ```
 
 When the path matches but the method doesn't, the HTTP adapter returns `405` with an `Allow` header; when no route matches at all, it returns `404`.
@@ -262,32 +263,28 @@ When the path matches but the method doesn't, the HTTP adapter returns `405` wit
 
 `route()` returns an **immutable** builder: every method returns a new frozen instance, and `.handler()` is **terminal**, it returns the finished route definition, not a builder. The builder's phantom type-state enforces a legal chain at compile time (you can't, for example, meaningfully combine `.schema()` and `.raw()`).
 
-| Method | Effect |
-| --- | --- |
+| Method                                                                    | Effect                                                                                                                                  |
+| ------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
 | `.get()` `.post()` `.put()` `.delete()` `.patch()` `.head()` `.options()` | Register the route's HTTP method. One route definition has one method; use method-suffixed files for multiple methods on the same path. |
-| `.schema(z…)` | Validate the input with Zod and switch to **JSON mode**. The handler receives a typed, validated `input`. |
-| `.outputSchema(z…)` | Validate/coerce the return value and make that schema the route's output type. JSON mode. Optional. |
-| `.params<{ … }>()` | **Type-only.** Declare the URL params shape so the handler can read `params.x`. No runtime effect, takes no argument. |
-| `.access(rule)` | Gate the route. A `boolean`, a `(ctx) => boolean \| Promise<boolean>` predicate, or `{ execute: rule }`. Omit for public. |
-| `.meta({ … })` | Attach serializable metadata: `title`, `description`, `tags`, `mcp`, plus arbitrary keys. Drives OpenAPI/MCP. No routing effect. |
-| `.raw()` | Switch to **raw mode**: the handler gets the `Request` and returns a `Response`. Clears any schema. |
-| `.handler(fn)` | **Terminal.** Define the handler. Its signature depends on the chain (below) and it returns the frozen route definition. |
-
-
+| `.schema(z…)`                                                             | Validate the input with Zod and switch to **JSON mode**. The handler receives a typed, validated `input`.                               |
+| `.outputSchema(z…)`                                                       | Validate/coerce the return value and make that schema the route's output type. JSON mode. Optional.                                     |
+| `.params<{ … }>()`                                                        | **Type-only.** Declare the URL params shape so the handler can read `params.x`. No runtime effect, takes no argument.                   |
+| `.access(rule)`                                                           | Gate the route. A `boolean`, a `(ctx) => boolean \| Promise<boolean>` predicate, or `{ execute: rule }`. Omit for public.               |
+| `.meta({ … })`                                                            | Attach serializable metadata: `title`, `description`, `tags`, `mcp`, plus arbitrary keys. Drives OpenAPI/MCP. No routing effect.        |
+| `.raw()`                                                                  | Switch to **raw mode**: the handler gets the `Request` and returns a `Response`. Clears any schema.                                     |
+| `.handler(fn)`                                                            | **Terminal.** Define the handler. Its signature depends on the chain (below) and it returns the frozen route definition.                |
 
 ### Handler argument
 
 The handler argument extends the full app context, the same `AppContext` your collections, hooks, and jobs receive, so `collections`, `globals`, `db`, `session`, `queue`, `kv`, `storage`, `search`, `realtime`, `logger`, and `t` are all on it. On top of that, the mode adds:
 
-| Mode | Extra fields | Return type |
-| --- | --- | --- |
+| Mode                         | Extra fields                                                | Return type                                               |
+| ---------------------------- | ----------------------------------------------------------- | --------------------------------------------------------- |
 | **JSON** (after `.schema()`) | `input` (typed, validated), `params`, `locale?`, `request?` | the handler's inferred return, or the `outputSchema` type |
-| **Raw** (after `.raw()`) | `request` (always present), `params`, `locale?` | `Response \| Promise<Response>` |
-
-
+| **Raw** (after `.raw()`)     | `request` (always present), `params`, `locale?`             | `Response \| Promise<Response>`                           |
 
 <Callout type="info" title="Use `ctx.collections` / `ctx.globals`, not `ctx.app.api.*`">
-The typed CRUD API lives on `collections` and `globals` directly. `session` may be `null` for an unauthenticated request, narrow it before use. `request` is **optional** on JSON handlers (a JSON route can be executed standalone, without an HTTP request, see below) but **required** on raw handlers.
+  The typed CRUD API lives on `collections` and `globals` directly. `session` may be `null` for an unauthenticated request, narrow it before use. `request` is **optional** on JSON handlers (a JSON route can be executed standalone, without an HTTP request, see below) but **required** on raw handlers.
 </Callout>
 
 ## Executing a route directly
@@ -335,11 +332,7 @@ A few behaviours worth internalising before they bite:
 Routes are typed end to end without any manual annotations, the handler infers `input` from `.schema()`, `params` from `.params<…>()`, and the return type flows to the client. When you need the types by hand (shared helpers, wrappers), import the inference helpers from `questpie/types`:
 
 ```ts title="Infer a route's input, output, and params"
-import type {
-  InferRouteInput,
-  InferRouteOutput,
-  InferRouteParams,
-} from "questpie/types";
+import type { InferRouteInput, InferRouteOutput, InferRouteParams } from "questpie/types";
 
 import type createBooking from "@/questpie/server/routes/create-booking.post";
 

--- a/apps/docs/content/docs/concepts/sandboxed-code.mdx
+++ b/apps/docs/content/docs/concepts/sandboxed-code.mdx
@@ -1,0 +1,74 @@
+---
+title: Sandboxed code
+description: Understand trusted and sandboxed execution, capability manifests, brokered application access, resource limits, and the executor lifecycle.
+---
+
+The executor runs dynamic code through an explicit isolation mode. Trusted execution is for application-owned code. Sandboxed execution is for user-authored, plugin-authored, or AI-authored code that needs a capability boundary.
+
+## Execution modes
+
+| Mode        | Boundary                       | Use case                               |
+| ----------- | ------------------------------ | -------------------------------------- |
+| `trusted`   | In-process application runtime | Code shipped and reviewed with the app |
+| `sandboxed` | Isolated executor adapter      | Dynamic or untrusted guest code        |
+
+Application code calls the same `ctx.executor.run()` service in both modes. Runtime configuration selects the adapter that enforces sandboxed runs.
+
+## Run guest code
+
+Guest source exports one function that receives serializable input:
+
+```ts
+const result = await ctx.executor.run({
+	isolation: "sandboxed",
+	source: `export default async function (input) {
+    const response = await fetch(input.url);
+    return response.json();
+  }`,
+	input: { url: "https://api.example.com/data" },
+	capabilities: {
+		net: ["api.example.com"],
+		import: [],
+		timeoutMs: 5_000,
+		memoryMb: 128,
+	},
+});
+```
+
+The result contains success state, output, captured logs, and runtime duration.
+
+## Capability manifest
+
+Every run declares its network hosts, import hosts, timeout, and memory budget. The adapter validates and clamps the manifest before starting the guest.
+
+Start with an empty capability set and add only the resources required by the task. Treat capability construction as an authorization decision, not as request data passthrough.
+
+## Brokered application access
+
+`appBindings` exposes a scoped QUESTPIE surface through a broker. The guest calls `questpie.collections`, files, or services through the binding proxy.
+
+The executor mints a per-run token and keeps it outside guest memory. The broker validates the token and capability scope on every application call.
+
+## Lifecycle
+
+A sandboxed run follows this path:
+
+1. The executor validates source, input, and capabilities.
+2. It mints the broker scope for the run.
+3. The sandbox adapter starts an isolated guest process.
+4. The guest returns serializable output and bounded logs.
+5. The adapter terminates the process and releases the run token.
+
+Each run starts with a clean environment. Time and memory limits bound resource consumption independently of application code.
+
+## Deploy the boundary
+
+The core package defines `ExecutorAdapter`. `@questpie/sandbox` provides the Deno supervisor and HTTP adapter that enforce process, filesystem, environment, network, import, and resource permissions.
+
+See [Sandbox adapter](/docs/adapters/sandbox) for supervisor deployment, security layers, environment variables, and documented platform limits.
+
+## Related
+
+- [Services](/docs/concepts/services), access to `ctx.executor`.
+- [Sandbox adapter](/docs/adapters/sandbox), Deno isolation and deployment.
+- [AI integration](/docs/integrations/ai), agent execution and its separate host sandbox model.

--- a/apps/docs/content/docs/concepts/search.mdx
+++ b/apps/docs/content/docs/concepts/search.mdx
@@ -1,0 +1,95 @@
+---
+title: Search
+description: Understand how QUESTPIE projects collection rows into a search index, keeps it synchronized, applies access rules, and serves lexical or semantic queries.
+---
+
+Search turns collection records into a query-optimized projection. Collections define the searchable content; the search service owns indexing and queries; an adapter supplies the storage and ranking engine.
+
+## The model
+
+The data flow has five stages:
+
+1. A collection declares its search projection with `.searchable()`.
+2. A committed write schedules the affected record for indexing.
+3. The search adapter stores the title, content, metadata, facets, locale, and optional embedding.
+4. `app.search.search()` ranks matching index rows.
+5. The client search endpoint applies access rules and hydrates allowed results into collection documents.
+
+The collection remains the source of truth. Search results are a derived view that can be rebuilt from collection records.
+
+## Define the projection
+
+Use `.searchable()` to select the text and metadata that belong in the index:
+
+```ts title="collections/posts.ts"
+import { collection } from "#questpie/factories";
+
+export default collection("posts")
+	.fields(({ f }) => ({
+		title: f.text().required(),
+		summary: f.textarea(),
+		status: f.select([
+			{ value: "draft", label: "Draft" },
+			{ value: "published", label: "Published" },
+		]),
+	}))
+	.title(({ f }) => f.title)
+	.searchable({
+		content: (record) => record.summary,
+		metadata: (record) => ({ status: record.status }),
+	});
+```
+
+The collection `.title()` field and searchable `content` drive ranking. `metadata` supports filters and facets. Localized collections produce one index projection per locale.
+
+## Query the index
+
+Server code uses the search service:
+
+```ts
+const result = await app.search.search({
+	query: "release notes",
+	collections: ["posts"],
+	filters: { status: "published" },
+	limit: 20,
+});
+```
+
+The response contains ranked index results, a total, and requested facets. The typed client exposes hydrated documents for UI use.
+
+## Indexing lifecycle
+
+Automatic indexing starts after a durable collection change. QUESTPIE batches rapid writes and dispatches the built-in `index-records` job when a queue is configured.
+
+Without a queue, indexing runs synchronously. `manual: true` moves lifecycle control to your application for imports, external synchronization, or specialized batching.
+
+## Ranking modes
+
+The public query contract supports three modes:
+
+| Mode       | Purpose                                                        |
+| ---------- | -------------------------------------------------------------- |
+| `lexical`  | Rank exact terms and full-text matches.                        |
+| `hybrid`   | Combine the lexical signals supported by the selected adapter. |
+| `semantic` | Rank by embedding similarity.                                  |
+
+Adapter capabilities determine which modes are available. Application query code stays stable when the backend changes.
+
+## Access and consistency
+
+The HTTP search route derives collection access filters before returning documents. Treat search as a read model: writes become searchable after the indexing step completes.
+
+Render record data from hydrated documents when freshness matters. Use indexed title, snippets, score, and facets for discovery UI.
+
+## Choose a backend
+
+The default Postgres adapter provides full-text and trigram search. The pgvector adapter adds semantic ranking through an embedding provider.
+
+See [Search adapters](/docs/adapters/search) for extensions, migrations, scoring options, embedding providers, and custom adapter contracts.
+
+## Related
+
+- [Collections](/docs/concepts/collections#searchable), projection configuration with `.searchable()`.
+- [Jobs](/docs/concepts/jobs), the queue-backed indexing lifecycle.
+- [Search adapters](/docs/adapters/search), backend setup and operational details.
+- [Access control](/docs/concepts/access-control), row-level result visibility.

--- a/apps/docs/content/docs/concepts/services.mdx
+++ b/apps/docs/content/docs/concepts/services.mdx
@@ -29,7 +29,10 @@ export default service({
   lifecycle: "singleton",
   create: () => ({
     computeReadingTime(content: string): number {
-      const words = content.replace(/<[^>]*>/g, " ").trim().split(/\s+/).length;
+      const words = content
+        .replace(/<[^>]*>/g, " ")
+        .trim()
+        .split(/\s+/).length;
       return Math.max(1, Math.ceil(words / WORDS_PER_MINUTE));
     },
   }),
@@ -125,17 +128,17 @@ export default service()
 Each chained method (`create`, `lifecycle`, `namespace`, `dispose`) spreads `this.state` into a **brand-new** `ServiceBuilder` and never mutates in place, the builder is immutable. The builder itself resolves nothing; the app's service container interprets the resulting `state` at registration time.
 
 <Callout type="warn" title="`namespace()` takes `string | null`, not `undefined`">
-The chained `.namespace()` method only accepts `string | null`. To put a service in the default `ctx.services` bucket, **omit** `namespace` entirely, don't pass `undefined`. (The object form's type allows `undefined`, but omitting is the idiom.)
+  The chained `.namespace()` method only accepts `string | null`. To put a service in the default `ctx.services` bucket, **omit** `namespace` entirely, don't pass `undefined`. (The object form's type allows `undefined`, but omitting is the idiom.)
 </Callout>
 
 ## Lifecycle: singleton vs request
 
 `lifecycle` decides how often `create` runs. The public type is `ServiceLifecycle = "singleton" | "request"`.
 
-| Lifecycle | When `create` runs | Use it for |
-|---|---|---|
-| `"singleton"` | Once, the first time it's resolved; the same instance is reused for the app's lifetime. | API clients, connection pools, caches, stateless domain logic. |
-| `"request"` | Per request scope, a fresh instance each time a new handler context is created. | Anything that holds per-request state (a request-scoped buffer, a memo cache scoped to one operation). |
+| Lifecycle     | When `create` runs                                                                      | Use it for                                                                                             |
+| ------------- | --------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `"singleton"` | Once, the first time it's resolved; the same instance is reused for the app's lifetime. | API clients, connection pools, caches, stateless domain logic.                                         |
+| `"request"`   | Per request scope, a fresh instance each time a new handler context is created.         | Anything that holds per-request state (a request-scoped buffer, a memo cache scoped to one operation). |
 
 ```ts title="src/questpie/server/services/request-cache.ts"
 import { service } from "questpie/services";
@@ -150,11 +153,12 @@ export default service({
 When `lifecycle` is omitted, the container decides; the framework's built-in core services, including email, set `"singleton"` explicitly.
 
 <Callout type="warn" title="Singletons outlive every request, don't store request state on them">
-A `"singleton"` is shared across all requests for the life of the process. Never cache the current user, a request's locale, or a per-request transaction on a singleton, it leaks across requests and corrupts data. Put per-request state on a `"request"` service, or read `ctx.session` / `ctx.locale` fresh inside the method that needs it.
+  A `"singleton"` is shared across all requests for the life of the process. Never cache the current user, a request's locale, or a per-request transaction on a singleton, it leaks across requests and corrupts data. Put per-request state on a `"request"` service, or read `ctx.session` / `ctx.locale` fresh inside the
+  method that needs it.
 </Callout>
 
-<Callout type="info" title="`ServiceLifecycle` is not the internal `Lifecycle`">
-The **public** enum is `"singleton" | "request"`. There is a separate, **non-exported** internal proof-of-concept (`ScopedContainer`) whose `Lifecycle` is `"singleton" | "scoped"`, different values, different type, and not part of the public API. Build your services against `"singleton" | "request"` only.
+<Callout type="info" title="Service lifecycle values">
+  Use `"singleton"` for one process-wide instance and `"request"` for one instance per request.
 </Callout>
 
 ## Consuming a service
@@ -198,7 +202,8 @@ collection("posts").hooks({
 ```
 
 <Callout type="info" title="Read `ctx` inside the method, not just at construction">
-A singleton's `create(ctx)` runs once, so the `ctx` it captures is **not** request-specific, `ctx.session` / `ctx.locale` captured there reflect the resolution moment, not the current caller. If a singleton method needs the current request's session or locale, accept it as an argument from the caller (which has the live request `ctx`) rather than closing over the construction-time `ctx`.
+  A singleton's `create(ctx)` runs once, so the `ctx` it captures is **not** request-specific, `ctx.session` / `ctx.locale` captured there reflect the resolution moment, not the current caller. If a singleton method needs the current request's session or locale, accept it as an argument from the caller (which has the
+  live request `ctx`) rather than closing over the construction-time `ctx`.
 </Callout>
 
 ## Full API
@@ -254,11 +259,11 @@ export default service({
 
 Controls **where** the resolved instance lands on `ctx`. It accepts `string | null` only (not `undefined`, to use the default bucket, just omit the field):
 
-| `namespace` value | Lands at | Example |
-|---|---|---|
-| omitted, or `"services"` | `ctx.services[name]` | `ctx.services.billing` |
-| `null` | top-level `ctx[name]` | `ctx.billing` |
-| any other string `"x"` | `ctx.x[name]` (grouped bucket) | `ctx.integrations.billing` |
+| `namespace` value        | Lands at                       | Example                    |
+| ------------------------ | ------------------------------ | -------------------------- |
+| omitted, or `"services"` | `ctx.services[name]`           | `ctx.services.billing`     |
+| `null`                   | top-level `ctx[name]`          | `ctx.billing`              |
+| any other string `"x"`   | `ctx.x[name]` (grouped bucket) | `ctx.integrations.billing` |
 
 ```ts title="src/questpie/server/services/billing.ts, grouped under ctx.integrations"
 import { service } from "questpie/services";
@@ -272,12 +277,13 @@ export default service({
 ```
 
 <Callout type="warn" title="A `null`-namespace service won't override a built-in `ctx` key">
-Top-level keys like `db`, `session`, `email`, `collections`, `globals`, `queue`, `storage`, `kv`, `logger` are populated directly by the context builder. A `namespace: null` service whose key collides with one of these is **silently skipped** and the existing built-in wins. Pick a unique key, or leave it in the default `ctx.services` bucket where collisions can't happen.
+  Top-level keys like `db`, `session`, `email`, `collections`, `globals`, `queue`, `storage`, `kv`, `logger` are populated directly by the context builder. A `namespace: null` service whose key collides with one of these is **silently skipped** and the existing built-in wins. Pick a unique key, or leave it in the
+  default `ctx.services` bucket where collisions can't happen.
 </Callout>
 
 ## Built-in services
 
-The framework's own core capabilities are services too, they follow the *exact same* `service()` convention as your code, with no privileged internal API. That's why `ctx.email`, `ctx.db`, `ctx.queue`, `ctx.storage`, `ctx.kv`, `ctx.search`, and `ctx.realtime` appear on the same context your services land on: each is a core service definition the `core` module ships.
+Core capabilities follow the same `service()` convention as application services. `ctx.email`, `ctx.db`, `ctx.queue`, `ctx.storage`, `ctx.kv`, `ctx.search`, and `ctx.realtime` therefore share one context surface with the services your modules register.
 
 The clearest example is the **email** (mailer) service. It is a plain `service({ namespace: null, lifecycle: "singleton", create })` that constructs the `MailerService` from your config and lands top-level as `ctx.email`:
 
@@ -300,7 +306,7 @@ Because the context builder pre-populates `ctx.email` directly, this `namespace:
 
 ## TypeScript
 
-After `questpie generate`, your services are typed onto the context automatically, destructuring `services.blog` in any handler gives you the full instance type with no annotation. The generated `Questpie.Services` interface extends `_AppServicesSeam`, the resolved fold of **every** registered service, across all namespaces, and **has no index signature**: referencing a service that doesn't exist is a compile error, not a silent `any`. (It's routed through an empty-base interface to defer the type fold, which avoids a TS2456 self-reference when a service's inferred instance reads `ctx.services` at create-time. The seam is intentionally *not* namespace-filtered, since re-reading each in-flight builder's namespace would reintroduce that cycle, so a create-ctx `ctx.services.<x>` can reach any namespace, a widening, never an `any`.) The namespace-filtered default-namespace fold is a different type, `_AppDefaultServices`, which backs the *outer* runtime `ctx.services` surface (`AppContext.services`).
+After `questpie generate`, every registered service is typed on application context. Destructuring `services.blog` in a handler gives the inferred instance type, and an unknown service name is a TypeScript error.
 
 To get the union of registered service names, or to extract a single service's instance / namespace type:
 
@@ -326,7 +332,8 @@ type BlogNs = ServiceNamespaceOf<typeof blog>; // undefined
 - **`ServiceNamespaceOf<T>`** computes the namespace placement (falls back through the builder generic → `state.namespace` → `namespace` → `undefined`).
 
 <Callout type="info" title="`ctx` types only fill in after codegen">
-Before you run `questpie generate`, `ServiceCreateContext` falls back to the base app context plus `{ app }`, so a brand-new service file may show a thinner `ctx`. This fallback is deliberate: two augmentable markers back it, `Questpie.ServiceCreateContext` (the real interface codegen fills with the typed app surface) and `Questpie.ServiceCreateContextGenerated` (a names-only marker the conditional probes to avoid a self-reference cycle). Run `questpie generate` after adding a service to pick up the full typed surface and have it appear on `ctx.services`.
+  Before you run `questpie generate`, `ServiceCreateContext` falls back to the base app context plus `{app}`, so a brand-new service file may show a thinner `ctx`. This fallback is deliberate: two augmentable markers back it, `Questpie.ServiceCreateContext` (the real interface codegen fills with the typed app surface)
+  and `Questpie.ServiceCreateContextGenerated` (a names-only marker the conditional probes to avoid a self-reference cycle). Run `questpie generate` after adding a service to pick up the full typed surface and have it appear on `ctx.services`.
 </Callout>
 
 ## Related

--- a/apps/docs/content/docs/concepts/storage.mdx
+++ b/apps/docs/content/docs/concepts/storage.mdx
@@ -1,0 +1,69 @@
+---
+title: Storage
+description: Understand how upload collections connect asset metadata, file bytes, visibility, URLs, and direct uploads through a stable storage service.
+---
+
+Storage manages file bytes while upload collections manage asset records. This split keeps application data relational and lets the byte backend move from local disk to object storage without changing collection code.
+
+## The asset model
+
+An upload collection stores metadata such as filename, MIME type, size, visibility, and resolved URL. The storage backend stores the bytes under the asset key.
+
+An `f.upload()` field is a relation to that upload collection. The owning record stores the asset ID and hydrates asset metadata through `with`.
+
+## Upload flow
+
+A server-mediated upload follows this sequence:
+
+1. QUESTPIE validates the upload collection and access rules.
+2. The storage service writes the file bytes.
+3. The upload collection stores the asset metadata.
+4. Reads resolve a public or signed URL from the asset and storage configuration.
+
+The database record and storage object share a stable key. Deletion hooks remove the object when the asset lifecycle ends.
+
+## Define an upload collection
+
+```ts title="collections/assets.ts"
+import { collection } from "#questpie/factories";
+
+export default collection("assets")
+	.fields(({ f }) => ({
+		alt: f.text(),
+	}))
+	.upload({
+		visibility: "public",
+	});
+```
+
+Reference it from another collection:
+
+```ts
+cover: f.upload({ to: "assets" }),
+```
+
+See [Upload fields](/docs/concepts/fields/upload) for relation typing, input shapes, and hydration.
+
+## Visibility and URLs
+
+Public assets resolve to stable URLs. Private assets resolve through signed URLs with an expiry window enforced by the backend.
+
+Keep authorization on the upload collection. Storage visibility determines URL delivery; collection access determines who can create, read, update, or delete the asset record.
+
+## Direct uploads
+
+Object-storage adapters can issue client upload instructions. The browser uploads bytes directly, then the application finalizes the asset record with the returned key and metadata.
+
+This path removes large byte streams from the application server while preserving the same collection and access lifecycle.
+
+## Choose a backend
+
+Local filesystem storage fits development and single-node deployments. Object storage fits replicated applications, CDN delivery, and direct uploads.
+
+See [Storage adapters](/docs/adapters/storage) for filesystem paths, object-storage configuration, signed URLs, environment variables, and custom adapters.
+
+## Related
+
+- [Upload fields](/docs/concepts/fields/upload), model an asset relation.
+- [Collections](/docs/concepts/collections), access rules and lifecycle hooks.
+- [Storage adapters](/docs/adapters/storage), backend configuration and operations.

--- a/apps/docs/content/docs/extend/build-a-plugin.mdx
+++ b/apps/docs/content/docs/extend/build-a-plugin.mdx
@@ -3,7 +3,7 @@ title: Building a plugin
 description: A plugin is the unit of extension in QUESTPIE, it teaches codegen new file conventions, wraps the collection/global/field builders with typed methods, and ships everything as one npm package. The framework's own admin is just a plugin, and yours reaches the exact same seams.
 ---
 
-QUESTPIE has one extension principle: **core, modules, and your own code reach the framework through the same seams.** There are no privileged internal APIs. The admin panel, the audit log, OpenAPI, each is a plugin that declares file conventions, extends the builders, and contributes generated output through the public `CodegenPlugin` contract. When you build a plugin, you reach for the same primitives. Add a custom field type and it appears on `f` next to `f.text()`; add a `config/<name>.ts` convention and it merges into every app that installs you; ship a scaffold and `questpie add` learns a new type.
+QUESTPIE has one extension principle: **core, modules, and application code use the same public seams.** The admin panel, audit log, and OpenAPI integration are plugins that declare file conventions, extend builders, and contribute generated output through `CodegenPlugin`. A custom field can appear beside `f.text()`, a `config/<name>.ts` convention can merge into every installed app, and a scaffold can teach `questpie add` a new type.
 
 This page is the build-your-own loop end to end: the **contract** (`CodegenPlugin`), the **seams** it can extend (categories, discover patterns, builder extensions, scaffolds, custom generators), the smaller per-feature extensions you'll reach for far more often (a **custom field type**, a **custom query operator**, a **custom adapter**, a **custom block/component**), how a plugin **extends config non-destructively**, and how to **publish** it as a module package.
 
@@ -17,32 +17,33 @@ This page is the build-your-own loop end to end: the **contract** (`CodegenPlugi
 - **Distribute as one package.** A module attaches its `plugin` and auto-registers on install, users add it to `modules.ts` and touch nothing else.
 
 <Callout type="info" title="Pick the smallest seam that fits">
-Most extension is *not* a full plugin. A custom field type, a custom operator, or a custom adapter is a single factory call you register where the built-in ones go. Reach for a `CodegenPlugin` only when you need codegen to discover *new file conventions* or wrap the *builders*. The [per-feature recipes](#custom-field-types) below come first for that reason; the [full plugin contract](#the-codegen-plugin-contract) is the deep end.
+  Most extension is *not* a full plugin. A custom field type, a custom operator, or a custom adapter is a single factory call you register where the built-in ones go. Reach for a `CodegenPlugin` only when you need codegen to discover *new file conventions* or wrap the *builders*. The [per-feature
+  recipes](#custom-field-types) below come first for that reason; the [full plugin contract](#the-codegen-plugin-contract) is the deep end.
 </Callout>
 
 ## The two layers of extension
 
 QUESTPIE extension splits cleanly in two, and most of what you build lives in the first:
 
-| Layer | What it is | How you register it | Touches codegen? |
-|---|---|---|---|
-| **Runtime primitives** | Custom field types, operators, adapters, blocks, components | A factory call registered where the built-ins live (a module's `fields` record or a `fields.ts` bundle, a `runtimeConfig()` adapter slot, a `blocks/`/`components/` file) | no |
-| **Codegen plugin** | New file conventions + builder-method extensions | `CodegenPlugin` in `runtimeConfig({ plugins })` or attached to a module's `plugin` | yes |
+| Layer                  | What it is                                                  | How you register it                                                                                                                                                       | Touches codegen? |
+| ---------------------- | ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| **Runtime primitives** | Custom field types, operators, adapters, blocks, components | A factory call registered where the built-ins live (a module's `fields` record or a `fields.ts` bundle, a `runtimeConfig()` adapter slot, a `blocks/`/`components/` file) | no               |
+| **Codegen plugin**     | New file conventions + builder-method extensions            | `CodegenPlugin` in `runtimeConfig({ plugins })` or attached to a module's `plugin`                                                                                        | yes              |
 
-A field type appears on `f` because the **core codegen plugin** already extracts field factories from a module's `fields` record (and from a root app's `fields.ts` bundle) and merges them into the `f` proxy, you register a factory, not write a plugin. A `CodegenPlugin` is only needed when you want to invent a *new* convention (your own `widgets/` directory) or add a *new builder method* (`collection().myThing()`). Start with the recipe, escalate to the contract.
+A field type appears on `f` because the **core codegen plugin** already extracts field factories from a module's `fields` record (and from a root app's `fields.ts` bundle) and merges them into the `f` proxy, you register a factory, not write a plugin. A `CodegenPlugin` is only needed when you want to invent a _new_ convention (your own `widgets/` directory) or add a _new builder method_ (`collection().myThing()`). Start with the recipe, escalate to the contract.
 
 ## Custom field types
 
-`f.*` is open. A custom field type is a factory function that returns a `Field`, it declares how the value maps to a Postgres column, how it validates, and what `where` operators it exposes. Register the factory on a module's `fields` record, run codegen, and it appears on `f` in every `.fields(({ f }) => …)` callback, exactly like a builtin. This is the QUESTPIE principle at its most concrete: **there is no privileged field API; builtins are authored the same way you author yours.**
+`f.*` is extensible. A custom field factory returns a `Field` that defines the Postgres column, validation, and `where` operators. Register it on a module's `fields` record and run codegen; the factory then appears in every `.fields(({ f }) => …)` callback beside the built-ins.
 
 The contract is the four runtime accessors every `Field` implements, codegen and the CRUD layer call them, you supply them through the field's runtime state:
 
-| Accessor | What it answers | Where it comes from |
-|---|---|---|
-| `toColumn(name)` | the Drizzle column to create | `columnFactory` in the field state |
-| `toZodSchema()` | how to validate the value | `schemaFactory` in the field state |
-| `getOperators()` | the `where` operator set | `operatorSet` in the field state |
-| `getMetadata()` | what the admin introspects (label, type, validation) | derived from state |
+| Accessor         | What it answers                                      | Where it comes from                |
+| ---------------- | ---------------------------------------------------- | ---------------------------------- |
+| `toColumn(name)` | the Drizzle column to create                         | `columnFactory` in the field state |
+| `toZodSchema()`  | how to validate the value                            | `schemaFactory` in the field state |
+| `getOperators()` | the `where` operator set                             | `operatorSet` in the field state   |
+| `getMetadata()`  | what the admin introspects (label, type, validation) | derived from state                 |
 
 ### Start with `.drizzle()` for column tweaks
 
@@ -73,9 +74,7 @@ When you need to control the operator set, metadata, or column factory directly,
 ```ts title="src/questpie/server/fields/color.ts (full control)"
 import { varchar } from "questpie/drizzle-pg-core";
 import { z } from "zod";
-import { field } from "questpie/builders";
-// operator sets live at the internal operators barrel, see the callout below.
-import { stringOps } from "#questpie/server/fields/operators/index.js";
+import { field, stringOps } from "questpie/builders";
 
 export function color() {
   return field({
@@ -96,28 +95,26 @@ export function color() {
 
 `field` comes from `questpie/builders`; `FieldRuntimeState` requires an `operatorSet`, so reusing `stringOps` gives a `color` field `eq` / `in` / `ilike` / `isNull` and friends for free.
 
-<Callout type="warn" title="`operator` / `operatorSet` / `stringOps` are not public exports">
-The operator-authoring primitives, `operator()`, `operatorSet()`, `extendOperatorSet()`, and the builtin sets (`stringOps`, `numberOps`, …), live at the internal path `#questpie/server/fields/operators/index.js` and are **not** re-exported from `questpie` or `questpie/builders`. Only their *types* (`OperatorFn`, `OperatorMap`, `ContextualOperators`) are public.
-</Callout>
-
 ### Adding chain methods with `fieldType()`
 
-A bare `field()` factory has the common methods (`.required()`, `.default()`, `.label()`, `.localized()`, …) but no *type-specific* ones. To add chainable methods like `.pattern()` or `.uppercase()`, use `fieldType()`, the declarative way to define a field type with methods, which is exactly how every builtin (`text`, `number`, `relation`, …) is built:
+A bare `field()` factory has the common methods (`.required()`, `.default()`, `.label()`, `.localized()`, …) but no _type-specific_ ones. To add chainable methods like `.pattern()` or `.uppercase()`, use `fieldType()`, the declarative way to define a field type with methods, which is exactly how every builtin (`text`, `number`, `relation`, …) is built:
 
 ```ts title="src/questpie/server/fields/slug.ts"
 import { varchar } from "questpie/drizzle-pg-core";
 import { z } from "zod";
-import { fieldType } from "questpie/builders";
+import { fieldType, stringOps } from "questpie/builders";
 import type { Field } from "questpie/builders";
-// stringOps is internal, see the operators callout above.
-import { stringOps } from "#questpie/server/fields/operators/index.js";
 
 export const slugFieldType = fieldType("slug", {
   // create(...args) → the FieldRuntimeState (same shape field() takes)
   create: (maxLength: number = 255) => ({
     type: "slug",
     columnFactory: (name: string) => varchar(name, { length: maxLength }),
-    schemaFactory: () => z.string().regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/).max(maxLength),
+    schemaFactory: () =>
+      z
+        .string()
+        .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/)
+        .max(maxLength),
     operatorSet: stringOps,
     notNull: false,
     hasDefault: false,
@@ -157,46 +154,14 @@ export const myModule = module({
 
 When a module declares a `fields` record, codegen extracts those factories (the core plugin's `fieldTypes` category sets `extractFromModules: true`) and merges them into the generated `f` proxy, so any app that installs your module gets `f.color()` and `f.slug()`. This is how `@questpie/admin` ships `richText` and `blocks`: it contributes them via `factoryImports` on the same `fieldTypes` category.
 
-In a **root app** (not a package), the same effect comes from a single `src/questpie/server/fields.ts` *bundle* file that exports your factories, codegen discovers it via the `fields` discover pattern, spreads its default export into the runtime field map, and augments the type-level `FieldTypesMap`.
+In a **root app** (not a package), the same effect comes from a single `src/questpie/server/fields.ts` _bundle_ file that exports your factories, codegen discovers it via the `fields` discover pattern, spreads its default export into the runtime field map, and augments the type-level `FieldTypesMap`.
 
 <Callout type="info" title="Two `fields` mechanisms, don't confuse them">
-The core plugin has *both* a `fields.ts` single-file discover pattern for the root-app bundle and a `fieldTypes` *category* that scans the `fields/` directory for `fieldType()` calls. The category feeds the `~fieldTypes` Registry and module extraction; it does **not** auto-inject loose `fields/`-directory files into a root app's `f` proxy. Register via a module's `fields` record (packages) or the `fields.ts` bundle (root apps).
+  The core plugin has *both* a `fields.ts` single-file discover pattern for the root-app bundle and a `fieldTypes` *category* that scans the `fields/` directory for `fieldType()` calls. The category feeds the `~fieldTypes` Registry and module extraction; it does **not** auto-inject loose `fields/`-directory files into
+  a root app's `f` proxy. Register via a module's `fields` record (packages) or the `fields.ts` bundle (root apps).
 </Callout>
 
 The full field surface, every common method (`.zod()`, `.drizzle()`, `.array()`, `.access()`, `.hooks()`, …), the `FieldRuntimeState` shape, and the per-type metadata, is in [Fields](/docs/concepts/fields). What's above is the minimum to add your own.
-
-## Custom query operators
-
-A field's `where` keys come from its **operator set**. When no builtin set fits (you need `domain`, `withinRadius`, a JSONB-path match), author one with `operatorSet()` / `extendOperatorSet()` and pass it as the field's `operatorSet`. The keys you declare become the typed `where` operators on every collection that uses the field.
-
-An operator is a function `(column, value, ctx) => SQL` wrapped by `operator()`. The `value` type you give it becomes the operand type in `where`:
-
-```ts title="src/questpie/server/fields/email-domain.ts (operators)"
-import { sql } from "questpie/drizzle";
-// operator / operatorSet / extendOperatorSet / stringOps are internal, they are
-// NOT exported from questpie/builders. Import them from the operators barrel.
-import {
-  operator,
-  extendOperatorSet,
-  stringOps,
-} from "#questpie/server/fields/operators/index.js";
-
-// Extend the builtin string operators with a `domain` filter.
-export const domainOps = extendOperatorSet(stringOps, {
-  column: {
-    // `value: string` → `where: { contact: { domain: "questpie.com" } }`
-    domain: operator<string>((col, value) => sql`${col} ILIKE ${"%@" + value}`),
-  },
-});
-```
-
-`operatorSet({ jsonbCast, column, jsonbOverrides? })` builds a set from scratch; `extendOperatorSet(base, { jsonbCast?, column?, jsonbOverrides? })` inherits every key of `base` and adds yours, all three extension fields are optional, and a missing `jsonbCast` falls back to the base's (this is exactly how `emailOps` and `urlOps` extend `stringOps`). `jsonbCast` (`"text" | "numeric" | "boolean" | "timestamp" | "jsonb" | null`) tells the engine how to compare the field when it's nested inside an `f.object()`, set it to match your column's storage. Wire the set onto a field via its `operatorSet` state (or `.operators(domainOps)` on an existing field).
-
-<Callout type="warn" title="`operator` / `operatorSet` are internal, not public exports">
-`operator()`, `operatorSet()`, and `extendOperatorSet()` are **not** re-exported from `questpie` or `questpie/builders`, import them from `#questpie/server/fields/operators/index.js`. Only the `OperatorFn` / `OperatorMap` / `ContextualOperators` **types** are public. Always type your operand precisely, `operator<string>(…)` makes the `where` operand `string`, which is what flows into the field's filter shape.
-</Callout>
-
-The complete operator catalog (what each builtin field exposes, the JSONB-path overrides, relation quantifiers) is in the [query reference under Relations](/docs/concepts/relations) and [Fields](/docs/concepts/fields).
 
 ## Custom adapters
 
@@ -204,31 +169,35 @@ Infrastructure in QUESTPIE is adapter-shaped. Every subsystem, queue, search, re
 
 Each subsystem has one interface. A few of them:
 
-| Subsystem | Interface | Wire it as |
-|---|---|---|
-| Search | `SearchAdapter` | `runtimeConfig({ search })` |
-| Realtime | `RealtimeAdapter` | `runtimeConfig({ realtime: { adapter } })` |
-| KV | `KVAdapter` | `runtimeConfig({ kv: { adapter } })` |
-| Executor | `ExecutorAdapter` | `runtimeConfig({ executor: { sandboxed } })` |
-| Storage | `files-sdk` `Adapter` | `runtimeConfig({ storage: { adapter } })` |
+| Subsystem | Interface             | Wire it as                                   |
+| --------- | --------------------- | -------------------------------------------- |
+| Search    | `SearchAdapter`       | `runtimeConfig({ search })`                  |
+| Realtime  | `RealtimeAdapter`     | `runtimeConfig({ realtime: { adapter } })`   |
+| KV        | `KVAdapter`           | `runtimeConfig({ kv: { adapter } })`         |
+| Executor  | `ExecutorAdapter`     | `runtimeConfig({ executor: { sandboxed } })` |
+| Storage   | `files-sdk` `Adapter` | `runtimeConfig({ storage: { adapter } })`    |
 
 A `RealtimeAdapter` is the smallest contract, four methods. Here is the shape of a custom transport adapter:
 
 ```ts title="src/questpie/server/adapters/my-realtime.ts"
-import type {
-  RealtimeAdapter,
-  RealtimeChangeEvent,
-  RealtimeNotice,
-} from "questpie/realtime";
+import type { RealtimeAdapter, RealtimeChangeEvent, RealtimeNotice } from "questpie/realtime";
 
 export function myRealtimeAdapter(): RealtimeAdapter {
   return {
-    async start() {/* open the connection */},
-    async stop() {/* close it */},
-    async notify(event: RealtimeChangeEvent) {/* broadcast to other instances */},
+    async start() {
+      /* open the connection */
+    },
+    async stop() {
+      /* close it */
+    },
+    async notify(event: RealtimeChangeEvent) {
+      /* broadcast to other instances */
+    },
     subscribe(handler: (notice: RealtimeNotice) => void) {
       // call handler(notice) on each incoming change; return an unsubscribe fn
-      return () => {/* unsubscribe */};
+      return () => {
+        /* unsubscribe */
+      };
     },
   };
 }
@@ -247,7 +216,8 @@ export default runtimeConfig({
 The adapter interfaces and their config types (`RealtimeAdapter` / `RealtimeConfig`, `SearchAdapter` / `SearchOptions` / `SearchResponse`, `KVAdapter` / `KVConfig`, `ExecutorAdapter` / `ExecutorConfig`) are all exported from the matching subpath, `questpie/realtime`, `questpie/search`, `questpie/kv`, `questpie/executor`. Build against the interface and the framework treats yours identically to a builtin. Each subsystem's contract and the built-in adapters are documented under Infrastructure.
 
 <Callout type="info" title="Adapters that need a runtime discriminator">
-A few adapters carry a `readonly runtime` field (e.g. the Cloudflare adapters set `runtime: "cloudflare"`) so the Cloudflare fetch/queue handlers can detect them. That's a built-in detail of those specific adapters, not a requirement of the interface, a plain transport adapter like the one above needs no discriminator.
+  A few adapters carry a `readonly runtime` field (e.g. the Cloudflare adapters set `runtime: "cloudflare"`) so the Cloudflare fetch/queue handlers can detect them. That's a built-in detail of those specific adapters, not a requirement of the interface, a plain transport adapter like the one above needs no
+  discriminator.
 </Callout>
 
 ## Custom blocks & components
@@ -276,14 +246,15 @@ export const heroBlock = block("hero")
 A **component** registers a named React-component reference you can hand to admin config (icons, custom cells, dashboard widgets) with typed props. Declare it server-side with `component(name, config)`; the `c` proxy in `.admin()` / `.actions()` / dashboard callbacks then offers `c.myComponent(props)` with autocomplete.
 
 <Callout type="info" title="Blocks and components are two-sided">
-A block or component has a **server definition** (`blocks/`, `components/`, schema + props) and a matching **client renderer** (`client/blocks/`, `client/components/`, the React component). `questpie add block hero` scaffolds both sides for you because the admin plugin declares the `block` scaffold on *both* its `server` and `admin-client` targets. The admin docs cover the client side; this page covers how the extension points exist.
+  A block or component has a **server definition** (`blocks/`, `components/`, schema + props) and a matching **client renderer** (`client/blocks/`, `client/components/`, the React component). `questpie add block hero` scaffolds both sides for you because the admin plugin declares the `block` scaffold on *both* its
+  `server` and `admin-client` targets. The admin docs cover the client side; this page covers how the extension points exist.
 </Callout>
 
 The full block/component authoring surface, field layouts, prefetch, the client renderer contract, custom views/widgets, is in the admin documentation. What matters here: they're standard file conventions, reachable by any app the moment admin is installed.
 
 ## The codegen plugin contract
 
-Everything above adds a *value* where the framework already looks. A `CodegenPlugin` adds a *new place to look*: a new file convention, a new builder method, a new generated file. This is the deep seam, and the canonical example is `adminPlugin()` itself.
+Everything above adds a _value_ where the framework already looks. A `CodegenPlugin` adds a _new place to look_: a new file convention, a new builder method, a new generated file. This is the deep seam, and the canonical example is `adminPlugin()` itself.
 
 A plugin is one object: a `name`, a map of **target contributions**, and optional cross-target **validators**.
 
@@ -332,29 +303,30 @@ export const myModule = module({
 });
 ```
 
-When a plugin rides on a module's `plugin` field, codegen's pre-pass (`extractPluginsFromModules`) auto-registers it the moment the module appears in `modules.ts`, the user adds nothing to `questpie.config.ts`. This is how `adminModule` works: `Object.assign(generatedModule, { plugin: adminPlugin() })`, and installing the module *is* installing the plugin. The `plugin` key is codegen-only, it's stripped from the runtime module merge.
+When a plugin rides on a module's `plugin` field, codegen's pre-pass (`extractPluginsFromModules`) auto-registers it the moment the module appears in `modules.ts`, the user adds nothing to `questpie.config.ts`. This is how `adminModule` works: `Object.assign(generatedModule, { plugin: adminPlugin() })`, and installing the module _is_ installing the plugin. The `plugin` key is codegen-only, it's stripped from the runtime module merge.
 
 <Callout type="warn" title="`plugins` is for codegen plugins; `modules.ts` is for dependencies">
-`runtimeConfig({ plugins })` registers **codegen plugins** (file discovery + generated output). Module *dependencies* go in `modules.ts`. Because a module can carry its own codegen plugin, most apps never touch `plugins` directly, they just install your module. The core codegen plugin is *always* prepended automatically; never register it.
+  `runtimeConfig({plugins})` registers **codegen plugins** (file discovery + generated output). Module *dependencies* go in `modules.ts`. Because a module can carry its own codegen plugin, most apps never touch `plugins` directly, they just install your module. The core codegen plugin is *always* prepended
+  automatically; never register it.
 </Callout>
 
 ### Target contribution, the surface
 
 A `CodegenTargetContribution` is what a plugin adds to one target. Every field is optional except `root` + `outputFile`:
 
-| Field | Type | What it adds |
-|---|---|---|
-| `root` | `string` | discovery root, relative to the server root (`"."` server, `"../admin"` client) |
-| `outDir` | `string` | output dir within root (default `.generated`) |
-| `outputFile` | `string` | the primary generated file (`index.ts`, `client.ts`) |
-| `moduleRoot` | `string` | subdir within each module dir this target discovers from (admin uses `"client"`) |
-| `categories` | `Record<string, CategoryDeclaration>` | directory conventions to scan (`views/`, `blocks/`) |
-| `discover` | `Record<string, DiscoverPattern>` | single-file / glob patterns (`config/x.ts`, `sidebar.ts`) |
-| `registries` | object | typed builder-method extensions (collection/global/field) + singleton/builder factories |
-| `callbackParams` | `Record<string, CallbackParamDefinition>` | runtime proxies for callback-style extension methods |
-| `transform` | `(ctx) => void` | mutate the codegen context before generation (add imports, type decls) |
-| `generate` | `(ctx) => CodegenTargetOutput` | take over generation of the whole file (one per target) |
-| `scaffolds` | `Record<string, ScaffoldConfig>` | `questpie add <type>` templates |
+| Field            | Type                                      | What it adds                                                                            |
+| ---------------- | ----------------------------------------- | --------------------------------------------------------------------------------------- |
+| `root`           | `string`                                  | discovery root, relative to the server root (`"."` server, `"../admin"` client)         |
+| `outDir`         | `string`                                  | output dir within root (default `.generated`)                                           |
+| `outputFile`     | `string`                                  | the primary generated file (`index.ts`, `client.ts`)                                    |
+| `moduleRoot`     | `string`                                  | subdir within each module dir this target discovers from (admin uses `"client"`)        |
+| `categories`     | `Record<string, CategoryDeclaration>`     | directory conventions to scan (`views/`, `blocks/`)                                     |
+| `discover`       | `Record<string, DiscoverPattern>`         | single-file / glob patterns (`config/x.ts`, `sidebar.ts`)                               |
+| `registries`     | object                                    | typed builder-method extensions (collection/global/field) + singleton/builder factories |
+| `callbackParams` | `Record<string, CallbackParamDefinition>` | runtime proxies for callback-style extension methods                                    |
+| `transform`      | `(ctx) => void`                           | mutate the codegen context before generation (add imports, type decls)                  |
+| `generate`       | `(ctx) => CodegenTargetOutput`            | take over generation of the whole file (one per target)                                 |
+| `scaffolds`      | `Record<string, ScaffoldConfig>`          | `questpie add <type>` templates                                                         |
 
 `root` / `outDir` / `outputFile` / `moduleRoot` **must be consistent** across every plugin contributing to a target, codegen throws if two plugins disagree. Only **one** `generate` is allowed per target.
 
@@ -380,28 +352,27 @@ categories: {
 
 The knobs you'll actually reach for:
 
-| Option | Type / default | Effect |
-|---|---|---|
-| `dirs` | `string[]` (required) | directories to scan; also scans `features/{name}/{dir}/` |
-| `prefix` | `string` (required) | generated variable-name prefix (`_view_…`) |
-| `recursive` | `boolean` | recurse into subdirectories |
-| `emit` | `"record"` \| `"array"` (default `"record"`) | `{ key: var }` vs flat `[var1, var2]` (migrations/seeds use `array`) |
-| `typeEmit` | `"standard"` \| `"services"` \| `"emails"` \| `"messages"` \| `"none"` | how the value type is emitted |
-| `registryKey` | `string` \| `boolean` (default `true` for standard) | key in the typed `Registry`; tilde keys like `~fieldTypes` are internal |
-| `factoryFunctions` | `string[]` | enables multi-export discovery, each matching factory call becomes a separate entity; files with none are skipped |
-| `keyFromProperty` | `string` | use a runtime prop as the key (views → `"name"`, blocks → `"state.name"`) |
-| `keyFromSource` | `"basename"` | use the source filename as the key (client convention files) |
-| `factoryImports` | `Array<{ name; from }>` | named exports spread-merged into `factories.ts` (admin merges `adminFields`) |
-
-
+| Option             | Type / default                                                         | Effect                                                                                                            |
+| ------------------ | ---------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `dirs`             | `string[]` (required)                                                  | directories to scan; also scans `features/{name}/{dir}/`                                                          |
+| `prefix`           | `string` (required)                                                    | generated variable-name prefix (`_view_…`)                                                                        |
+| `recursive`        | `boolean`                                                              | recurse into subdirectories                                                                                       |
+| `emit`             | `"record"` \| `"array"` (default `"record"`)                           | `{ key: var }` vs flat `[var1, var2]` (migrations/seeds use `array`)                                              |
+| `typeEmit`         | `"standard"` \| `"services"` \| `"emails"` \| `"messages"` \| `"none"` | how the value type is emitted                                                                                     |
+| `registryKey`      | `string` \| `boolean` (default `true` for standard)                    | key in the typed `Registry`; tilde keys like `~fieldTypes` are internal                                           |
+| `factoryFunctions` | `string[]`                                                             | enables multi-export discovery, each matching factory call becomes a separate entity; files with none are skipped |
+| `keyFromProperty`  | `string`                                                               | use a runtime prop as the key (views → `"name"`, blocks → `"state.name"`)                                         |
+| `keyFromSource`    | `"basename"`                                                           | use the source filename as the key (client convention files)                                                      |
+| `factoryImports`   | `Array<{ name; from }>`                                                | named exports spread-merged into `factories.ts` (admin merges `adminFields`)                                      |
 
 <Callout type="info" title="`factoryFunctions` is how one file yields many entities">
-Without `factoryFunctions`, a file is one entity keyed off its default/named export. With it, codegen scans for every call to a named factory (`view(…)`, `block(…)`) and emits one entity per call, keyed off the factory's first string argument, and silently skips files that contain no such call (so utility/type files in the same directory don't pollute the registry).
+  Without `factoryFunctions`, a file is one entity keyed off its default/named export. With it, codegen scans for every call to a named factory (`view(…)`, `block(…)`) and emits one entity per call, keyed off the factory's first string argument, and silently skips files that contain no such call (so utility/type files
+  in the same directory don't pollute the registry).
 </Callout>
 
 ### Discover patterns, single files & spreads
 
-Where a category scans a *directory*, a `DiscoverPattern` matches a *single file* or a *spread* of files. This is how a plugin claims `config/my-plugin.ts`, `sidebar.ts`, or `fields.ts`:
+Where a category scans a _directory_, a `DiscoverPattern` matches a _single file_ or a _spread_ of files. This is how a plugin claims `config/my-plugin.ts`, `sidebar.ts`, or `fields.ts`:
 
 ```ts
 discover: {
@@ -432,20 +403,20 @@ registries: {
 
 Codegen turns that into a typed `.preview(config: PreviewConfig)` method on the generated `collection()` that stores the value under `adminPreview`. `RegistryExtension` fields:
 
-| Field | Purpose |
-|---|---|
-| `stateKey` | the builder `.set()` key the value lands under |
-| `configType` | TS type of the method's argument (defaults to `any`) |
-| `imports` | imports the `configType` needs, added to `factories.ts` |
+| Field                                  | Purpose                                                                         |
+| -------------------------------------- | ------------------------------------------------------------------------------- |
+| `stateKey`                             | the builder `.set()` key the value lands under                                  |
+| `configType`                           | TS type of the method's argument (defaults to `any`)                            |
+| `imports`                              | imports the `configType` needs, added to `factories.ts`                         |
 | `isCallback` + `callbackContextParams` | mark a callback method (e.g. `["v","f","a","c"]`) and which proxies it receives |
-| `callbackParams` | per-extension proxy overrides (precedence over the plugin-level map) |
-| `configTypePlaceholders` | replace tokens (`$COMPONENTS`) with module-extracted type aliases |
-| `defaults` | wrap user config as `{ ...defaults, ...userConfig }` |
+| `callbackParams`                       | per-extension proxy overrides (precedence over the plugin-level map)            |
+| `configTypePlaceholders`               | replace tokens (`$COMPONENTS`) with module-extracted type aliases               |
+| `defaults`                             | wrap user config as `{ ...defaults, ...userConfig }`                            |
 
 Field-level extensions (`fieldExtensions`) work the same way and produce `.admin()` / `.form()` on every `f.*()`. Alongside them, `singletonFactories` generate typed identity wrappers for convention files (`branding<T>(config: T): T`), and `builderFactories` generate factory functions that need your merged field defs at construction (admin contributes `block`).
 
 <Callout type="warn" title="Callback extensions reference a real factory, never an inline string">
-When an extension is `isCallback` and lists `callbackContextParams: ["f"]`, codegen looks up `f` in the merged `callbackParams` and emits the proxy by calling the **named factory** it points at (`{ factory: "createFieldNameProxy", from: "questpie/builders" }`). The factory must be a real exported function. There are no inline JS strings in generated code, every proxy is a real import.
+When an extension is `isCallback` and lists `callbackContextParams: ["f"]`, codegen resolves `f` from merged `callbackParams` and emits the proxy through its named exported factory, such as `{ factory: "createFieldNameProxy", from: "questpie/builders" }`.
 </Callout>
 
 ### Transforms & custom generators
@@ -480,7 +451,7 @@ A plugin that spans targets can enforce consistency between them with a `CrossTa
 
 Plugins extend an app **additively**, they never overwrite. Two mechanisms guarantee it:
 
-**Merge, don't replace.** When multiple plugins contribute to the same target, codegen *merges* their categories, discover patterns, registries, and scaffolds; transforms run in plugin order. The one rule that can fail is structural: `root` / `outputFile` / a second `generate` must not conflict. Module-contributed collections/globals are merged by key (later modules override), and a user can extend a module's collection with `collection("user").merge(starter.collections.user).fields(...)`, the merge preserves admin config keys and prior fields.
+**Merge, don't replace.** When multiple plugins contribute to the same target, codegen _merges_ their categories, discover patterns, registries, and scaffolds; transforms run in plugin order. The one rule that can fail is structural: `root` / `outputFile` / a second `generate` must not conflict. Module-contributed collections/globals are merged by key (later modules override), and a user can extend a module's collection with `collection("user").merge(starter.collections.user).fields(...)`, the merge preserves admin config keys and prior fields.
 
 **Claim your own config file.** The cleanest way to ship configurable behavior is a `config/<name>.ts` convention that maps to one key in `AppStateConfig` (the config bucket). Declare a discover pattern and augment the interface, your config merges per-key across every module, and no framework code changes:
 
@@ -501,12 +472,13 @@ declare module "questpie" {
 A user then drops `config/my-plugin.ts` exporting your config, and it lands at `app.config.myPlugin`. This is exactly how `config/admin.ts` and `config/openapi.ts` work, they're not special-cased, just instances of this pattern. The [Configuration](/docs/concepts/configuration) page covers the config bucket from the app author's side.
 
 <Callout type="info" title="Why non-destructive matters">
-A QUESTPIE app composes N plugins (admin, audit, OpenAPI, yours) and its own files. If any plugin could overwrite another's output, ordering would become load-bearing and installs would be fragile. Merge-not-replace + per-key config buckets mean plugins are *commutative* in the common case, you install them in any order and they coexist. The only hard conflicts (same `outputFile`, two `generate`s) fail loudly at codegen time, not silently at runtime.
+  A QUESTPIE app composes N plugins (admin, audit, OpenAPI, yours) and its own files. If any plugin could overwrite another's output, ordering would become load-bearing and installs would be fragile. Merge-not-replace + per-key config buckets mean plugins are *commutative* in the common case, you install them in any
+  order and they coexist. The only hard conflicts (same `outputFile`, two `generate`s) fail loudly at codegen time, not silently at runtime.
 </Callout>
 
 ## Packaging & publishing
 
-A plugin ships as a **module package**. The shape that makes `questpie generate` discover your conventions both *inside your package* (so you commit a generated `.generated/module.ts`) and *in the consuming app* (so your plugin runs there too):
+A plugin ships as a **module package**. The shape that makes `questpie generate` discover your conventions both _inside your package_ (so you commit a generated `.generated/module.ts`) and _in the consuming app_ (so your plugin runs there too):
 
 1. **Author your conventions**, your collections, blocks, custom fields, and the `CodegenPlugin` itself, in your package's source.
 2. **Attach the plugin to a module** and export it:
@@ -516,6 +488,7 @@ A plugin ships as a **module package**. The shape that makes `questpie generate`
    export const myModule = module({ name: "acme-thing", plugin: myPlugin() });
    ```
 3. **Generate `.generated/module.ts` at build time** with a `packageConfig`, the dev-only entry for the static-module pattern. It scans `modulesDir/*`, derives each module's name, and emits a static module definition per subdir:
+
    ```ts title="questpie.config.ts (in your package)"
    import { packageConfig } from "questpie/cli";
    import { myPlugin } from "./src/plugin";
@@ -526,19 +499,21 @@ A plugin ships as a **module package**. The shape that makes `questpie generate`
      plugins: [myPlugin()],
    });
    ```
-4. **Ship only the generated `module.ts`**, `packageConfig` itself is dev-only and not distributed. Consumers add your module to `modules.ts`; because it carries `.plugin`, your codegen plugin auto-registers in *their* app with no extra config.
+
+4. **Ship only the generated `module.ts`**, `packageConfig` itself is dev-only and not distributed. Consumers add your module to `modules.ts`; because it carries `.plugin`, your codegen plugin auto-registers in _their_ app with no extra config.
 
 `packageConfig` is `{ modulesDir; modulePrefix?; plugins? }`, exported from `questpie/cli` (which is side-effect-free on import, importing it must never start a CLI command). The core framework itself uses this exact pattern: `packageConfig({ modulesDir: "src/server/modules", modulePrefix: "questpie" })`.
 
 <Callout type="warn" title="Import the type from `questpie/codegen`, the lightweight `plugin` entry">
-Author your `CodegenPlugin` against `questpie/codegen` (types) and keep the plugin factory in a *standalone* entry like `@acme/thing/plugin` that does **not** pull in `drizzle-orm` or runtime code, so a user importing your plugin into `questpie.config.ts` stays lightweight. This is why `@questpie/admin` exposes `adminPlugin()` from `@questpie/admin/plugin` separately from the heavy server entry.
+  Author your `CodegenPlugin` against `questpie/codegen` (types) and keep the plugin factory in a *standalone* entry like `@acme/thing/plugin` that does **not** pull in `drizzle-orm` or runtime code, so a user importing your plugin into `questpie.config.ts` stays lightweight. This is why `@questpie/admin` exposes
+  `adminPlugin()` from `@questpie/admin/plugin` separately from the heavy server entry.
 </Callout>
 
 ## The whole loop
 
 Putting the build-your-own loop together, the four moves, smallest seam first:
 
-1. **Contract.** Decide the seam. A new *value* where the framework already looks (field type, operator, adapter, block) → a single factory call, no plugin. A new *file convention* or *builder method* → a `CodegenPlugin`.
+1. **Contract.** Decide the seam. A new _value_ where the framework already looks (field type, operator, adapter, block) → a single factory call, no plugin. A new _file convention_ or _builder method_ → a `CodegenPlugin`.
 2. **Scaffold / template.** For a plugin, declare categories + discover patterns + registries on a target; add `scaffolds` so users get `questpie add <type>`.
 3. **Non-destructive config.** Claim a `config/<name>.ts` and augment `AppStateConfig` rather than overwriting anything; rely on codegen's merge-not-replace.
 4. **Publish.** Attach the plugin to a `module()`, generate `.generated/module.ts` with `packageConfig`, ship it. Users add one line to `modules.ts`.
@@ -550,33 +525,18 @@ Every step rides the same primitives the framework's own admin uses, that's the 
 Plugin authors import codegen types from `questpie/codegen`, field factories from `questpie/builders`, and `module` / `packageConfig` from `questpie/app` and `questpie/cli`:
 
 ```ts
-import type {
-  CodegenPlugin,
-  CodegenTargetContribution,
-  CategoryDeclaration,
-  DiscoverPattern,
-  RegistryExtension,
-  SingletonFactory,
-  BuilderFactory,
-  ScaffoldConfig,
-  CrossTargetValidator,
-  CodegenContext,
-  CodegenTargetGenerateContext,
-} from "questpie/codegen";
+import type { CodegenPlugin, CodegenTargetContribution, CategoryDeclaration, DiscoverPattern, RegistryExtension, SingletonFactory, BuilderFactory, ScaffoldConfig, CrossTargetValidator, CodegenContext, CodegenTargetGenerateContext } from "questpie/codegen";
 
-// Public field factories + operator/field types.
+// Public field factories, builtin operator sets, and field types.
 import { field, fieldType, from } from "questpie/builders";
 import type { OperatorFn, OperatorMap, ContextualOperators } from "questpie/builders";
 
-// Operator-authoring functions are internal (not on questpie/builders).
-import { operator, operatorSet, extendOperatorSet } from "#questpie/server/fields/operators/index.js";
-
-import { module } from "questpie/app";          // module(), NOT on questpie/cli
-import { packageConfig } from "questpie/cli";    // packageConfig (dev-only)
+import { module } from "questpie/app"; // module(), NOT on questpie/cli
+import { packageConfig } from "questpie/cli"; // packageConfig (dev-only)
 import type { ModuleDefinition } from "questpie/types";
 ```
 
-`questpie/codegen` is the public entry for plugin authoring, it re-exports every codegen type plus the emit helpers (`categoryRecordEntry`, `categoryTypeEntry`, `importStatement`, `safeKey`, …). The same types are also on `questpie/types` (minus a few authoring-only ones). The public field primitives, `field`, `fieldType`, `from`, `wrapFieldComplete`, `FieldTypeDefinition`, and the *types* `OperatorFn` / `OperatorMap` / `ContextualOperators`, live on `questpie` / `questpie/builders`; the operator-authoring *functions* (`operator`, `operatorSet`, `extendOperatorSet`, the builtin sets) are internal at `#questpie/server/fields/operators/index.js`.
+`questpie/codegen` is the public entry for plugin authoring. It exports codegen types and emit helpers such as `categoryRecordEntry`, `categoryTypeEntry`, `importStatement`, and `safeKey`. Field primitives, builtin operator sets, and field types are exported from `questpie/builders`.
 
 ## Related
 

--- a/apps/docs/content/docs/extend/codegen.mdx
+++ b/apps/docs/content/docs/extend/codegen.mdx
@@ -3,7 +3,7 @@ title: Codegen
 description: Codegen is the compiler that turns your file-convention source, collections, globals, routes, config, into one typed .generated/ app. You write declarations, run `questpie generate`, and every layer (CRUD, admin, REST, OpenAPI, typed client) wires itself up in sync.
 ---
 
-**Codegen** is what makes QUESTPIE's "define once, get everything" promise real. You drop files in conventional directories (`collections/`, `globals/`, `routes/`, `jobs/`, `config/…`), run one command, and codegen discovers every file, merges in your modules, and emits a fully typed `.generated/` app: the `app` instance, the `AppContext`, the `#questpie/factories` builders, and the `#questpie` type barrel (`CollectionDoc`, `CollectionWhere`, `App`, `AppConfig`). There is no central registry to edit and nothing is wired by hand, the file system _is_ the registry, and codegen is the compiler.
+**Codegen** turns file conventions into the typed application. It discovers `collections/`, `globals/`, `routes/`, `jobs/`, `config/…`, merges installed modules, and emits `.generated/` with the `app` instance, `AppContext`, `#questpie/factories`, and the `#questpie` type barrel. The file system is the registry and codegen is its compiler.
 
 This page covers the pipeline (file convention → `.generated/`), the export-discovery rules, the `questpie generate` / `dev` / `add` commands, the committed outputs you get, and, for plugin and module authors, the full `CodegenPlugin` API that lets a package contribute its own file conventions without you touching `questpie.config.ts`.
 
@@ -15,7 +15,7 @@ This page covers the pipeline (file convention → `.generated/`), the export-di
 - **Folds in modules and their plugins.** `modules.ts` is read in a pre-pass; each module can contribute collections, globals, jobs, and its _own_ codegen plugin, auto-wired before the rest of discovery runs.
 - **Watches in dev.** `questpie dev` regenerates on file add/remove (content-only edits are skipped, `typeof import` is stable), so the typed surface tracks your file tree live.
 - **Scaffolds from the same registry.** `questpie add <type> <name>` writes the right boilerplate into every target that declares that scaffold, then re-runs codegen.
-- **Is extensible to the core.** Every built-in category (collections, globals, routes, …) is declared through the _same_ `CodegenPlugin` API a third-party package uses. Modules add `views`, `blocks`, `config/admin.ts` the same way you would, there are no privileged internal codegen hooks.
+- **Uses one extension contract.** Built-in and third-party categories are declared through `CodegenPlugin`. Modules add `views`, `blocks`, and `config/admin.ts` through that same contract.
 
 ## Quick start
 
@@ -43,10 +43,7 @@ questpie dev        # same pipeline, in watch mode (100ms debounce)
 ```
 
 <Callout type="info" title="Codegen is what wires the `#questpie/*` imports">
-	The `#questpie/factories` and `#questpie` imports your app code uses resolve
-	to codegen's output. Until you run `questpie generate` they don't exist, which
-	is why a fresh checkout or a CI build starts with `questpie generate`. Mode is
-	auto-detected from the config file shape (root app vs. module vs. package).
+  The `#questpie/factories` and `#questpie` imports your app code uses resolve to codegen's output. Until you run `questpie generate` they don't exist, which is why a fresh checkout or a CI build starts with `questpie generate`. Mode is auto-detected from the config file shape (root app vs. module vs. package).
 </Callout>
 
 ## The pipeline
@@ -72,17 +69,9 @@ flowchart TD
   Src --> Discover --> Files --> Transform --> Template --> Write --> Out
 ```
 
-<Callout
-	type="info"
-	title="`coreCodegenPlugin()` is the canonical category map"
->
-	Every built-in category and scaffold lives in one place:
-	`coreCodegenPlugin()`. It declares `collections` (factory `collection`),
-	`globals` (factory `global`), `jobs`, `routes` (dirs `routes` + `functions`,
-	recursive, `/`-separated keys), `messages`, `services`, `emails` (emitted as
-	`emailTemplates`), `migrations` + `seeds` (array emit), and `fieldTypes`
-	(factory `fieldType`). It is prepended automatically, you never register it.
-	Reading it is the fastest way to see exactly which dirs are scanned.
+<Callout type="info" title="`coreCodegenPlugin()` is the canonical category map">
+  Every built-in category and scaffold lives in one place: `coreCodegenPlugin()`. It declares `collections` (factory `collection`), `globals` (factory `global`), `jobs`, `routes` (dirs `routes` + `functions`, recursive, `/`-separated keys), `messages`, `services`, `emails` (emitted as `emailTemplates`), `migrations` +
+  `seeds` (array emit), and `fieldTypes` (factory `fieldType`). It is prepended automatically, you never register it. Reading it is the fastest way to see exactly which dirs are scanned.
 </Callout>
 
 ## By-feature folders
@@ -92,9 +81,7 @@ layout when the app is small; use `features/<feature>/...` when a domain slice
 owns several kinds of files.
 
 <Callout type="info" title="Requires the file-convention codegen line">
-	This is a `questpie@3.0.2+` convention. Older 1.x / 2.x projects do not have
-	the `features/` discovery contract; migrate them to the v3 file-convention
-	codegen before using this layout.
+  This is a `questpie@3.0.2+` convention. Older 1.x / 2.x projects do not have the `features/` discovery contract; migrate them to the v3 file-convention codegen before using this layout.
 </Callout>
 
 ```txt
@@ -164,18 +151,9 @@ export const posts = collection("posts"); // named
 export default collection("posts"); // default
 ```
 
-<Callout
-	type="info"
-	title="Multi-export files are allowed for factory categories"
->
-	Categories with `factoryFunctions` use a two-pass scan that finds *every*
-	matching factory call in a file, so one factory-category file can hold several
-	`collection()`, `global()`, `block()`, or `fieldType()` definitions. Routes,
-	jobs, services, emails, migrations, and seeds do not use this mode; keep those
-	as one entity per file. Files with **zero** matching factory calls are skipped
-	entirely, that's how utility and type-only files in a scanned dir are ignored.
-	Entity key still comes from the factory's first string argument when present,
-	else the export name.
+<Callout type="info" title="Multi-export files are allowed for factory categories">
+  Categories with `factoryFunctions` use a two-pass scan that finds *every* matching factory call in a file, so one factory-category file can hold several `collection()`, `global()`, `block()`, or `fieldType()` definitions. Routes, jobs, services, emails, migrations, and seeds do not use this mode; keep those as one
+  entity per file. Files with **zero** matching factory calls are skipped entirely, that's how utility and type-only files in a scanned dir are ignored. Entity key still comes from the factory's first string argument when present, else the export name.
 </Callout>
 
 ### What codegen skips
@@ -200,22 +178,19 @@ The rule of thumb: **import `collection` / `global` from `#questpie/factories`**
 
 The generated files are the ground truth for the app surface. If an agent or developer needs to verify what exists, inspect these before inventing imports or names:
 
-| Question | Ground truth |
-| --- | --- |
+| Question                                         | Ground truth                                                                                                                                 |
+| ------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------- |
 | Which collections/globals/routes/services exist? | `src/questpie/server/.generated/entities.gen.ts` and the `AppCollections`, `AppGlobals`, `AppRoutes`, `AppServices` exports from `#questpie` |
-| Which relation target keys autocomplete? | `src/questpie/server/.generated/names.gen.ts` |
-| What is the handler context shape? | `src/questpie/server/.generated/context.gen.ts` and `Questpie.AppContext` |
-| What is the auth/session shape? | `AppSession`, `AppSessionUser`, and `AppConfig.auth` from `#questpie` |
-| Which builder methods/fields are enabled? | `src/questpie/server/.generated/factories.ts` |
+| Which relation target keys autocomplete?         | `src/questpie/server/.generated/names.gen.ts`                                                                                                |
+| What is the handler context shape?               | `src/questpie/server/.generated/context.gen.ts` and `Questpie.AppContext`                                                                    |
+| What is the auth/session shape?                  | `AppSession`, `AppSessionUser`, and `AppConfig.auth` from `#questpie`                                                                        |
+| Which builder methods/fields are enabled?        | `src/questpie/server/.generated/factories.ts`                                                                                                |
 
 Convention files starting with `_`, `index.ts`, tests, and declaration files do not appear here by design. If a collection, route, custom field, or auth role is missing from the generated ground truth, fix discovery/module/config first and rerun `questpie generate`; do not patch the call site with casts or duplicate registries.
 
 <Callout type="warn" title="Regenerate before you migrate, seed, or push">
-	`questpie.config.ts` carries `app.url` but is not itself the built app, on a
-	CLI command it auto-resolves `.generated/index.ts` for the real instance and
-	errors with *"Run `questpie generate` first"* if that file is missing. A stale
-	or absent `.generated/` is the most common cause of "my new collection isn't
-	on `app.collections`". Generate first.
+  `questpie.config.ts` carries `app.url` but is not itself the built app, on a CLI command it auto-resolves `.generated/index.ts` for the real instance and errors with *"Run `questpie generate` first"* if that file is missing. A stale or absent `.generated/` is the most common cause of "my new collection isn't on
+  `app.collections`". Generate first.
 </Callout>
 
 ## The `#questpie` type barrel
@@ -223,13 +198,7 @@ Convention files starting with `_`, `index.ts`, tests, and declaration files do 
 `index.ts` re-exports a small, stable public type surface off the `#questpie` package root. These are the aliases you reach for instead of `Record<string, any>`:
 
 ```ts
-import type {
-	CollectionDoc,
-	CollectionWhere,
-	GlobalDoc,
-	App,
-	AppConfig,
-} from "#questpie";
+import type { CollectionDoc, CollectionWhere, GlobalDoc, App, AppConfig } from "#questpie";
 
 type Post = CollectionDoc<"posts">; // full selected row for app.collections.posts
 type PostFilter = CollectionWhere<"posts">; // typed `where` clause for posts
@@ -308,10 +277,7 @@ export const myModule = module({
 The `plugin` key is **auto-extracted at codegen time and excluded from the runtime module merge**, it exists purely so a package ships its file conventions without you editing `questpie.config.ts`. Extraction is a depth-first walk (sub-modules before self), deduped by plugin `name` (first occurrence wins); config-registered plugins win over module-extracted ones on a name collision.
 
 <Callout type="info" title="`module()` is type-only">
-	`module(def)` is an identity function, it returns the definition unchanged and
-	has no runtime behavior. It exists so TypeScript captures the literal module
-	shape. Modules are *static plain data*; there are no factory functions inside
-	a module definition.
+  `module(def)` is an identity function, it returns the definition unchanged and has no runtime behavior. It exists so TypeScript captures the literal module shape. Modules are static data composed from arrays, records, and nested modules.
 </Callout>
 
 ## Extending codegen: the `CodegenPlugin` API
@@ -322,52 +288,44 @@ This is the part that makes "core = module = userland" literal. A `CodegenPlugin
 import type { CodegenPlugin } from "questpie/codegen";
 
 export function billingPlugin(): CodegenPlugin {
-	return {
-		name: "questpie-billing", // unique; dedup key
-		targets: {
-			server: {
-				root: ".",
-				outputFile: "index.ts",
-				// Scan a new conventional directory:
-				categories: {
-					webhooks: {
-						dirs: ["webhooks"],
-						prefix: "wh",
-						factoryFunctions: ["webhook"],
-					},
-				},
-				// Claim a composite config file:
-				discover: {
-					billingConfig: { pattern: "config/billing.ts", configKey: "billing" },
-				},
-			},
-		},
-	};
+  return {
+    name: "questpie-billing", // unique; dedup key
+    targets: {
+      server: {
+        root: ".",
+        outputFile: "index.ts",
+        // Scan a new conventional directory:
+        categories: {
+          webhooks: {
+            dirs: ["webhooks"],
+            prefix: "wh",
+            factoryFunctions: ["webhook"],
+          },
+        },
+        // Claim a composite config file:
+        discover: {
+          billingConfig: { pattern: "config/billing.ts", configKey: "billing" },
+        },
+      },
+    },
+  };
 }
 ```
 
 Register it on `runtimeConfig({ plugins: [...] })` **or** ship it from a module's `plugin` key, both reach the same merge.
 
-<Callout
-	type="info"
-	title="`questpie/codegen` is the plugin-author entry point"
->
-	`questpie/codegen` re-exports the full surface: every codegen type
-	(`CodegenPlugin`, `CodegenTargetContribution`, `CategoryDeclaration`,
-	`DiscoverPattern`, `RegistryExtension`, `SingletonFactory`, `BuilderFactory`,
-	`ScaffoldConfig`, …) plus the emit helpers (`categoryRecordEntry`,
-	`categoryTypeEntry`, `importStatement`, `safeKey`, `sortedValues`,
-	`sourceBasename`). This is the only entry point that exposes the codegen
-	types, `questpie/types` does **not** re-export any of them.
+<Callout type="info" title="`questpie/codegen` is the plugin-author entry point">
+  `questpie/codegen` re-exports the full surface: every codegen type (`CodegenPlugin`, `CodegenTargetContribution`, `CategoryDeclaration`, `DiscoverPattern`, `RegistryExtension`, `SingletonFactory`, `BuilderFactory`, `ScaffoldConfig`, …) plus the emit helpers (`categoryRecordEntry`, `categoryTypeEntry`,
+  `importStatement`, `safeKey`, `sortedValues`, `sourceBasename`). This is the only entry point that exposes the codegen types, `questpie/types` does **not** re-export any of them.
 </Callout>
 
 ### `CodegenPlugin` shape
 
 ```ts
 interface CodegenPlugin {
-	name: string; // unique; dedup key
-	targets: Record<string, CodegenTargetContribution>;
-	validators?: CrossTargetValidator[]; // run after ALL targets generate
+  name: string; // unique; dedup key
+  targets: Record<string, CodegenTargetContribution>;
+  validators?: CrossTargetValidator[]; // run after ALL targets generate
 }
 ```
 
@@ -391,15 +349,9 @@ One plugin's contribution to one target. Multiple plugins' contributions to the 
 | `generate`       | `(ctx) => CodegenTargetOutput \| Promise<…>`                                                        | Custom generator that _replaces_ the default template for this target.                     |
 | `scaffolds`      | `Record<string, ScaffoldConfig>`                                                                    | `questpie add` templates this target provides.                                             |
 
-<Callout
-	type="warn"
-	title="`root` / `outDir` / `outputFile` / `moduleRoot` must agree across contributors"
->
-	When several plugins contribute to the same target ID, `resolveTargetGraph()`
-	merges them, but a conflict in `root`, `outDir`, `outputFile`, or `moduleRoot`
-	**throws**, and a second `generate` per target **throws**. Categories are
-	shallow-merged per key (with one exception: `factoryImports` arrays are
-	*concatenated*), and `transforms` run in plugin order.
+<Callout type="warn" title="`root` / `outDir` / `outputFile` / `moduleRoot` must agree across contributors">
+  When several plugins contribute to the same target ID, `resolveTargetGraph()` merges them, but a conflict in `root`, `outDir`, `outputFile`, or `moduleRoot` **throws**, and a second `generate` per target **throws**. Categories are shallow-merged per key (with one exception: `factoryImports` arrays are
+  *concatenated*), and `transforms` run in plugin order.
 </Callout>
 
 ### `CategoryDeclaration`
@@ -408,19 +360,19 @@ The primary unit of the plugin system, one declaration scans a directory and emi
 
 ```ts
 interface CategoryDeclaration {
-	dirs: string[]; // scanned as dir/ AND features/{name}/dir/
-	prefix: string; // generated var prefix (varName = _<prefix>_<key>)
-	recursive?: boolean; // descend subdirs (routes)
-	keySeparator?: "." | "/"; // for recursive keys (routes: "webhooks/stripe")
-	emit?: "record" | "array"; // "record" (default) | flat array (migrations/seeds)
-	typeEmit?: "standard" | "services" | "emails" | "messages" | "none";
-	registryKey?: string | boolean; // include in Registry; string overrides the key
-	factoryFunctions?: string[]; // enable multi-export factory discovery
-	keyFromProperty?: string; // use a runtime prop as the key (views → "name")
-	keyFromSource?: "basename"; // use the source filename as the key
-	createAppKey?: string; // emit under a different createApp key (emails → emailTemplates)
-	factoryImports?: Array<{ name: string; from: string }>; // spread runtime values into factories.ts
-	// …includeInAppState, extractFromModules, placeholder, recordPlaceholder, typeRegistry…
+  dirs: string[]; // scanned as dir/ AND features/{name}/dir/
+  prefix: string; // generated var prefix (varName = _<prefix>_<key>)
+  recursive?: boolean; // descend subdirs (routes)
+  keySeparator?: "." | "/"; // for recursive keys (routes: "webhooks/stripe")
+  emit?: "record" | "array"; // "record" (default) | flat array (migrations/seeds)
+  typeEmit?: "standard" | "services" | "emails" | "messages" | "none";
+  registryKey?: string | boolean; // include in Registry; string overrides the key
+  factoryFunctions?: string[]; // enable multi-export factory discovery
+  keyFromProperty?: string; // use a runtime prop as the key (views → "name")
+  keyFromSource?: "basename"; // use the source filename as the key
+  createAppKey?: string; // emit under a different createApp key (emails → emailTemplates)
+  factoryImports?: Array<{ name: string; from: string }>; // spread runtime values into factories.ts
+  // …includeInAppState, extractFromModules, placeholder, recordPlaceholder, typeRegistry…
 }
 ```
 
@@ -439,16 +391,16 @@ For single files and spreads rather than directory categories:
 
 ```ts
 type DiscoverPattern =
-	| string // shorthand
-	| {
-			pattern: string;
-			resolve?: "default" | "named" | "all" | "auto"; // default "auto"
-			keyFrom?: "filename" | "exportName";
-			cardinality?: "single" | "map";
-			mergeStrategy?: "spread"; // collect root + every features/*/pattern
-			registryKey?: string; // augment Registry with typeof the single
-			configKey?: string; // emit the whole file as config.<key>
-	  };
+  | string // shorthand
+  | {
+      pattern: string;
+      resolve?: "default" | "named" | "all" | "auto"; // default "auto"
+      keyFrom?: "filename" | "exportName";
+      cardinality?: "single" | "map";
+      mergeStrategy?: "spread"; // collect root + every features/*/pattern
+      registryKey?: string; // augment Registry with typeof the single
+      configKey?: string; // emit the whole file as config.<key>
+    };
 ```
 
 The string shorthand: a pattern containing `*` (or with no file extension) is a **map / directory** pattern; a single file with an extension (`"config/auth.ts"`, `"sidebar.ts"`) is a **single**. `mergeStrategy: "spread"` collects the root file plus every `features/*/pattern` into an ordered array, that's how sidebar entries and dashboard widgets accumulate from many feature modules. `configKey` emits the whole file as one entry in the config bucket, the modern way to add a composite `config/<name>.ts` file.
@@ -473,10 +425,10 @@ A `ScaffoldConfig` powers `questpie add <type>`:
 
 ```ts
 interface ScaffoldConfig {
-	dir: string; // relative to the target root
-	extension?: string; // default ".ts"
-	description?: string; // shown in `questpie add --list`
-	template: (ctx: ScaffoldContext) => string;
+  dir: string; // relative to the target root
+  extension?: string; // default ".ts"
+  description?: string; // shown in `questpie add --list`
+  template: (ctx: ScaffoldContext) => string;
 }
 // ScaffoldContext = { kebab, camel, pascal, title, targetId }
 ```
@@ -507,18 +459,15 @@ A package that ships file conventions (its own collections, routes, etc.) uses `
 import { packageConfig } from "questpie/cli";
 
 export default packageConfig({
-	modulesDir: "src/server/modules",
-	modulePrefix: "questpie", // module "admin" → name "questpie-admin"
+  modulesDir: "src/server/modules",
+  modulePrefix: "questpie", // module "admin" → name "questpie-admin"
 });
 ```
 
 QUESTPIE's own core uses exactly this (`modulesDir: "src/server/modules"`, `modulePrefix: "questpie"`). `importRewriteMap` (on the module options) rewrites self-package specifiers so generated imports resolve to source rather than stale `dist/` types. `packageConfig` and `config` are exported from `questpie/cli`.
 
 <Callout type="warn" title="Importing `questpie/cli` must not start a command">
-	The CLI is side-effect-free on import, command parsing is guarded by
-	`import.meta.main`. Importing `questpie/cli` just to grab `packageConfig` will
-	**not** kick off a command run, which matters in a workspace where a
-	src-vs-dist double-instance could otherwise corrupt `.generated/`.
+  The CLI is side-effect-free on import, command parsing is guarded by `import.meta.main`. Importing `questpie/cli` just to grab `packageConfig` will **not** kick off a command run, which matters in a workspace where a src-vs-dist double-instance could otherwise corrupt `.generated/`.
 </Callout>
 
 ## TypeScript
@@ -526,26 +475,9 @@ QUESTPIE's own core uses exactly this (`modulesDir: "src/server/modules"`, `modu
 The plugin-author types all come from `questpie/codegen`:
 
 ```ts
-import type {
-	CodegenPlugin,
-	CodegenTargetContribution,
-	CategoryDeclaration,
-	DiscoverPattern,
-	RegistryExtension,
-	SingletonFactory,
-	BuilderFactory,
-	ScaffoldConfig,
-	ScaffoldContext,
-	CodegenContext,
-	CrossTargetValidator,
-	ProjectionError,
-} from "questpie/codegen";
+import type { CodegenPlugin, CodegenTargetContribution, CategoryDeclaration, DiscoverPattern, RegistryExtension, SingletonFactory, BuilderFactory, ScaffoldConfig, ScaffoldContext, CodegenContext, CrossTargetValidator, ProjectionError } from "questpie/codegen";
 
-import {
-	categoryRecordEntry,
-	importStatement,
-	safeKey,
-} from "questpie/codegen";
+import { categoryRecordEntry, importStatement, safeKey } from "questpie/codegen";
 ```
 
 App-level generated types, `CollectionDoc<K>`, `CollectionWhere<K>`, `GlobalDoc<K>`, `App`, `AppConfig`, come from `#questpie` (above). The codegen types are exposed **only** via `questpie/codegen`; `questpie/types` does not re-export them.

--- a/apps/docs/content/docs/extend/modules.mdx
+++ b/apps/docs/content/docs/extend/modules.mdx
@@ -11,7 +11,7 @@ A **module** is a plain data object that bundles up a slice of an app, collectio
 - **Auto-wires its file conventions.** A module carries its own codegen `plugin`, so adding it to `modules.ts` registers its discovery rules and generated output, you never touch `questpie.config.ts`.
 - **Merges depth-first into your app.** Dependencies resolve before dependents; later modules override earlier ones by key. The result is one flat, typed app where module entities sit beside yours.
 - **Stays composable, not magic.** Module-contributed types (a collection, an auth `role`) surface in your typed context, modules are visible, not hidden behind imperative registration.
-- **Same shape as userland.** Core, `@questpie/admin`, and a module you publish all use the one `ModuleDefinition` shape and the same `packageConfig` build, there are no privileged internal module APIs.
+- **One module contract.** Core, `@questpie/admin`, and published modules all use `ModuleDefinition` and the same `packageConfig` build.
 - **Authored as static data.** You write a module with the `module()` identity factory (for hand-authored ones) or generate it from file convention with `packageConfig()` (for packages), never with runtime logic inside.
 
 ## Quick start
@@ -42,32 +42,23 @@ import { collection } from "#questpie/factories";
 import { module } from "questpie/app";
 
 export const blogModule = module({
-	name: "blog", // unique, modules de-dupe by name
-	collections: {
-		posts: collection("posts").fields(({ f }) => ({
-			title: f.text().required(),
-			body: f.richText(), // richText is a module-contributed field, see callout
-		})),
-	},
-	messages: { en: { "blog.published": "Published" } },
+  name: "blog", // unique, modules de-dupe by name
+  collections: {
+    posts: collection("posts").fields(({ f }) => ({
+      title: f.text().required(),
+      body: f.richText(), // richText is a module-contributed field, see callout
+    })),
+  },
+  messages: { en: { "blog.published": "Published" } },
 });
 ```
 
 Add `blogModule` to `modules.ts` like any other, run `questpie generate`, and `app.collections.posts` exists.
 
-<Callout
-	type="info"
-	title="`module` from `questpie/app`, `collection` from `#questpie/factories`"
->
-	`module()` is exported from both `questpie` and the lighter `questpie/app`
-	barrel, the starter templates use `questpie/app`. It is a pure **identity**
-	function: it returns your definition unchanged and runs no code, so it adds
-	nothing at runtime. Its only job is type inference. `collection()`, on the
-	other hand, comes from your generated **`#questpie/factories`** factory, *not*
-	`questpie/app`, which doesn't re-export it, because that's the import that
-	knows your enabled modules, so module-contributed field types like
-	`f.richText()` (added by `@questpie/admin`) and `f.blocks()` appear on `f`.
-	The bare `collection()` from `questpie` only sees builtin fields.
+<Callout type="info" title="`module` from `questpie/app`, `collection` from `#questpie/factories`">
+  `module()` is exported from both `questpie` and the lighter `questpie/app` barrel, the starter templates use `questpie/app`. It is a pure **identity** function: it returns your definition unchanged and runs no code, so it adds nothing at runtime. Its only job is type inference. `collection()`, on the other hand,
+  comes from your generated **`#questpie/factories`** factory, *not* `questpie/app`, which doesn't re-export it, because that's the import that knows your enabled modules, so module-contributed field types like `f.richText()` (added by `@questpie/admin`) and `f.blocks()` appear on `f`. The bare `collection()` from
+  `questpie` only sees builtin fields.
 </Callout>
 
 ## What a module contributes
@@ -76,20 +67,20 @@ A module is a `ModuleDefinition`, a static plain object. Every key beyond `name`
 
 ```ts
 export interface ModuleDefinition {
-	name: string; // unique, required
-	modules?: ModuleDefinition[]; // dependency modules (resolved first)
-	collections?: Record<string, AnyCollectionOrBuilder>;
-	globals?: Record<string, AnyGlobalOrBuilder>;
-	jobs?: Record<string, JobDefinition<any, any>>;
-	routes?: Record<string, RouteDefinition>;
-	fields?: Record<string, any>; // custom field types (extend the `f` proxy)
-	services?: Record<string, ServiceBuilder<any>>;
-	migrations?: Migration[]; // concatenated with others
-	seeds?: Seed[]; // concatenated with others
-	messages?: Record<string, Record<string, string>>; // backend i18n, deep-merged per locale
-	config?: ResolvedAppStateConfig; // the config bucket (config/*.ts files)
-	plugin?: CodegenPlugin | CodegenPlugin[]; // codegen-only, see below
-	[key: string]: unknown; // open: plugins add keys via declaration merging
+  name: string; // unique, required
+  modules?: ModuleDefinition[]; // dependency modules (resolved first)
+  collections?: Record<string, AnyCollectionOrBuilder>;
+  globals?: Record<string, AnyGlobalOrBuilder>;
+  jobs?: Record<string, JobDefinition<any, any>>;
+  routes?: Record<string, RouteDefinition>;
+  fields?: Record<string, any>; // custom field types (extend the `f` proxy)
+  services?: Record<string, ServiceBuilder<any>>;
+  migrations?: Migration[]; // concatenated with others
+  seeds?: Seed[]; // concatenated with others
+  messages?: Record<string, Record<string, string>>; // backend i18n, deep-merged per locale
+  config?: ResolvedAppStateConfig; // the config bucket (config/*.ts files)
+  plugin?: CodegenPlugin | CodegenPlugin[]; // codegen-only, see below
+  [key: string]: unknown; // open: plugins add keys via declaration merging
 }
 ```
 
@@ -111,16 +102,8 @@ export interface ModuleDefinition {
 
 The trailing `[key: string]: unknown` index signature is what lets module **packages** extend the shape: `@questpie/admin`'s generated module carries `listViews`, `formViews`, `components`, `blocks`, `sidebar`, `dashboard`, `branding`, and `adminLocale` keys, and they merge into your app the same way. These are concrete properties codegen **derives** from the package's file convention (e.g. `listViews` / `formViews` are produced by `filterViewsByKind`, exported as named type aliases like `AdminViews` from the generated `module.ts`); they satisfy `ModuleDefinition` purely through that index signature, there's no `declare module "questpie" { interface ModuleDefinition { … } }` augmenting the interface. You never set these by hand, they come from the package's codegen plugin.
 
-<Callout
-	type="warn"
-	title="A module is static data, no factory functions inside"
->
-	A `ModuleDefinition` is plain, serializable-shaped data: maps of already-built
-	definitions, arrays, and config objects. It does **not** run logic at load,
-	there is no `setup()`, no constructor, no runtime-options callback. This is
-	deliberate: codegen reads the shape by `typeof import(...)`, which only stays
-	stable if nothing executes. Build your collections/jobs/services with their
-	own factories and put the **results** in the module.
+<Callout type="warn" title="A module is static data">
+  A `ModuleDefinition` is plain, serializable-shaped data: maps of already-built definitions, arrays, and config objects. Build collections, jobs, and services with their own factories, then place the built definitions in the module. Runtime setup belongs in service lifecycle methods rather than module loading.
 </Callout>
 
 ## How modules merge into your app
@@ -159,12 +142,8 @@ export default [adminModule] as const;
 If a module contributes auth, fields, services, routes, or config that affects generated types, it must be a static entry in `modules.ts` or nested under another static module. Do not hide it behind runtime conditions or a factory whose returned plugin/config shape changes by environment; codegen needs to know what is in the app before runtime.
 
 <Callout type="info" title="Your app files always win">
-	Because module resolution runs first and your own `collections/`, `globals/`,
-	`routes/` (etc.) are discovered last, anything you define under the same key
-	as a module **overrides** the module's version. This is the mechanism behind
-	extending a module-provided collection: import its builder, `.merge()` it, add
-	your fields, and re-export under the same key. See [Collections → merging
-	builders](/docs/concepts/collections).
+  Because module resolution runs first and your own `collections/`, `globals/`, `routes/` (etc.) are discovered last, anything you define under the same key as a module **overrides** the module's version. This is the mechanism behind extending a module-provided collection: import its builder, `.merge()` it, add your
+  fields, and re-export under the same key. See [Collections → merging builders](/docs/concepts/collections).
 </Callout>
 
 ## The `plugin` key, how a module ships its file conventions
@@ -178,12 +157,12 @@ import { module } from "questpie";
 import { openApiPlugin } from "./plugin.js";
 
 export const openApiModule = module({
-	name: "questpie-openapi",
-	plugin: openApiPlugin(), // codegen-only, extracted, never merged at runtime
-	routes: {
-		"openapi.json": openApiRoute(),
-		docs: docsRoute(),
-	},
+  name: "questpie-openapi",
+  plugin: openApiPlugin(), // codegen-only, extracted, never merged at runtime
+  routes: {
+    "openapi.json": openApiRoute(),
+    docs: docsRoute(),
+  },
 });
 ```
 
@@ -196,18 +175,15 @@ import { adminPlugin } from "../../plugin.js";
 // The generated module is static data; attach the codegen plugin so
 // extractPluginsFromModules auto-discovers it from modules.ts.
 export const adminModule = Object.assign(_generatedModule, {
-	plugin: adminPlugin(),
+  plugin: adminPlugin(),
 });
 ```
 
 At codegen time, `extractPluginsFromModules` walks the module tree **depth-first** (the same order as the runtime merge), collects every `plugin`, and de-dups by plugin `name` (**first occurrence wins**). Those plugins are merged _after_ any plugins you registered directly in `runtimeConfig({ plugins })`, so a config-level plugin wins a name collision.
 
 <Callout type="warn" title="`plugin` is excluded from the runtime merge">
-	The `plugin` key is read **only** at codegen time. It is never folded into
-	`app.state` and never reaches a running request. That separation is what lets
-	`[adminModule, openApiModule]` in `modules.ts` be enough, adding the module
-	registers its conventions *and* its entities in one step, with no parallel
-	`plugins: [...]` list to keep in sync.
+  The `plugin` key is read **only** at codegen time. It is never folded into `app.state` and never reaches a running request. That separation is what lets `[adminModule, openApiModule]` in `modules.ts` be enough, adding the module registers its conventions *and* its entities in one step, with no parallel `plugins:
+  [...]` list to keep in sync.
 </Callout>
 
 The plugin itself, what categories and discovery it declares, and how you write one, is covered in its own pages: see [Building a plugin](/docs/extend/build-a-plugin) for the authoring loop and [Codegen](/docs/extend/codegen) for the full `CodegenPlugin` API. A short treatment of how a module _ships_ one is [below](#shipping-a-codegen-plugin).
@@ -221,15 +197,15 @@ import { packageConfig } from "questpie/cli";
 import { myPlugin } from "./src/server/plugin.js";
 
 export default packageConfig({
-	modulesDir: "src/server/modules", // each subdir → one module
-	modulePrefix: "questpie", // dir "admin" → module "questpie-admin"
-	plugins: [myPlugin()], // codegen plugins shared across every module
+  modulesDir: "src/server/modules", // each subdir → one module
+  modulePrefix: "questpie", // dir "admin" → module "questpie-admin"
+  plugins: [myPlugin()], // codegen plugins shared across every module
 });
 ```
 
 In package mode, `questpie generate` scans `modulesDir/*`, derives each module's `name` as `${modulePrefix}-${dirName}`, and runs codegen in **module mode** for each subdirectory, emitting `.generated/module.ts` (a static `ModuleDefinition`), plus a `registries.ts` when there are type augmentations. Only those generated `module.ts` files ship in the package; `packageConfig` itself is dev-only and never distributed. `PackageConfig` is `{ __type, modulesDir, modulePrefix?, plugins? }` (`modulePrefix` defaults from `package.json` name).
 
-This is the QUESTPIE extensibility principle made concrete: **the framework's own built-in modules are built with the exact same `packageConfig` + file convention a userland package would use.** The core itself is configured with `packageConfig({ modulesDir: "src/server/modules", modulePrefix: "questpie" })`, `core` and `starter` are just modules in that directory. There is no privileged internal module API.
+Built-in and published modules use the same `packageConfig` and file conventions. Core is configured with `packageConfig({ modulesDir: "src/server/modules", modulePrefix: "questpie" })`; `core` and `starter` are modules in that directory.
 
 A generated module is the static object you'd otherwise write by hand:
 
@@ -239,27 +215,18 @@ import _appConfig from "../config/app";
 import _authConfig from "../config/auth";
 
 const _module = {
-	name: "questpie-starter" as const,
-	collections: { user: _coll_user /* … */ },
-	jobs: {
-		/* … */
-	},
-	config: { app: _appConfig, auth: _authConfig },
-	// …
+  name: "questpie-starter" as const,
+  collections: { user: _coll_user /* … */ },
+  jobs: {/* … */},
+  config: { app: _appConfig, auth: _authConfig },
+  // …
 };
 export default _module;
 ```
 
-<Callout
-	type="info"
-	title="`packageConfig` is for building packages, not consuming them"
->
-	You only reach for `packageConfig()` when **publishing** a module package.
-	Consuming a module is just importing it into `modules.ts`. The CLI factory
-	lives in `questpie/cli` (alongside `config()`), and importing `questpie/cli`
-	is side-effect-free, command parsing is guarded by `import.meta.main`, so a
-	config file can import `packageConfig` without accidentally running a CLI
-	command.
+<Callout type="info" title="`packageConfig` is for building packages, not consuming them">
+  You only reach for `packageConfig()` when **publishing** a module package. Consuming a module is just importing it into `modules.ts`. The CLI factory lives in `questpie/cli` (alongside `config()`), and importing `questpie/cli` is side-effect-free, command parsing is guarded by `import.meta.main`, so a config file can
+  import `packageConfig` without accidentally running a CLI command.
 </Callout>
 
 ## Module visibility & ejecting
@@ -303,17 +270,17 @@ The module and plugin types are exported for when you author a module or a plugi
 
 ```ts
 import type {
-	ModuleDefinition, // the static module shape
-	AppModuleInput, // the looser shape createApp() accepts
-	AppStateConfig, // the plugin-extensible config bucket
+  ModuleDefinition, // the static module shape
+  AppModuleInput, // the looser shape createApp() accepts
+  AppStateConfig, // the plugin-extensible config bucket
 } from "questpie";
 
 import type {
-	CodegenPlugin, // the plugin object a module's `plugin` key holds
-	CategoryDeclaration, // a file-convention category
-	DiscoverPattern, // single-file / spread discovery
-	RegistryExtension, // a builder method a plugin adds
-	ScaffoldConfig, // a `questpie add` template
+  CodegenPlugin, // the plugin object a module's `plugin` key holds
+  CategoryDeclaration, // a file-convention category
+  DiscoverPattern, // single-file / spread discovery
+  RegistryExtension, // a builder method a plugin adds
+  ScaffoldConfig, // a `questpie add` template
 } from "questpie/codegen";
 ```
 

--- a/apps/docs/content/docs/extend/multi-tenancy.mdx
+++ b/apps/docs/content/docs/extend/multi-tenancy.mdx
@@ -3,9 +3,9 @@ title: Multi-tenancy
 description: Serve many tenants, organizations, properties, cities, from one app by deriving the active scope from the request, isolating data with access rules and scoped globals, and letting admins switch tenants from the sidebar.
 ---
 
-**Multi-tenancy** in QUESTPIE is one app serving many isolated tenants, call them organizations, workspaces, properties, or cities. There is no special "tenant mode": you assemble it from primitives you already know. The client sends the active scope as a request header, an `appConfig({ context })` resolver turns that header into a typed value on every request context, and your access rules and scoped globals read that value to isolate data. Pick the tenant from a sidebar dropdown, and every API call carries it.
+**Multi-tenancy** in QUESTPIE is one app serving many isolated tenants: organizations, workspaces, properties, or cities. Compose it from request context, access rules, scoped globals, and tenant-owned collections. The client sends the active scope as a request header, and `appConfig({ context })` resolves it into a typed value for every request.
 
-This page shows the full loop end to end, server resolver, scoped collections, scoped globals, the admin scope picker, and the two isolation footguns that bite hardest: relations that reach across scopes, and the shared user table that is *not* tenant-scoped.
+This page shows the full loop end to end, server resolver, scoped collections, scoped globals, the admin scope picker, and the two isolation footguns that bite hardest: relations that reach across scopes, and the shared user table that is _not_ tenant-scoped.
 
 ## What it does
 
@@ -83,15 +83,10 @@ export const posts = collection("posts")
   .title(({ f }) => f.title);
 ```
 
-**3. Wire the admin** so an editor can switch tenants. `ScopeProvider` holds the selection, `useScopedFetch` builds a client that injects the header, and `ScopePicker` is the dropdown. Wrap `ScopeProvider` **above** `AdminProvider` (or `AdminLayoutProvider`), and build the client *inside* it so the picker's value reaches every request.
+**3. Wire the admin** so an editor can switch tenants. `ScopeProvider` holds the selection, `useScopedFetch` builds a client that injects the header, and `ScopePicker` is the dropdown. Wrap `ScopeProvider` **above** `AdminProvider` (or `AdminLayoutProvider`), and build the client _inside_ it so the picker's value reaches every request.
 
 ```tsx title="src/routes/admin.tsx"
-import {
-  AdminLayoutProvider,
-  ScopePicker,
-  ScopeProvider,
-  useScopedFetch,
-} from "@questpie/admin/client";
+import { AdminLayoutProvider, ScopePicker, ScopeProvider, useScopedFetch } from "@questpie/admin/client";
 import { createClient } from "questpie/client";
 import { useMemo } from "react";
 import admin from "@/questpie/admin/.generated/client";
@@ -109,10 +104,7 @@ function ScopedAdmin({ children }: { children: React.ReactNode }) {
   // useScopedFetch reads the active scope from ScopeProvider and sets the
   // x-tenant-id header on every request. A plain client would NOT send it, // the picker would change scopeId without changing what the API returns.
   const scopedFetch = useScopedFetch();
-  const client = useMemo(
-    () => createClient<typeof app>({ baseURL: "/api", fetch: scopedFetch }),
-    [scopedFetch],
-  );
+  const client = useMemo(() => createClient<typeof app>({ baseURL: "/api", fetch: scopedFetch }), [scopedFetch]);
   return (
     <AdminLayoutProvider
       admin={admin}
@@ -139,7 +131,7 @@ questpie push       # creates the posts + tenants tables in dev
 That is the whole loop. Pick a tenant in the sidebar → the scoped client sends `x-tenant-id` → the resolver returns `{ tenantId }` → the access rule filters `posts` to that tenant. The scoped fetch is the load-bearing seam: skip `useScopedFetch` and the picker still changes `scopeId`, but no header leaves the browser, so the API keeps returning everything.
 
 <Callout type="warn" title="The resolver only *derives* scope, it does not enforce it">
-`appConfig({ context })` returns a value; it does not filter anything by itself. Isolation happens only where you **read** that value, in access rules (collections) or the `scoped` resolver (globals). A collection with no scope rule is fully visible across every tenant. Derive once, enforce per collection.
+  `appConfig({context})` returns a value; it does not filter anything by itself. Isolation happens only where you **read** that value, in access rules (collections) or the `scoped` resolver (globals). A collection with no scope rule is fully visible across every tenant. Derive once, enforce per collection.
 </Callout>
 
 ## The scope resolver, `appConfig({ context })`
@@ -157,8 +149,6 @@ interface ContextResolverParams {
   db: /* your db client */;
 }
 ```
-
-
 
 **What you get in the resolver.** Beyond `request`, `session`, and `db`, the framework passes the full **system-mode** service surface, `collections`, `globals`, `kv`, `queue`, `logger`, `t`, and your services, typed via the codegen-emitted `Questpie.ContextResolverContext` augmentation. So you can validate membership or load tenant config from inside the resolver:
 
@@ -182,16 +172,12 @@ export default appConfig({
 });
 ```
 
-
-
 **Where the return value lands.** The resolved object is merged **flat** into the request context and also carried as an internal `"~contextExtensions"` bundle, so it reaches:
 
 - **access rules**, `read`/`create`/`update`/`delete`/`transition`/`serve` (collections) and global access rules,
 - **hooks**, every collection/global hook context spreads it,
 - **route handlers**, `ctx.tenantId` in `routes/`,
 - **`getContext()`**, anywhere inside the request scope (`getContext<typeof app>().tenantId`).
-
-
 
 <Callout type="warn" title="`accessMode` is `system` off-request, scope is not auto-applied in jobs and scripts">
 The resolver runs **only when there is a `request`**. CRUD calls with no request (jobs, seeds, scripts, the resolver itself) default to `accessMode: "system"`, which bypasses access rules entirely, so your scope `where` never fires there. Inside a job you must pass the tenant explicitly (`find({ where: { tenant: id } })`) or set `{ accessMode: "user", session }` and inject the context yourself. HTTP requests default to `accessMode: "user"`, where the rules apply.
@@ -209,7 +195,7 @@ app, collections, globals, "~contextExtensions"
 
 Returning one of these from your resolver does **not** throw, in development it logs a one-time warning, and in production it is silent. So watch your console: name your scope key something domain-specific (`tenantId`, `organizationId`, `propertyId`, `cityId`) and you'll never hit it.
 
-The protection itself is partial. Your resolver's result is merged **flat** into the context, then five base keys, `session`, `locale`, `defaultLocale`, `accessMode`, `db`, are re-set on top, so those genuinely can't be shadowed. The other reserved keys (`request`, `requestId`, `data`, `operation`, `collections`, `globals`, …) are **not** re-set, so a resolver that returns one of those names *would* overwrite it in the flat context. Treat the warning as a real signal, not a guardrail.
+The protection itself is partial. Your resolver's result is merged **flat** into the context, then five base keys, `session`, `locale`, `defaultLocale`, `accessMode`, `db`, are re-set on top, so those genuinely can't be shadowed. The other reserved keys (`request`, `requestId`, `data`, `operation`, `collections`, `globals`, …) are **not** re-set, so a resolver that returns one of those names _would_ overwrite it in the flat context. Treat the warning as a real signal, not a guardrail.
 
 <Callout type="info" title="The resolver must return an object">
 `ValidateContextResolver` rejects a resolver that resolves to only a primitive (`async () => "x"`) or only `null`, extensions are an object bundle. The common `session ? { tenantId } : null` shape passes because it has an object arm; returning `{ tenantId: id || null }` is the clean form.
@@ -220,7 +206,7 @@ The protection itself is partial. Your resolver's result is merged **flat** into
 Collections have **no `scoped` option**, collection isolation is access rules, and that is deliberate: it composes with everything else access already does (row filtering, field rules, `serve`). The pattern is three parts:
 
 1. **A scope-FK field**, `f.relation("tenants")` (or a plain `f.text()` if the tenant id is external). This is the column the filter keys on.
-2. **An access `where` filter**, `read`/`update`/`delete` rules that return `{ tenant: tenantId }`. A rule that returns a `where` object grants *filtered* access: rows are narrowed, not denied. (See [Access control](/docs/concepts/access-control) for the full `where`-returning model.)
+2. **An access `where` filter**, `read`/`update`/`delete` rules that return `{ tenant: tenantId }`. A rule that returns a `where` object grants _filtered_ access: rows are narrowed, not denied. (See [Access control](/docs/concepts/access-control) for the full `where`-returning model.)
 3. **A `beforeChange` stamp**, set the FK from the resolved scope on `create` so a row cannot be written into the wrong tenant.
 
 ```ts
@@ -230,10 +216,9 @@ collection("invoices")
     amount: f.number().required(),
   }))
   .access({
-    read: ({ tenantId }) => ({ tenant: tenantId }),     // narrows the list
-    update: ({ tenantId }) => ({ tenant: tenantId }),   // can't update others' rows
-    delete: ({ tenantId, session }) =>
-      session?.user.role === "admin" ? { tenant: tenantId } : false,
+    read: ({ tenantId }) => ({ tenant: tenantId }), // narrows the list
+    update: ({ tenantId }) => ({ tenant: tenantId }), // can't update others' rows
+    delete: ({ tenantId, session }) => (session?.user.role === "admin" ? { tenant: tenantId } : false),
   })
   .hooks({
     beforeChange: ({ data, operation, ...ctx }) => {
@@ -271,12 +256,11 @@ export default global("siteSettings")
 
 - adds a `scope_id` text column to the global's main table,
 - adds a unique index `<name>_scope_idx` on `scope_id`,
-- makes `get()` / `update()` filter and upsert by the resolved scope id, `get()` returns *this tenant's* row (auto-created on first **access**, read or write, with its `scope_id`), and a `null` scope resolves the one row where `scope_id IS NULL` (the unscoped/global instance).
-
-
+- makes `get()` / `update()` filter and upsert by the resolved scope id, `get()` returns _this tenant's_ row (auto-created on first **access**, read or write, with its `scope_id`), and a `null` scope resolves the one row where `scope_id IS NULL` (the unscoped/global instance).
 
 <Callout type="info" title="Scoped globals self-provision per tenant">
-You never create the per-tenant row manually. The first time you **touch** `siteSettings` while `tenantId` resolves to `"t_42"`, a `get()` is enough, you don't have to `update()` first, the read path inserts a row with `scope_id = "t_42"` inside a locked transaction and returns it. Switching scope switches which row you read and write, same global name, isolated rows.
+  You never create the per-tenant row manually. The first time you **touch** `siteSettings` while `tenantId` resolves to `"t_42"`, a `get()` is enough, you don't have to `update()` first, the read path inserts a row with `scope_id = "t_42"` inside a locked transaction and returns it. Switching scope switches which row
+  you read and write, same global name, isolated rows.
 </Callout>
 
 ## The admin scope picker
@@ -295,13 +279,11 @@ Holds the selected scope and persists it. Wrap it **above** `AdminProvider` / `A
 
 `ScopeProviderProps`:
 
-| Prop | Type | Default | Purpose |
-|---|---|---|---|
-| `headerName` | `string` | none *(required)* | HTTP header carrying the scope id (must match what the resolver reads). |
-| `storageKey` | `string` | none | `localStorage` key to persist the selection across reloads. Omit to not persist. |
-| `defaultScope` | `string \| null` | `null` | Scope id used when nothing is stored. |
-
-
+| Prop           | Type             | Default           | Purpose                                                                          |
+| -------------- | ---------------- | ----------------- | -------------------------------------------------------------------------------- |
+| `headerName`   | `string`         | none _(required)_ | HTTP header carrying the scope id (must match what the resolver reads).          |
+| `storageKey`   | `string`         | none              | `localStorage` key to persist the selection across reloads. Omit to not persist. |
+| `defaultScope` | `string \| null` | `null`            | Scope id used when nothing is stored.                                            |
 
 ### Reading and setting scope
 
@@ -318,7 +300,7 @@ function TenantBadge() {
 
 ### `useScopedFetch` / `createScopedFetch`
 
-The provider only holds the value, you must give the typed client a fetch that *sends* it. `useScopedFetch()` returns a `fetch` wrapper that sets `headerName: scopeId` on every request (only when `scopeId` is truthy). Build the client with it:
+The provider only holds the value, you must give the typed client a fetch that _sends_ it. `useScopedFetch()` returns a `fetch` wrapper that sets `headerName: scopeId` on every request (only when `scopeId` is truthy). Build the client with it:
 
 ```tsx
 import { createClient } from "questpie/client";
@@ -327,10 +309,7 @@ import { useMemo } from "react";
 
 function AdminWithScopedClient() {
   const scopedFetch = useScopedFetch();
-  const client = useMemo(
-    () => createClient<typeof app>({ baseURL: "/api", fetch: scopedFetch }),
-    [scopedFetch],
-  );
+  const client = useMemo(() => createClient<typeof app>({ baseURL: "/api", fetch: scopedFetch }), [scopedFetch]);
   return <AdminProvider client={client} {...rest} />;
 }
 ```
@@ -338,7 +317,8 @@ function AdminWithScopedClient() {
 For client construction **outside** React, use `createScopedFetch(headerName, () => currentScopeId)`, same behavior, no hook.
 
 <Callout type="warn" title="`AdminLayoutProvider` does *not* auto-scope your client">
-`AdminLayoutProvider` forwards the `client` you pass straight through to `AdminProvider`, it does **not** wrap it with a scope-aware fetch. So when the active scope changes, the admin only re-issues queries with the new header if the client *you handed it* already uses a scoped fetch. Build that client with `useScopedFetch` (as above), or the dropdown will change `scopeId` without changing what the API returns.
+  `AdminLayoutProvider` forwards the `client` you pass straight through to `AdminProvider`, it does **not** wrap it with a scope-aware fetch. So when the active scope changes, the admin only re-issues queries with the new header if the client *you handed it* already uses a scoped fetch. Build that client with
+  `useScopedFetch` (as above), or the dropdown will change `scopeId` without changing what the API returns.
 </Callout>
 
 ### `ScopePicker`
@@ -347,35 +327,36 @@ The dropdown. It sources options three ways, in priority order: static `options`
 
 ```tsx
 <ScopePicker
-  collection="tenants"     // fetches { value: id, label: name } from this collection
-  labelField="name"        // default "name"
-  valueField="id"          // default "id"
+  collection="tenants" // fetches { value: id, label: name } from this collection
+  labelField="name" // default "name"
+  valueField="id" // default "id"
   placeholder="Select tenant..."
-  allowClear               // adds an "All" option that calls setScope(null)
-  clearText="All tenants"  // default "All"
-  compact                  // smaller, no label, fits a sidebar slot
+  allowClear // adds an "All" option that calls setScope(null)
+  clearText="All tenants" // default "All"
+  compact // smaller, no label, fits a sidebar slot
 />
 ```
 
 `ScopePickerProps`:
 
-| Prop | Type | Default | Purpose |
-|---|---|---|---|
-| `collection` | `string` | none | Collection to fetch options from (`find` limit 100). |
-| `labelField` | `string` | `"name"` | Field used as each option's label. |
-| `valueField` | `string` | `"id"` | Field used as each option's value (the scope id). |
-| `options` | `ScopeOption[]` | none | Static options; wins over `collection`/`loadOptions`. |
-| `loadOptions` | `() => Promise<ScopeOption[]>` | none | Async options loader. |
-| `placeholder` | `string` | `"Select..."` | Shown when nothing is selected. |
-| `label` | `string` | none | Label above the picker (hidden in `compact`). |
-| `allowClear` | `boolean` | `false` | Adds an "All" option mapping to `setScope(null)`. |
-| `clearText` | `string` | `"All"` | Text for the clear/all option. |
-| `compact` | `boolean` | `false` | Compact rendering for a sidebar slot. |
+| Prop          | Type                           | Default       | Purpose                                               |
+| ------------- | ------------------------------ | ------------- | ----------------------------------------------------- |
+| `collection`  | `string`                       | none          | Collection to fetch options from (`find` limit 100).  |
+| `labelField`  | `string`                       | `"name"`      | Field used as each option's label.                    |
+| `valueField`  | `string`                       | `"id"`        | Field used as each option's value (the scope id).     |
+| `options`     | `ScopeOption[]`                | none          | Static options; wins over `collection`/`loadOptions`. |
+| `loadOptions` | `() => Promise<ScopeOption[]>` | none          | Async options loader.                                 |
+| `placeholder` | `string`                       | `"Select..."` | Shown when nothing is selected.                       |
+| `label`       | `string`                       | none          | Label above the picker (hidden in `compact`).         |
+| `allowClear`  | `boolean`                      | `false`       | Adds an "All" option mapping to `setScope(null)`.     |
+| `clearText`   | `string`                       | `"All"`       | Text for the clear/all option.                        |
+| `compact`     | `boolean`                      | `false`       | Compact rendering for a sidebar slot.                 |
 
 `ScopeOption` is `{ value, label, description?, icon? }`.
 
 <Callout type="warn" title="The options collection must be visible at the current scope">
-`ScopePicker collection="tenants"` reads the `tenants` collection through the **same scoped client**, so the tenant *list itself* must not be scoped away to nothing, or the picker comes up empty. Keep the directory collection (`tenants`/`organizations`) readable across scopes, and isolate the *content* collections that hang off it.
+  `ScopePicker collection="tenants"` reads the `tenants` collection through the **same scoped client**, so the tenant *list itself* must not be scoped away to nothing, or the picker comes up empty. Keep the directory collection (`tenants`/`organizations`) readable across scopes, and isolate the *content* collections
+  that hang off it.
 </Callout>
 
 ## Gotcha: relations reach across scopes
@@ -388,55 +369,54 @@ This is the isolation footgun that bites hardest. Scope lives in each collection
 ```ts
 // posts is scoped (read: ({ tenantId }) => ({ tenant: tenantId }))
 // comments is NOT scoped → this hydrates comments from ALL tenants
-await app.collections.posts.find(
-  { with: { comments: true } },
-  { accessMode: "user", session },
-);
+await app.collections.posts.find({ with: { comments: true } }, { accessMode: "user", session });
 ```
 
-The fix is uniform: **scope every collection that holds tenant data**, including the ones you only ever reach through a relation. There is no "scope a relation" shortcut, isolation is per-collection by design.
+The fix is uniform: **scope every collection that holds tenant data**, including collections reached only through relations. Isolation is enforced per collection.
 
 <Callout type="warn" title="Only upload relations inherit the parent's read decision">
-The one exception is `f.upload()` relations: they carry an internal `inheritAccess` flag (defaulting to `true` *only* for uploads), so the file relation populates from the parent row's read decision instead of re-running collection-level access, field-level read rules still apply. Every **non-upload** relation defaults to `inheritAccess: undefined` and re-runs the target's own access. That symbol is framework-internal and cannot be injected over HTTP (JSON can't carry symbols), so a request can never opt a relation out of its scope rule.
+  The one exception is `f.upload()` relations: they carry an internal `inheritAccess` flag (defaulting to `true` *only* for uploads), so the file relation populates from the parent row's read decision instead of re-running collection-level access, field-level read rules still apply. Every **non-upload** relation
+  defaults to `inheritAccess: undefined` and re-runs the target's own access. That symbol is framework-internal and cannot be injected over HTTP (JSON can't carry symbols), so a request can never opt a relation out of its scope rule.
 </Callout>
 
 ## Gotcha: the user / auth collection is not tenant-scoped
 
 The `user` collection ships from the starter module (the admin module `.merge()`s it to add the admin UI), and it has **no `scoped` option**, it is a single shared identity store across every tenant, by design. A user is one account that may belong to many tenants; you don't fork the user row per tenant.
 
-Model the *relationship* between users and tenants as its own collection, a membership/join collection, and scope **that**:
+Model the _relationship_ between users and tenants as its own collection, a membership/join collection, and scope **that**:
 
 ```ts title="collections/tenant-members.ts"
 collection("tenantMembers")
   .fields(({ f }) => ({
-    user: f.relation("user").required(),     // the SHARED user collection
+    user: f.relation("user").required(), // the SHARED user collection
     tenant: f.relation("tenants").required(),
-    role: f.select([
-      { value: "admin", label: "Admin" },
-      { value: "editor", label: "Editor" },
-      { value: "viewer", label: "Viewer" },
-    ]).default("editor").required(),
+    role: f
+      .select([
+        { value: "admin", label: "Admin" },
+        { value: "editor", label: "Editor" },
+        { value: "viewer", label: "Viewer" },
+      ])
+      .default("editor")
+      .required(),
   }))
-  .indexes(({ table }) => [
-    uniqueIndex("tenant_members_unique").on(table.user, table.tenant),
-  ]);
+  .indexes(({ table }) => [uniqueIndex("tenant_members_unique").on(table.user, table.tenant)]);
 ```
 
 This is exactly what `examples/city-portal` does with its `cityMembers` collection (user ↔ city + role, with a unique index on the pair). From there, the [membership-validating resolver](#the-scope-resolver--appconfig-context-) above is the recommended next step: check that the session user actually belongs to the requested tenant before trusting the header. (The example derives `cityId` from the header but leaves that membership check to you.)
 
 <Callout type="warn" title="Don't try to scope `user`, scope membership instead">
-Adding a scope rule to `user` breaks login, the admin people-list, and every `f.relation("user")` picker, because authentication needs the global user lookup. Keep `user` shared; put the per-tenant boundary on a membership collection and enforce it in the resolver and in each content collection's access rules.
+  Adding a scope rule to `user` breaks login, the admin people-list, and every `f.relation("user")` picker, because authentication needs the global user lookup. Keep `user` shared; put the per-tenant boundary on a membership collection and enforce it in the resolver and in each content collection's access rules.
 </Callout>
 
 ## Common shape, picking a scope strategy
 
-| You want | Use | Storage |
-|---|---|---|
-| Per-tenant **rows** in a collection | scope-FK field + access `where` filter + `beforeChange` stamp | a shared table, filtered per request |
-| Per-tenant **singleton** (settings, theme) | `global().options({ scoped })` | one row per scope (`scope_id` + unique index) |
-| Per-tenant **membership / roles** | a dedicated join collection (`tenantMembers`), itself scoped | a shared table |
-| **Shared** identity across tenants | the built-in `user` collection (leave unscoped) | one table, global |
-| **Hard** isolation (separate Postgres schema) | `.options({ schema: "tenant_x" })` per tenant set | distinct schemas (static tenant set only) |
+| You want                                      | Use                                                           | Storage                                       |
+| --------------------------------------------- | ------------------------------------------------------------- | --------------------------------------------- |
+| Per-tenant **rows** in a collection           | scope-FK field + access `where` filter + `beforeChange` stamp | a shared table, filtered per request          |
+| Per-tenant **singleton** (settings, theme)    | `global().options({ scoped })`                                | one row per scope (`scope_id` + unique index) |
+| Per-tenant **membership / roles**             | a dedicated join collection (`tenantMembers`), itself scoped  | a shared table                                |
+| **Shared** identity across tenants            | the built-in `user` collection (leave unscoped)               | one table, global                             |
+| **Hard** isolation (separate Postgres schema) | `.options({ schema: "tenant_x" })` per tenant set             | distinct schemas (static tenant set only)     |
 
 The first two cover almost every app. Reach for `schema` only when you need physical separation and your tenant set is known at build time, it is not a per-request switch.
 

--- a/apps/docs/content/docs/getting-started/index.mdx
+++ b/apps/docs/content/docs/getting-started/index.mdx
@@ -24,10 +24,7 @@ flowchart LR
 The admin panel, the client SDK, and the OpenAPI spec are **projections** of your schema, the same way a mobile app would be, not separate definitions you keep in sync by hand. Change a field, re-run codegen, and every layer updates with correct types.
 
 <Callout type="info" title="One term, one concept">
-	A *collection* is a database table. A *global* is a singleton. A *field*
-	describes one column. A *module* (or *plugin*) is config you add. These names
-	mean the same thing on the server, in codegen, in the client, and in the
-	admin, no synonyms.
+  A *collection* is a database table. A *global* is a singleton. A *field* describes one column. A *module* (or *plugin*) is config you add. These names mean the same thing on the server, in codegen, in the client, and in the admin, no synonyms.
 </Callout>
 
 ## What you get out of the box
@@ -45,10 +42,7 @@ Scaffold a new app with `bunx create-questpie my-app` and you ship from a real s
 Pick a runtime and follow its [getting-started guide](/docs/getting-started/tanstack-start) to a booting app.
 
 <Callout type="info" title="Four runtimes, one core">
-	TanStack Start and Next.js are fullstack (admin UI included); Hono and Elysia
-	are headless API + typed-client. The `src/questpie/**` core is identical
-	across all four, only a thin runtime adapter (how the handler is mounted)
-	differs.
+  TanStack Start and Next.js are fullstack (admin UI included); Hono and Elysia are headless API + typed-client. The `src/questpie/**` core is identical across all four, only a thin runtime adapter (how the handler is mounted) differs.
 </Callout>
 
 ## Your first collection, end to end
@@ -61,25 +55,22 @@ Here is the whole payoff in three steps: define a collection, generate, query it
 import { collection } from "#questpie/factories";
 
 export const posts = collection("posts")
-	.fields(({ f }) => ({
-		title: f.text(255).required(),
-		body: f.richText(),
-		author: f.relation("user"),
-		status: f.select([
-			{ value: "draft", label: "Draft" },
-			{ value: "published", label: "Published" },
-		]),
-		publishedAt: f.datetime(),
-	}))
-	.title(({ f }) => f.title);
+  .fields(({ f }) => ({
+    title: f.text(255).required(),
+    body: f.richText(),
+    author: f.relation("user"),
+    status: f.select([
+      { value: "draft", label: "Draft" },
+      { value: "published", label: "Published" },
+    ]),
+    publishedAt: f.datetime(),
+  }))
+  .title(({ f }) => f.title);
 ```
 
 <Callout type="info" title="Import from `#questpie/factories`, not `questpie`">
-	Codegen generates the `collection()` factory so that module-contributed field
-	types (`f.richText()`, `f.blocks()` from the admin module) appear on `f`. A
-	bare `import {collection} from "questpie"` only sees the 15 built-in field
-	types. Always import from `#questpie/factories`. See
-	[Codegen](/docs/extend/codegen) for how the generated factory is wired.
+  Codegen generates the `collection()` factory so that module-contributed field types (`f.richText()`, `f.blocks()` from the admin module) appear on `f`. A bare `import {collection} from "questpie"` only sees the 15 built-in field types. Always import from `#questpie/factories`. See [Codegen](/docs/extend/codegen) for
+  how the generated factory is wired.
 </Callout>
 
 **2. Run codegen.** This discovers your files and writes the typed runtime to `src/questpie/server/.generated/`.
@@ -94,10 +85,10 @@ questpie generate
 import { client } from "@/lib/client";
 
 const result = await client.collections.posts.find({
-	where: { status: "published" },
-	orderBy: { publishedAt: "desc" },
-	with: { author: true },
-	limit: 10,
+  where: { status: "published" },
+  orderBy: { publishedAt: "desc" },
+  with: { author: true },
+  limit: 10,
 });
 
 result.docs[0].title;
@@ -149,9 +140,7 @@ comments: f.relation("comment").hasMany({ foreignKey: "postId" });
 ```
 
 <Callout type="info" title="Relation targets are validated after codegen">
-	Pre-codegen, `f.relation("usr")` is just a string. Once codegen runs, the
-	target name is validated against your real collections, a typo becomes a
-	compile error.
+  Pre-codegen, `f.relation("usr")` is just a string. Once codegen runs, the target name is validated against your real collections, a typo becomes a compile error.
 </Callout>
 
 ### Rules and lifecycle
@@ -160,32 +149,27 @@ comments: f.relation("comment").hasMany({ foreignKey: "postId" });
 
 ```ts
 collection("posts").access({
-	read: true,
-	update: ({ session }) => !!session?.user,
+  read: true,
+  update: ({ session }) => !!session?.user,
 });
 ```
 
 <Callout type="warn" title="Secure by default, except routes">
-	An `undefined` access rule on a collection requires a session, it does not
-	default to public. Routes are the opposite: a route with no `.access()` is
-	**public** until you add one. Be deliberate about both. See [Access
-	control](/docs/concepts/access-control) and [Routes](/docs/concepts/routes).
+  An `undefined` access rule on a collection requires a session, it does not default to public. Routes are the opposite: a route with no `.access()` is **public** until you add one. Be deliberate about both. See [Access control](/docs/concepts/access-control) and [Routes](/docs/concepts/routes).
 </Callout>
 
 **[Hooks](/docs/concepts/hooks)**, lifecycle callbacks on `.hooks({ ... })`: `beforeChange`, `afterChange`, `beforeDelete`, and more. Each receives the full app context. Use `onAfterCommit(cb)` for side effects (jobs, emails, search) so they only fire once the transaction is durable.
 
 ```ts
 collection("posts").hooks({
-	afterChange: async ({ data, queue, onAfterCommit }) => {
-		onAfterCommit(() => queue.notifySubscribers.publish({ postId: data.id }));
-	},
+  afterChange: async ({ data, queue, onAfterCommit }) => {
+    onAfterCommit(() => queue.notifySubscribers.publish({ postId: data.id }));
+  },
 });
 ```
 
 <Callout type="warn" title="Don't run output hooks inside an open transaction">
-	Block/upload `afterRead` work re-entering an open tx can deadlock the database
-	driver. Schedule durable-data side effects with `onAfterCommit` instead. See
-	[Hooks](/docs/concepts/hooks).
+  Block/upload `afterRead` work re-entering an open tx can deadlock the database driver. Schedule durable-data side effects with `onAfterCommit` instead. See [Hooks](/docs/concepts/hooks).
 </Callout>
 
 **[Validation](/docs/concepts/validation)**, Zod schemas for create and update are generated automatically from your field definitions. Use `.validation({ refine, exclude })` only when you need to tighten or drop a specific field.
@@ -199,11 +183,11 @@ import { route } from "questpie/services";
 import { z } from "zod";
 
 export default route()
-	.post()
-	.schema(z.object({ postId: z.string() }))
-	.handler(async ({ input, collections }) => {
-		return collections.posts.findOne({ where: { id: input.postId } });
-	});
+  .post()
+  .schema(z.object({ postId: z.string() }))
+  .handler(async ({ input, collections }) => {
+    return collections.posts.findOne({ where: { id: input.postId } });
+  });
 ```
 
 **[Jobs](/docs/concepts/jobs)**, background work as files in `jobs/`. Define a payload schema and handler; dispatch with `queue.<name>.publish(payload)`. Add `options.cron` for a recurring schedule. Adapters: pg-boss, BullMQ, Cloudflare Queues.
@@ -213,27 +197,25 @@ import { job } from "questpie";
 import { z } from "zod";
 
 export default job({
-	name: "send-digest",
-	schema: z.object({ userId: z.string() }),
-	handler: async ({ payload, email }) => {
-		/* … */
-	},
+  name: "send-digest",
+  schema: z.object({ userId: z.string() }),
+  handler: async ({ payload, email }) => {
+    /* … */
+  },
 });
 ```
 
-<Callout type="warn" title="There is no `questpie worker` CLI command">
-	Workers start in code. Write a script that imports your built app and calls
-	`app.queue.listen()` (long-running) or `app.queue.runOnce()` (one serverless
-	batch). See [Jobs](/docs/concepts/jobs).
+<Callout type="info" title="Workers start from application entrypoints">
+  Import the built app and call `app.queue.listen()` for a long-running worker or `app.queue.runOnce()` for one serverless batch. See [Jobs](/docs/concepts/jobs).
 </Callout>
 
-**[Services](/docs/concepts/services)**, reusable singletons (a Stripe client, a third-party SDK) injected into context. Dependencies come from the `create(ctx)` argument, there is no separate `deps` array.
+**[Services](/docs/concepts/services)**, reusable singletons (a Stripe client, a third-party SDK) injected into context. Resolve dependencies from the `create(ctx)` argument.
 
 ```ts
 import { service } from "questpie/services";
 
 export default service({
-	create: ({ db }) => new BillingClient(db),
+  create: ({ db }) => new BillingClient(db),
 });
 ```
 
@@ -244,9 +226,9 @@ import { email } from "questpie/services";
 import { z } from "zod";
 
 export default email({
-	name: "welcome",
-	schema: z.object({ name: z.string() }),
-	handler: ({ input }) => ({ subject: `Welcome, ${input.name}`, html: "…" }),
+  name: "welcome",
+  schema: z.object({ name: z.string() }),
+  handler: ({ input }) => ({ subject: `Welcome, ${input.name}`, html: "…" }),
 });
 ```
 
@@ -270,7 +252,7 @@ const { data } = useQuery(q.collections.posts.find({ limit: 10 }));
 const create = useMutation(q.collections.posts.create());
 ```
 
-**[Realtime](/docs/client/realtime)**, `client.collections.posts.live(query, onSnapshot)` opens a live subscription; the first snapshot arrives immediately, then updates stream over a single multiplexed SSE connection.
+**[Realtime](/docs/concepts/realtime)**, live queries keep collection and global snapshots synchronized while channels carry typed application events. Use the [client realtime API](/docs/client/realtime) for subscription signatures.
 
 ### Infrastructure (adapters)
 
@@ -279,20 +261,20 @@ QUESTPIE talks to infrastructure through **adapters**, you swap the backend with
 | Concern                                 | Built-in / default       | Other adapters                     |
 | --------------------------------------- | ------------------------ | ---------------------------------- |
 | **[Queue](/docs/adapters/queue)**       | none                     | pg-boss, BullMQ, Cloudflare Queues |
-| **[Search](/docs/adapters/search)**     | Postgres (FTS + trigram) | pgvector (semantic)                |
-| **[Realtime](/docs/adapters/realtime)** | poll-based               | Postgres `NOTIFY`, Redis Streams   |
-| **[Storage](/docs/adapters/storage)**   | local filesystem         | S3, R2 (via files-sdk)             |
+| **[Search](/docs/concepts/search)**     | Postgres (FTS + trigram) | pgvector (semantic)                |
+| **[Realtime](/docs/concepts/realtime)** | poll-based               | Postgres `NOTIFY`, Redis Streams   |
+| **[Storage](/docs/concepts/storage)**   | local filesystem         | S3, R2 (via files-sdk)             |
 | **[Email](/docs/adapters/email)**       | console (dev)            | SMTP, Resend, Plunk                |
-| **[KV](/docs/adapters/kv)**             | in-memory                | Redis, Cloudflare KV               |
+| **[KV](/docs/concepts/kv)**             | in-memory                | Redis, Cloudflare KV               |
 
 ```ts title="src/questpie/server/questpie.config.ts"
 import { runtimeConfig } from "questpie/app";
 import { pgBossAdapter } from "questpie/adapters/pg-boss";
 
 export default runtimeConfig({
-	queue: {
-		adapter: pgBossAdapter({ connectionString: process.env.DATABASE_URL }),
-	},
+  queue: {
+    adapter: pgBossAdapter({ connectionString: process.env.DATABASE_URL }),
+  },
 });
 ```
 
@@ -307,9 +289,7 @@ export default runtimeConfig({
 **[Codegen](/docs/extend/codegen)**, the engine that turns your files into the typed runtime. `questpie generate` runs it once; `questpie dev` watches and regenerates on file add/remove. Codegen output is committed to git. A module's codegen `plugin` lets a package contribute its own file conventions without you editing config.
 
 <Callout type="warn" title="Re-run codegen after adding or removing files">
-	New collections, routes, and jobs only enter the typed runtime once `questpie
-	generate` (or `questpie dev`) regenerates `.generated/`. Editing the *body* of
-	an existing file does not require a regen, only adding/removing files does.
+  New collections, routes, and jobs only enter the typed runtime once `questpie generate` (or `questpie dev`) regenerates `.generated/`. Editing the *body* of an existing file does not require a regen, only adding/removing files does.
 </Callout>
 
 ## Where to next

--- a/apps/docs/content/docs/getting-started/mcp-ai-agent.mdx
+++ b/apps/docs/content/docs/getting-started/mcp-ai-agent.mdx
@@ -59,11 +59,7 @@ bun run db:push
 ```
 
 <Callout type="warn" title="db:push is local development only">
-	`bun run db:push` calls `questpie push`. Never run it against production, in a
-	deployment job, or in an init container. `--force` does not make it
-	production-safe. For production, generate a migration with `bun run
-	migrate:create`, review and commit it, then apply it with `bun run migrate`
-	during deployment.
+  `bun run db:push` calls `questpie push`. Never run it against production, in a deployment job, or in an init container. `--force` does not make it production-safe. For production, generate a migration with `bun run migrate:create`, review and commit it, then apply it with `bun run migrate` during deployment.
 </Callout>
 
 Start the app:
@@ -82,14 +78,14 @@ HTTP MCP is read-only by default. Add `config/mcp.ts` to allow authenticated age
 import { mcpConfig } from "@questpie/mcp";
 
 export default mcpConfig({
-	crud: {
-		collections: {
-			posts: { read: true, write: true, delete: false },
-		},
-		globals: {
-			siteSettings: { read: true, write: false },
-		},
-	},
+  crud: {
+    collections: {
+      posts: { read: true, write: true, delete: false },
+    },
+    globals: {
+      siteSettings: { read: true, write: false },
+    },
+  },
 });
 ```
 
@@ -114,19 +110,19 @@ import { mcpTool } from "@questpie/mcp";
 import { z } from "zod";
 
 export default mcpTool("posts.countPublished", {
-	description: "Count published posts.",
-	inputSchema: z.object({}),
-	outputSchema: z.object({ count: z.number() }),
-	annotations: { readOnlyHint: true },
+  description: "Count published posts.",
+  inputSchema: z.object({}),
+  outputSchema: z.object({ count: z.number() }),
+  annotations: { readOnlyHint: true },
 }).handler(async ({ ctx }) => {
-	const count = await ctx.collections.posts.count({
-		where: { published: true },
-	});
+  const count = await ctx.collections.posts.count({
+    where: { published: true },
+  });
 
-	return {
-		structuredContent: { count },
-		content: [{ type: "text", text: `${count} published posts` }],
-	};
+  return {
+    structuredContent: { count },
+    content: [{ type: "text", text: `${count} published posts` }],
+  };
 });
 ```
 
@@ -190,9 +186,7 @@ bun run migrate
 ```
 
 <Callout type="warn" title="Never replace migrate with push">
-	Production uses `questpie migrate`, not `questpie push`. Do not put `push`,
-	`db:push`, or `push --force` in a container command, init container, CI deploy
-	step, or production runbook.
+  Production uses `questpie migrate`, not `questpie push`. Do not put `push`, `db:push`, or `push --force` in a container command, init container, CI deploy step, or production runbook.
 </Callout>
 
 Before connecting a client, confirm that `/api/mcp`, both root `/.well-known/*` documents, `/api/auth/oauth2/register`, `/admin/login`, and `/admin/oauth/consent` all route to the same deployment.
@@ -220,16 +214,16 @@ Add a workspace MCP configuration:
 
 ```json title=".vscode/mcp.json"
 {
-	"servers": {
-		"questpie": {
-			"type": "http",
-			"url": "https://cms.example.com/api/mcp"
-		}
-	}
+  "servers": {
+    "questpie": {
+      "type": "http",
+      "url": "https://cms.example.com/api/mcp"
+    }
+  }
 }
 ```
 
-There is intentionally no static token and no `oauth.clientId`: VS Code starts with DCR when the server advertises it. See the official [VS Code MCP developer guide](https://code.visualstudio.com/api/extension-guides/ai/mcp) and [MCP server configuration guide](https://code.visualstudio.com/docs/agent-customization/mcp-servers).
+VS Code discovers the server, registers through DCR, then completes browser login and consent. See the official [VS Code MCP developer guide](https://code.visualstudio.com/api/extension-guides/ai/mcp) and [MCP server configuration guide](https://code.visualstudio.com/docs/agent-customization/mcp-servers).
 
 Open the Command Palette and run **MCP: List Servers**. Start `questpie`, confirm that you trust the server, then complete the browser login and consent flow. VS Code lists the discovered tools in Chat's tool picker. If you need to discard a stale DCR registration, run **Authentication: Remove Dynamic Authentication Providers** and reconnect.
 

--- a/apps/docs/content/docs/integrations/mcp-oauth.mdx
+++ b/apps/docs/content/docs/integrations/mcp-oauth.mdx
@@ -8,7 +8,8 @@ Your [MCP endpoint](/docs/integrations/mcp) at `/api/mcp` is not meant to be ope
 This is the remote, network-facing story. Local, trusted clients (a CLI on your own machine) use the [stdio transport](/docs/integrations/mcp#stdio-transport) and are unaffected - they run as a `system` principal with no OAuth.
 
 <Callout type="info" title="Prerequisites">
-Read the [MCP integration](/docs/integrations/mcp) page first - it covers `mcpModule`, how collections/globals/routes become tools, and the `config/mcp.ts` policy surface. This page adds the OAuth 2.1 auth layer on top. Familiarity with [Access control](/docs/concepts/access-control) helps too, since scopes layer on top of your existing RBAC.
+  Read the [MCP integration](/docs/integrations/mcp) page first - it covers `mcpModule`, how collections/globals/routes become tools, and the `config/mcp.ts` policy surface. This page adds the OAuth 2.1 auth layer on top. Familiarity with [Access control](/docs/concepts/access-control) helps too, since scopes layer on
+  top of your existing RBAC.
 </Callout>
 
 ## What you get
@@ -23,7 +24,7 @@ Read the [MCP integration](/docs/integrations/mcp) page first - it covers `mcpMo
 
 ## Enabling it
 
-The OAuth provider, the token tables, and the discovery endpoints all ship with the **starter module**, which the **admin module** bundles. So on a runtime that includes admin (TanStack Start, Next.js), an admin-enabled app **already has** the OAuth provider, the `jwks`/`oauth-*` tables, and root discovery - there is nothing extra to configure for auth. All you add is the MCP route itself.
+The **starter module**, bundled by the **admin module**, provides the OAuth provider, `jwks` and `oauth-*` tables, and root discovery endpoints. On an admin-enabled TanStack Start or Next.js app, add the MCP route to use that built-in authorization server.
 
 **Scaffolding a new app** - select the `MCP` module in `create-questpie`:
 
@@ -54,7 +55,9 @@ questpie generate
 That is the whole setup on an admin-enabled app: `adminModule` provides the OAuth provider + tables + discovery (via the starter it bundles), and `mcpModule` mounts the OAuth-gated `/api/mcp` route. This composition is covered end to end by the framework test suite.
 
 <Callout type="info" title="Headless runtimes (Hono, Elysia) add the OAuth provider with `oauthModule`">
-The OAuth provider lives in the self-contained, composable **`oauthModule`**, alongside the `oauthProvider()` + `jwt()` plugins, the `oauth-*` tables + `jwks`, and the discovery routes. `starterModule` bundles it and `adminModule` pulls the starter in, so an admin-enabled app gets it for free (as above). A **headless / custom-auth** app that ships neither can add `oauthModule` on top of its own better-auth model to get the same provider + tables + discovery, HTTP MCP then works there too. (This shipped in 3.3.0, it is no longer a hand-wire-it-yourself follow-up.) With no provider at all, `/api/mcp` still mounts but stays `401` with nothing to discover. Local [stdio](/docs/integrations/mcp#stdio-transport) needs no OAuth and works everywhere.
+  The OAuth provider lives in the self-contained, composable **`oauthModule`**, alongside the `oauthProvider()` + `jwt()` plugins, the `oauth-*` tables + `jwks`, and the discovery routes. `starterModule` bundles it and `adminModule` pulls the starter in, so an admin-enabled app gets it for free (as above). A **headless
+  / custom-auth** app that ships neither can add `oauthModule` on top of its own better-auth model to get the same provider + tables + discovery, HTTP MCP then works there too. (This shipped in 3.3.0, it is no longer a hand-wire-it-yourself follow-up.) With no provider at all, `/api/mcp` still mounts but stays `401`
+  with nothing to discover. Local [stdio](/docs/integrations/mcp#stdio-transport) needs no OAuth and works everywhere.
 </Callout>
 
 ## The flow
@@ -96,7 +99,8 @@ Step by step:
 6. **Call the endpoint.** The client sends `Authorization: Bearer <token>` on `POST /mcp`. The app verifies the token statelessly against `/jwks`, resolves it to an `oauth` principal (the real user + consented scopes), and dispatches tool calls under `scopes ∩ RBAC`.
 
 <Callout type="info" title="Discovery lives at the server root, not under `/api/auth`">
-Better Auth serves OAuth metadata under its own base path (`/api/auth/*`), but MCP clients expect it at the server root. QUESTPIE's core module (always included) re-exposes all three documents at the root as ordinary routes - `/.well-known/oauth-authorization-server`, `/.well-known/oauth-protected-resource`, and `/jwks` - each delegating to the provider's own helpers, so the advertised issuer/JWKS/audience always match how tokens are actually issued.
+  Better Auth serves OAuth metadata under its own base path (`/api/auth/*`), but MCP clients expect it at the server root. QUESTPIE's core module (always included) re-exposes all three documents at the root as ordinary routes - `/.well-known/oauth-authorization-server`, `/.well-known/oauth-protected-resource`, and
+  `/jwks` - each delegating to the provider's own helpers, so the advertised issuer/JWKS/audience always match how tokens are actually issued.
 </Callout>
 
 <Callout type="warn" title="A token is a verifiable JWT only when the client sets `resource`">
@@ -107,21 +111,22 @@ The `resource=<mcp-endpoint-url>` parameter (RFC 8707) at both **authorize** and
 
 Scopes describe **what slice of your app** an agent asked for. They are declarative and derived from your data model - one per resource and operation - plus two coarse umbrellas for convenience.
 
-| Scope pattern | Grants | Example |
-|---|---|---|
-| `collections:<name>:read` | list / get / count on that collection | `collections:posts:read` |
-| `collections:<name>:write` | create / update on that collection | `collections:posts:write` |
-| `collections:<name>:delete` | delete on that collection | `collections:posts:delete` |
-| `globals:<name>:read` | read that global | `globals:settings:read` |
-| `globals:<name>:write` | update that global | `globals:settings:write` |
-| `routes:<key>:invoke` | call that exposed route tool | `routes:reports/revenue:invoke` |
-| `collections:read` *(umbrella)* | the `:read` verb across **all** collections | - |
-| `collections:write` *(umbrella)* | the `:write` verb across **all** collections | - |
+| Scope pattern                    | Grants                                       | Example                         |
+| -------------------------------- | -------------------------------------------- | ------------------------------- |
+| `collections:<name>:read`        | list / get / count on that collection        | `collections:posts:read`        |
+| `collections:<name>:write`       | create / update on that collection           | `collections:posts:write`       |
+| `collections:<name>:delete`      | delete on that collection                    | `collections:posts:delete`      |
+| `globals:<name>:read`            | read that global                             | `globals:settings:read`         |
+| `globals:<name>:write`           | update that global                           | `globals:settings:write`        |
+| `routes:<key>:invoke`            | call that exposed route tool                 | `routes:reports/revenue:invoke` |
+| `collections:read` _(umbrella)_  | the `:read` verb across **all** collections  | -                               |
+| `collections:write` _(umbrella)_ | the `:write` verb across **all** collections | -                               |
 
 The mapping is pure data, parameterized by `(resource kind, name, verb)` - adding a collection, global, or route contributes its scopes automatically, with no framework code to touch.
 
 <Callout type="info" title="Umbrellas exist for `read` and `write` only - never `delete` or `invoke`">
-A granular `collections:posts:read` requirement is *also* satisfied by holding the coarse `collections:read` umbrella (and likewise for `write`). But there is **no** umbrella for `:delete` or `routes:…:invoke`: those always require the exact granular scope. `read` and `write` umbrellas are independent - holding `collections:write` never satisfies a `:read` requirement, and vice versa - and an umbrella never crosses resource kinds (`collections:read` never grants a `globals:…` scope). This keeps the convenience narrow and least-privilege.
+  A granular `collections:posts:read` requirement is *also* satisfied by holding the coarse `collections:read` umbrella (and likewise for `write`). But there is **no** umbrella for `:delete` or `routes:…:invoke`: those always require the exact granular scope. `read` and `write` umbrellas are independent - holding
+  `collections:write` never satisfies a `:read` requirement, and vice versa - and an umbrella never crosses resource kinds (`collections:read` never grants a `globals:…` scope). This keeps the convenience narrow and least-privilege.
 </Callout>
 
 ### Effective permission = scopes ∩ RBAC
@@ -142,29 +147,30 @@ Both gates must pass, in either direction of narrowing:
 - **Scopes narrow RBAC.** A collection whose RBAC allows a user everything, reached with a token that only holds `collections:posts:read`, exposes only the read tools - create/update/delete stay hidden and are denied even on a direct call.
 - **RBAC narrows scopes.** A collection whose RBAC denies `update`/`delete` stays locked even if the token holds `…:write` and `…:delete` scopes. The scope gate can't grant past what `.access()` allows.
 
-Out-of-scope (and out-of-RBAC) tools are **absent from `tools/list`** *and* rejected if the client calls them directly by name.
+Out-of-scope (and out-of-RBAC) tools are **absent from `tools/list`** _and_ rejected if the client calls them directly by name.
 
 <Callout type="info" title="`user` and `system` principals are unchanged">
-The scope gate only applies to the `oauth` principal. A first-party admin cookie/bearer session is a `user` principal - no scopes, RBAC as today. A trusted local [stdio](/docs/integrations/mcp#stdio-transport) worker is a `system` principal - it bypasses both the RBAC and scope gates entirely (full access). Only the network-facing OAuth path is scope-gated.
+  The scope gate only applies to the `oauth` principal. A first-party admin cookie/bearer session is a `user` principal - no scopes, RBAC as today. A trusted local [stdio](/docs/integrations/mcp#stdio-transport) worker is a `system` principal - it bypasses both the RBAC and scope gates entirely (full access). Only the
+  network-facing OAuth path is scope-gated.
 </Callout>
 
 ### What the user sees on the consent screen
 
 The consent page renders each requested scope as a human-readable line, so the granting user understands exactly what they're approving:
 
-| Scope | Rendered as |
-|---|---|
-| `openid` | Verify your identity |
-| `email` | View your email address |
-| `collections:posts:read` | Read the Posts collection |
-| `collections:posts:write` | Create and update the Posts collection |
-| `collections:read` | Read all your collections |
-| `routes:reports/revenue:invoke` | Run the Reports/revenue action |
+| Scope                           | Rendered as                            |
+| ------------------------------- | -------------------------------------- |
+| `openid`                        | Verify your identity                   |
+| `email`                         | View your email address                |
+| `collections:posts:read`        | Read the Posts collection              |
+| `collections:posts:write`       | Create and update the Posts collection |
+| `collections:read`              | Read all your collections              |
+| `routes:reports/revenue:invoke` | Run the Reports/revenue action         |
 
 Unknown scopes fall back to a readable rendering of the raw string rather than a blank row, so a new resource never shows up unlabeled.
 
-<Callout type="warn" title="Consent is a real admin page, not a server-rendered provider template">
-The consent screen is a QUESTPIE admin page at `/admin/oauth/consent` (the provider's `consentPage`). It reads the signed authorization query from the URL and drives `POST /oauth2/consent`. There is no `getConsentHTML` helper - the installed provider does not expose one. Trusted clients that skip consent (`skip_consent`) never reach this page; the provider handles them server-side.
+<Callout type="info" title="Consent uses the admin page">
+  The consent screen lives at `/admin/oauth/consent`, the configured `consentPage`. It reads the signed authorization query, presents the requested scopes, and submits the decision to `POST /oauth2/consent`. The provider approves trusted clients with `skip_consent` server-side.
 </Callout>
 
 ## Custom tool scopes
@@ -197,10 +203,10 @@ As always, `scopes` is an OAuth-only narrowing on top of `access` - a `user` or 
 - **Short TTL.** Access tokens expire in **1 hour**, so a leaked token has a small window and revocation stays cheap (there's a `/oauth2/revoke` endpoint for refresh tokens and consent).
 - **Stateless verification.** Tokens are verified locally against the published `/jwks` key set on every request - no database round-trip on the hot path. The token is signed with **EdDSA (Ed25519)**; an unsigned or wrong-key token can never pass verification.
 - **No token ever elevates.** A malformed, expired, wrong-audience, or wrong-issuer token resolves to **no principal** - the request falls through to the normal (unauthenticated) path and the `/mcp` route answers `401`. `system` mode is only ever set by a trusted transport (stdio), never derived from a token.
-- **PKCE, always.** Every DCR-registered client is public and must use PKCE; there is no way to register a client that opts out.
+- **PKCE, always.** Every DCR-registered client is public and must use PKCE.
 
 <Callout type="info" title="RBAC is the floor, scopes are the ceiling">
-Because effective permission is `scopes ∩ RBAC`, an over-broad scope grant can never bypass your access rules, and a misconfigured access rule can never be widened by a scope. Design your `.access()` rules as the real security boundary; treat scopes as the user's least-privilege consent on top.
+  Because effective permission is `scopes ∩ RBAC`, an over-broad scope grant can never bypass your access rules, and a misconfigured access rule can never be widened by a scope. Design your `.access()` rules as the real security boundary; treat scopes as the user's least-privilege consent on top.
 </Callout>
 
 ## Related

--- a/apps/docs/content/docs/integrations/mcp.mdx
+++ b/apps/docs/content/docs/integrations/mcp.mdx
@@ -11,10 +11,11 @@ You also get custom tools: drop an `mcpTool()` file under `mcp-tools/` to expose
 This page covers the MCP surface itself - tools, policy, transports. For letting **external** AI agents (Claude, IDEs) connect over HTTP, QUESTPIE ships a real **OAuth 2.1 authorization-code + PKCE flow**: dynamic client registration, a human consent screen, per-user delegation, and least-privilege **scopes** layered on top of RBAC as `scopes ∩ RBAC`, plus a first-class `principal` (`user` / `oauth` / `system`). See **[MCP over OAuth 2.1](/docs/integrations/mcp-oauth)**.
 
 On an admin-enabled app the HTTP `/api/mcp` route requires a verified principal - a first-party admin session (`user`) or a valid OAuth access token (`oauth`); an unauthenticated request gets a `401` pointing at the OAuth discovery metadata. A trusted local [stdio](#stdio-transport) worker runs as `system` and needs no OAuth.
+
 </Callout>
 
 <Callout type="info" title="Prerequisites">
-Read [Routes](/docs/concepts/routes) and [Access control](/docs/concepts/access-control) first, routes opt into MCP via `meta.mcp`, and every HTTP tool call runs through your collection/global access rules. The module registers like any other (see [Modules](/docs/extend/modules)).
+  Read [Routes](/docs/concepts/routes) and [Access control](/docs/concepts/access-control) first, routes opt into MCP via `meta.mcp`, and every HTTP tool call runs through your collection/global access rules. The module registers like any other (see [Modules](/docs/extend/modules)).
 </Callout>
 
 ## What it does
@@ -28,7 +29,7 @@ Read [Routes](/docs/concepts/routes) and [Access control](/docs/concepts/access-
 
 ## Quick start
 
-Add `mcpModule` to your app's modules. It carries its own codegen plugin, so registering the module also wires MCP into codegen, there is nothing else to install.
+Add `mcpModule` to your app's modules. The module carries its codegen plugin and registers the MCP file conventions automatically.
 
 ```ts title="src/questpie/modules.ts"
 import { mcpModule } from "@questpie/mcp";
@@ -48,7 +49,7 @@ questpie generate
 That is the whole setup. With no `config/mcp.ts`, every collection and global is exposed **read-only over HTTP** (writes and deletes off), and every read still passes the connecting user's access rules. Point an MCP client at `https://your-app/api/mcp` and it can list your tools.
 
 <Callout type="info" title="Re-run codegen after adding the module or a tool file">
-Adding `mcpModule` to `modules.ts` and adding files under `mcp-tools/` both change what codegen discovers, so run `questpie generate` (or keep `questpie dev` running). Editing a tool's handler body does not need a regen. See [Codegen](/docs/extend/codegen).
+  Adding `mcpModule` to `modules.ts` and adding files under `mcp-tools/` both change what codegen discovers, so run `questpie generate` (or keep `questpie dev` running). Editing a tool's handler body does not need a regen. See [Codegen](/docs/extend/codegen).
 </Callout>
 
 ## The HTTP endpoint
@@ -56,7 +57,7 @@ Adding `mcpModule` to `modules.ts` and adding files under `mcp-tools/` both chan
 `mcpModule` contributes one raw route at the key `mcp`, which resolves to **`/api/mcp`** by file convention. It accepts `POST`, `GET`, `DELETE`, and `OPTIONS`, and boots a stateless Streamable-HTTP MCP transport per request (`sessionIdGenerator` is `undefined`). CORS is added to every response and reflects the request `Origin`.
 
 <Callout type="warn" title='HTTP is always `accessMode: "user"`'>
-The bundled HTTP route hardcodes `accessMode: "user"`, it always runs under the request's session, and access rules are always evaluated. The `http.accessMode` config field is therefore ignored for this route; it only matters if you mount MCP on your own transport via `createMcpServer`.
+  The bundled HTTP route hardcodes `accessMode: "user"`, it always runs under the request's session, and access rules are always evaluated. The `http.accessMode` config field is therefore ignored for this route; it only matters if you mount MCP on your own transport via `createMcpServer`.
 </Callout>
 
 The route requires a **verified principal** before it dispatches anything: the framework resolves identity onto the request first, and without one, the route answers `401` with a `WWW-Authenticate` header pointing at the OAuth discovery metadata (so an MCP client auto-discovers the authorization server and starts the flow). A principal comes from either a first-party admin cookie/bearer session (`kind: "user"`) or a valid OAuth access token (`kind: "oauth"`). The CORS allow-list already permits `Authorization`, `x-api-key`, and `Mcp-Session-Id` headers. For the full external-agent OAuth flow - registration, consent, scopes - see [MCP over OAuth 2.1](/docs/integrations/mcp-oauth).
@@ -69,20 +70,18 @@ When a client connects, the server registers tools from four sources (in this or
 
 Each exposed collection registers up to six tools and each exposed global up to two. Tool names are `collections.<name>.<op>` and `globals.<name>.<op>`:
 
-| Entity | Operations (tool name suffix) | Kind |
-|---|---|---|
-| Collection | `list`, `count`, `get` | read |
-| Collection | `create`, `update` | write |
-| Collection | `delete` | delete |
-| Global | `get` | read |
-| Global | `update` | write |
+| Entity     | Operations (tool name suffix) | Kind   |
+| ---------- | ----------------------------- | ------ |
+| Collection | `list`, `count`, `get`        | read   |
+| Collection | `create`, `update`            | write  |
+| Collection | `delete`                      | delete |
+| Global     | `get`                         | read   |
+| Global     | `update`                      | write  |
 
 A tool is registered for a given call only if **both** gates pass:
 
 1. **MCP policy**, the entity is `expose`d and the operation's policy rule (from `config/mcp.ts`) evaluates truthy.
 2. **Access rules**, the collection/global `.access()` introspection says the operation is `visible` and `allowed` for the connecting session (skipped entirely when `accessMode` is `"system"`).
-
-
 
 Tools carry MCP annotations automatically: read operations get `readOnlyHint: true`, `delete` gets `destructiveHint: true`, and `update`/`delete` get `idempotentHint: true`. The `list` tool clamps its `limit` to `crud.maxLimit` (default `100`).
 
@@ -114,7 +113,7 @@ export default route()
 The generated tool name is `meta.mcp.name` if set, otherwise `routes.<sanitized-route-key>` (path separators and brackets collapse to dots). `title` and `description` fall back to the top-level `meta.*`; `annotations` come only from `meta.mcp.annotations`. The tool's input schema is the route's `.schema()`; for routes with path params, the input becomes `{ params: { … }, input: <schema> }`.
 
 <Callout type="info" title="`meta.mcp` is declared on the route, not here">
-The route exposure shape (`RouteMcpMeta`: `expose`, `name`, `title`, `description`, `annotations`) lives in core and is documented on the [Routes](/docs/concepts/routes) page. It is kept structural so the framework carries no MCP SDK dependency.
+  The route exposure shape (`RouteMcpMeta`: `expose`, `name`, `title`, `description`, `annotations`) lives in core and is documented on the [Routes](/docs/concepts/routes) page. It is kept structural so the framework carries no MCP SDK dependency.
 </Callout>
 
 ### Schema resources
@@ -161,9 +160,9 @@ The full `McpConfig` interface:
 
 ```ts
 interface McpConfig {
-  name?: string;          // MCP server name (default "questpie")
-  version?: string;       // MCP server version (default "0.0.0")
-  crud?: McpCrudConfig;   // collection & global exposure
+  name?: string; // MCP server name (default "questpie")
+  version?: string; // MCP server version (default "0.0.0")
+  crud?: McpCrudConfig; // collection & global exposure
   routes?: McpRoutesConfig;
   resources?: McpResourcesConfig;
   http?: McpHttpConfig;
@@ -173,20 +172,20 @@ interface McpConfig {
 
 **`crud`, collection & global exposure** (`McpCrudConfig`):
 
-| Field | Type | Default | Notes |
-|---|---|---|---|
-| `maxLimit` | `number` | `100` | Upper bound the `list` tool clamps `limit` to. |
-| `defaults.collections` | `{ read?, write?, delete? }` | per-transport (below) | Baseline for every collection. Each is `boolean \| McpAccessRule`. |
-| `defaults.globals` | `{ read?, write? }` | per-transport (below) | Baseline for every global. |
-| `collections` | `Record<string, McpEntityPolicy>` | `{}` | Per-collection override. |
-| `globals` | `Record<string, McpEntityPolicy>` | `{}` | Per-global override. |
+| Field                  | Type                              | Default               | Notes                                                              |
+| ---------------------- | --------------------------------- | --------------------- | ------------------------------------------------------------------ |
+| `maxLimit`             | `number`                          | `100`                 | Upper bound the `list` tool clamps `limit` to.                     |
+| `defaults.collections` | `{ read?, write?, delete? }`      | per-transport (below) | Baseline for every collection. Each is `boolean \| McpAccessRule`. |
+| `defaults.globals`     | `{ read?, write? }`               | per-transport (below) | Baseline for every global.                                         |
+| `collections`          | `Record<string, McpEntityPolicy>` | `{}`                  | Per-collection override.                                           |
+| `globals`              | `Record<string, McpEntityPolicy>` | `{}`                  | Per-global override.                                               |
 
 **`routes`, route tool exposure** (`McpRoutesConfig`):
 
-| Field | Type | Default | Notes |
-|---|---|---|---|
-| `exposeAnnotated` | `boolean` | `true` | Set `false` to disable **all** route tools globally. Even when `true`, a route needs `meta.mcp.expose === true`. |
-| `routes` | `Record<string, McpEntityPolicy>` | `{}` | Per-route override, keyed by route key. |
+| Field             | Type                              | Default | Notes                                                                                                            |
+| ----------------- | --------------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------- |
+| `exposeAnnotated` | `boolean`                         | `true`  | Set `false` to disable **all** route tools globally. Even when `true`, a route needs `meta.mcp.expose === true`. |
+| `routes`          | `Record<string, McpEntityPolicy>` | `{}`    | Per-route override, keyed by route key.                                                                          |
 
 **`resources`** (`McpResourcesConfig`): `schemas?` (default `true`) and `routes?` (default `true`) toggle the published JSON-schema and route-catalog resources.
 
@@ -202,13 +201,13 @@ A collection/global/route entry is either a boolean or an object:
 type McpEntityPolicy =
   | boolean // false = fully hidden; true = use defaults
   | {
-      expose?: boolean;                              // false fully hides the entity
-      read?: boolean | McpAccessRule;                // read ops (list/count/get)
-      write?: boolean | McpAccessRule;               // write ops (create/update)
-      delete?: boolean | McpAccessRule;              // delete op
+      expose?: boolean; // false fully hides the entity
+      read?: boolean | McpAccessRule; // read ops (list/count/get)
+      write?: boolean | McpAccessRule; // write ops (create/update)
+      delete?: boolean | McpAccessRule; // delete op
       operations?: Record<string, boolean | McpAccessRule>; // per-operation override
       fields?: { include?: string[]; exclude?: string[] }; // column allow/deny list
-      description?: string;                          // overrides the default tool description
+      description?: string; // overrides the default tool description
     };
 ```
 
@@ -217,7 +216,7 @@ type McpEntityPolicy =
 - `fields.include` / `fields.exclude` is applied to the CRUD tool's input/output schemas, so excluded columns never appear in tool args or results.
 
 <Callout type="info" title="HTTP defaults are read-only; stdio is full-trust">
-Per-transport CRUD defaults differ on purpose. Over **HTTP**, collections default to `read: true, write: false, delete: false` and globals to `read: true, write: false`. Over **stdio**, everything defaults `true` (local stdio is trusted). Override per-entity to open writes where you want them.
+  Per-transport CRUD defaults differ on purpose. Over **HTTP**, collections default to `read: true, write: false, delete: false` and globals to `read: true, write: false`. Over **stdio**, everything defaults `true` (local stdio is trusted). Override per-entity to open writes where you want them.
 </Callout>
 
 ### Access rules on tools
@@ -225,9 +224,7 @@ Per-transport CRUD defaults differ on purpose. Over **HTTP**, collections defaul
 Anywhere a policy field accepts a rule, you can pass an `McpAccessRule` function:
 
 ```ts
-type McpAccessRule =
-  | boolean
-  | ((ctx: McpAccessRuleContext) => boolean | Promise<boolean>);
+type McpAccessRule = boolean | ((ctx: McpAccessRuleContext) => boolean | Promise<boolean>);
 
 interface McpAccessRuleContext {
   transport: "http" | "stdio";
@@ -249,7 +246,8 @@ collections: {
 ```
 
 <Callout type="info" title="MCP rules layer on top of `.access()`, they don't replace it">
-An undefined rule evaluates to `true` at the MCP layer, but the collection/global `.access()` rules still run for the connecting user (unless `accessMode` is `"system"`). The MCP policy decides *what is reachable via MCP at all*; your access rules decide *what this user may do*. For OAuth callers, a per-user **scope** gate narrows further still (`scopes ∩ RBAC`) - see [MCP over OAuth 2.1](/docs/integrations/mcp-oauth). See [Access control](/docs/concepts/access-control).
+  An undefined rule evaluates to `true` at the MCP layer, but the collection/global `.access()` rules still run for the connecting user (unless `accessMode` is `"system"`). The MCP policy decides *what is reachable via MCP at all*; your access rules decide *what this user may do*. For OAuth callers, a per-user
+  **scope** gate narrows further still (`scopes ∩ RBAC`) - see [MCP over OAuth 2.1](/docs/integrations/mcp-oauth). See [Access control](/docs/concepts/access-control).
 </Callout>
 
 ## Custom tools
@@ -283,25 +281,25 @@ Scaffold one with `questpie add mcp-tool recalculate-stats`, which creates the f
 
 **`config` (`McpToolConfig`)**, all optional:
 
-| Field | Type | Notes |
-|---|---|---|
-| `title` | `string` | Human-readable tool title. |
-| `description` | `string` | Shown to the model. |
-| `inputSchema` | Zod schema | Parsed before your handler runs; types the handler's `input`. |
-| `outputSchema` | Zod schema | Advertised output shape. |
-| `annotations` | `ToolAnnotations` | MCP hints: `readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`. |
-| `access` | `McpAccessRule` | Evaluated per call; a falsy result hides the tool / denies the call. |
-| `_meta` | `Record<string, unknown>` | Arbitrary metadata passed through to the MCP tool. |
+| Field          | Type                      | Notes                                                                            |
+| -------------- | ------------------------- | -------------------------------------------------------------------------------- |
+| `title`        | `string`                  | Human-readable tool title.                                                       |
+| `description`  | `string`                  | Shown to the model.                                                              |
+| `inputSchema`  | Zod schema                | Parsed before your handler runs; types the handler's `input`.                    |
+| `outputSchema` | Zod schema                | Advertised output shape.                                                         |
+| `annotations`  | `ToolAnnotations`         | MCP hints: `readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`. |
+| `access`       | `McpAccessRule`           | Evaluated per call; a falsy result hides the tool / denies the call.             |
+| `_meta`        | `Record<string, unknown>` | Arbitrary metadata passed through to the MCP tool.                               |
 
 **Handler args (`McpToolHandlerArgs`)**:
 
-| Arg | Type | Notes |
-|---|---|---|
-| `input` | `z.infer<inputSchema>` | The parsed, typed input. |
-| `ctx` | `AppContext & Partial<RequestContext>` | Full app context: `collections`, `globals`, `db`, `services`, `session`, … |
-| `transport` | `"http" \| "stdio"` | Which transport the call came in on. |
-| `accessMode` | `"user" \| "system"` | The resolved access mode. |
-| `request` | `Request \| undefined` | The underlying HTTP request, when available. |
+| Arg          | Type                                   | Notes                                                                      |
+| ------------ | -------------------------------------- | -------------------------------------------------------------------------- |
+| `input`      | `z.infer<inputSchema>`                 | The parsed, typed input.                                                   |
+| `ctx`        | `AppContext & Partial<RequestContext>` | Full app context: `collections`, `globals`, `db`, `services`, `session`, … |
+| `transport`  | `"http" \| "stdio"`                    | Which transport the call came in on.                                       |
+| `accessMode` | `"user" \| "system"`                   | The resolved access mode.                                                  |
+| `request`    | `Request \| undefined`                 | The underlying HTTP request, when available.                               |
 
 The handler returns a `CallToolResult`. Include an MCP `content` array; add `structuredContent` when the model should also receive a machine-readable result. The public handler type requires `content`, so a custom tool must not return only `structuredContent`.
 
@@ -318,7 +316,7 @@ import { app } from "#questpie";
 await startStdioServer(app);
 ```
 
-stdio defaults to `accessMode: "system"`, which **bypasses the `.access()` RBAC rules** (the RBAC introspection short-circuits to `allowed`). The **MCP policy gate still applies**, an explicit `expose: false`, a config rule, or a custom tool's `access` still gates a `system` caller, with no `config/mcp.ts` the policy defaults are all-permissive, so it *feels* like full access. This is intended for a trusted, local process, not a network-exposed one. To run stdio under user-scoped access instead, set `stdio.accessMode: "user"` in `config/mcp.ts`.
+stdio defaults to `accessMode: "system"`, which **bypasses the `.access()` RBAC rules** (the RBAC introspection short-circuits to `allowed`). The **MCP policy gate still applies**, an explicit `expose: false`, a config rule, or a custom tool's `access` still gates a `system` caller, with no `config/mcp.ts` the policy defaults are all-permissive, so it _feels_ like full access. This is intended for a trusted, local process, not a network-exposed one. To run stdio under user-scoped access instead, set `stdio.accessMode: "user"` in `config/mcp.ts`.
 
 ## Custom transports
 
@@ -326,10 +324,10 @@ To mount MCP on a transport the package doesn't bundle, build the server yoursel
 
 ## Access mode summary
 
-| `accessMode` | When | MCP policy gate | `.access()` rules |
-|---|---|---|---|
-| `"user"` | HTTP (always); stdio if you opt in | evaluated | evaluated as the request's session |
-| `"system"` | stdio (default) | evaluated | **bypassed** (full access) |
+| `accessMode` | When                               | MCP policy gate | `.access()` rules                  |
+| ------------ | ---------------------------------- | --------------- | ---------------------------------- |
+| `"user"`     | HTTP (always); stdio if you opt in | evaluated       | evaluated as the request's session |
+| `"system"`   | stdio (default)                    | evaluated       | **bypassed** (full access)         |
 
 `"system"` is the full-trust escape hatch for local stdio. HTTP is always `"user"`, so a remote client never gets the bypass.
 
@@ -347,7 +345,7 @@ import type {
   McpToolHandlerArgs,
   McpToolDefinition,
   McpTransportKind, // "http" | "stdio"
-  McpAccessMode,    // "user" | "system"
+  McpAccessMode, // "user" | "system"
 } from "@questpie/mcp";
 ```
 
@@ -356,11 +354,11 @@ import type {
 ## Gotchas & footguns
 
 <Callout type="warn" title="A collection is exposed read-only over HTTP until you opt into writes">
-The HTTP default is `read: true, write: false, delete: false`. If a client can't create or update a record, that is the default, open `write`/`delete` per collection in `config/mcp.ts`.
+  The HTTP default is `read: true, write: false, delete: false`. If a client can't create or update a record, that is the default, open `write`/`delete` per collection in `config/mcp.ts`.
 </Callout>
 
 <Callout type="warn" title="A route is never an MCP tool unless `meta.mcp.expose === true`">
-There is no global "expose all routes" switch, `routes.exposeAnnotated: true` only *permits* exposure; each route must still opt in via its metadata. Setting `exposeAnnotated: false` disables route tools entirely.
+  `routes.exposeAnnotated: true` permits route exposure, and each route opts in through its own metadata. Set `exposeAnnotated: false` to disable route tools entirely.
 </Callout>
 
 <Callout type="info" title="`fields.exclude` is the way to hide sensitive columns">
@@ -368,7 +366,8 @@ CRUD tools mirror your collection's columns. Use `fields: { exclude: [...] }` (o
 </Callout>
 
 <Callout type="warn" title="stdio's default `system` mode bypasses your `.access()` RBAC">
-`startStdioServer` runs as `"system"` by default, so the collection/global `.access()` RBAC rules are skipped. The MCP policy gate (`expose`, config rules, custom-tool `access`) still applies, but with no `config/mcp.ts` the policy defaults are all-permissive, so effectively every operation is reachable. Only run it as a trusted local process, or set `stdio.accessMode: "user"`.
+  `startStdioServer` runs as `"system"` by default, so the collection/global `.access()` RBAC rules are skipped. The MCP policy gate (`expose`, config rules, custom-tool `access`) still applies, but with no `config/mcp.ts` the policy defaults are all-permissive, so effectively every operation is reachable. Only run it
+  as a trusted local process, or set `stdio.accessMode: "user"`.
 </Callout>
 
 ## Related

--- a/apps/docs/content/docs/integrations/openapi.mdx
+++ b/apps/docs/content/docs/integrations/openapi.mdx
@@ -6,7 +6,7 @@ description: Add one module and your whole API documents itself, an OpenAPI 3.1 
 The **`@questpie/openapi`** module turns your running app into self-documenting API. Register one module and QUESTPIE introspects everything it already knows, your [collections](/docs/concepts/collections), [globals](/docs/concepts/globals), [routes](/docs/concepts/routes), auth endpoints, and [search](/docs/adapters/search), and emits a complete **OpenAPI 3.1** spec at `GET /api/openapi.json`, plus an interactive [Scalar](https://scalar.com) API reference at `GET /api/docs`. No decorators, no hand-written spec, no separate build step: the spec is generated from the same runtime metadata that powers your typed client and admin panel.
 
 <Callout type="info" title="Prerequisites">
-Read [Routes](/docs/concepts/routes) and [Collections](/docs/concepts/collections) first, the spec is projected from your route definitions and CRUD surface. The module registers like any other (see [Configuration → modules.ts](/docs/concepts/configuration)).
+  Read [Routes](/docs/concepts/routes) and [Collections](/docs/concepts/collections) first, the spec is projected from your route definitions and CRUD surface. The module registers like any other (see [Configuration → modules.ts](/docs/concepts/configuration)).
 </Callout>
 
 ## What it does
@@ -18,12 +18,14 @@ Read [Routes](/docs/concepts/routes) and [Collections](/docs/concepts/collection
 - **Cacheable spec.** The JSON spec is generated once per app instance and served with an `ETag` and `Cache-Control`, so repeat fetches are cheap.
 
 <Callout type="warn" title="Generator quality is in active rework">
-The endpoints and Scalar UI are stable and shipping today. The **schema-generation quality** is being hardened under the `openapi-quality-v1` effort, more accurate Zod→JSON-Schema conversion (transforms/refinements currently fall back to a permissive object), **per-operation security** (today security is declared once at the spec root, not per path), richer **path-parameter** typing, and wiring **route [`.meta()`](/docs/concepts/routes#metadata-openapi-and-mcp)** (`title`/`description`/`tags`) into the generated route operations. This page documents the **current** behavior; the gaps below are called out inline so you know what to expect. None of the in-flight improvements are documented here as if they already work.
+  The endpoints and Scalar UI are stable and shipping today. The **schema-generation quality** is being hardened under the `openapi-quality-v1` effort, more accurate Zod→JSON-Schema conversion (transforms/refinements currently fall back to a permissive object), **per-operation security** (today security is declared
+  once at the spec root, not per path), richer **path-parameter** typing, and wiring **route [`.meta()`](/docs/concepts/routes#metadata-openapi-and-mcp)** (`title`/`description`/`tags`) into the generated route operations. This page documents the **current** behavior; the gaps below are called out inline so you know
+  what to expect. None of the in-flight improvements are documented here as if they already work.
 </Callout>
 
 ## Quick start
 
-Add the module to your `modules.ts`. Modules are auto-wired, there is nothing imperative to register.
+Add the module to `modules.ts`; its routes and codegen plugin register automatically.
 
 ```ts title="src/questpie/server/modules.ts"
 import { adminModule } from "@questpie/admin/modules/admin";
@@ -76,36 +78,35 @@ export default openApiConfig({
 
 The config object accepts every field below. All are optional; the defaults produce a working spec for an unconfigured app.
 
-| Option | Type | Default | What it controls |
-|---|---|---|---|
-| `info.title` | `string` | `"QUESTPIE API"` | Spec title (and Scalar tab title). |
-| `info.version` | `string` | `"1.0.0"` | Spec version. |
-| `info.description` | `string` | none | Spec description. |
-| `servers` | `Array<{ url; description? }>` | none | OpenAPI server list (for Scalar's environment switcher). |
-| `basePath` | `string` | `"/"` | Path prefix prepended to every generated path. **Set this to match your fetch handler's `basePath`** (e.g. `/api`) so the documented URLs match the served ones. |
-| `exclude.collections` | `string[]` | `[]` | Collection names to omit from the spec. |
-| `exclude.globals` | `string[]` | `[]` | Global names to omit from the spec. |
-| `auth` | `boolean` | `true` (included) | Set `false` to omit the Better Auth endpoints. |
-| `search` | `boolean` | `true` (included) | Set `false` to omit the search endpoints. |
-| `scalar` | `ScalarConfig` | none | Scalar UI options (see below). |
-
-
+| Option                | Type                           | Default           | What it controls                                                                                                                                                 |
+| --------------------- | ------------------------------ | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `info.title`          | `string`                       | `"QUESTPIE API"`  | Spec title (and Scalar tab title).                                                                                                                               |
+| `info.version`        | `string`                       | `"1.0.0"`         | Spec version.                                                                                                                                                    |
+| `info.description`    | `string`                       | none              | Spec description.                                                                                                                                                |
+| `servers`             | `Array<{ url; description? }>` | none              | OpenAPI server list (for Scalar's environment switcher).                                                                                                         |
+| `basePath`            | `string`                       | `"/"`             | Path prefix prepended to every generated path. **Set this to match your fetch handler's `basePath`** (e.g. `/api`) so the documented URLs match the served ones. |
+| `exclude.collections` | `string[]`                     | `[]`              | Collection names to omit from the spec.                                                                                                                          |
+| `exclude.globals`     | `string[]`                     | `[]`              | Global names to omit from the spec.                                                                                                                              |
+| `auth`                | `boolean`                      | `true` (included) | Set `false` to omit the Better Auth endpoints.                                                                                                                   |
+| `search`              | `boolean`                      | `true` (included) | Set `false` to omit the search endpoints.                                                                                                                        |
+| `scalar`              | `ScalarConfig`                 | none              | Scalar UI options (see below).                                                                                                                                   |
 
 <Callout type="warn" title="`specPath` / `docsPath` are not yet honored">
-`OpenApiModuleConfig` declares `specPath` and `docsPath` fields, but the `openApiModule` mounts its routes under the **fixed** keys `openapi.json` and `docs`, these two options have no effect today. To serve the docs at a different path, mount the route factories yourself (see [Custom mounting](#custom-mounting-and-standalone-generation)).
+  `OpenApiModuleConfig` declares `specPath` and `docsPath` fields, but the `openApiModule` mounts its routes under the **fixed** keys `openapi.json` and `docs`, these two options have no effect today. To serve the docs at a different path, mount the route factories yourself (see [Custom
+  mounting](#custom-mounting-and-standalone-generation)).
 </Callout>
 
 ### `ScalarConfig`
 
 Options passed straight through to the Scalar API reference.
 
-| Option | Type | Default | What it controls |
-|---|---|---|---|
-| `theme` | `string` | `"purple"` | Scalar theme name. |
-| `title` | `string` | the spec `info.title` | Page `<title>` override. |
-| `customCss` | `string` | none | Inline CSS injected into the Scalar page. |
-| `hideDownloadButton` | `boolean` | `false` | Hide Scalar's "Download OpenAPI Spec" button. |
-| `defaultHttpClient` | `{ targetKey; clientKey }` | none | The HTTP client preselected for code samples (e.g. `{ targetKey: "shell", clientKey: "curl" }`). |
+| Option               | Type                       | Default               | What it controls                                                                                 |
+| -------------------- | -------------------------- | --------------------- | ------------------------------------------------------------------------------------------------ |
+| `theme`              | `string`                   | `"purple"`            | Scalar theme name.                                                                               |
+| `title`              | `string`                   | the spec `info.title` | Page `<title>` override.                                                                         |
+| `customCss`          | `string`                   | none                  | Inline CSS injected into the Scalar page.                                                        |
+| `hideDownloadButton` | `boolean`                  | `false`               | Hide Scalar's "Download OpenAPI Spec" button.                                                    |
+| `defaultHttpClient`  | `{ targetKey; clientKey }` | none                  | The HTTP client preselected for code samples (e.g. `{ targetKey: "shell", clientKey: "curl" }`). |
 
 The Scalar UI is a tiny HTML page that inlines the generated spec as JSON and loads `@scalar/api-reference` from a CDN.
 
@@ -113,13 +114,13 @@ The Scalar UI is a tiny HTML page that inlines the generated spec as JSON and lo
 
 Internally, `generateOpenApiSpec(app, routes, config)` walks the app's runtime metadata and merges five sources into one spec.
 
-| Source | OpenAPI output |
-|---|---|
+| Source          | OpenAPI output                                                                                                                                                                                                                                                                                                                                              |
+| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Collections** | CRUD paths per collection, list, create, findOne, update, delete, count, deleteMany, restore, versions, revert, upload, schema, meta (plus `transition` for workflow-enabled collections), with `*Document` / `*Insert` / `*Update` component schemas derived from your field definitions. Tagged `Collections: <name>`. Exclude via `exclude.collections`. |
-| **Globals** | Get / update / versions / revert / schema paths per global (plus `transition` for workflow-enabled globals). Tagged `Globals: <name>`. Exclude via `exclude.globals`. |
-| **Routes** | One operation per [route](/docs/concepts/routes) (per method), with request/response schemas from the route's `.schema()` / `.outputSchema()` when present. Tagged `Routes: <top-level-segment>`. |
-| **Auth** | Common Better Auth endpoints (sign-in, sign-up, session, sign-out). Omit via `auth: false`. |
-| **Search** | `POST /search` and `POST /search/reindex/{collection}`. Omit via `search: false`. |
+| **Globals**     | Get / update / versions / revert / schema paths per global (plus `transition` for workflow-enabled globals). Tagged `Globals: <name>`. Exclude via `exclude.globals`.                                                                                                                                                                                       |
+| **Routes**      | One operation per [route](/docs/concepts/routes) (per method), with request/response schemas from the route's `.schema()` / `.outputSchema()` when present. Tagged `Routes: <top-level-segment>`.                                                                                                                                                           |
+| **Auth**        | Common Better Auth endpoints (sign-in, sign-up, session, sign-out). Omit via `auth: false`.                                                                                                                                                                                                                                                                 |
+| **Search**      | `POST /search` and `POST /search/reindex/{collection}`. Omit via `search: false`.                                                                                                                                                                                                                                                                           |
 
 Every spec also includes shared component schemas (`ErrorResponse`, `SuccessResponse`, `CountResponse`, `DeleteManyResponse`) and two security schemes, `bearerAuth` (HTTP bearer) and `cookieAuth` (the `better-auth.session_token` cookie).
 
@@ -151,14 +152,33 @@ projects to roughly:
       "summary": "reports/[year]",
       "tags": ["Routes: reports"],
       "parameters": [
-        { "name": "year", "in": "path", "required": true, "schema": { "type": "string" } }
+        {
+          "name": "year",
+          "in": "path",
+          "required": true,
+          "schema": { "type": "string" }
+        }
       ],
       "requestBody": {
         "required": true,
-        "content": { "application/json": { "schema": { "$ref": "#/components/schemas/route_reports_[year]_Input" } } }
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/route_reports_[year]_Input"
+            }
+          }
+        }
       },
       "responses": {
-        "200": { "content": { "application/json": { "schema": { "$ref": "#/components/schemas/route_reports_[year]_Output" } } } }
+        "200": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/route_reports_[year]_Output"
+              }
+            }
+          }
+        }
       }
     }
   }
@@ -212,8 +232,6 @@ const spec = generateOpenApiSpec(app, {
 // spec.openapi === "3.1.0"; routes are read from app.config.routes automatically.
 ```
 
-
-
 ## Access control
 
 The spec and docs routes are ordinary QUESTPIE routes, so they are **public by default**, anyone who can reach `/api/docs` and `/api/openapi.json` can read your full API shape. This mirrors how all [routes](/docs/concepts/routes#access-control) behave: public unless you add an `.access()` rule.
@@ -221,7 +239,7 @@ The spec and docs routes are ordinary QUESTPIE routes, so they are **public by d
 To restrict who can see the docs, mount the factories yourself (see [Custom mounting](#custom-mounting-and-standalone-generation)) and add an access rule, but note that `openApiRoute()` / `docsRoute()` return a finished raw route definition, so you wrap them at a higher level (e.g. gate the path in your HTTP layer or a reverse proxy) rather than chaining `.access()` onto the factory result. Most teams leave the spec public and protect the **endpoints** it documents via each collection's and route's own access rules, the spec describes the surface; [access control](/docs/concepts/access-control) governs who can actually call it.
 
 <Callout type="info" title="The spec documents endpoints; it does not bypass access">
-Listing an endpoint in the spec does not make it callable. Every documented collection/global/route is still gated by its own [access rules](/docs/concepts/access-control) at request time. The two declared security schemes (`bearerAuth`, `cookieAuth`) advertise *how* to authenticate, not *what* is allowed.
+  Listing an endpoint in the spec does not make it callable. Every documented collection/global/route is still gated by its own [access rules](/docs/concepts/access-control) at request time. The two declared security schemes (`bearerAuth`, `cookieAuth`) advertise *how* to authenticate, not *what* is allowed.
 </Callout>
 
 ## Gotchas
@@ -237,20 +255,9 @@ Listing an endpoint in the spec does not make it callable. Every documented coll
 Types and factories are exported from `@questpie/openapi/server` (re-exported from the package root):
 
 ```ts
-import {
-  openApiConfig,
-  generateOpenApiSpec,
-  openApiRoute,
-  docsRoute,
-  openApiModule,
-} from "@questpie/openapi/server";
+import { openApiConfig, generateOpenApiSpec, openApiRoute, docsRoute, openApiModule } from "@questpie/openapi/server";
 
-import type {
-  OpenApiConfig,
-  OpenApiModuleConfig,
-  OpenApiSpec,
-  ScalarConfig,
-} from "@questpie/openapi/server";
+import type { OpenApiConfig, OpenApiModuleConfig, OpenApiSpec, ScalarConfig } from "@questpie/openapi/server";
 ```
 
 The codegen plugin (which discovers `config/openapi.ts` and emits an `AppRouteKeys` type) is exported separately as `openApiPlugin` from `@questpie/openapi/plugin`; you only need it if you wire the plugin manually instead of using `openApiModule` (the module bundles it).

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -49,6 +49,7 @@
 		"@vitejs/plugin-react": "^6.0.1",
 		"babel-plugin-react-compiler": "^1.0.0",
 		"nitro": "3.0.260429-beta",
+		"questpie": "workspace:*",
 		"shadcn": "^3.6.3",
 		"tailwindcss": "^4.1.18",
 		"typescript": "^5.9.3"

--- a/bun.lock
+++ b/bun.lock
@@ -107,6 +107,7 @@
         "@vitejs/plugin-react": "^6.0.1",
         "babel-plugin-react-compiler": "^1.0.0",
         "nitro": "3.0.260429-beta",
+        "questpie": "workspace:*",
         "shadcn": "^3.6.3",
         "tailwindcss": "^4.1.18",
         "typescript": "^5.9.3",


### PR DESCRIPTION
## What changed

- declare `questpie` as a build-time workspace dependency of the docs app so Turbo includes package metadata used by the landing version
- add first-class concept guides for Search, Realtime, Storage, KV, and Sandboxed code
- make adapter pages backend-focused and link each one to the concept it implements
- rewrite public docs around supported workflows and contracts instead of missing helpers, rejected guesses, or internal implementation notes
- add docs authoring rules under `apps/docs/AGENTS.md` to keep that reader contract durable

## Why

The landing imports `packages/questpie/package.json` to display the current framework version. The production Dockerfile runs `turbo prune @questpie/docs --docker`; without a workspace dependency Turbo omitted `packages/questpie` and the image failed with `UNRESOLVED_IMPORT`.

The docs also treated Search, Realtime, Storage, KV, and sandboxed execution primarily as adapter configuration. Readers need the feature lifecycle, data flow, consistency model, and public API before backend-specific reference.

## Verification

- `bun run validate:docs` — 169 files, 0 errors, 0 warnings
- `git diff --check`
- full production Docker build with `apps/docs/Dockerfile` on `linux/amd64`
  - Turbo prune includes `questpie`
  - Fumadocs generation passes
  - client build passes
  - SSR build passes
  - Nitro and runner stages pass

No package release or changeset is required; this changes the private docs application only.
