### PR TITLE
feat(realtime): make topology control HA-safe

### DIFF
--- a/.changeset/tidy-rivers-coordinate.md
+++ b/.changeset/tidy-rivers-coordinate.md
@@ -1,0 +1,5 @@
+---
+"questpie": minor
+---
+
+Add HA-safe Realtime v2 desired-topology control backed by Postgres leases, fencing, revisioned durable state, metadata-only broker wakes, and reconciliation. Postgres apps now default to `PgNotifyChangeBroker`, with `redisStreamsChangeBroker` available as an explicit override. Legacy realtime adapters and rollout modes remain deprecated through QuestPie 3.x and are removed in QuestPie 4.

--- a/.changeset/tidy-rivers-coordinate.md
+++ b/.changeset/tidy-rivers-coordinate.md
@@ -2,4 +2,4 @@
 "questpie": minor
 ---
 
-Add HA-safe Realtime v2 desired-topology control backed by Postgres leases, fencing, revisioned durable state, metadata-only broker wakes, and reconciliation. Postgres apps now default to `PgNotifyChangeBroker`, with `redisStreamsChangeBroker` available as an explicit override. Legacy realtime adapters and rollout modes remain deprecated through QuestPie 3.x and are removed in QuestPie 4.
+Add HA-safe Realtime v2 desired-topology control backed by Postgres leases, fencing, revisioned durable state, metadata-only broker wakes, and reconciliation. Rejected realtime topics now expose a safe, non-retryable `REALTIME_TOPIC_REJECTED` error to the exact client subscriber, and TanStack live queries enter a visible error state without retrying admission failures. Postgres apps now default to `PgNotifyChangeBroker`, with `redisStreamsChangeBroker` available as an explicit override. Legacy realtime adapters and rollout modes remain deprecated through QuestPie 3.x and are removed in QuestPie 4.

--- a/apps/docs/content/docs/adapters/index.mdx
+++ b/apps/docs/content/docs/adapters/index.mdx
@@ -25,11 +25,16 @@ QUESTPIE ships seven infrastructure adapter slots. Learn the feature contract on
 
 You select an adapter once, in `questpie.config.ts` (or the `.build({ ... })` call), and the rest of your code is untouched. See [Configuration](/docs/concepts/configuration) for where each slot lives and how the runtime resolves it.
 
-<Callout type="info">Each adapter declares its own capabilities, so the runtime can fail fast or branch, for example, a queue adapter advertises whether it supports long-running workers or push delivery. The per-adapter pages document the relevant flags.</Callout>
+<Callout type="info">
+	Each adapter declares its own capabilities, so the runtime can fail fast or
+	branch, for example, a queue adapter advertises whether it supports
+	long-running workers or push delivery. The per-adapter pages document the
+	relevant flags.
+</Callout>
 
 ## Custom adapters
 
-Every adapter is defined by a public contract, `QueueAdapter`, `SearchAdapter`, `RealtimeAdapter`, `StorageConfig`, `MailAdapter`, `KVAdapter`, and the built-ins are just implementations of it. To back a concern with a broker the built-ins don't cover, implement the contract and wire your instance into the same config slot. The full build-your-own loop, which applies to every adapter kind, lives in [Building a plugin](/docs/extend/build-a-plugin).
+Every adapter is defined by a public contract, including `QueueAdapter`, `SearchAdapter`, realtime `ChangeBroker`, `StorageConfig`, `MailAdapter`, and `KVAdapter`; the built-ins are implementations of those contracts. To back a concern with infrastructure the built-ins don't cover, implement the matching contract and wire it into its config slot. The full build-your-own loop lives in [Building a plugin](/docs/extend/build-a-plugin).
 
 ## Related
 

--- a/apps/docs/content/docs/adapters/realtime-v2-migration.mdx
+++ b/apps/docs/content/docs/adapters/realtime-v2-migration.mdx
@@ -130,6 +130,12 @@ Do **not** roll back migrations or delete `questpie_realtime_log`, `questpie_rea
 
 Sticky sessions may temporarily reduce reconnects while old replicas remain in service, but they are emergency mitigation only. They do not replace the migration, fencing, durable desired state, or a complete fleet rollout.
 
+After the migration is applied, every request-handling replica advertises
+desired-topology v1, and cross-replica add/remove/reconnect verification passes,
+remove the sticky-session manifest or ingress affinity configuration. Leaving
+affinity enabled after that verification hides routing regressions and is not a
+supported steady-state HA design.
+
 ## Measured topology baseline
 
 The committed benchmark compares one cached-topic replacement with full reconnect at 1, 5, and 15 topics for 1, 100, and 500 clients. On Bun 1.3.14, Apple M2 Pro, and an in-process PGLite fixture:
@@ -149,4 +155,6 @@ These are reproducible workload counts and fixture-specific bytes, not a univers
 - Dual mode never sends two snapshot streams to one client.
 - Custom adapter consumers accept consolidated bulk events.
 - Every request-handling replica is upgraded before claiming no-reconnect HA behavior.
+- Cross-replica add/remove and reconnect/resume pass before removing temporary affinity.
+- The sticky-session manifest or ingress affinity is removed after that verification.
 - The rollback drill succeeds without a down migration or data deletion.

--- a/apps/docs/content/docs/adapters/realtime-v2-migration.mdx
+++ b/apps/docs/content/docs/adapters/realtime-v2-migration.mdx
@@ -103,7 +103,7 @@ Pusher/Soketi also supplies a v2 broker and client transport. Generic KV is not 
 Replace `realtime.adapter` with `realtime.changeBroker`, and remove `rollout.mode: "legacy" | "dual"` after your compatibility drill. `RealtimeAdapter`, `realtime.adapter`, `pgNotifyAdapter`, and the `legacy`/`dual` modes remain functional but deprecated for the rest of QuestPie 3.x. They are removed in QuestPie 4.
 
 ```ts
-// QuestPie 3.x legacy compatibility — migrate away from this
+// QuestPie 3.x legacy compatibility - migrate away from this
 realtime: {
 	adapter: pgNotifyAdapter({ connectionString: env.DATABASE_URL });
 }

--- a/apps/docs/content/docs/adapters/realtime-v2-migration.mdx
+++ b/apps/docs/content/docs/adapters/realtime-v2-migration.mdx
@@ -1,13 +1,27 @@
 ---
-title: Realtime v2 migration and rollback
-description: Canary Realtime v2 beside an existing adapter, understand the bulk-event change, and roll back without changing schema or losing outbox data.
+title: Realtime v2 HA migration
+description: Apply the topology migration, roll QuestPie 3.x safely across replicas, move legacy adapters to ChangeBroker, and understand the QuestPie 4 removal window.
 ---
 
-Realtime v2 keeps the existing `client.collections.*.live()`, `client.globals.*.live()`, raw `client.realtime`, TanStack `{ realtime: true }`, and `RealtimeConfig.adapter` APIs. The SSE wire remains protocol `1`; responses advertise it as `X-Questpie-Realtime-Protocol: 1`, which existing clients safely ignore.
+Realtime v2 keeps the existing `client.collections.*.live()`, `client.globals.*.live()`, raw `client.realtime`, and TanStack `{ realtime: true }` APIs. In QuestPie 3.x, it also keeps legacy control frames and `RealtimeConfig.adapter` as deprecated compatibility paths.
 
-The rollout flag changes server transport selection only. It does not create, delete, or rewrite a table.
+The HA control path stores complete revisioned desired topology in Postgres. A companion `POST /realtime` may land on any replica: it commits the new desired revision, publishes a metadata-only `ChangeBroker` wake, and the process that owns the live SSE or provider sink applies the local diff. A one-second reconciliation loop heals lost wakes. No callback, request context, raw session id, token, identity, query, or channel body is sent through the broker.
 
-Realtime v2 channels add framework-owned ledger tables, and SSE presence adds `questpie_channel_presence`. Generate and apply the normal QUESTPIE database migration before enabling channel traffic. Do not hand-edit these tables. The presence table contains expiring connection leases; multiple app instances sharing the application database reconcile the same roster.
+This makes sticky routing unnecessary once every request-handling replica supports desired-topology v1 and the migration is applied. The owner lease is not transferable: if the owner dies, the client reconnects and establishes a new session.
+
+## Required database migration
+
+The framework schema adds `questpie_realtime_topology` beside the existing realtime outbox, channel ledger, and presence tables. It stores hashed session/token/identity keys, owner and fencing data, lease expiry, desired/applied revisions, and a bounded desired topology document.
+
+Generate, review, and commit the application migration before enabling the HA path:
+
+```sh
+bunx questpie migrate:create
+# review and commit the generated migration
+bunx questpie migrate
+```
+
+Never use `questpie push` or `db:push` for this production rollout. QUESTPIE owns the framework table definition; each application owns and deploys its generated migration.
 
 ## The breaking behavior to audit
 
@@ -25,94 +39,114 @@ Bulk update and bulk delete emit **one durable event per logical operation**, no
 
 Do not count adapter notifications to count changed records. Use `payload.count`. Do not expect N per-record events from one bulk mutation.
 
-## Rollout modes
+## Recommended 3.x rollout
 
-`realtime.rollout.mode` accepts three values:
+### 1. Apply the migration before the mixed-version deploy
 
-| Mode       | Cross-instance invalidation                                                                           | Edge delivery                               | Use it for                                                |
-| ---------- | ----------------------------------------------------------------------------------------------------- | ------------------------------------------- | --------------------------------------------------------- |
-| `"legacy"` | Existing `adapter` or the poll/implicit-pg fallback                                                   | Existing SSE protocol                       | Baseline and immediate rollback                           |
-| `"v2"`     | `changeBroker`; an existing `adapter` remains the compatibility fallback when no broker is configured | Configured `clientTransport`, otherwise SSE | Normal operation; this is the default                     |
-| `"dual"`   | Existing `adapter` and `changeBroker` both publish the same durable outbox sequence                   | One v2 edge path only                       | Canary comparison without double-delivering client frames |
+Deploy the generated migration while the old application version is still serving. The additional framework table does not change old-client behavior.
 
-Dual mode requires both `adapter` and `changeBroker`. It compares whether both invalidation publishes accepted the same durable sequence. A one-sided failure is reported through `onComparison` and logs a warning, while the healthy path continues. If both fail, normal reconciliation polling still provides the durable recovery path and the publish reports failure.
+### 2. Roll every request-handling replica to the new 3.x version
 
-## Recommended migration
+New clients send complete desired topology only after the opening server advertises:
 
-### 1. Deploy the new code on the legacy path
+```ts
+control: {
+  protocol: "questpie-realtime-topology",
+  versions: [1],
+}
+```
 
-Keep the current adapter and pin the baseline explicitly:
+Desired revisions start at `1`; the opening topology is revision `0`. A `202 accepted` means the authoritative row committed, not necessarily that the owner already applied the diff. Equal retries receive `200 duplicate`; stale or conflicting revisions receive `409`; missing/expired sessions and token or identity mismatches receive the same `404 REALTIME_CONTROL_UNAVAILABLE`; storage failures receive `503`.
+
+Old clients continue sending legacy add/remove frames. An upgraded server translates those frames into the same durable desired state. During a mixed rolling deploy, a request that reaches an old replica may force a reconnect, but it cannot falsely acknowledge or apply another principal's topology. The no-reconnect cross-replica guarantee begins when every request-handling replica is upgraded.
+
+### 3. Use the v2 broker configuration
+
+For a normal Postgres application, no realtime transport object is required:
 
 ```ts
 export default runtimeConfig({
+	db: { url: env.DATABASE_URL },
+	realtime: true,
+});
+```
+
+QUESTPIE automatically constructs the Postgres `PgNotifyChangeBroker`. To use a different connection or channel, configure the v2 seam explicitly:
+
+```ts
+import { pgNotifyChangeBroker } from "questpie/adapters/pg-notify";
+
+export default runtimeConfig({
+	db: { url: env.DATABASE_URL },
 	realtime: {
-		adapter: existingAdapter,
-		rollout: { mode: "legacy" },
+		changeBroker: pgNotifyChangeBroker({
+			connectionString: env.DATABASE_URL,
+		}),
 	},
 });
 ```
 
-Verify existing admin, Autopilot, `live()`, `liveIter()`, and TanStack realtime consumers. No client release is required.
-
-### 2. Canary both invalidation paths
-
-Add the v2 broker and compare outcomes. Client snapshots are still emitted once:
+Redis is an explicit v2 broker override:
 
 ```ts
-export default runtimeConfig({
-	realtime: {
-		adapter: existingAdapter,
-		changeBroker: nextBroker,
-		rollout: {
-			mode: "dual",
-			onComparison(result) {
-				if (!result.equivalent) {
-					metrics.increment("realtime.dual_run_mismatch", {
-						legacy: result.legacy,
-						v2: result.v2,
-					});
-				}
-			},
-		},
-	},
-});
+import { redisStreamsChangeBroker } from "questpie/adapters/redis-streams";
+
+realtime: {
+  changeBroker: redisStreamsChangeBroker({ client: redis }),
+}
 ```
 
-Run dual mode long enough to cover deploys, reconnects, bulk mutations, and a broker interruption. The durable outbox remains the source of truth; dual mode compares invalidation acceptance, not application row payloads.
+Pusher/Soketi also supplies a v2 broker and client transport. Generic KV is not a topology coordinator: it does not supply live-callback ownership, leases, fencing, revision acknowledgements, or reconciliation.
 
-### 3. Select v2
+### 4. Retire legacy configuration
 
-After the canary is clean:
+Replace `realtime.adapter` with `realtime.changeBroker`, and remove `rollout.mode: "legacy" | "dual"` after your compatibility drill. `RealtimeAdapter`, `realtime.adapter`, `pgNotifyAdapter`, and the `legacy`/`dual` modes remain functional but deprecated for the rest of QuestPie 3.x. They are removed in QuestPie 4.
 
 ```ts
-export default runtimeConfig({
-	realtime: {
-		changeBroker: nextBroker,
-		clientTransport: nextClientTransport,
-		rollout: { mode: "v2" },
-	},
-});
+// QuestPie 3.x legacy compatibility — migrate away from this
+realtime: {
+	adapter: pgNotifyAdapter({ connectionString: env.DATABASE_URL });
+}
+
+// Realtime v2
+realtime: {
+	changeBroker: pgNotifyChangeBroker({ connectionString: env.DATABASE_URL });
+}
 ```
 
-An app that only has `adapter` can also use the default `v2` mode. QUESTPIE maps that adapter onto the new invalidation/compute/delivery pipeline as a compatibility fallback, so existing configuration does not need a flag-day rewrite.
+`legacy` and `dual` remain available only for a short rollback/canary window. They are not the target architecture and a clean v2 deployment does not configure both seams.
 
 ## Rollback drill
 
-Rollback is a config change:
+If an incident happens before the fleet is fully upgraded, the 3.x compatibility rollback is a config change:
 
 1. Set `realtime.rollout.mode` to `"legacy"`.
 2. Keep the existing `adapter` configured.
 3. Redeploy or restart every instance.
-4. Confirm `POST /realtime` returns protocol header `1` and a known `live()` consumer receives a fresh snapshot.
+4. Confirm a known `live()` consumer receives a fresh snapshot.
 5. Confirm outbox lag returns to normal through the adapter or reconciliation poll.
 
-Do **not** roll back migrations or delete `questpie_realtime_log`, channel-ledger rows, or `questpie_channel_presence`. Both modes consume the same durable data, so changing the flag loses neither schema nor committed events. Presence lease rows expire or are removed by the runtime. If the adapter itself is unavailable, leave reconciliation polling enabled while restoring it.
+Do **not** roll back migrations or delete `questpie_realtime_log`, `questpie_realtime_topology`, channel-ledger rows, or `questpie_channel_presence`. Both modes consume the same durable data. If the adapter itself is unavailable, leave reconciliation polling enabled while restoring it.
+
+Sticky sessions may temporarily reduce reconnects while old replicas remain in service, but they are emergency mitigation only. They do not replace the migration, fencing, durable desired state, or a complete fleet rollout.
+
+## Measured topology baseline
+
+The committed benchmark compares one cached-topic replacement with full reconnect at 1, 5, and 15 topics for 1, 100, and 500 clients. On Bun 1.3.14, Apple M2 Pro, and an in-process PGLite fixture:
+
+- With globally advanced cursors at 500 clients and 5 topics, incremental topology executed 500 snapshot queries and recomputed no stable topics; reconnect executed 2,500 queries and recomputed 2,000 stable topics. Response bytes were 2,384,890 versus 11,984,950.
+- At 500 clients and 15 topics, incremental topology executed 500 queries and no stable recomputations; reconnect executed 7,500 queries and 7,000 stable recomputations. Response bytes were 145,390 versus 25,518,350; the incremental replacement page was empty in this fixture.
+- With current cursors, both strategies executed zero snapshot queries. Complete desired-state input was not always smaller: at 500 clients and 15 topics it encoded 1,992,350 bytes versus 1,882,350 reconnect-input bytes.
+- The one-topic case did not establish a latency win.
+
+These are reproducible workload counts and fixture-specific bytes, not a universal speedup percentage. The recorded wall time used the pre-implementation legacy-frame bridge, so it is not published as desired-v1/Postgres coordinator performance.
 
 ## Compatibility checklist
 
 - Existing `realtime: true` works.
 - Existing `realtime: { adapter }` works without adding a broker.
-- Existing SSE clients remain on protocol `1`.
+- Desired topology is sent only when the opening server advertises protocol version `1`.
 - Dual mode never sends two snapshot streams to one client.
 - Custom adapter consumers accept consolidated bulk events.
+- Every request-handling replica is upgraded before claiming no-reconnect HA behavior.
 - The rollback drill succeeds without a down migration or data deletion.

--- a/apps/docs/content/docs/adapters/realtime.mdx
+++ b/apps/docs/content/docs/adapters/realtime.mdx
@@ -8,7 +8,8 @@ The **realtime adapter** supplies delivery for the [Realtime](/docs/concepts/rea
 This page covers server configuration, the outbox and broker topology, and each transport adapter. For application-level behavior, start with [Realtime concepts](/docs/concepts/realtime). For subscription signatures, use [Client realtime](/docs/client/realtime) and [Channels](/docs/client/channels).
 
 <Callout type="info" title="Prerequisites">
-  Read [Realtime concepts](/docs/concepts/realtime) first. Wiring the transport follows the [Configuration](/docs/concepts/configuration) runtime pattern.
+	Read [Realtime concepts](/docs/concepts/realtime) first. Wiring the transport
+	follows the [Configuration](/docs/concepts/configuration) runtime pattern.
 </Callout>
 
 ## What it does
@@ -16,7 +17,7 @@ This page covers server configuration, the outbox and broker topology, and each 
 - **Records every logical change transactionally.** Each create/update/delete (and bulk variant) appends one row to `questpie_realtime_log` using the mutation's database transaction.
 - **Fans out across instances.** The adapter broadcasts a tiny _notice_ ("seq N on collection posts changed") to every process, which then drains the outbox and pushes snapshots to its own SSE subscribers.
 - **Zero-infrastructure edge default.** `realtime: true` serves multiplexed SSE. It polls on a non-Postgres setup or auto-wires pg_notify when a normal Postgres connection string is available.
-- **Push transports for scale.** `pgNotifyAdapter` rides the database you already run; `redisStreamsAdapter` gives every instance an independent Redis Stream tail; `cloudflareRealtimeAdapter` is backed by a Durable Object.
+- **Push transports for scale.** `pgNotifyChangeBroker` rides the database you already run; Redis Streams and Pusher/Soketi provide explicit v2 broker overrides. Cloudflare's existing adapter remains on the 3.x compatibility path.
 - **Two explicit seams.** `ChangeBroker` carries lossy notice-only wakes between instances. `ClientTransport` carries already-authorized frames to edge sessions. Live snapshots and channel events have different QoS and are not conflated in a driver.
 - **Privacy-safe by design.** Brokers never carry rows or snapshots. Snapshot sharing is per-principal by default; managed WS delivers access-filtered live-query frames on private per-session channels. Shared multicast is reserved for schema-validated, channel-authorized events.
 - **Switch without changing consumers.** Choose SSE or the Pusher/Soketi preset under `realtime`; `live()`, `{ realtime: true }`, and `client.channels.*` remain unchanged.
@@ -31,8 +32,8 @@ import { runtimeConfig } from "questpie/app";
 import env from "./env"; // declared + validated in env.ts, see Environment
 
 export default runtimeConfig({
-  db: { url: env.DATABASE_URL },
-  realtime: true,
+	db: { url: env.DATABASE_URL },
+	realtime: true,
 });
 ```
 
@@ -65,42 +66,45 @@ Use `realtime: true` to turn on the default transport. Use an object when you wa
 
 ```ts
 interface RealtimeConfig {
-  observer?: RealtimeObserver;
-  rollout?: RealtimeRolloutConfig;
-  admission?: Partial<RealtimeAdmissionConfig>;
-  connectionAcceptPacingMs?: number;
-  adapter?: RealtimeAdapter; // existing broker compatibility adapter
-  changeBroker?: ChangeBroker; // v2 cross-instance notice seam
-  clientTransport?: ClientTransport; // managed edge transport; omit → SSE
-  channelEvents?: Partial<ChannelEventLedgerConfig>;
-  channelPresence?: Partial<ChannelPresenceConfig>;
-  channelSecurity?: ChannelSecurityConfig;
-  pollIntervalMs?: number; // 15000 with push, 2000 without
-  batchSize?: number; // default 500, max outbox rows read per drain
-  retentionDays?: number; // default 3; set 0 to disable time-based cleanup
-  keepAliveIntervalMs?: number; // default 8000, SSE keep-alive ping interval
+	observer?: RealtimeObserver;
+	rollout?: RealtimeRolloutConfig;
+	admission?: Partial<RealtimeAdmissionConfig>;
+	connectionAcceptPacingMs?: number;
+	adapter?: RealtimeAdapter; // deprecated 3.x compatibility adapter
+	changeBroker?: ChangeBroker; // v2 cross-instance notice seam
+	clientTransport?: ClientTransport; // managed edge transport; omit → SSE
+	channelEvents?: Partial<ChannelEventLedgerConfig>;
+	channelPresence?: Partial<ChannelPresenceConfig>;
+	channelSecurity?: ChannelSecurityConfig;
+	pollIntervalMs?: number; // 15000 with push, 2000 without
+	batchSize?: number; // default 500, max outbox rows read per drain
+	retentionDays?: number; // default 3; set 0 to disable time-based cleanup
+	keepAliveIntervalMs?: number; // default 8000, SSE keep-alive ping interval
 }
 ```
 
-| Option                     | Default                                       | What it controls                                                                                                                                                                                                         |
-| -------------------------- | --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `observer`                 | _(none)_                                      | Structured lifecycle/admission/transport diagnostics. Observer failures are isolated from delivery.                                                                                                                      |
-| `rollout`                  | v2                                            | Compatibility/canary selection used by the migration and rollback path.                                                                                                                                                  |
-| `admission`                | limits below                                  | Edge-session topic, connection, query-shape, concurrency, and buffer caps.                                                                                                                                               |
-| `connectionAcceptPacingMs` | `0`                                           | Optional maximum random delay before accepting a new edge session.                                                                                                                                                       |
-| `adapter`                  | _(none)_                                      | Existing `RealtimeAdapter` compatibility path, including pg_notify, Redis, and Cloudflare.                                                                                                                               |
-| `changeBroker`             | _(none)_                                      | Realtime v2 notice-only broker. If absent, v2 maps an existing `adapter` onto the new runtime.                                                                                                                           |
-| `clientTransport`          | SSE                                           | Optional managed edge transport. The Pusher preset supplies both `changeBroker` and `clientTransport`.                                                                                                                   |
-| `channelEvents`            | bounded defaults                              | Ordered-channel replay retention, lease, and slow-consumer buffer tuning.                                                                                                                                                |
-| `channelPresence`          | 30s lease / 10s heartbeat / 1s reconciliation | SSE Postgres presence leases, cross-instance convergence, and provider-parity member limits. Pusher/Soketi presence remains provider-managed.                                                                            |
-| `channelSecurity`          | secure defaults                               | Trusted origins, payload size, publish rate, and authorization timeout policy.                                                                                                                                           |
-| `pollIntervalMs`           | `15000` with push; `2000` without             | Reconciliation interval. It runs **alongside** a broker/adapter so dropped wakes heal; provider failure temporarily tightens it to at most 2s. Set `0` only when deliberately accepting loss of that recovery path.      |
-| `batchSize`                | `500`                                         | Max outbox rows pulled per drain. Raise it for very high write volume.                                                                                                                                                   |
-| `retentionDays`            | `3`                                           | Time horizon for outbox cleanup, including apps with zero subscribers. Set `0` to disable. Cleanup never uses a process-local subscriber watermark, because that could delete rows another instance has not drained yet. |
-| `keepAliveIntervalMs`      | `8000`                                        | Interval between `ping` keep-alive events on each `POST /realtime` SSE stream.                                                                                                                                           |
+| Option                     | Default                                        | What it controls                                                                                                                                                                                                         |
+| -------------------------- | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `observer`                 | _(none)_                                       | Structured lifecycle/admission/transport diagnostics. Observer failures are isolated from delivery.                                                                                                                      |
+| `rollout`                  | v2                                             | Deprecated 3.x compatibility/canary selection. `legacy` and `dual` are removed in QuestPie 4.                                                                                                                            |
+| `admission`                | limits below                                   | Edge-session topic, connection, query-shape, concurrency, and buffer caps.                                                                                                                                               |
+| `connectionAcceptPacingMs` | `0`                                            | Optional maximum random delay before accepting a new edge session.                                                                                                                                                       |
+| `adapter`                  | _(none)_                                       | Deprecated `RealtimeAdapter` compatibility path. It remains functional through QuestPie 3.x and is removed in QuestPie 4.                                                                                                |
+| `changeBroker`             | Postgres `PgNotifyChangeBroker` when available | Realtime v2 notice-only broker. Set it explicitly for Redis, Pusher, Cloudflare, or a custom broker.                                                                                                                     |
+| `clientTransport`          | SSE                                            | Optional managed edge transport. The Pusher preset supplies both `changeBroker` and `clientTransport`.                                                                                                                   |
+| `channelEvents`            | bounded defaults                               | Ordered-channel replay retention, lease, and slow-consumer buffer tuning.                                                                                                                                                |
+| `channelPresence`          | 30s lease / 10s heartbeat / 1s reconciliation  | SSE Postgres presence leases, cross-instance convergence, and provider-parity member limits. Pusher/Soketi presence remains provider-managed.                                                                            |
+| `channelSecurity`          | secure defaults                                | Trusted origins, payload size, publish rate, and authorization timeout policy.                                                                                                                                           |
+| `pollIntervalMs`           | `15000` with push; `2000` without              | Reconciliation interval. It runs **alongside** a broker/adapter so dropped wakes heal; provider failure temporarily tightens it to at most 2s. Set `0` only when deliberately accepting loss of that recovery path.      |
+| `batchSize`                | `500`                                          | Max outbox rows pulled per drain. Raise it for very high write volume.                                                                                                                                                   |
+| `retentionDays`            | `3`                                            | Time horizon for outbox cleanup, including apps with zero subscribers. Set `0` to disable. Cleanup never uses a process-local subscriber watermark, because that could delete rows another instance has not drained yet. |
+| `keepAliveIntervalMs`      | `8000`                                         | Interval between `ping` keep-alive events on each `POST /realtime` SSE stream.                                                                                                                                           |
 
 <Callout type="warn" title="Keep `keepAliveIntervalMs` under your idle timeout">
-  The default `8000` ms is deliberately under Bun's default 10s `idleTimeout`, so SSE streams survive on an untuned `Bun.serve`. Behind a proxy with a shorter read timeout (some default to 30-60s, but custom ones can be lower), drop it further so the connection never goes idle long enough to be culled.
+	The default `8000` ms is deliberately under Bun's default 10s `idleTimeout`,
+	so SSE streams survive on an untuned `Bun.serve`. Behind a proxy with a
+	shorter read timeout (some default to 30-60s, but custom ones can be lower),
+	drop it further so the connection never goes idle long enough to be culled.
 </Callout>
 
 ### Admission defaults
@@ -129,51 +133,62 @@ realtime: {
 
 Equivalent subscriptions compute once and fan out serialized bytes, but the access-equivalence key is session/principal-scoped by default. Row access, field access, and `afterRead` hooks may depend on the current session, so cross-user sharing requires an explicit deterministic opt-in and isolation tests.
 
-## The default: poll vs auto `pg_notify`
+## The default: Postgres broker vs polling
 
-Omitting `adapter` does **not** always mean naive polling. The runtime selects the compatibility broker like this:
+Clean Realtime v2 does not require both a `RealtimeAdapter` and a `ChangeBroker`. The runtime selects one notice path:
 
-1. **Explicit `adapter` set** → use it.
-2. **No adapter/broker, but a Postgres connection string is available** → construct `pgNotifyAdapter` on `questpie_realtime`. Its publisher starts with the app lifecycle, including write-only workers with no local subscribers.
-3. **No adapter and no Postgres connection** → fall back to polling the outbox every `pollIntervalMs` (default 2s).
+1. **Explicit `changeBroker` set** → use it.
+2. **No broker, but a Postgres connection string is available** → construct `PgNotifyChangeBroker` on `questpie_realtime_v2`. Its publisher starts with the app lifecycle, including write-only workers with no local subscribers.
+3. **No broker and no Postgres connection** → fall back to polling the durable state every `pollIntervalMs` (default 2s for the outbox).
+4. **Deprecated `adapter` set** → keep using the 3.x compatibility bridge. Do not add one to a clean v2 configuration.
 
 <Callout type="info" title="Polling is the recovery guarantee">
-  The poll drains the same outbox and pushes the same access-controlled snapshots. Without push it is the 2s primary path; with push it is the slower 15s reconciliation path. A notice lowers latency, but missing it does not permanently stall an instance.
+	The poll drains the same outbox and pushes the same access-controlled
+	snapshots. Without push it is the 2s primary path; with push it is the slower
+	15s reconciliation path. A notice lowers latency, but missing it does not
+	permanently stall an instance.
 </Callout>
 
-<Callout type="warn" title="Multi-tier deployments need a broker every writer can reach">
-  The outbox and reconciliation preserve correctness when every tier shares the same database, but latency and DB load degrade when split workers only poll. Ensure API, worker, and subscriber-serving instances use the same explicit pg/Redis/Pusher broker. Do not assume an implicit database URL exists in every process.
+<Callout
+	type="warn"
+	title="Multi-tier deployments need a broker every writer can reach"
+>
+	The outbox and reconciliation preserve correctness when every tier shares the
+	same database, but latency and DB load degrade when split workers only poll.
+	Ensure API, worker, and subscriber-serving instances use the same explicit
+	pg/Redis/Pusher broker. Do not assume an implicit database URL exists in every
+	process.
 </Callout>
 
-## `pgNotifyAdapter`, Postgres `LISTEN`/`NOTIFY`
+## `pgNotifyChangeBroker`, Postgres `LISTEN`/`NOTIFY`
 
 The simplest push transport: it broadcasts change notices over a Postgres channel with `pg_notify`, and every instance `LISTEN`s. No infrastructure beyond the database you already run.
 
 ```ts title="src/questpie/server/questpie.config.ts"
 import { runtimeConfig } from "questpie/app";
-import { pgNotifyAdapter } from "questpie/adapters/pg-notify";
+import { pgNotifyChangeBroker } from "questpie/adapters/pg-notify";
 
 import env from "./env";
 
 export default runtimeConfig({
-  db: { url: env.DATABASE_URL },
-  realtime: {
-    adapter: pgNotifyAdapter({
-      connectionString: env.DATABASE_URL,
-      // channel: "questpie_realtime", // default
-    }),
-  },
+	db: { url: env.DATABASE_URL },
+	realtime: {
+		changeBroker: pgNotifyChangeBroker({
+			connectionString: env.DATABASE_URL,
+			// channel: "questpie_realtime_v2", // default
+		}),
+	},
 });
 ```
 
-`PgNotifyAdapterOptions` is `{ channel?, client?, connection?, connectionString? }`. You must supply **one** connection source.
+`PgNotifyChangeBrokerOptions` is `{ channel?, client?, connection?, connectionString? }`. When configured explicitly, supply **one** connection source.
 
-| Option             | Type              | Default               | Notes                                                                                                 |
-| ------------------ | ----------------- | --------------------- | ----------------------------------------------------------------------------------------------------- |
-| `channel`          | `string`          | `"questpie_realtime"` | Postgres channel name. Validated against `/^[a-zA-Z0-9_]+$/`, an invalid name throws at construction. |
-| `client`           | `pg.Client`       | none                  | An existing `pg` client to reuse. **Not** `.end()`-ed by the adapter on stop (you own its lifecycle). |
-| `connection`       | `pg.ClientConfig` | none                  | A `pg` connection config; the adapter constructs and owns the client.                                 |
-| `connectionString` | `string`          | none                  | A connection URL; the adapter constructs and owns the client.                                         |
+| Option             | Type              | Default                  | Notes                                                                                                 |
+| ------------------ | ----------------- | ------------------------ | ----------------------------------------------------------------------------------------------------- |
+| `channel`          | `string`          | `"questpie_realtime_v2"` | Postgres channel name. Validated against `/^[a-zA-Z0-9_]+$/`, an invalid name throws at construction. |
+| `client`           | `pg.Client`       | none                     | An existing `pg` client to reuse. **Not** `.end()`-ed by the adapter on stop (you own its lifecycle). |
+| `connection`       | `pg.ClientConfig` | none                     | A `pg` connection config; the adapter constructs and owns the client.                                 |
+| `connectionString` | `string`          | none                     | A connection URL; the adapter constructs and owns the client.                                         |
 
 Behavior:
 
@@ -183,8 +198,11 @@ Behavior:
 - **Uses `LISTEN`/`UNLISTEN` + `pg_notify($1, $2)`.** The notice JSON (`{ seq, resourceType, resource, operation }`) is the channel payload.
 
 <Callout type="info" title="You usually don't need to write this">
-  On a Postgres app, `realtime: true` already auto-wires `pg_notify` on the default channel (see [the default](#the-default-poll-vs-auto-pg-notify) above). Configure `pgNotifyAdapter` explicitly only when you want a **non-default channel**, want to **reuse an existing `pg` client**, or are pointing realtime at a
-  **different database** than your main `db`.
+	On a Postgres app, `realtime: true` already auto-wires the v2 Postgres broker
+	(see [the default](#the-default-postgres-broker-vs-polling) above). Configure
+	`pgNotifyChangeBroker` explicitly only when you want a **non-default
+	channel**, want to **reuse an existing `pg` client**, or are pointing realtime
+	at a **different database** than your main `db`.
 </Callout>
 
 ## Pusher/Soketi preset, managed WebSockets
@@ -196,15 +214,15 @@ import { pusherRealtime } from "questpie/adapters/pusher";
 import { runtimeConfig } from "questpie/app";
 
 const managed = pusherRealtime({
-  appId: env.PUSHER_APP_ID,
-  key: env.PUSHER_KEY,
-  secret: env.PUSHER_SECRET,
-  cluster: env.PUSHER_CLUSTER,
-  // Soketi: host, port, wsHost, wsPort/wssPort, useTLS
+	appId: env.PUSHER_APP_ID,
+	key: env.PUSHER_KEY,
+	secret: env.PUSHER_SECRET,
+	cluster: env.PUSHER_CLUSTER,
+	// Soketi: host, port, wsHost, wsPort/wssPort, useTLS
 });
 
 export default runtimeConfig({
-  realtime: { ...managed },
+	realtime: { ...managed },
 });
 ```
 
@@ -224,13 +242,13 @@ clientEvents: {
 
 That allowlist only constrains the QUESTPIE SDK. Raw provider clients can bypass it, and their events bypass framework schemas, publish authorization, rate limits, ordered replay, and delivery guarantees.
 
-## `redisStreamsAdapter`, Redis Streams
+## `redisStreamsChangeBroker`, Redis Streams
 
 For Redis-backed fan-out across many instances, use Redis Streams with an independent `XREAD` cursor per app instance. The `client` is **required**, QUESTPIE doesn't ship a Redis driver, so you bring your own (a small command-shaped object modeled on `node-redis`):
 
 ```ts title="src/questpie/server/questpie.config.ts"
 import { runtimeConfig } from "questpie/app";
-import { redisStreamsAdapter } from "questpie/adapters/redis-streams";
+import { redisStreamsChangeBroker } from "questpie/adapters/redis-streams";
 import { createClient } from "redis";
 
 import env from "./env";
@@ -239,35 +257,35 @@ const redis = createClient({ url: env.REDIS_URL });
 await redis.connect();
 
 export default runtimeConfig({
-  db: { url: env.DATABASE_URL },
-  realtime: {
-    adapter: redisStreamsAdapter({
-      client: redis,
-      // stream: "questpie:realtime",   // default
-      // blockMs: 5000, batchSize: 100, // defaults
-      // maxLen: 10_000,                // approximate stream cap
-    }),
-  },
+	db: { url: env.DATABASE_URL },
+	realtime: {
+		changeBroker: redisStreamsChangeBroker({
+			client: redis,
+			// stream: "questpie:realtime:v2", // default
+			// blockMs: 5000, batchSize: 100, // defaults
+			// maxLen: 10_000,                // approximate stream cap
+		}),
+	},
 });
 ```
 
 `RedisStreamsAdapterOptions` is `{ client (required), reader?, stream?, blockMs?, batchSize?, maxLen?, retryDelayMs?, onError? }`.
 
-| Option         | Type                 | Default               | Notes                                                                                                                        |
-| -------------- | -------------------- | --------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| `client`       | `RedisStreamsClient` | none **required**     | Publishing client. Must implement `xAdd` + `xRead`; node-redis clients are automatically duplicated for the blocking reader. |
-| `reader`       | `RedisStreamsClient` | auto                  | Optional already-connected blocking-read client for structural clients without `duplicate()`.                                |
-| `stream`       | `string`             | `"questpie:realtime"` | The Redis stream key notices are `XADD`-ed to.                                                                               |
-| `blockMs`      | `number`             | `5000`                | How long `XREAD` blocks waiting for new messages.                                                                            |
-| `batchSize`    | `number`             | `100`                 | `COUNT` per `XREAD` call.                                                                                                    |
-| `maxLen`       | `number`             | `10000`               | Approximate `MAXLEN ~` cap applied by every `XADD`.                                                                          |
-| `retryDelayMs` | `number`             | `500`                 | Backoff after a read-loop failure.                                                                                           |
-| `onError`      | `(error) => void`    | `console.warn`        | Error hook for read/listener failures.                                                                                       |
+| Option         | Type                 | Default                  | Notes                                                                                                                        |
+| -------------- | -------------------- | ------------------------ | ---------------------------------------------------------------------------------------------------------------------------- |
+| `client`       | `RedisStreamsClient` | none **required**        | Publishing client. Must implement `xAdd` + `xRead`; node-redis clients are automatically duplicated for the blocking reader. |
+| `reader`       | `RedisStreamsClient` | auto                     | Optional already-connected blocking-read client for structural clients without `duplicate()`.                                |
+| `stream`       | `string`             | `"questpie:realtime:v2"` | The Redis stream key wakes are `XADD`-ed to.                                                                                 |
+| `blockMs`      | `number`             | `5000`                   | How long `XREAD` blocks waiting for new messages.                                                                            |
+| `batchSize`    | `number`             | `100`                    | `COUNT` per `XREAD` call.                                                                                                    |
+| `maxLen`       | `number`             | `10000`                  | Approximate `MAXLEN ~` cap applied by every `XADD`.                                                                          |
+| `retryDelayMs` | `number`             | `500`                    | Backoff after a read-loop failure.                                                                                           |
+| `onError`      | `(error) => void`    | `console.warn`           | Error hook for read/listener failures.                                                                                       |
 
 Behavior:
 
 - **Broadcasts instead of load-balancing.** Every adapter tails from `$` with its own `XREAD` cursor, so each running app instance receives every new wake independently.
-- **Bounds the stream.** `notify()` uses `XADD MAXLEN ~ 10000` by default and stores only the notice fields (`seq`, `resourceType`, `resource`, `operation`).
+- **Bounds the stream.** `publish()` uses `XADD MAXLEN ~ 10000` by default and stores only a normalized `ChangeWake`; it never stores rows, snapshots, credentials, or topology bodies.
 - **Resilient lifecycle.** A failed loop iteration is reported, backed off, and retried. `stop()` awaits the blocking read's exit before a later `start()` can create another loop.
 - **Driver-agnostic.** Any client matching the `RedisStreamsClient` shape works, the type is modeled on `node-redis` command names but isn't tied to it.
 
@@ -289,24 +307,24 @@ type RedisStreamsClient = {
 Only `xAdd` and `xRead` are mandatory. Pass `reader` when a custom client cannot duplicate itself; blocking reads should not share the publishing connection.
 </Callout>
 
-## `cloudflareRealtimeAdapter`, Durable Objects
+## `cloudflareRealtimeAdapter`, Durable Objects (3.x compatibility)
 
-On Cloudflare Workers, realtime is backed by a **Durable Object**: there's no long-lived process to hold subscriptions or a poll timer, so the DO is the fan-out point. `cloudflareRealtimeAdapter({ namespace })` proxies subscribe/notify through it.
+On Cloudflare Workers, the existing realtime adapter is backed by a **Durable Object**: there's no long-lived process to hold subscriptions or a poll timer, so the DO is the fan-out point. `cloudflareRealtimeAdapter({ namespace })` proxies subscribe/notify through the deprecated `RealtimeAdapter` compatibility seam. A dedicated v2 `ChangeBroker` replacement is not part of this release.
 
 ```ts title="src/questpie/server/questpie.config.ts"
 import { runtimeConfig } from "questpie/app";
 import { cloudflareRealtimeAdapter } from "questpie/adapters/cloudflare-realtime";
 
 export default runtimeConfig({
-  realtime: {
-    adapter: cloudflareRealtimeAdapter({
-      // A Durable Object namespace binding, or a zero-arg function that
-      // returns one (so you can resolve it lazily from your Worker env).
-      namespace: () => getEnv().QUESTPIE_REALTIME,
-      // objectName: "questpie-realtime",  // default shard-name prefix
-      // hubPath: "/__questpie/realtime",   // default internal hub path
-    }),
-  },
+	realtime: {
+		adapter: cloudflareRealtimeAdapter({
+			// A Durable Object namespace binding, or a zero-arg function that
+			// returns one (so you can resolve it lazily from your Worker env).
+			namespace: () => getEnv().QUESTPIE_REALTIME,
+			// objectName: "questpie-realtime",  // default shard-name prefix
+			// hubPath: "/__questpie/realtime",   // default internal hub path
+		}),
+	},
 });
 ```
 
@@ -323,7 +341,10 @@ export default runtimeConfig({
 This adapter carries a `runtime: "cloudflare"` discriminator so the Cloudflare fetch/queue handlers detect it, and it's wired together with the **`createCloudflareRealtimeDurableObjectHandler`** export (from `questpie/adapters/cloudflare`) that implements the DO itself. Durable Objects are sharded by `resourceType` and resource; mutation publish is non-blocking, only the minimal notice crosses the DO boundary, and snapshot queries stay in the requesting Worker.
 
 <Callout type="info" title="Cloudflare realtime is a deployment-specific setup">
-  Unlike `pg_notify` / Redis, this adapter requires a Durable Object class bound in your `wrangler` config plus the DO handler. It's part of the Cloudflare Workers deployment story rather than a drop-in line. The other two adapters need no Workers-specific wiring.
+	Unlike `pg_notify` / Redis, this adapter requires a Durable Object class bound
+	in your `wrangler` config plus the DO handler. It's part of the Cloudflare
+	Workers deployment story rather than a drop-in line. The other two adapters
+	need no Workers-specific wiring.
 </Callout>
 
 ## The outbox table
@@ -346,42 +367,48 @@ The transport contract and config types are exported from `questpie` (and `quest
 
 ```ts
 import type {
-  RealtimeAdapter, // the transport contract you implement for a custom adapter
-  RealtimeConfig, // the `realtime` config shape
-  RealtimeChangeEvent, // a full outbox event
-  RealtimeChangePayload, // { before, after } or { count, recordIds }
-  RealtimeEqualityProjection, // shallow scalar fields used for equality routing
-  RealtimeNotice, // the minimal broadcast notice
-  RealtimeOperation, // "create" | "update" | "delete" | "bulk_update" | "bulk_delete"
-  RealtimeResourceType, // "collection" | "global"
+	ChangeBroker, // the notice-only contract for a custom v2 broker
+	RealtimeAdapter, // deprecated 3.x compatibility contract
+	RealtimeConfig, // the `realtime` config shape
+	RealtimeChangeEvent, // a full outbox event
+	RealtimeChangePayload, // { before, after } or { count, recordIds }
+	RealtimeEqualityProjection, // shallow scalar fields used for equality routing
+	RealtimeNotice, // the minimal broadcast notice
+	RealtimeOperation, // "create" | "update" | "delete" | "bulk_update" | "bulk_delete"
+	RealtimeResourceType, // "collection" | "global"
 } from "questpie/realtime";
 ```
 
-Each adapter's option type ships from its own entry, `PgNotifyAdapterOptions` from `questpie/adapters/pg-notify`, `RedisStreamsAdapterOptions` + `RedisStreamsClient` from `questpie/adapters/redis-streams`, `CloudflareRealtimeAdapterOptions` from `questpie/adapters/cloudflare-realtime`.
+Each adapter's option type ships from its own entry, `PgNotifyChangeBrokerOptions` from `questpie/adapters/pg-notify`, `RedisStreamsAdapterOptions` + `RedisStreamsClient` from `questpie/adapters/redis-streams`, `CloudflareRealtimeAdapterOptions` from `questpie/adapters/cloudflare-realtime`.
 
 ## Build your own transport
 
-`RealtimeAdapter` remains the compatibility contract for an invalidation driver. Realtime v2 internally separates that concern into `ChangeBroker` and keeps edge delivery in `ClientTransport`; new managed presets should implement those independent seams instead of combining broker, auth, and delivery in one object.
+Implement `ChangeBroker` for a new Realtime v2 invalidation driver. It carries metadata-only wakes; the durable database state remains authoritative and `ClientTransport` handles already-authorized edge delivery.
 
 The compatibility adapter shape is:
 
 ```ts
-interface RealtimeAdapter {
-  start(): Promise<void>;
-  stop(): Promise<void>;
-  notify(event: RealtimeChangeEvent): Promise<void>; // broadcast a change
-  subscribe(handler: (notice: RealtimeNotice) => void): () => void; // receive changes; returns unsubscribe
+interface ChangeBroker {
+	start(input: {
+		onWake: (wake: ChangeWake) => void;
+		onError: (error: unknown) => void;
+		onStateChange?: (state: ChangeBrokerState) => void;
+	}): Promise<void>;
+	stop(): Promise<void>;
+	publish(wake: ChangeWake): Promise<void>;
 }
 ```
 
-`notify` publishes a change to all instances; `subscribe` registers a handler that fires on every received notice (the service uses it to trigger a `drain()`) and returns an unsubscribe function. You only need to move the four notice fields (`seq`, `resourceType`, `resource`, `operation`), never the payload. Wire your instance as `realtime.adapter`.
+Wakes may be lost, duplicated, delayed, reordered, or coalesced. They never carry rows, snapshots, credentials, or topology bodies. Wire the broker as `realtime.changeBroker`; reconciliation against durable state supplies correctness.
+
+`RealtimeAdapter` and `realtime.adapter` remain functional only as deprecated QuestPie 3.x compatibility surfaces. New integrations must not implement or configure them. See the migration guide for the removal window.
 
 ## Related
 
 - [Realtime](/docs/client/realtime), the client API this transport powers: `live()`, `liveIter()`, and the TanStack Query `{ realtime: true }` flag.
 - [Channels](/docs/client/channels), typed ordered application events over SSE or Pusher/Soketi.
-- [Realtime v2 migration and rollback](/docs/adapters/realtime-v2-migration), dual-run canaries and the rollback flag.
+- [Realtime v2 HA migration](/docs/adapters/realtime-v2-migration), schema rollout, mixed versions, and 3.x deprecations.
 - [Configuration](/docs/concepts/configuration), where `realtime` lives in `QuestpieConfig`, alongside the other adapters.
 - [Adapters](/docs/adapters), the hub listing every adapter kind and the swap-the-backend model.
-- [Building a plugin](/docs/extend/build-a-plugin), implement `RealtimeAdapter` (or any adapter contract) yourself.
+- [Building a plugin](/docs/extend/build-a-plugin), implement a `ChangeBroker` (or another adapter contract) yourself.
 - [Multi-tenancy](/docs/extend/multi-tenancy), how access rules re-run per subscriber keep tenant data isolated over realtime.

--- a/apps/docs/content/docs/adapters/realtime.mdx
+++ b/apps/docs/content/docs/adapters/realtime.mdx
@@ -131,6 +131,23 @@ realtime: {
 }
 ```
 
+`maxFindLimit` applies to each realtime `find` snapshot, including the initial
+snapshot and every refresh. The default remains `100`. A topic above the limit
+is rejected; QUESTPIE does not clamp or split it because doing so would change
+ordering, pagination, result completeness, and the number of admitted topics.
+Raise the limit only after measuring snapshot compute time, serialized bytes,
+fan-out load, and slow-client behavior for the real query shape.
+
+Large or paginated read models should not be represented by one giant realtime
+snapshot. Keep the paginated reads bounded and use ordinary pagination or a
+purpose-built projection/event flow for the rest of the model.
+
+Rejected topics return `REALTIME_TOPIC_REJECTED` with the topic id, resource,
+operation, `retryable: false`, and bounded details such as the requested and
+configured limits. Query filters are not included. The client delivers the
+error only to that topic, and the TanStack adapter exposes the query as an error
+without retrying the rejected admission.
+
 Equivalent subscriptions compute once and fan out serialized bytes, but the access-equivalence key is session/principal-scoped by default. Row access, field access, and `afterRead` hooks may depend on the current session, so cross-user sharing requires an explicit deterministic opt-in and isolation tests.
 
 ## The default: Postgres broker vs polling

--- a/apps/docs/content/docs/adapters/realtime.mdx
+++ b/apps/docs/content/docs/adapters/realtime.mdx
@@ -67,10 +67,8 @@ Use `realtime: true` to turn on the default transport. Use an object when you wa
 ```ts
 interface RealtimeConfig {
 	observer?: RealtimeObserver;
-	rollout?: RealtimeRolloutConfig;
 	admission?: Partial<RealtimeAdmissionConfig>;
 	connectionAcceptPacingMs?: number;
-	adapter?: RealtimeAdapter; // deprecated 3.x compatibility adapter
 	changeBroker?: ChangeBroker; // v2 cross-instance notice seam
 	clientTransport?: ClientTransport; // managed edge transport; omit → SSE
 	channelEvents?: Partial<ChannelEventLedgerConfig>;
@@ -86,10 +84,8 @@ interface RealtimeConfig {
 | Option                     | Default                                        | What it controls                                                                                                                                                                                                         |
 | -------------------------- | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `observer`                 | _(none)_                                       | Structured lifecycle/admission/transport diagnostics. Observer failures are isolated from delivery.                                                                                                                      |
-| `rollout`                  | v2                                             | Deprecated 3.x compatibility/canary selection. `legacy` and `dual` are removed in QuestPie 4.                                                                                                                            |
 | `admission`                | limits below                                   | Edge-session topic, connection, query-shape, concurrency, and buffer caps.                                                                                                                                               |
 | `connectionAcceptPacingMs` | `0`                                            | Optional maximum random delay before accepting a new edge session.                                                                                                                                                       |
-| `adapter`                  | _(none)_                                       | Deprecated `RealtimeAdapter` compatibility path. It remains functional through QuestPie 3.x and is removed in QuestPie 4.                                                                                                |
 | `changeBroker`             | Postgres `PgNotifyChangeBroker` when available | Realtime v2 notice-only broker. Set it explicitly for Redis, Pusher, Cloudflare, or a custom broker.                                                                                                                     |
 | `clientTransport`          | SSE                                            | Optional managed edge transport. The Pusher preset supplies both `changeBroker` and `clientTransport`.                                                                                                                   |
 | `channelEvents`            | bounded defaults                               | Ordered-channel replay retention, lease, and slow-consumer buffer tuning.                                                                                                                                                |
@@ -152,12 +148,11 @@ Equivalent subscriptions compute once and fan out serialized bytes, but the acce
 
 ## The default: Postgres broker vs polling
 
-Clean Realtime v2 does not require both a `RealtimeAdapter` and a `ChangeBroker`. The runtime selects one notice path:
+Clean Realtime v2 uses one `ChangeBroker` notice path:
 
 1. **Explicit `changeBroker` set** → use it.
 2. **No broker, but a Postgres connection string is available** → construct `PgNotifyChangeBroker` on `questpie_realtime_v2`. Its publisher starts with the app lifecycle, including write-only workers with no local subscribers.
 3. **No broker and no Postgres connection** → fall back to polling the durable state every `pollIntervalMs` (default 2s for the outbox).
-4. **Deprecated `adapter` set** → keep using the 3.x compatibility bridge. Do not add one to a clean v2 configuration.
 
 <Callout type="info" title="Polling is the recovery guarantee">
 	The poll drains the same outbox and pushes the same access-controlled
@@ -324,45 +319,9 @@ type RedisStreamsClient = {
 Only `xAdd` and `xRead` are mandatory. Pass `reader` when a custom client cannot duplicate itself; blocking reads should not share the publishing connection.
 </Callout>
 
-## `cloudflareRealtimeAdapter`, Durable Objects (3.x compatibility)
+## Cloudflare deployments
 
-On Cloudflare Workers, the existing realtime adapter is backed by a **Durable Object**: there's no long-lived process to hold subscriptions or a poll timer, so the DO is the fan-out point. `cloudflareRealtimeAdapter({ namespace })` proxies subscribe/notify through the deprecated `RealtimeAdapter` compatibility seam. A dedicated v2 `ChangeBroker` replacement is not part of this release.
-
-```ts title="src/questpie/server/questpie.config.ts"
-import { runtimeConfig } from "questpie/app";
-import { cloudflareRealtimeAdapter } from "questpie/adapters/cloudflare-realtime";
-
-export default runtimeConfig({
-	realtime: {
-		adapter: cloudflareRealtimeAdapter({
-			// A Durable Object namespace binding, or a zero-arg function that
-			// returns one (so you can resolve it lazily from your Worker env).
-			namespace: () => getEnv().QUESTPIE_REALTIME,
-			// objectName: "questpie-realtime",  // default shard-name prefix
-			// hubPath: "/__questpie/realtime",   // default internal hub path
-		}),
-	},
-});
-```
-
-`CloudflareRealtimeAdapterOptions` is `{ namespace (required), objectName?, hubPath?, waitUntil?, onError? }`. The `namespace` is a Durable Object namespace binding, or a **zero-argument** function that returns one (resolved lazily when the adapter first needs it, so you can defer reading it out of your Worker env).
-
-| Option       | Type                                    | Default                  | Notes                                                                                  |
-| ------------ | --------------------------------------- | ------------------------ | -------------------------------------------------------------------------------------- |
-| `namespace`  | `CloudflareDurableObjectNamespaceInput` | none **required**        | The DO namespace binding, or `() => namespace`.                                        |
-| `objectName` | `string`                                | `"questpie-realtime"`    | Base DO name; the runtime appends resource type and resource name to shard notices.    |
-| `hubPath`    | `string`                                | `"/__questpie/realtime"` | Internal hub path; the adapter derives `${hubPath}/subscribe` and `${hubPath}/notify`. |
-| `waitUntil`  | `(promise) => void`                     | none                     | Keeps the non-blocking notify relay alive for the current Worker event.                |
-| `onError`    | `(error) => void`                       | `console.error`          | Reports background publish and relay failures.                                         |
-
-This adapter carries a `runtime: "cloudflare"` discriminator so the Cloudflare fetch/queue handlers detect it, and it's wired together with the **`createCloudflareRealtimeDurableObjectHandler`** export (from `questpie/adapters/cloudflare`) that implements the DO itself. Durable Objects are sharded by `resourceType` and resource; mutation publish is non-blocking, only the minimal notice crosses the DO boundary, and snapshot queries stay in the requesting Worker.
-
-<Callout type="info" title="Cloudflare realtime is a deployment-specific setup">
-	Unlike `pg_notify` / Redis, this adapter requires a Durable Object class bound
-	in your `wrangler` config plus the DO handler. It's part of the Cloudflare
-	Workers deployment story rather than a drop-in line. The other two adapters
-	need no Workers-specific wiring.
-</Callout>
+Cloudflare Workers need a Durable Object fan-out path because they do not keep a long-lived process-local poller. Use the [Realtime v2 HA migration guide](/docs/adapters/realtime-v2-migration) for the supported QuestPie 3.x deployment path and its v2 migration status.
 
 ## The outbox table
 
@@ -385,7 +344,6 @@ The transport contract and config types are exported from `questpie` (and `quest
 ```ts
 import type {
 	ChangeBroker, // the notice-only contract for a custom v2 broker
-	RealtimeAdapter, // deprecated 3.x compatibility contract
 	RealtimeConfig, // the `realtime` config shape
 	RealtimeChangeEvent, // a full outbox event
 	RealtimeChangePayload, // { before, after } or { count, recordIds }
@@ -396,13 +354,13 @@ import type {
 } from "questpie/realtime";
 ```
 
-Each adapter's option type ships from its own entry, `PgNotifyChangeBrokerOptions` from `questpie/adapters/pg-notify`, `RedisStreamsAdapterOptions` + `RedisStreamsClient` from `questpie/adapters/redis-streams`, `CloudflareRealtimeAdapterOptions` from `questpie/adapters/cloudflare-realtime`.
+Each broker's option type ships from its own entry, `PgNotifyChangeBrokerOptions` from `questpie/adapters/pg-notify` and `RedisStreamsAdapterOptions` plus `RedisStreamsClient` from `questpie/adapters/redis-streams`.
 
 ## Build your own transport
 
 Implement `ChangeBroker` for a new Realtime v2 invalidation driver. It carries metadata-only wakes; the durable database state remains authoritative and `ClientTransport` handles already-authorized edge delivery.
 
-The compatibility adapter shape is:
+The broker shape is:
 
 ```ts
 interface ChangeBroker {
@@ -418,7 +376,7 @@ interface ChangeBroker {
 
 Wakes may be lost, duplicated, delayed, reordered, or coalesced. They never carry rows, snapshots, credentials, or topology bodies. Wire the broker as `realtime.changeBroker`; reconciliation against durable state supplies correctness.
 
-`RealtimeAdapter` and `realtime.adapter` remain functional only as deprecated QuestPie 3.x compatibility surfaces. New integrations must not implement or configure them. See the migration guide for the removal window.
+See the migration guide for the QuestPie 3.x transition and QuestPie 4 removal window.
 
 ## Related
 

--- a/apps/docs/content/docs/client/reactive-apps.mdx
+++ b/apps/docs/content/docs/client/reactive-apps.mdx
@@ -225,4 +225,4 @@ Before shipping a reactive screen:
 - [Channels](/docs/client/channels), channel definitions, authorization, publishing, presence, and delivery semantics.
 - [TanStack Query](/docs/client/tanstack-query), generated query options, keys, invalidation, and streamed queries.
 - [Realtime adapter](/docs/adapters/realtime), server admission, slow-consumer limits, transport selection, and per-principal refresh sharing.
-- [Realtime v2 migration](/docs/adapters/realtime-v2-migration), rollout, observability, and rollback.
+- [Realtime v2 HA migration](/docs/adapters/realtime-v2-migration), schema rollout, mixed versions, and rollback.

--- a/apps/docs/content/docs/client/realtime.mdx
+++ b/apps/docs/content/docs/client/realtime.mdx
@@ -24,8 +24,8 @@ import { runtimeConfig } from "questpie/app";
 import env from "./env"; // declared + validated in env.ts, see Environment
 
 export default runtimeConfig({
-  db: { url: env.DATABASE_URL },
-  realtime: true,
+	db: { url: env.DATABASE_URL },
+	realtime: true,
 });
 ```
 
@@ -35,10 +35,13 @@ Now subscribe from the client. `live()` takes your query options, a snapshot cal
 import { client } from "@/lib/client.js";
 
 // First snapshot fires immediately; then on every matching change.
-const unsubscribe = client.collections.posts.live({ where: { published: true }, orderBy: { createdAt: "desc" }, limit: 10 }, (snapshot) => {
-  // snapshot is the SAME shape & type as client.collections.posts.find(...)
-  console.log(snapshot.totalDocs, snapshot.docs[0]?.title);
-});
+const unsubscribe = client.collections.posts.live(
+	{ where: { published: true }, orderBy: { createdAt: "desc" }, limit: 10 },
+	(snapshot) => {
+		// snapshot is the SAME shape & type as client.collections.posts.find(...)
+		console.log(snapshot.totalDocs, snapshot.docs[0]?.title);
+	},
+);
 
 // Later, stop listening (e.g. on unmount):
 unsubscribe();
@@ -47,7 +50,9 @@ unsubscribe();
 That callback now re-fires with a fresh, access-filtered top-10 every time a published post changes.
 
 <Callout type="info" title="The first snapshot is your initial data">
-  You do **not** need a separate `find()` before subscribing. `live()` delivers a full snapshot the moment the connection opens, then keeps it fresh. Treat the first callback invocation as "data loaded".
+	You do **not** need a separate `find()` before subscribing. `live()` delivers
+	a full snapshot the moment the connection opens, then keeps it fresh. Treat
+	the first callback invocation as "data loaded".
 </Callout>
 
 ## Example → inferred snapshot
@@ -55,12 +60,15 @@ That callback now re-fires with a fresh, access-filtered top-10 every time a pub
 The snapshot type equals the `find()` result type for the same options, `FindResult<Row, Relations, TQuery>`. Narrow with `columns`? No: `live()` deliberately carries a **subset** of `find()` options (no `columns`), so a snapshot is always the full row plus any `with` relations you requested:
 
 ```ts
-client.collections.posts.live({ where: { published: true }, with: { author: true }, limit: 5 }, (snapshot) => {
-  snapshot.docs[0].author.name;
-  //         ^? string, `with: { author: true }` hydrated the relation
-  snapshot.hasNextPage;
-  //         ^? boolean, full PaginatedResult envelope, same as find()
-});
+client.collections.posts.live(
+	{ where: { published: true }, with: { author: true }, limit: 5 },
+	(snapshot) => {
+		snapshot.docs[0].author.name;
+		//         ^? string, `with: { author: true }` hydrated the relation
+		snapshot.hasNextPage;
+		//         ^? boolean, full PaginatedResult envelope, same as find()
+	},
+);
 ```
 
 A snapshot is a `PaginatedResult<T>` (`{ docs, totalDocs, totalPages, page, hasPrevPage, hasNextPage, prevPage, nextPage, ... }`), or, if your query uses `groupBy`… it can't, because `groupBy` isn't a live option (see below).
@@ -71,18 +79,25 @@ A snapshot is a `PaginatedResult<T>` (`{ docs, totalDocs, totalPages, page, hasP
 
 ```ts
 type LiveQueryOptions<TSelect, TRelations> = {
-  where?: Where<TSelect, TRelations>;
-  with?: With<TRelations>;
-  limit?: number;
-  offset?: number;
-  orderBy?: OrderBy<TSelect>;
-  locale?: string;
+	where?: Where<TSelect, TRelations>;
+	with?: With<TRelations>;
+	limit?: number;
+	offset?: number;
+	orderBy?: OrderBy<TSelect>;
+	locale?: string;
 };
 ```
 
-<Callout type="warn" title="`columns`, `groupBy`, `search`, `includeDeleted`, `stage` are not live options">
-  `LiveQueryOptions` intentionally **excludes** `columns`, `groupBy`, `search`, `includeDeleted`, and `stage`. Realtime snapshots are the full query re-run server-side from the topic fields, so column projection / grouping / soft-delete-included / stage-pinned reads aren't expressed over the wire. If you pass them
-  they're simply not part of the subscription. For those, use a one-shot `find()`.
+<Callout
+	type="warn"
+	title="`columns`, `groupBy`, `search`, `includeDeleted`, `stage` are not live options"
+>
+	`LiveQueryOptions` intentionally **excludes** `columns`, `groupBy`, `search`,
+	`includeDeleted`, and `stage`. Realtime snapshots are the full query re-run
+	server-side from the topic fields, so column projection / grouping /
+	soft-delete-included / stage-pinned reads aren't expressed over the wire. If
+	you pass them they're simply not part of the subscription. For those, use a
+	one-shot `find()`.
 </Callout>
 
 ### `LiveSubscribeOptions`, the third argument
@@ -91,17 +106,21 @@ type LiveQueryOptions<TSelect, TRelations> = {
 
 ```ts
 type LiveSubscribeOptions = {
-  signal?: AbortSignal; // abort → auto-unsubscribe
-  onError?: (error: Error) => void; // SSE connection failed
+	signal?: AbortSignal; // abort → auto-unsubscribe
+	onError?: (error: Error) => void; // SSE connection failed
 };
 ```
 
 ```ts
 const ac = new AbortController();
-client.collections.posts.live({ where: { published: true } }, (snapshot) => render(snapshot), {
-  signal: ac.signal,
-  onError: (err) => console.error("realtime dropped:", err),
-});
+client.collections.posts.live(
+	{ where: { published: true } },
+	(snapshot) => render(snapshot),
+	{
+		signal: ac.signal,
+		onError: (err) => console.error("realtime dropped:", err),
+	},
+);
 // ac.abort() unsubscribes, equivalent to calling the returned function.
 ```
 
@@ -114,9 +133,12 @@ client.collections.posts.live({ where: { published: true } }, (snapshot) => rend
 ```ts
 const ac = new AbortController();
 
-for await (const snapshot of client.collections.posts.liveIter({ where: { published: true }, limit: 10 }, { signal: ac.signal })) {
-  console.log("posts now:", snapshot.totalDocs);
-  // ac.abort() ends the loop.
+for await (const snapshot of client.collections.posts.liveIter(
+	{ where: { published: true }, limit: 10 },
+	{ signal: ac.signal },
+)) {
+	console.log("posts now:", snapshot.totalDocs);
+	// ac.abort() ends the loop.
 }
 ```
 
@@ -127,10 +149,13 @@ It takes only `{ signal? }`, **no `onError`** (unlike `live()`). A connection fa
 Globals are singletons, so their live API mirrors `get()` with a smaller option set. `GlobalLiveQueryOptions` is `{ with?, locale? }` only, no `where`/`limit`/`offset`/`orderBy`:
 
 ```ts
-const stop = client.globals.siteSettings.live({ with: { logo: true } }, (snapshot) => {
-  // snapshot is the SAME shape & type as client.globals.siteSettings.get(...)
-  document.title = snapshot.title;
-});
+const stop = client.globals.siteSettings.live(
+	{ with: { logo: true } },
+	(snapshot) => {
+		// snapshot is the SAME shape & type as client.globals.siteSettings.get(...)
+		document.title = snapshot.title;
+	},
+);
 ```
 
 `live()` and `liveIter()` carry the same `LiveSubscribeOptions` / `{ signal? }` semantics as collections.
@@ -145,12 +170,15 @@ import { useQuery } from "@tanstack/react-query";
 import { q } from "@/lib/query.js";
 
 function LivePosts() {
-  const { data } = useQuery(
-    // 1st arg: query options. 2nd arg: { realtime: true }.
-    q.collections.posts.find({ where: { published: true }, limit: 10 }, { realtime: true }),
-  );
+	const { data } = useQuery(
+		// 1st arg: query options. 2nd arg: { realtime: true }.
+		q.collections.posts.find(
+			{ where: { published: true }, limit: 10 },
+			{ realtime: true },
+		),
+	);
 
-  return <p>{data?.totalDocs ?? 0} published posts (live)</p>;
+	return <p>{data?.totalDocs ?? 0} published posts (live)</p>;
 }
 ```
 
@@ -164,9 +192,16 @@ Under the hood the hook uses TanStack's `experimental_streamedQuery` with `refet
 `findOne` and every mutation **reject** a `{ realtime: true }` argument at the type level, passing it is a compile error (the tests assert `@ts-expect-error`). There's no live `findOne`; subscribe with `find({ where: { id } })` (or `live()`) and read `docs[0]`.
 </Callout>
 
-<Callout type="warn" title="If the server has no realtime, `{ realtime: true }` errors">
-  The client always wires `client.realtime`, so the TanStack flag is honored client-side regardless. The real prerequisite is **server-side realtime**: set `realtime` in your config so `POST /realtime` exists. Without it the SSE connect fails, the stream errors out (and `find()`/`get()`/`live()`'s `onError` fires)
-  rather than silently degrading to a poll. Turn `realtime` on in the server config before relying on live queries.
+<Callout
+	type="warn"
+	title="If the server has no realtime, `{ realtime: true }` errors"
+>
+	The client always wires `client.realtime`, so the TanStack flag is honored
+	client-side regardless. The real prerequisite is **server-side realtime**: set
+	`realtime` in your config so `POST /realtime` exists. Without it the SSE
+	connect fails, the stream errors out (and `find()`/`get()`/`live()`'s
+	`onError` fires) rather than silently degrading to a poll. Turn `realtime` on
+	in the server config before relying on live queries.
 </Callout>
 
 The TanStack realtime topic is derived purely from your read `options` via `buildCollectionTopic` / `buildGlobalTopic`, config-level `locale`/`stage` are **not** added to the topic, only `options.locale` is. Two subscriptions that differ only by `where` get distinct live streams.
@@ -175,11 +210,15 @@ The TanStack realtime topic is derived purely from your read `options` via `buil
 
 Everything above is the **client** API. None of it works until you turn realtime on in the **server** config, that's the one server requirement, and you've already seen it in [Quick start](#quick-start). Each mutation appends its outbox row inside the business transaction. With a normal Postgres URL, `realtime: true` auto-wires pg_notify; otherwise the service polls. Every configured broker also keeps a slower reconciliation poll, so a dropped wake cannot stall delivery forever.
 
-The full server surface, `RealtimeConfig` options, the outbox/poll model, every transport adapter (`pgNotifyAdapter`, `redisStreamsAdapter`, `cloudflareRealtimeAdapter`), and building your own, lives on one page: see [Realtime adapter](/docs/adapters/realtime).
+The full server surface, `RealtimeConfig` options, durable topology/outbox reconciliation, v2 brokers (`pgNotifyChangeBroker`, `redisStreamsChangeBroker`, Pusher/Soketi), and building your own lives on one page: see [Realtime adapter](/docs/adapters/realtime).
 
 <Callout type="info" title="One client transport, by design">
-  On the default path, `live()` / `liveIter()` calls (and the TanStack flag) share a multiplexed `POST /realtime` SSE connection within the server's admission caps. With Pusher/Soketi selected, the same APIs share the managed provider connection. Always subscribe through the typed wrappers (or `client.realtime`) so the
-  runtime can multiplex, resume, and tear down correctly.
+	On the default path, `live()` / `liveIter()` calls (and the TanStack flag)
+	share a multiplexed `POST /realtime` SSE connection within the server's
+	admission caps. With Pusher/Soketi selected, the same APIs share the managed
+	provider connection. Always subscribe through the typed wrappers (or
+	`client.realtime`) so the runtime can multiplex, resume, and tear down
+	correctly.
 </Callout>
 
 ## Raw realtime, `client.realtime`
@@ -190,15 +229,18 @@ The typed wrappers are the recommended path. If you need to subscribe to a hand-
 import { buildCollectionTopic } from "questpie/client";
 
 // Typed wrapper (preferred), TData inferred, topic built for you:
-const stop = client.collections.posts.live({ where: { published: true } }, onSnap);
+const stop = client.collections.posts.live(
+	{ where: { published: true } },
+	onSnap,
+);
 
 // Raw equivalent, you build the topic and supply TData yourself:
 const stopRaw = client.realtime.subscribe<MySnapshot>(
-  buildCollectionTopic("posts", { where: { published: true } }),
-  (data) => onSnap(data),
-  /* signal */ undefined,
-  /* customId */ undefined,
-  /* onError */ (err) => console.error(err),
+	buildCollectionTopic("posts", { where: { published: true } }),
+	(data) => onSnap(data),
+	/* signal */ undefined,
+	/* customId */ undefined,
+	/* onError */ (err) => console.error(err),
 );
 ```
 
@@ -211,7 +253,10 @@ const stopRaw = client.realtime.subscribe<MySnapshot>(
 Pass `locale` in the live options to subscribe to a specific localized variant, it becomes part of the topic, so the `en` and `de` views of the same query are independent subscriptions:
 
 ```ts
-client.collections.posts.live({ where: { published: true }, locale: "de" }, onSnap);
+client.collections.posts.live(
+	{ where: { published: true }, locale: "de" },
+	onSnap,
+);
 ```
 
 `setLocale()` on the client mutates request headers for `find`/`create`/etc., but does **not** retarget already-open realtime subscriptions, realtime carries `locale` per topic. To switch a subscription's locale, unsubscribe and re-subscribe with the new `locale`.
@@ -228,7 +273,13 @@ client.collections.posts.live({ where: { published: true }, locale: "de" }, onSn
 The realtime option and result types come from `questpie/client`:
 
 ```ts
-import type { RealtimeAPI, TopicConfig, TopicInput, FindResult, PaginatedResult } from "questpie/client";
+import type {
+	RealtimeAPI,
+	TopicConfig,
+	TopicInput,
+	FindResult,
+	PaginatedResult,
+} from "questpie/client";
 ```
 
 `LiveQueryOptions`, `GlobalLiveQueryOptions`, and `LiveSubscribeOptions` are structural option types on the client method signatures (inferred at the call site, you rarely import them by name). The snapshot type is `FindResult<Row, Relations, TQuery>` for collections and `ApplyQuery<GlobalSelect, Relations, TQuery>` for globals, identical to `find()` / `get()`.

--- a/apps/docs/content/docs/client/tanstack-query.mdx
+++ b/apps/docs/content/docs/client/tanstack-query.mdx
@@ -47,36 +47,47 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { q } from "@/lib/query.js";
 
 function Posts() {
-  const queryClient = useQueryClient();
+	const queryClient = useQueryClient();
 
-  // Read: q.collections.posts.find(...) returns queryOptions()
-  const { data } = useQuery(q.collections.posts.find({ where: { published: true }, limit: 10 }));
+	// Read: q.collections.posts.find(...) returns queryOptions()
+	const { data } = useQuery(
+		q.collections.posts.find({ where: { published: true }, limit: 10 }),
+	);
 
-  // Write: q.collections.posts.create() returns mutationOptions()
-  const create = useMutation({
-    ...q.collections.posts.create(),
-    onSuccess: () => {
-      // Invalidate every posts query with the top-level key helper.
-      queryClient.invalidateQueries({
-        queryKey: q.key(["collections", "posts"]),
-      });
-    },
-  });
+	// Write: q.collections.posts.create() returns mutationOptions()
+	const create = useMutation({
+		...q.collections.posts.create(),
+		onSuccess: () => {
+			// Invalidate every posts query with the top-level key helper.
+			queryClient.invalidateQueries({
+				queryKey: q.key(["collections", "posts"]),
+			});
+		},
+	});
 
-  return (
-    <div>
-      <p>{data?.totalDocs ?? 0} published posts</p>
-      <button onClick={() => create.mutate({ title: "Hello", slug: "hello", published: true })}>Add post</button>
-    </div>
-  );
+	return (
+		<div>
+			<p>{data?.totalDocs ?? 0} published posts</p>
+			<button
+				onClick={() =>
+					create.mutate({ title: "Hello", slug: "hello", published: true })
+				}
+			>
+				Add post
+			</button>
+		</div>
+	);
 }
 ```
 
 `find()` resolves to the same **paginated envelope** the client returns, `{ docs, totalDocs, page, hasNextPage, … }`, so read your rows off `data.docs`. The mutation variables (`{ title, slug, published }`) are the collection's create input, inferred from your schema.
 
 <Callout type="info" title="Build the proxy once, not per render">
-  `createQuestpieQueryOptions(client)` is cheap, but the returned proxies are stable identities, create it once at module scope (as the scaffold does) and import `q` everywhere. The builders themselves are pure: calling `q.collections.posts.find(opts)` only *builds* an options object; nothing fetches until you hand it
-  to `useQuery`.
+	`createQuestpieQueryOptions(client)` is cheap, but the returned proxies are
+	stable identities, create it once at module scope (as the scaffold does) and
+	import `q` everywhere. The builders themselves are pure: calling
+	`q.collections.posts.find(opts)` only *builds* an options object; nothing
+	fetches until you hand it to `useQuery`.
 </Callout>
 
 ## Example → inferred types
@@ -85,8 +96,8 @@ Each builder mirrors the client method it wraps, so the inferred result is ident
 
 ```ts
 const opts = q.collections.posts.find({
-  where: { published: true },
-  limit: 10,
+	where: { published: true },
+	limit: 10,
 });
 //    ^? UseQueryOptions<FindResult<…, { docs: Post[]; totalDocs: number; … }>>
 
@@ -108,10 +119,10 @@ The selection generic is applied **per call**, `find<TQuery>(options?)` narrows 
 ```ts
 // List, paginated envelope. Optional second arg enables realtime (below).
 q.collections.posts.find({
-  where: { published: true },
-  with: { author: true },
-  orderBy: { createdAt: "desc" },
-  limit: 10,
+	where: { published: true },
+	with: { author: true },
+	orderBy: { createdAt: "desc" },
+	limit: 10,
 });
 
 // Count, number (or live total with { realtime: true }).
@@ -200,7 +211,9 @@ A global always exists (it's a singleton with defaults), so `q.globals.<name>.ge
 
 ```ts
 // Read a route as a query.
-const stats = useQuery(q.routes.dashboard.getStats.post.query({ period: "week" }));
+const stats = useQuery(
+	q.routes.dashboard.getStats.post.query({ period: "week" }),
+);
 
 // Call a route as a mutation.
 const send = useMutation(q.routes.notifications.send.post.mutation());
@@ -219,8 +232,12 @@ const key = q.routes.dashboard.getStats.post.key({ period: "week" });
 </Callout>
 
 <Callout type="warn" title="Unknown routes throw at fetch time, not build time">
-  The routes proxy is loose, `q.routes.a.b.c.post.query()` *builds* an options object for any dot-path. The path is only resolved against `client.routes` when the query runs; if it doesn't resolve to a function the fetcher throws `Route not found at path: a.b.c.post`. There's no build-time check that the route exists,
-  so a typo'd path surfaces as a runtime query error, not a red squiggle. The same lazy-resolution applies to unknown collection/global names.
+	The routes proxy is loose, `q.routes.a.b.c.post.query()` *builds* an options
+	object for any dot-path. The path is only resolved against `client.routes`
+	when the query runs; if it doesn't resolve to a function the fetcher throws
+	`Route not found at path: a.b.c.post`. There's no build-time check that the
+	route exists, so a typo'd path surfaces as a runtime query error, not a red
+	squiggle. The same lazy-resolution applies to unknown collection/global names.
 </Callout>
 
 ## Realtime
@@ -229,9 +246,14 @@ Three reads can become **live** by passing `{ realtime: true }` as their second 
 
 ```tsx
 function LivePosts() {
-  // Re-renders whenever a matching post changes, no manual invalidation.
-  const { data } = useQuery(q.collections.posts.find({ where: { published: true } }, { realtime: true }));
-  return <p>{data?.totalDocs ?? 0} published posts (live)</p>;
+	// Re-renders whenever a matching post changes, no manual invalidation.
+	const { data } = useQuery(
+		q.collections.posts.find(
+			{ where: { published: true } },
+			{ realtime: true },
+		),
+	);
+	return <p>{data?.totalDocs ?? 0} published posts (live)</p>;
 }
 ```
 
@@ -244,8 +266,14 @@ Admission failures such as a `find` limit above the server's configured `maxFind
 </Callout>
 
 <Callout type="info" title="Realtime topic ignores some read options">
-  The live subscription's topic is derived from your read `options` via `buildCollectionTopic` / `buildGlobalTopic`, which carry only `where` / `with` / `limit` / `offset` / `orderBy` / `locale` (globals: `where` / `with` / `locale`). `columns`, `stage`, `includeDeleted`, and `localeFallback` are **dropped from the
-  topic**, and the config-level `locale`/`stage` are *not* added to it, so live matching ignores those. Both builders are re-exported from the package if you want to subscribe manually via `client.realtime.subscribe`.
+	The live subscription's topic is derived from your read `options` via
+	`buildCollectionTopic` / `buildGlobalTopic`, which carry only `where` / `with`
+	/ `limit` / `offset` / `orderBy` / `locale` (globals: `where` / `with` /
+	`locale`). `columns`, `stage`, `includeDeleted`, and `localeFallback` are
+	**dropped from the topic**, and the config-level `locale`/`stage` are *not*
+	added to it, so live matching ignores those. Both builders are re-exported
+	from the package if you want to subscribe manually via
+	`client.realtime.subscribe`.
 </Callout>
 
 ## Channel subscriptions
@@ -253,9 +281,13 @@ Admission failures such as a `find` limit above the server's configured `maxFind
 Generated channels appear beside collections, globals, and routes:
 
 ```tsx
-const { data: messages = [] } = useQuery(q.channels.chatRoom.subscription({ roomId }));
+const { data: messages = [] } = useQuery(
+	q.channels.chatRoom.subscription({ roomId }),
+);
 
-const { data: members = [] } = useQuery(q.channels.chatRoom.presence({ roomId }));
+const { data: members = [] } = useQuery(
+	q.channels.chatRoom.presence({ roomId }),
+);
 ```
 
 No-param channels use `.subscription()` or `.presence()` with no argument. Parameterized channels require their exact generated params. The event query appends each typed `{ event, eventId, data }` message; the presence query replaces its value with each newest member roster. Aborting or unmounting closes the underlying iterator. See [Channels](/docs/client/channels) for definitions, authorization, publish, presence, and transport behavior.
@@ -266,10 +298,10 @@ No-param channels use `.subscription()` or `.presence()` with no argument. Param
 
 ```ts
 export const q = createQuestpieQueryOptions(client, {
-  keyPrefix: ["questpie"], // QueryKey prepended to every key. Default ['questpie'].
-  errorMap: defaultErrorMap, // (error: unknown) => unknown. Wraps every fetcher/mutator.
-  locale: undefined, // string, baked into keys AND threaded into every call.
-  stage: undefined, // string, same: keyed and threaded.
+	keyPrefix: ["questpie"], // QueryKey prepended to every key. Default ['questpie'].
+	errorMap: defaultErrorMap, // (error: unknown) => unknown. Wraps every fetcher/mutator.
+	locale: undefined, // string, baked into keys AND threaded into every call.
+	stage: undefined, // string, same: keyed and threaded.
 });
 ```
 
@@ -280,9 +312,19 @@ export const q = createQuestpieQueryOptions(client, {
 | `locale`    | `string`                      | `undefined`       | Pinned read/write locale, see the warning below.                                                   |
 | `stage`     | `string`                      | `undefined`       | Pinned workflow stage, see the warning below.                                                      |
 
-<Callout type="warn" title="`locale` and `stage` are global to the proxy and override per-call options for globals">
-  A `locale`/`stage` set in `config` is baked into **every** query key and threaded into **every** read and mutation, for collections as the call's options/`LocaleOptions` second argument, for globals **merged into the options object**. Because they're spread *after* the caller's options, they **override** any per-call
-  `locale`/`stage` on `globals.update` / `revertToVersion` / `findVersions`. If you need different locales in different parts of the UI, create a second proxy with its own `config` rather than fighting the override. (One asymmetry: `globals.transitionStage` merges only `locale` from config, not `stage`.
+<Callout
+	type="warn"
+	title="`locale` and `stage` are global to the proxy and override per-call options for globals"
+>
+	A `locale`/`stage` set in `config` is baked into **every** query key and
+	threaded into **every** read and mutation, for collections as the call's
+	options/`LocaleOptions` second argument, for globals **merged into the options
+	object**. Because they're spread *after* the caller's options, they
+	**override** any per-call `locale`/`stage` on `globals.update` /
+	`revertToVersion` / `findVersions`. If you need different locales in different
+	parts of the UI, create a second proxy with its own `config` rather than
+	fighting the override. (One asymmetry: `globals.transitionStage` merges only
+	`locale` from config, not `stage`.
 </Callout>
 
 ### Custom error mapping
@@ -291,10 +333,10 @@ The default `errorMap` coerces non-`Error` throws into `Error` (passes `Error` t
 
 ```ts
 export const q = createQuestpieQueryOptions(client, {
-  errorMap: (error) => {
-    if (error instanceof MyApiError) return error;
-    return new Error("Request failed", { cause: error });
-  },
+	errorMap: (error) => {
+		if (error instanceof MyApiError) return error;
+		return new Error("Request failed", { cause: error });
+	},
 });
 ```
 
@@ -321,7 +363,7 @@ queryClient.invalidateQueries({ queryKey: q.key(["collections", "posts"]) });
 
 // Invalidate one route query exactly.
 queryClient.invalidateQueries({
-  queryKey: q.routes.dashboard.getStats.post.key({ period: "week" }),
+	queryKey: q.routes.dashboard.getStats.post.key({ period: "week" }),
 });
 
 // Or read the key straight off any builder result:
@@ -330,12 +372,19 @@ queryClient.invalidateQueries({ queryKey });
 ```
 
 <Callout type="info" title="Collection and global query keys">
-  Use top-level `q.key([...])` for partial collection or global invalidation, or read `.queryKey` from the options returned by a builder. Per-route builders also provide `.key()`. Partial invalidation with `q.key(["collections", "posts"])` covers every locale, stage, and option variant for that collection.
+	Use top-level `q.key([...])` for partial collection or global invalidation, or
+	read `.queryKey` from the options returned by a builder. Per-route builders
+	also provide `.key()`. Partial invalidation with `q.key(["collections",
+	"posts"])` covers every locale, stage, and option variant for that collection.
 </Callout>
 
 <Callout type="info" title="Functions in options are stripped from the key">
-  Key options are sanitized: function-valued properties are removed and `undefined`-valued keys are dropped (`null` is kept) before they land in the query key, so non-serializable values don't break React Query's structural key equality. The footgun: two `find()` calls that differ **only** by a function argument
-  produce the **same** key and therefore share a cache entry. Don't encode a discriminator as a function in your options.
+	Key options are sanitized: function-valued properties are removed and
+	`undefined`-valued keys are dropped (`null` is kept) before they land in the
+	query key, so non-serializable values don't break React Query's structural key
+	equality. The footgun: two `find()` calls that differ **only** by a function
+	argument produce the **same** key and therefore share a cache entry. Don't
+	encode a discriminator as a function in your options.
 </Callout>
 
 ## Custom queries & mutations
@@ -345,14 +394,14 @@ For anything the proxies don't cover, a third-party endpoint, a composed call, a
 ```ts
 // Query
 const opts = q.custom.query<DashboardData>({
-  key: ["dashboard", "summary"], // suffix only, keyPrefix is prepended for you
-  queryFn: () => fetchDashboard(),
+	key: ["dashboard", "summary"], // suffix only, keyPrefix is prepended for you
+	queryFn: () => fetchDashboard(),
 });
 
 // Mutation
 const mut = q.custom.mutation<{ id: string }, void>({
-  key: ["dashboard", "refresh"],
-  mutationFn: (vars) => refreshDashboard(vars.id),
+	key: ["dashboard", "refresh"],
+	mutationFn: (vars) => refreshDashboard(vars.id),
 });
 ```
 
@@ -364,28 +413,34 @@ The package re-exports the React Query types you'll reference, plus its own:
 
 ```ts
 import type {
-  // Re-exported from @tanstack/react-query for convenience:
-  QueryKey,
-  DefaultError,
-  UseQueryOptions,
-  UseMutationOptions,
-  // This package's types:
-  QuestpieQueryOptionsProxy, // return type of createQuestpieQueryOptions
-  QuestpieQueryOptionsConfig, // the config argument
-  QuestpieQueryErrorMap, // (error: unknown) => unknown
-  RealtimeQueryConfig, // { realtime?: boolean }
-  // Realtime topic helpers (re-exported from questpie/client):
-  TopicConfig,
-  RealtimeAPI,
+	// Re-exported from @tanstack/react-query for convenience:
+	QueryKey,
+	DefaultError,
+	UseQueryOptions,
+	UseMutationOptions,
+	// This package's types:
+	QuestpieQueryOptionsProxy, // return type of createQuestpieQueryOptions
+	QuestpieQueryOptionsConfig, // the config argument
+	QuestpieQueryErrorMap, // (error: unknown) => unknown
+	RealtimeQueryConfig, // { realtime?: boolean }
+	// Realtime topic helpers (re-exported from questpie/client):
+	TopicConfig,
+	RealtimeAPI,
 } from "@questpie/tanstack-query";
 
-import { buildCollectionTopic, buildGlobalTopic } from "@questpie/tanstack-query";
+import {
+	buildCollectionTopic,
+	buildGlobalTopic,
+} from "@questpie/tanstack-query";
 ```
 
 `QuestpieQueryOptionsProxy<TApp>` is the typed shape of `q`; you rarely name it directly because the scaffold exports `typeof q`. `buildCollectionTopic` / `buildGlobalTopic` are runtime values (re-exported from `questpie/client`) for building realtime topics manually.
 
 <Callout type="info" title="The proxies don't enumerate">
-  `q.collections`, `q.globals`, and `q.routes` are JS `Proxy` objects with a get-trap only. `Object.keys(q.collections)`, spreading, or `for…in` over them returns nothing useful, access builders by name (`q.collections.posts`). `q.custom` and `q.key` are plain.
+	`q.collections`, `q.globals`, and `q.routes` are JS `Proxy` objects with a
+	get-trap only. `Object.keys(q.collections)`, spreading, or `for…in` over them
+	returns nothing useful, access builders by name (`q.collections.posts`).
+	`q.custom` and `q.key` are plain.
 </Callout>
 
 ## Related

--- a/apps/docs/content/docs/client/tanstack-query.mdx
+++ b/apps/docs/content/docs/client/tanstack-query.mdx
@@ -237,6 +237,8 @@ function LivePosts() {
 
 Under the hood a live query uses React Query's `experimental_streamedQuery` with `refetchMode: "append"` and replaces the cached value with each newest snapshot. `count` uses an operation-aware server topic and streams one scalar number, not the matching rows.
 
+Admission failures such as a `find` limit above the server's configured `maxFindLimit` enter the normal TanStack query `error` state. They are marked non-retryable and are not automatically retried, so the UI does not remain on a silent `undefined` placeholder. Inspect `error.code === "REALTIME_TOPIC_REJECTED"` to render a targeted fallback.
+
 <Callout type="warn" title="Realtime must be enabled on the server">
 `createClient()` always exposes `client.realtime`, so `{ realtime: true }` attempts a stream. If server runtime config does not enable realtime, the connection errors; it does not silently fall back to a one-shot read. `findOne`, `findVersions`, and all mutations never stream.
 </Callout>

--- a/apps/docs/content/docs/concepts/realtime.mdx
+++ b/apps/docs/content/docs/concepts/realtime.mdx
@@ -84,4 +84,4 @@ See [Realtime adapters](/docs/adapters/realtime) for topology, admission, outbox
 - [Channels](/docs/client/channels), typed application events and presence.
 - [Reactive apps](/docs/client/reactive-apps), subscription sizing and React performance.
 - [Realtime adapters](/docs/adapters/realtime), server transport and broker selection.
-- [Realtime v2 migration](/docs/adapters/realtime-v2-migration), canary rollout and rollback.
+- [Realtime v2 HA migration](/docs/adapters/realtime-v2-migration), schema rollout, mixed versions, and 3.x deprecations.

--- a/apps/docs/content/docs/extend/build-a-plugin.mdx
+++ b/apps/docs/content/docs/extend/build-a-plugin.mdx
@@ -17,8 +17,12 @@ This page is the build-your-own loop end to end: the **contract** (`CodegenPlugi
 - **Distribute as one package.** A module attaches its `plugin` and auto-registers on install, users add it to `modules.ts` and touch nothing else.
 
 <Callout type="info" title="Pick the smallest seam that fits">
-  Most extension is *not* a full plugin. A custom field type, a custom operator, or a custom adapter is a single factory call you register where the built-in ones go. Reach for a `CodegenPlugin` only when you need codegen to discover *new file conventions* or wrap the *builders*. The [per-feature
-  recipes](#custom-field-types) below come first for that reason; the [full plugin contract](#the-codegen-plugin-contract) is the deep end.
+	Most extension is *not* a full plugin. A custom field type, a custom operator,
+	or a custom adapter is a single factory call you register where the built-in
+	ones go. Reach for a `CodegenPlugin` only when you need codegen to discover
+	*new file conventions* or wrap the *builders*. The [per-feature
+	recipes](#custom-field-types) below come first for that reason; the [full
+	plugin contract](#the-codegen-plugin-contract) is the deep end.
 </Callout>
 
 ## The two layers of extension
@@ -54,14 +58,14 @@ import { sql } from "drizzle-orm";
 import { collection } from "#questpie/factories";
 
 export default collection("products").fields(({ f }) => ({
-  sku: f
-    .text(64)
-    .required()
-    .drizzle((column) => column.$type<`sku_${string}`>()),
-  createdAt: f
-    .datetime()
-    .inputFalse()
-    .drizzle((column) => column.default(sql`now()`)),
+	sku: f
+		.text(64)
+		.required()
+		.drizzle((column) => column.$type<`sku_${string}`>()),
+	createdAt: f
+		.datetime()
+		.inputFalse()
+		.drizzle((column) => column.default(sql`now()`)),
 }));
 ```
 
@@ -77,19 +81,19 @@ import { z } from "zod";
 import { field, stringOps } from "questpie/builders";
 
 export function color() {
-  return field({
-    type: "color",
-    columnFactory: (name: string) => varchar(name, { length: 7 }),
-    schemaFactory: () => z.string().regex(/^#[0-9a-fA-F]{6}$/),
-    operatorSet: stringOps, // reuse the builtin string operator set
-    notNull: false,
-    hasDefault: false,
-    localized: false,
-    virtual: false,
-    input: true,
-    output: true,
-    isArray: false,
-  });
+	return field({
+		type: "color",
+		columnFactory: (name: string) => varchar(name, { length: 7 }),
+		schemaFactory: () => z.string().regex(/^#[0-9a-fA-F]{6}$/),
+		operatorSet: stringOps, // reuse the builtin string operator set
+		notNull: false,
+		hasDefault: false,
+		localized: false,
+		virtual: false,
+		input: true,
+		output: true,
+		isArray: false,
+	});
 }
 ```
 
@@ -106,29 +110,29 @@ import { fieldType, stringOps } from "questpie/builders";
 import type { Field } from "questpie/builders";
 
 export const slugFieldType = fieldType("slug", {
-  // create(...args) → the FieldRuntimeState (same shape field() takes)
-  create: (maxLength: number = 255) => ({
-    type: "slug",
-    columnFactory: (name: string) => varchar(name, { length: maxLength }),
-    schemaFactory: () =>
-      z
-        .string()
-        .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/)
-        .max(maxLength),
-    operatorSet: stringOps,
-    notNull: false,
-    hasDefault: false,
-    localized: false,
-    virtual: false,
-    input: true,
-    output: true,
-    isArray: false,
-    maxLength,
-  }),
-  // type-specific chain methods: (field, ...args) => field
-  methods: {
-    maxLen: (f: Field<any>, n: number) => f.derive({ maxLength: n }),
-  },
+	// create(...args) → the FieldRuntimeState (same shape field() takes)
+	create: (maxLength: number = 255) => ({
+		type: "slug",
+		columnFactory: (name: string) => varchar(name, { length: maxLength }),
+		schemaFactory: () =>
+			z
+				.string()
+				.regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/)
+				.max(maxLength),
+		operatorSet: stringOps,
+		notNull: false,
+		hasDefault: false,
+		localized: false,
+		virtual: false,
+		input: true,
+		output: true,
+		isArray: false,
+		maxLength,
+	}),
+	// type-specific chain methods: (field, ...args) => field
+	methods: {
+		maxLen: (f: Field<any>, n: number) => f.derive({ maxLength: n }),
+	},
 });
 
 // The callable factory the `f` proxy uses:
@@ -147,8 +151,8 @@ import { color } from "./fields/color";
 import { slug } from "./fields/slug";
 
 export const myModule = module({
-  name: "acme-fields",
-  fields: { color, slug }, // each entry becomes a method on f
+	name: "acme-fields",
+	fields: { color, slug }, // each entry becomes a method on f
 });
 ```
 
@@ -157,8 +161,12 @@ When a module declares a `fields` record, codegen extracts those factories (the 
 In a **root app** (not a package), the same effect comes from a single `src/questpie/server/fields.ts` _bundle_ file that exports your factories, codegen discovers it via the `fields` discover pattern, spreads its default export into the runtime field map, and augments the type-level `FieldTypesMap`.
 
 <Callout type="info" title="Two `fields` mechanisms, don't confuse them">
-  The core plugin has *both* a `fields.ts` single-file discover pattern for the root-app bundle and a `fieldTypes` *category* that scans the `fields/` directory for `fieldType()` calls. The category feeds the `~fieldTypes` Registry and module extraction; it does **not** auto-inject loose `fields/`-directory files into
-  a root app's `f` proxy. Register via a module's `fields` record (packages) or the `fields.ts` bundle (root apps).
+	The core plugin has *both* a `fields.ts` single-file discover pattern for the
+	root-app bundle and a `fieldTypes` *category* that scans the `fields/`
+	directory for `fieldType()` calls. The category feeds the `~fieldTypes`
+	Registry and module extraction; it does **not** auto-inject loose
+	`fields/`-directory files into a root app's `f` proxy. Register via a module's
+	`fields` record (packages) or the `fields.ts` bundle (root apps).
 </Callout>
 
 The full field surface, every common method (`.zod()`, `.drizzle()`, `.array()`, `.access()`, `.hooks()`, …), the `FieldRuntimeState` shape, and the per-type metadata, is in [Fields](/docs/concepts/fields). What's above is the minimum to add your own.
@@ -169,55 +177,52 @@ Infrastructure in QUESTPIE is adapter-shaped. Every subsystem, queue, search, re
 
 Each subsystem has one interface. A few of them:
 
-| Subsystem | Interface             | Wire it as                                   |
-| --------- | --------------------- | -------------------------------------------- |
-| Search    | `SearchAdapter`       | `runtimeConfig({ search })`                  |
-| Realtime  | `RealtimeAdapter`     | `runtimeConfig({ realtime: { adapter } })`   |
-| KV        | `KVAdapter`           | `runtimeConfig({ kv: { adapter } })`         |
-| Executor  | `ExecutorAdapter`     | `runtimeConfig({ executor: { sandboxed } })` |
-| Storage   | `files-sdk` `Adapter` | `runtimeConfig({ storage: { adapter } })`    |
+| Subsystem | Interface             | Wire it as                                      |
+| --------- | --------------------- | ----------------------------------------------- |
+| Search    | `SearchAdapter`       | `runtimeConfig({ search })`                     |
+| Realtime  | `ChangeBroker`        | `runtimeConfig({ realtime: { changeBroker } })` |
+| KV        | `KVAdapter`           | `runtimeConfig({ kv: { adapter } })`            |
+| Executor  | `ExecutorAdapter`     | `runtimeConfig({ executor: { sandboxed } })`    |
+| Storage   | `files-sdk` `Adapter` | `runtimeConfig({ storage: { adapter } })`       |
 
-A `RealtimeAdapter` is the smallest contract, four methods. Here is the shape of a custom transport adapter:
+A Realtime v2 `ChangeBroker` is a notice-only wake seam. Durable database state remains authoritative, so wakes may be lost, duplicated, delayed, reordered, or coalesced:
 
 ```ts title="src/questpie/server/adapters/my-realtime.ts"
-import type { RealtimeAdapter, RealtimeChangeEvent, RealtimeNotice } from "questpie/realtime";
+import type { ChangeBroker } from "questpie/realtime";
 
-export function myRealtimeAdapter(): RealtimeAdapter {
-  return {
-    async start() {
-      /* open the connection */
-    },
-    async stop() {
-      /* close it */
-    },
-    async notify(event: RealtimeChangeEvent) {
-      /* broadcast to other instances */
-    },
-    subscribe(handler: (notice: RealtimeNotice) => void) {
-      // call handler(notice) on each incoming change; return an unsubscribe fn
-      return () => {
-        /* unsubscribe */
-      };
-    },
-  };
+export function myRealtimeBroker(): ChangeBroker {
+	return {
+		async start({ onWake, onError, onStateChange }) {
+			/* open the connection and pass normalized metadata wakes to onWake */
+		},
+		async stop() {
+			/* close it */
+		},
+		async publish(wake) {
+			/* broadcast only the bounded ChangeWake metadata */
+		},
+	};
 }
 ```
 
 ```ts title="src/questpie/server/questpie.config.ts"
 import { runtimeConfig } from "questpie/app";
-import { myRealtimeAdapter } from "./adapters/my-realtime";
+import { myRealtimeBroker } from "./adapters/my-realtime";
 
 export default runtimeConfig({
-  db: { url: process.env.DATABASE_URL! },
-  realtime: { adapter: myRealtimeAdapter() },
+	db: { url: process.env.DATABASE_URL! },
+	realtime: { changeBroker: myRealtimeBroker() },
 });
 ```
 
-The adapter interfaces and their config types (`RealtimeAdapter` / `RealtimeConfig`, `SearchAdapter` / `SearchOptions` / `SearchResponse`, `KVAdapter` / `KVConfig`, `ExecutorAdapter` / `ExecutorConfig`) are all exported from the matching subpath, `questpie/realtime`, `questpie/search`, `questpie/kv`, `questpie/executor`. Build against the interface and the framework treats yours identically to a builtin. Each subsystem's contract and the built-in adapters are documented under Infrastructure.
+The adapter interfaces and their config types (`ChangeBroker` / `RealtimeConfig`, `SearchAdapter` / `SearchOptions` / `SearchResponse`, `KVAdapter` / `KVConfig`, `ExecutorAdapter` / `ExecutorConfig`) are all exported from the matching subpath, `questpie/realtime`, `questpie/search`, `questpie/kv`, `questpie/executor`. `RealtimeAdapter` remains only as a deprecated QuestPie 3.x compatibility contract and is removed in QuestPie 4. Each subsystem's contract and built-in adapters are documented under Infrastructure.
 
 <Callout type="info" title="Adapters that need a runtime discriminator">
-  A few adapters carry a `readonly runtime` field (e.g. the Cloudflare adapters set `runtime: "cloudflare"`) so the Cloudflare fetch/queue handlers can detect them. That's a built-in detail of those specific adapters, not a requirement of the interface, a plain transport adapter like the one above needs no
-  discriminator.
+	A few adapters carry a `readonly runtime` field (e.g. the Cloudflare adapters
+	set `runtime: "cloudflare"`) so the Cloudflare fetch/queue handlers can detect
+	them. That's a built-in detail of those specific adapters, not a requirement
+	of the interface, a plain transport adapter like the one above needs no
+	discriminator.
 </Callout>
 
 ## Custom blocks & components
@@ -230,15 +235,15 @@ A **block** is a reusable content unit for the visual block editor (`f.blocks()`
 import { block } from "#questpie/factories";
 
 export const heroBlock = block("hero")
-  .admin(({ c }) => ({
-    label: "Hero",
-    icon: c.icon("ph:image"),
-    category: { label: "Layout" },
-  }))
-  .fields(({ f }) => ({
-    heading: f.text(120).label("Heading").required(),
-    subheading: f.textarea().label("Subheading"),
-  }));
+	.admin(({ c }) => ({
+		label: "Hero",
+		icon: c.icon("ph:image"),
+		category: { label: "Layout" },
+	}))
+	.fields(({ f }) => ({
+		heading: f.text(120).label("Heading").required(),
+		subheading: f.textarea().label("Subheading"),
+	}));
 ```
 
 `block` comes from `#questpie/factories` (the generated factory, like `collection`) because the block builder needs your merged field defs at construction. Codegen keys blocks off the name you pass (`block("hero")`).
@@ -246,8 +251,12 @@ export const heroBlock = block("hero")
 A **component** registers a named React-component reference you can hand to admin config (icons, custom cells, dashboard widgets) with typed props. Declare it server-side with `component(name, config)`; the `c` proxy in `.admin()` / `.actions()` / dashboard callbacks then offers `c.myComponent(props)` with autocomplete.
 
 <Callout type="info" title="Blocks and components are two-sided">
-  A block or component has a **server definition** (`blocks/`, `components/`, schema + props) and a matching **client renderer** (`client/blocks/`, `client/components/`, the React component). `questpie add block hero` scaffolds both sides for you because the admin plugin declares the `block` scaffold on *both* its
-  `server` and `admin-client` targets. The admin docs cover the client side; this page covers how the extension points exist.
+	A block or component has a **server definition** (`blocks/`, `components/`,
+	schema + props) and a matching **client renderer** (`client/blocks/`,
+	`client/components/`, the React component). `questpie add block hero`
+	scaffolds both sides for you because the admin plugin declares the `block`
+	scaffold on *both* its `server` and `admin-client` targets. The admin docs
+	cover the client side; this page covers how the extension points exist.
 </Callout>
 
 The full block/component authoring surface, field layouts, prefetch, the client renderer contract, custom views/widgets, is in the admin documentation. What matters here: they're standard file conventions, reachable by any app the moment admin is installed.
@@ -262,17 +271,17 @@ A plugin is one object: a `name`, a map of **target contributions**, and optiona
 import type { CodegenPlugin } from "questpie/codegen";
 
 export function myPlugin(): CodegenPlugin {
-  return {
-    name: "my-plugin", // unique; dedup is by name (first wins on collision)
-    targets: {
-      server: {
-        root: ".",
-        outputFile: "index.ts",
-        // categories, discover, registries, transform, scaffolds, generate…
-      },
-    },
-    validators: [], // cross-target checks, run after all targets generate
-  };
+	return {
+		name: "my-plugin", // unique; dedup is by name (first wins on collision)
+		targets: {
+			server: {
+				root: ".",
+				outputFile: "index.ts",
+				// categories, discover, registries, transform, scaffolds, generate…
+			},
+		},
+		validators: [], // cross-target checks, run after all targets generate
+	};
 }
 ```
 
@@ -287,8 +296,8 @@ import { runtimeConfig } from "questpie/app";
 import { myPlugin } from "@acme/questpie-thing/plugin";
 
 export default runtimeConfig({
-  db: { url: process.env.DATABASE_URL! },
-  plugins: [myPlugin()], // codegen plugins, NOT module dependencies
+	db: { url: process.env.DATABASE_URL! },
+	plugins: [myPlugin()], // codegen plugins, NOT module dependencies
 });
 ```
 
@@ -297,17 +306,23 @@ import { module } from "questpie/app";
 import { myPlugin } from "./plugin";
 
 export const myModule = module({
-  name: "acme-thing",
-  plugin: myPlugin(), // auto-extracted at codegen time
-  // collections, jobs, messages… all merged at runtime
+	name: "acme-thing",
+	plugin: myPlugin(), // auto-extracted at codegen time
+	// collections, jobs, messages… all merged at runtime
 });
 ```
 
 When a plugin rides on a module's `plugin` field, codegen's pre-pass (`extractPluginsFromModules`) auto-registers it the moment the module appears in `modules.ts`, the user adds nothing to `questpie.config.ts`. This is how `adminModule` works: `Object.assign(generatedModule, { plugin: adminPlugin() })`, and installing the module _is_ installing the plugin. The `plugin` key is codegen-only, it's stripped from the runtime module merge.
 
-<Callout type="warn" title="`plugins` is for codegen plugins; `modules.ts` is for dependencies">
-  `runtimeConfig({plugins})` registers **codegen plugins** (file discovery + generated output). Module *dependencies* go in `modules.ts`. Because a module can carry its own codegen plugin, most apps never touch `plugins` directly, they just install your module. The core codegen plugin is *always* prepended
-  automatically; never register it.
+<Callout
+	type="warn"
+	title="`plugins` is for codegen plugins; `modules.ts` is for dependencies"
+>
+	`runtimeConfig({plugins})` registers **codegen plugins** (file discovery +
+	generated output). Module *dependencies* go in `modules.ts`. Because a module
+	can carry its own codegen plugin, most apps never touch `plugins` directly,
+	they just install your module. The core codegen plugin is *always* prepended
+	automatically; never register it.
 </Callout>
 
 ### Target contribution, the surface
@@ -365,9 +380,15 @@ The knobs you'll actually reach for:
 | `keyFromSource`    | `"basename"`                                                           | use the source filename as the key (client convention files)                                                      |
 | `factoryImports`   | `Array<{ name; from }>`                                                | named exports spread-merged into `factories.ts` (admin merges `adminFields`)                                      |
 
-<Callout type="info" title="`factoryFunctions` is how one file yields many entities">
-  Without `factoryFunctions`, a file is one entity keyed off its default/named export. With it, codegen scans for every call to a named factory (`view(…)`, `block(…)`) and emits one entity per call, keyed off the factory's first string argument, and silently skips files that contain no such call (so utility/type files
-  in the same directory don't pollute the registry).
+<Callout
+	type="info"
+	title="`factoryFunctions` is how one file yields many entities"
+>
+	Without `factoryFunctions`, a file is one entity keyed off its default/named
+	export. With it, codegen scans for every call to a named factory (`view(…)`,
+	`block(…)`) and emits one entity per call, keyed off the factory's first
+	string argument, and silently skips files that contain no such call (so
+	utility/type files in the same directory don't pollute the registry).
 </Callout>
 
 ### Discover patterns, single files & spreads
@@ -472,8 +493,12 @@ declare module "questpie" {
 A user then drops `config/my-plugin.ts` exporting your config, and it lands at `app.config.myPlugin`. This is exactly how `config/admin.ts` and `config/openapi.ts` work, they're not special-cased, just instances of this pattern. The [Configuration](/docs/concepts/configuration) page covers the config bucket from the app author's side.
 
 <Callout type="info" title="Why non-destructive matters">
-  A QUESTPIE app composes N plugins (admin, audit, OpenAPI, yours) and its own files. If any plugin could overwrite another's output, ordering would become load-bearing and installs would be fragile. Merge-not-replace + per-key config buckets mean plugins are *commutative* in the common case, you install them in any
-  order and they coexist. The only hard conflicts (same `outputFile`, two `generate`s) fail loudly at codegen time, not silently at runtime.
+	A QUESTPIE app composes N plugins (admin, audit, OpenAPI, yours) and its own
+	files. If any plugin could overwrite another's output, ordering would become
+	load-bearing and installs would be fragile. Merge-not-replace + per-key config
+	buckets mean plugins are *commutative* in the common case, you install them in
+	any order and they coexist. The only hard conflicts (same `outputFile`, two
+	`generate`s) fail loudly at codegen time, not silently at runtime.
 </Callout>
 
 ## Packaging & publishing
@@ -493,20 +518,27 @@ A plugin ships as a **module package**. The shape that makes `questpie generate`
    import { packageConfig } from "questpie/cli";
    import { myPlugin } from "./src/plugin";
 
-   export default packageConfig({
-     modulesDir: "src/modules",
-     modulePrefix: "acme",
-     plugins: [myPlugin()],
-   });
+   const modulesDir = "src/modules";
+   const modulePrefix = "acme";
+   const plugins = [myPlugin()];
+
+   export default packageConfig({ modulesDir, modulePrefix, plugins });
    ```
 
 4. **Ship only the generated `module.ts`**, `packageConfig` itself is dev-only and not distributed. Consumers add your module to `modules.ts`; because it carries `.plugin`, your codegen plugin auto-registers in _their_ app with no extra config.
 
 `packageConfig` is `{ modulesDir; modulePrefix?; plugins? }`, exported from `questpie/cli` (which is side-effect-free on import, importing it must never start a CLI command). The core framework itself uses this exact pattern: `packageConfig({ modulesDir: "src/server/modules", modulePrefix: "questpie" })`.
 
-<Callout type="warn" title="Import the type from `questpie/codegen`, the lightweight `plugin` entry">
-  Author your `CodegenPlugin` against `questpie/codegen` (types) and keep the plugin factory in a *standalone* entry like `@acme/thing/plugin` that does **not** pull in `drizzle-orm` or runtime code, so a user importing your plugin into `questpie.config.ts` stays lightweight. This is why `@questpie/admin` exposes
-  `adminPlugin()` from `@questpie/admin/plugin` separately from the heavy server entry.
+<Callout
+	type="warn"
+	title="Import the type from `questpie/codegen`, the lightweight `plugin` entry"
+>
+	Author your `CodegenPlugin` against `questpie/codegen` (types) and keep the
+	plugin factory in a *standalone* entry like `@acme/thing/plugin` that does
+	**not** pull in `drizzle-orm` or runtime code, so a user importing your plugin
+	into `questpie.config.ts` stays lightweight. This is why `@questpie/admin`
+	exposes `adminPlugin()` from `@questpie/admin/plugin` separately from the
+	heavy server entry.
 </Callout>
 
 ## The whole loop
@@ -525,11 +557,27 @@ Every step rides the same primitives the framework's own admin uses, that's the 
 Plugin authors import codegen types from `questpie/codegen`, field factories from `questpie/builders`, and `module` / `packageConfig` from `questpie/app` and `questpie/cli`:
 
 ```ts
-import type { CodegenPlugin, CodegenTargetContribution, CategoryDeclaration, DiscoverPattern, RegistryExtension, SingletonFactory, BuilderFactory, ScaffoldConfig, CrossTargetValidator, CodegenContext, CodegenTargetGenerateContext } from "questpie/codegen";
+import type {
+	CodegenPlugin,
+	CodegenTargetContribution,
+	CategoryDeclaration,
+	DiscoverPattern,
+	RegistryExtension,
+	SingletonFactory,
+	BuilderFactory,
+	ScaffoldConfig,
+	CrossTargetValidator,
+	CodegenContext,
+	CodegenTargetGenerateContext,
+} from "questpie/codegen";
 
 // Public field factories, builtin operator sets, and field types.
 import { field, fieldType, from } from "questpie/builders";
-import type { OperatorFn, OperatorMap, ContextualOperators } from "questpie/builders";
+import type {
+	OperatorFn,
+	OperatorMap,
+	ContextualOperators,
+} from "questpie/builders";
 
 import { module } from "questpie/app"; // module(), NOT on questpie/cli
 import { packageConfig } from "questpie/cli"; // packageConfig (dev-only)

--- a/apps/docs/content/docs/extend/build-a-plugin.mdx
+++ b/apps/docs/content/docs/extend/build-a-plugin.mdx
@@ -215,7 +215,7 @@ export default runtimeConfig({
 });
 ```
 
-The adapter interfaces and their config types (`ChangeBroker` / `RealtimeConfig`, `SearchAdapter` / `SearchOptions` / `SearchResponse`, `KVAdapter` / `KVConfig`, `ExecutorAdapter` / `ExecutorConfig`) are all exported from the matching subpath, `questpie/realtime`, `questpie/search`, `questpie/kv`, `questpie/executor`. `RealtimeAdapter` remains only as a deprecated QuestPie 3.x compatibility contract and is removed in QuestPie 4. Each subsystem's contract and built-in adapters are documented under Infrastructure.
+The adapter interfaces and their config types (`ChangeBroker` / `RealtimeConfig`, `SearchAdapter` / `SearchOptions` / `SearchResponse`, `KVAdapter` / `KVConfig`, `ExecutorAdapter` / `ExecutorConfig`) are all exported from the matching subpath, `questpie/realtime`, `questpie/search`, `questpie/kv`, `questpie/executor`. Each subsystem's current contract and built-in adapters are documented under Infrastructure; the Realtime migration guide owns version-transition details.
 
 <Callout type="info" title="Adapters that need a runtime discriminator">
 	A few adapters carry a `readonly runtime` field (e.g. the Cloudflare adapters

--- a/packages/questpie/bench/realtime-baseline.ts
+++ b/packages/questpie/bench/realtime-baseline.ts
@@ -10,6 +10,10 @@ import {
 	type RealtimeAdapter,
 	type RealtimeChangeEvent,
 } from "../src/exports/index.js";
+import type {
+	RealtimeObservation,
+	RealtimeObserver,
+} from "../src/server/modules/core/integrated/realtime/observer.js";
 import { buildMockApp } from "../test/utils/mocks/mock-app-builder.js";
 import { createTestContext } from "../test/utils/test-context.js";
 import { runTestDbMigrations } from "../test/utils/test-db.js";
@@ -26,7 +30,20 @@ type Topic = {
 	offset?: number;
 	orderBy?: Record<string, "asc" | "desc">;
 	locale?: string;
+	sinceSeq?: number;
 };
+
+class BenchmarkObserver implements RealtimeObserver {
+	private refreshes = 0;
+
+	record(event: RealtimeObservation): void {
+		if (event.type === "refresh.started") this.refreshes += 1;
+	}
+
+	checkpoint(): number {
+		return this.refreshes;
+	}
+}
 
 class LocalRealtimeAdapter implements RealtimeAdapter {
 	private listeners = new Set<(event: RealtimeChangeEvent) => void>();
@@ -49,24 +66,80 @@ class SnapshotReader {
 	private buffer = "";
 	private decoder = new TextDecoder();
 	private reader: ReadableStreamDefaultReader<Uint8Array>;
+	private receivedBytes = 0;
+	private controlSession: { sessionId: string; token: string } | null = null;
 
 	constructor(stream: ReadableStream<Uint8Array>) {
 		this.reader = stream.getReader();
 	}
 
-	async readSnapshots(count: number): Promise<void> {
+	async readSnapshots(
+		count: number,
+	): Promise<Array<{ topicId: string; seq: number }>> {
 		let received = 0;
+		const snapshots: Array<{ topicId: string; seq: number }> = [];
 		while (received < count) {
 			const event = await this.readEvent();
 			if (event.type === "error") {
 				throw new Error(`Realtime stream error: ${event.data}`);
 			}
-			if (event.type === "snapshot") received += 1;
+			this.captureSession(event);
+			if (event.type === "snapshot") {
+				const frame = JSON.parse(event.data) as {
+					topicId?: unknown;
+					seq?: unknown;
+				};
+				if (
+					typeof frame.topicId === "string" &&
+					typeof frame.seq === "number"
+				) {
+					snapshots.push({ topicId: frame.topicId, seq: frame.seq });
+				}
+				received += 1;
+			}
 		}
+		return snapshots;
+	}
+
+	async readSession(): Promise<void> {
+		while (!this.controlSession) {
+			const event = await this.readEvent();
+			if (event.type === "error") {
+				throw new Error(`Realtime stream error: ${event.data}`);
+			}
+			this.captureSession(event);
+		}
+	}
+
+	get session(): { sessionId: string; token: string } {
+		if (!this.controlSession)
+			throw new Error("Realtime session metadata missing");
+		return this.controlSession;
+	}
+
+	get bytesRead(): number {
+		return this.receivedBytes;
 	}
 
 	async close() {
 		await this.reader.cancel();
+	}
+
+	private captureSession(event: { type: string; data: string }): void {
+		if (event.type !== "session") return;
+		const session = JSON.parse(event.data) as {
+			sessionId?: unknown;
+			token?: unknown;
+		};
+		if (
+			typeof session.sessionId === "string" &&
+			typeof session.token === "string"
+		) {
+			this.controlSession = {
+				sessionId: session.sessionId,
+				token: session.token,
+			};
+		}
 	}
 
 	private async readEvent(): Promise<{ type: string; data: string }> {
@@ -86,14 +159,19 @@ class SnapshotReader {
 
 			const { done, value } = await this.reader.read();
 			if (done) throw new Error("Realtime stream closed before snapshot");
+			this.receivedBytes += value.byteLength;
 			this.buffer += this.decoder.decode(value, { stream: true });
 		}
 	}
 }
 
 type OpenConnection = {
+	appContext: ReturnType<typeof createTestContext>;
 	close: () => Promise<void>;
+	connectionId: string;
 	initialMs: number;
+	initialRequestBytes: number;
+	initialSnapshots: Array<{ topicId: string; seq: number }>;
 	reader: SnapshotReader;
 };
 
@@ -146,6 +224,9 @@ const herdClients = Number(
 const pgNotifyCount = Number(
 	process.env.REALTIME_BENCH_NOTIFY_COUNT ?? (quick ? 1_000 : 20_000),
 );
+const topologyRounds = Number(process.env.REALTIME_BENCH_TOPOLOGY_ROUNDS ?? 1);
+const topologyClients = quick ? [1, 3] : [1, 100, 500];
+const topologySizes = [1, 5, 15];
 
 const authors = collection("benchAuthors").fields(({ f }) => ({
 	name: f.text().required().localized(),
@@ -191,6 +272,15 @@ async function main() {
 			outboxWrites,
 			herdClients,
 			pgNotifyCount,
+			topologyRounds,
+			topologyClients,
+			topologySizes,
+			fixture: {
+				authors: 1,
+				posts: 30,
+				locales: ["en", "sk"],
+				operation: "swap one topic while retaining stable topics",
+			},
 			runtime: `Bun ${Bun.version}`,
 			platform: `${process.platform}/${process.arch}`,
 			revision,
@@ -201,6 +291,7 @@ async function main() {
 	);
 
 	const adapter = new LocalRealtimeAdapter();
+	const observer = new BenchmarkObserver();
 	const setup = await buildMockApp(
 		{
 			collections: { benchAuthors: authors, benchPosts: posts },
@@ -212,6 +303,7 @@ async function main() {
 		{
 			realtime: {
 				adapter,
+				observer,
 				keepAliveIntervalMs: 60_000,
 			},
 		},
@@ -252,40 +344,48 @@ async function main() {
 		const openConnection = async (
 			connectionId: string,
 			topics: Topic[],
+			expectedSnapshots = topics.length,
 		): Promise<OpenConnection> => {
 			const controller = new AbortController();
+			const appContext = createTestContext({
+				accessMode: "user",
+				role: "bench",
+				locale: "sk",
+			});
+			const body = JSON.stringify({
+				topics: topics.map((topic) => ({
+					...topic,
+					id: `${connectionId}:${topic.id}`,
+				})),
+			});
 			const request = new Request("http://localhost/realtime", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
-				body: JSON.stringify({
-					topics: topics.map((topic) => ({
-						...topic,
-						id: `${connectionId}:${topic.id}`,
-					})),
-				}),
+				body,
 				signal: controller.signal,
 			});
 			const startedAt = performance.now();
 			const response = await routes.realtime.subscribe(
 				request,
 				{},
-				{
-					appContext: createTestContext({
-						accessMode: "user",
-						role: "bench",
-						locale: "sk",
-					}),
-				},
+				{ appContext },
 			);
 			if (!response.ok || !response.body) {
 				throw new Error(`Realtime connection failed: ${response.status}`);
 			}
 			const reader = new SnapshotReader(response.body);
-			await reader.readSnapshots(topics.length);
+			const initialSnapshots =
+				expectedSnapshots > 0
+					? await reader.readSnapshots(expectedSnapshots)
+					: (await reader.readSession(), []);
 			const initialMs = performance.now() - startedAt;
 			return {
+				appContext,
+				connectionId,
 				reader,
 				initialMs,
+				initialRequestBytes: Buffer.byteLength(body),
+				initialSnapshots,
 				close: async () => {
 					controller.abort();
 					await reader.close().catch(() => {});
@@ -340,6 +440,301 @@ async function main() {
 		printTable(
 			"Refresh pipeline (ACL + i18n + relation + afterRead)",
 			refreshRows,
+		);
+
+		const topologyTopics = (count: number): Topic[] =>
+			Array.from({ length: count }, (_, index) => ({
+				...refreshTopic,
+				id: `topology-${index}`,
+				limit: 10,
+				offset: index,
+			}));
+		const topicConfig = (input: Topic) => {
+			const { id: _id, sinceSeq: _sinceSeq, ...topic } = input;
+			return topic;
+		};
+		const advanceGlobalOutbox = async () => {
+			await setup.app.db.insert(questpieRealtimeLogTable).values({
+				resourceType: "collection",
+				resource: "benchPosts",
+				operation: "update",
+				recordId: "benchmark-global-advance",
+				payload: {},
+			});
+		};
+
+		type TopologyStrategy = "incremental" | "reconnect";
+		type CursorState = "current" | "globally-advanced";
+		const runTopologyChange = async (input: {
+			strategy: TopologyStrategy;
+			cursorState: CursorState;
+			clients: number;
+			topicCount: number;
+			round: number;
+		}) => {
+			const baseTopics = topologyTopics(input.topicCount);
+			const replacement: Topic = {
+				...refreshTopic,
+				id: `topology-replacement-${input.round}`,
+				limit: 10,
+				offset: input.topicCount + input.round,
+			};
+			const prefix = [
+				"topology",
+				input.strategy,
+				input.cursorState,
+				input.clients,
+				input.topicCount,
+				input.round,
+			].join("-");
+			let connections = await Promise.all(
+				Array.from({ length: input.clients }, (_, index) =>
+					openConnection(`${prefix}-${index}`, [...baseTopics, replacement]),
+				),
+			);
+			const cursorFor = (connection: OpenConnection, topicId: string) => {
+				const snapshot = connection.initialSnapshots.find(
+					(candidate) =>
+						candidate.topicId === `${connection.connectionId}:${topicId}`,
+				);
+				if (!snapshot) throw new Error(`Missing cached cursor for ${topicId}`);
+				return snapshot.seq;
+			};
+			await Promise.all(
+				connections.map(async (connection) => {
+					const body = JSON.stringify({
+						sessionId: connection.reader.session.sessionId,
+						token: connection.reader.session.token,
+						frames: [
+							{
+								type: "remove_topic",
+								topicId: `${connection.connectionId}:${replacement.id}`,
+							},
+						],
+					});
+					const response = await routes.realtime.subscribe(
+						new Request("http://localhost/realtime", {
+							method: "POST",
+							headers: { "Content-Type": "application/json" },
+							body,
+						}),
+						{},
+						{ appContext: connection.appContext },
+					);
+					if (!response.ok) {
+						throw new Error(
+							`Realtime setup control failed: ${response.status}`,
+						);
+					}
+				}),
+			);
+			if (input.cursorState === "globally-advanced") {
+				await advanceGlobalOutbox();
+			}
+
+			const refreshCheckpoint = observer.checkpoint();
+			const wallStartedAt = performance.now();
+			let controlRequests = 0;
+			let connectionRequests = 0;
+			let requestBytes = 0;
+			let responseBytes = 0;
+			let latencies: number[] = [];
+
+			if (input.strategy === "incremental") {
+				latencies = await Promise.all(
+					connections.map(async (connection) => {
+						const replacementCursor = cursorFor(connection, replacement.id);
+						const topic = topicConfig(replacement);
+						const desiredBody = JSON.stringify({
+							sessionId: connection.reader.session.sessionId,
+							token: connection.reader.session.token,
+							topology: {
+								protocol: "questpie-realtime-topology",
+								version: 1,
+								revision: 1,
+								topics: [
+									...baseTopics.slice(0, -1).map((stable) => ({
+										id: `${connection.connectionId}:${stable.id}`,
+										topic: topicConfig(stable),
+										sinceSeq: cursorFor(connection, stable.id),
+									})),
+									{
+										id: `${connection.connectionId}:${replacement.id}`,
+										topic,
+										sinceSeq: replacementCursor,
+									},
+								],
+								channels: [],
+							},
+						});
+						const bridgeBody = JSON.stringify({
+							sessionId: connection.reader.session.sessionId,
+							token: connection.reader.session.token,
+							frames: [
+								{
+									type: "add_topic",
+									topicId: `${connection.connectionId}:${replacement.id}`,
+									topic,
+									sinceSeq: replacementCursor,
+								},
+								{
+									type: "remove_topic",
+									topicId: `${connection.connectionId}:${baseTopics.at(-1)!.id}`,
+								},
+							],
+						});
+						requestBytes += Buffer.byteLength(desiredBody);
+						controlRequests += 1;
+						const bytesBefore = connection.reader.bytesRead;
+						const snapshot =
+							input.cursorState === "globally-advanced"
+								? connection.reader.readSnapshots(1)
+								: null;
+						const startedAt = performance.now();
+						const response = await routes.realtime.subscribe(
+							new Request("http://localhost/realtime", {
+								method: "POST",
+								headers: { "Content-Type": "application/json" },
+								body: bridgeBody,
+							}),
+							{},
+							{ appContext: connection.appContext },
+						);
+						if (!response.ok) {
+							throw new Error(`Realtime control failed: ${response.status}`);
+						}
+						await snapshot;
+						responseBytes += connection.reader.bytesRead - bytesBefore;
+						return performance.now() - startedAt;
+					}),
+				);
+			} else {
+				const previous = connections;
+				const next = await Promise.all(
+					previous.map(async (connection, index) => {
+						const replacementTopics = [
+							...baseTopics.slice(0, -1).map((topic) => ({
+								...topic,
+								sinceSeq: cursorFor(connection, topic.id),
+							})),
+							{
+								...replacement,
+								sinceSeq: cursorFor(connection, replacement.id),
+							},
+						];
+						const startedAt = performance.now();
+						await connection.close();
+						const opened = await openConnection(
+							`${prefix}-reconnect-${index}`,
+							replacementTopics,
+							input.cursorState === "globally-advanced" ? input.topicCount : 0,
+						);
+						return {
+							connection: opened,
+							latency: performance.now() - startedAt,
+						};
+					}),
+				);
+				connections = next.map((result) => result.connection);
+				latencies = next.map((result) => result.latency);
+				connectionRequests = connections.length;
+				requestBytes = connections.reduce(
+					(total, connection) => total + connection.initialRequestBytes,
+					0,
+				);
+				responseBytes = connections.reduce(
+					(total, connection) => total + connection.reader.bytesRead,
+					0,
+				);
+			}
+
+			const wallMs = performance.now() - wallStartedAt;
+			const snapshotQueries = observer.checkpoint() - refreshCheckpoint;
+			await Promise.all(connections.map((connection) => connection.close()));
+			await delay(10);
+			return {
+				latencies,
+				wallMs,
+				controlRequests,
+				connectionRequests,
+				requestBytes,
+				responseBytes,
+				snapshotQueries,
+				stableTopicRecomputations: Math.max(0, snapshotQueries - input.clients),
+			};
+		};
+
+		const topologyRows: BenchmarkRow[] = [];
+		for (const cursorState of ["current", "globally-advanced"] as const) {
+			for (const topicCount of topologySizes) {
+				for (const clients of topologyClients) {
+					for (const strategy of ["incremental", "reconnect"] as const) {
+						console.log(
+							`Topology case: strategy=${strategy} cursor=${cursorState} clients=${clients} topics=${topicCount}`,
+						);
+						const results = [];
+						for (let round = 0; round < topologyRounds; round += 1) {
+							results.push(
+								await runTopologyChange({
+									strategy,
+									cursorState,
+									clients,
+									topicCount,
+									round,
+								}),
+							);
+						}
+						const latencies = results.flatMap((result) => result.latencies);
+						topologyRows.push({
+							strategy,
+							executionProtocol:
+								strategy === "incremental"
+									? "desired-v1 logical / legacy bridge"
+									: "full reconnect",
+							cursorState,
+							clients,
+							topics: topicCount,
+							samples: latencies.length,
+							wallMs: rounded(
+								results.reduce((total, result) => total + result.wallMs, 0),
+							),
+							p50Ms: rounded(percentile(latencies, 0.5)),
+							p99Ms: rounded(percentile(latencies, 0.99)),
+							snapshotQueries: results.reduce(
+								(total, result) => total + result.snapshotQueries,
+								0,
+							),
+							stableRecomputations: results.reduce(
+								(total, result) => total + result.stableTopicRecomputations,
+								0,
+							),
+							controlRequests: results.reduce(
+								(total, result) => total + result.controlRequests,
+								0,
+							),
+							connectionRequests: results.reduce(
+								(total, result) => total + result.connectionRequests,
+								0,
+							),
+							requestBytes: results.reduce(
+								(total, result) => total + result.requestBytes,
+								0,
+							),
+							responseBytes: results.reduce(
+								(total, result) => total + result.responseBytes,
+								0,
+							),
+						});
+					}
+				}
+			}
+		}
+		printTable(
+			"Measured topology swap: incremental desired-state semantics vs reconnect",
+			topologyRows,
+		);
+		console.log(
+			"Inference (not a measured percentage): fewer stable-topic recomputations and response bytes indicate the work avoided by incremental topology. The incremental wall-time path currently executes through the legacy-frame bridge until desired-v1 server control lands; do not publish bridge timing as final desired-v1 performance.",
 		);
 
 		const relationSize = async () => {

--- a/packages/questpie/src/client/channels/sse.ts
+++ b/packages/questpie/src/client/channels/sse.ts
@@ -33,6 +33,15 @@ type ControlFrame =
 
 type SseEvent = { type: string; data: string };
 
+type ControlSession = {
+	sessionId: string;
+	token: string;
+	control?: {
+		protocol: "questpie-realtime-topology";
+		versions: number[];
+	};
+};
+
 function channelId(input: ChannelConnectionInput): string {
 	return `channel:${input.resolvedName}`;
 }
@@ -46,8 +55,12 @@ export class SseChannelTransport implements ChannelClientTransport {
 	private destroyed = false;
 	private reconnectPending = false;
 	private retryAttempt = 0;
-	private controlSession: { sessionId: string; token: string } | null = null;
+	private controlSession: ControlSession | null = null;
 	private controlOperation: Promise<void> = Promise.resolve();
+	private desiredRevision = 0;
+	private desiredFlushPromise: Promise<void> | null = null;
+	private desiredTopologyGeneration = 0;
+	private desiredFlushedGeneration = 0;
 
 	constructor(
 		private readonly options: {
@@ -198,11 +211,14 @@ export class SseChannelTransport implements ChannelClientTransport {
 
 	private removeEntry(name: string, entry: Entry): void {
 		this.entries.delete(name);
+		if (this.entries.size === 0) {
+			this.abortController?.abort();
+			return;
+		}
 		this.applyTopology({
 			type: "unsubscribe_channel",
 			subscriptionId: entry.id,
 		});
-		if (this.entries.size === 0) this.abortController?.abort();
 	}
 
 	private scheduleConnect(delayMs: number): void {
@@ -216,6 +232,9 @@ export class SseChannelTransport implements ChannelClientTransport {
 		this.reconnectTimer = null;
 		this.connecting = true;
 		this.controlSession = null;
+		this.desiredRevision = 0;
+		this.desiredTopologyGeneration = 0;
+		this.desiredFlushedGeneration = 0;
 		this.abortController = new AbortController();
 		try {
 			const authHeaders = await this.options.getAuthHeaders?.();
@@ -265,6 +284,14 @@ export class SseChannelTransport implements ChannelClientTransport {
 	private async sendControl(frames: ControlFrame[]): Promise<void> {
 		const session = this.controlSession;
 		if (!session || frames.length === 0) return;
+		if (this.supportsDesiredTopology()) {
+			try {
+				await this.sendDesiredTopology();
+			} catch (error) {
+				this.handleControlError(error);
+			}
+			return;
+		}
 		this.controlOperation = this.controlOperation
 			.catch(() => {})
 			.then(async () => {
@@ -289,10 +316,77 @@ export class SseChannelTransport implements ChannelClientTransport {
 		try {
 			await this.controlOperation;
 		} catch (error) {
-			this.notifyAll(error instanceof Error ? error : new Error(String(error)));
-			this.reconnectPending = true;
-			this.abortController?.abort();
+			this.handleControlError(error);
 		}
+	}
+
+	private supportsDesiredTopology(): boolean {
+		return Boolean(
+			this.controlSession?.control?.protocol === "questpie-realtime-topology" &&
+			this.controlSession.control.versions.includes(1),
+		);
+	}
+
+	private sendDesiredTopology(): Promise<void> {
+		this.desiredTopologyGeneration += 1;
+		if (this.desiredFlushPromise) return this.desiredFlushPromise;
+		this.desiredFlushPromise = (async () => {
+			await Promise.resolve();
+			while (this.desiredFlushedGeneration < this.desiredTopologyGeneration) {
+				const generation = this.desiredTopologyGeneration;
+				const session = this.controlSession;
+				if (!session) return;
+				const topology = {
+					protocol: "questpie-realtime-topology",
+					version: 1,
+					revision: ++this.desiredRevision,
+					topics: [],
+					channels: [...this.entries.values()].map((entry) => ({
+						id: entry.id,
+						channel: entry.input.registryKey,
+						params: entry.input.params,
+						...(entry.lastEventId ? { lastEventId: entry.lastEventId } : {}),
+					})),
+				};
+				const operation = this.controlOperation
+					.catch(() => {})
+					.then(async () => {
+						const authHeaders = await this.options.getAuthHeaders?.();
+						const response = await this.options.fetcher(
+							`${this.options.baseUrl}/realtime`,
+							{
+								method: "POST",
+								headers: {
+									"Content-Type": "application/json",
+									...authHeaders,
+								},
+								body: JSON.stringify({
+									sessionId: session.sessionId,
+									token: session.token,
+									topology,
+								}),
+								credentials: this.options.withCredentials ? "include" : "omit",
+							},
+						);
+						if (!response.ok) {
+							throw new Error(`Channel SSE control failed: ${response.status}`);
+						}
+					});
+				this.controlOperation = operation;
+				await operation;
+				if (this.controlSession !== session) return;
+				this.desiredFlushedGeneration = generation;
+			}
+		})().finally(() => {
+			this.desiredFlushPromise = null;
+		});
+		return this.desiredFlushPromise;
+	}
+
+	private handleControlError(error: unknown): void {
+		this.notifyAll(error instanceof Error ? error : new Error(String(error)));
+		this.reconnectPending = true;
+		this.abortController?.abort();
 	}
 
 	private async readStream(body: ReadableStream<Uint8Array>): Promise<void> {
@@ -333,6 +427,7 @@ export class SseChannelTransport implements ChannelClientTransport {
 				const session = JSON.parse(event.data) as {
 					sessionId?: unknown;
 					token?: unknown;
+					control?: ControlSession["control"];
 				};
 				if (
 					typeof session.sessionId === "string" &&
@@ -341,6 +436,7 @@ export class SseChannelTransport implements ChannelClientTransport {
 					this.controlSession = {
 						sessionId: session.sessionId,
 						token: session.token,
+						...(session.control ? { control: session.control } : {}),
 					};
 				}
 			} catch {}

--- a/packages/questpie/src/client/index.ts
+++ b/packages/questpie/src/client/index.ts
@@ -1946,8 +1946,18 @@ export type {
 } from "#questpie/shared/collection-meta.js";
 export type { GlobalMeta } from "#questpie/shared/global-meta.js";
 // Re-export realtime types and helpers
-export type { RealtimeAPI, TopicConfig, TopicInput } from "./realtime/index.js";
-export { buildCollectionTopic, buildGlobalTopic } from "./realtime/index.js";
+export type {
+	RealtimeAPI,
+	RealtimeTopicRejectedDetails,
+	RealtimeTopicRejectedPayload,
+	TopicConfig,
+	TopicInput,
+} from "./realtime/index.js";
+export {
+	buildCollectionTopic,
+	buildGlobalTopic,
+	RealtimeTopicRejectedError,
+} from "./realtime/index.js";
 export type {
 	ChannelClient,
 	ChannelMessage,

--- a/packages/questpie/src/client/realtime/index.ts
+++ b/packages/questpie/src/client/realtime/index.ts
@@ -1,8 +1,13 @@
 export {
 	RealtimeMultiplexer,
+	RealtimeTopicRejectedError,
 	type TopicConfig,
 	type TopicInput,
 } from "./multiplexer.js";
+export type {
+	RealtimeTopicRejectedDetails,
+	RealtimeTopicRejectedPayload,
+} from "../../shared/realtime-error.js";
 export {
 	buildCollectionTopic,
 	buildGlobalTopic,

--- a/packages/questpie/src/client/realtime/multiplexer.ts
+++ b/packages/questpie/src/client/realtime/multiplexer.ts
@@ -71,6 +71,15 @@ type ControlFrame =
 	  }
 	| { type: "remove_topic"; topicId: string };
 
+type ControlSession = {
+	sessionId: string;
+	token: string;
+	control?: {
+		protocol: "questpie-realtime-topology";
+		versions: number[];
+	};
+};
+
 export type RealtimeMultiplexerRuntime = {
 	retryBaseMs?: number;
 	maxRetryMs?: number;
@@ -135,9 +144,11 @@ export class RealtimeMultiplexer implements RealtimeClientTransport {
 	private destroyed = false;
 	private reconnectPending = false;
 	private watchdogTriggered = false;
-	private controlSession: { sessionId: string; token: string } | null = null;
+	private controlSession: ControlSession | null = null;
 	private pendingControlFrames: ControlFrame[] = [];
 	private controlOperation: Promise<void> = Promise.resolve();
+	private controlFlushScheduled = false;
+	private desiredRevision = 0;
 	private readonly retryBaseMs: number;
 	private readonly maxRetryMs: number;
 	private readonly pingWatchdogMs: number;
@@ -246,7 +257,12 @@ export class RealtimeMultiplexer implements RealtimeClientTransport {
 		if (this.destroyed) return;
 		if (this.controlSession) {
 			this.pendingControlFrames.push(frame);
-			this.flushControlFrames();
+			if (this.supportsDesiredTopology() && this.topics.size === 0) {
+				this.pendingControlFrames = [];
+				this.abortController?.abort();
+				return;
+			}
+			this.scheduleControlFlush();
 			return;
 		}
 		if (this.connecting) {
@@ -256,10 +272,41 @@ export class RealtimeMultiplexer implements RealtimeClientTransport {
 		this.scheduleReconnect();
 	}
 
+	private supportsDesiredTopology(): boolean {
+		return Boolean(
+			this.controlSession?.control?.protocol === "questpie-realtime-topology" &&
+			this.controlSession.control.versions.includes(1),
+		);
+	}
+
+	private scheduleControlFlush(): void {
+		if (this.controlFlushScheduled) return;
+		this.controlFlushScheduled = true;
+		queueMicrotask(() => {
+			this.controlFlushScheduled = false;
+			this.flushControlFrames();
+		});
+	}
+
 	private flushControlFrames(): void {
 		if (!this.controlSession || this.pendingControlFrames.length === 0) return;
 		const session = this.controlSession;
 		const frames = this.pendingControlFrames.splice(0);
+		const useDesiredTopology = this.supportsDesiredTopology();
+		const revision = useDesiredTopology ? ++this.desiredRevision : 0;
+		const topology = useDesiredTopology
+			? {
+					protocol: "questpie-realtime-topology" as const,
+					version: 1 as const,
+					revision,
+					topics: [...this.topics.entries()].map(([id, topic]) => ({
+						id,
+						topic,
+						...(this.lastSeq.has(id) ? { sinceSeq: this.lastSeq.get(id) } : {}),
+					})),
+					channels: [],
+				}
+			: undefined;
 		this.controlOperation = this.controlOperation
 			.then(async () => {
 				const authHeaders = await this.getAuthHeaders?.();
@@ -269,7 +316,7 @@ export class RealtimeMultiplexer implements RealtimeClientTransport {
 					body: JSON.stringify({
 						sessionId: session.sessionId,
 						token: session.token,
-						frames,
+						...(topology ? { topology } : { frames }),
 					}),
 					credentials: this.withCredentials ? "include" : "omit",
 				});
@@ -363,6 +410,8 @@ export class RealtimeMultiplexer implements RealtimeClientTransport {
 		this.controlSession = null;
 		this.pendingControlFrames = [];
 		this.controlOperation = Promise.resolve();
+		this.controlFlushScheduled = false;
+		this.desiredRevision = 0;
 		this.watchdogTriggered = false;
 
 		const getTopicsPayload = () =>
@@ -485,13 +534,10 @@ export class RealtimeMultiplexer implements RealtimeClientTransport {
 			}
 		} else if (event.type === "session") {
 			try {
-				const session = JSON.parse(event.data) as {
-					sessionId: string;
-					token: string;
-				};
+				const session = JSON.parse(event.data) as ControlSession;
 				if (session.sessionId && session.token) {
 					this.controlSession = session;
-					this.flushControlFrames();
+					this.scheduleControlFlush();
 				}
 			} catch {
 				// Ignore malformed control metadata.
@@ -563,6 +609,7 @@ export class RealtimeMultiplexer implements RealtimeClientTransport {
 		this.lastSeq.clear();
 		this.customIds.clear();
 		this.pendingControlFrames = [];
+		this.controlFlushScheduled = false;
 		this.controlSession = null;
 	}
 

--- a/packages/questpie/src/client/realtime/multiplexer.ts
+++ b/packages/questpie/src/client/realtime/multiplexer.ts
@@ -5,6 +5,10 @@
  * Solves the HTTP/1.1 connection limit problem (6 connections per domain).
  */
 
+import {
+	isRealtimeTopicRejectedPayload,
+	type RealtimeTopicRejectedPayload,
+} from "../../shared/realtime-error.js";
 import type { GetAuthHeaders } from "../auth.js";
 import type { RealtimeClientTransport } from "./transport.js";
 
@@ -61,6 +65,30 @@ type SSEEvent = {
 	type: string;
 	data: string;
 };
+
+export class RealtimeTopicRejectedError extends Error {
+	readonly code = "REALTIME_TOPIC_REJECTED";
+	readonly retryable = false;
+	readonly topicId: string;
+	readonly resource: string;
+	readonly operation: RealtimeTopicRejectedPayload["operation"];
+	readonly details: RealtimeTopicRejectedPayload["details"];
+
+	constructor(payload: RealtimeTopicRejectedPayload) {
+		super(payload.message);
+		this.name = "RealtimeTopicRejectedError";
+		this.topicId = payload.topicId;
+		this.resource = payload.resource;
+		this.operation = payload.operation;
+		this.details = payload.details;
+	}
+}
+
+function toRealtimeError(payload: unknown): Error | null {
+	return isRealtimeTopicRejectedPayload(payload)
+		? new RealtimeTopicRejectedError(payload)
+		: null;
+}
 
 type ControlFrame =
 	| {
@@ -321,16 +349,23 @@ export class RealtimeMultiplexer implements RealtimeClientTransport {
 					credentials: this.withCredentials ? "include" : "omit",
 				});
 				if (!response.ok) {
-					throw new Error(`Realtime control failed: ${response.status}`);
+					const payload = await response.json().catch(() => null);
+					throw (
+						toRealtimeError((payload as { error?: unknown } | null)?.error) ??
+						new Error(`Realtime control failed: ${response.status}`)
+					);
 				}
 			})
 			.catch((error) => {
 				if (this.destroyed || this.controlSession !== session) return;
 				const normalized =
 					error instanceof Error ? error : new Error(String(error));
-				for (const frame of frames) {
-					this.notifyTopicError(frame.topicId, normalized);
+				if (normalized instanceof RealtimeTopicRejectedError) {
+					this.rejectTopic(normalized);
+					return;
 				}
+				for (const frame of frames)
+					this.notifyTopicError(frame.topicId, normalized);
 				this.reconnectPending = true;
 				this.abortController?.abort();
 			});
@@ -342,6 +377,17 @@ export class RealtimeMultiplexer implements RealtimeClientTransport {
 				? Array.from(this.errorCallbacks.values()).flatMap((set) => [...set])
 				: [...(this.errorCallbacks.get(topicId) ?? [])];
 		for (const callback of new Set(callbacks)) callback(error);
+	}
+
+	private rejectTopic(error: RealtimeTopicRejectedError): void {
+		this.notifyTopicError(error.topicId, error);
+		this.subscribers.delete(error.topicId);
+		this.errorCallbacks.delete(error.topicId);
+		this.topics.delete(error.topicId);
+		this.lastSeq.delete(error.topicId);
+		for (const [topicHash, customId] of this.customIds) {
+			if (customId === error.topicId) this.customIds.delete(topicHash);
+		}
 	}
 
 	/**
@@ -437,6 +483,19 @@ export class RealtimeMultiplexer implements RealtimeClientTransport {
 			});
 
 			if (!response.ok) {
+				const payload = (await response.json().catch(() => null)) as {
+					errors?: unknown[];
+				} | null;
+				const admissionErrors =
+					payload?.errors
+						?.map(toRealtimeError)
+						.filter((error) => error !== null) ?? [];
+				if (admissionErrors.length > 0) {
+					for (const error of admissionErrors) {
+						this.rejectTopic(error as RealtimeTopicRejectedError);
+					}
+					return;
+				}
 				throw new Error(`Realtime connection failed: ${response.status}`);
 			}
 
@@ -546,11 +605,16 @@ export class RealtimeMultiplexer implements RealtimeClientTransport {
 			this.reconnectAttempts = 0;
 		} else if (event.type === "error") {
 			try {
-				const { topicId, message } = JSON.parse(event.data) as {
+				const payload = JSON.parse(event.data) as {
 					topicId: string;
 					message: string;
 				};
-				this.notifyTopicError(topicId, new Error(message));
+				const error = toRealtimeError(payload);
+				if (error instanceof RealtimeTopicRejectedError) {
+					this.rejectTopic(error);
+				} else {
+					this.notifyTopicError(payload.topicId, new Error(payload.message));
+				}
 			} catch {
 				// Ignore parse errors
 			}

--- a/packages/questpie/src/client/realtime/pusher.ts
+++ b/packages/questpie/src/client/realtime/pusher.ts
@@ -32,6 +32,10 @@ type SessionResponse = {
 	sessionId: string;
 	token: string;
 	channel: string;
+	control?: {
+		protocol: "questpie-realtime-topology";
+		versions: number[];
+	};
 	errors?: Array<{ id: string; message: string }>;
 };
 
@@ -64,6 +68,8 @@ export class PusherRealtimeTransport implements RealtimeClientTransport {
 	> | null = null;
 	private sessionPromise: Promise<void> | null = null;
 	private controlOperation: Promise<void> = Promise.resolve();
+	private desiredRevision = 0;
+	private desiredFlushPromise: Promise<void> | null = null;
 	private refreshPromise: Promise<void> | null = null;
 	private refreshPending = false;
 	private destroyed = false;
@@ -117,6 +123,10 @@ export class PusherRealtimeTransport implements RealtimeClientTransport {
 			if (current.subscribers.size > 0) return;
 			this.topics.delete(topicId);
 			if (current.registered) {
+				if (this.supportsDesiredTopology() && this.topics.size === 0) {
+					this.disconnect();
+					return;
+				}
 				void this.sendControl([{ type: "remove_topic", topicId }]).finally(
 					() => {
 						if (this.topics.size === 0) this.disconnect();
@@ -295,6 +305,7 @@ export class PusherRealtimeTransport implements RealtimeClientTransport {
 	private sendControl(frames: Array<Record<string, unknown>>): Promise<void> {
 		const session = this.session;
 		if (!session || frames.length === 0) return Promise.resolve();
+		if (this.supportsDesiredTopology()) return this.sendDesiredTopology();
 		this.controlOperation = this.controlOperation
 			.catch(() => {})
 			.then(async () => {
@@ -317,6 +328,64 @@ export class PusherRealtimeTransport implements RealtimeClientTransport {
 				}
 			});
 		return this.controlOperation;
+	}
+
+	private supportsDesiredTopology(): boolean {
+		return Boolean(
+			this.session?.control?.protocol === "questpie-realtime-topology" &&
+			this.session.control.versions.includes(1),
+		);
+	}
+
+	private sendDesiredTopology(): Promise<void> {
+		if (this.desiredFlushPromise) return this.desiredFlushPromise;
+		this.desiredFlushPromise = new Promise<void>((resolve, reject) => {
+			queueMicrotask(() => {
+				const session = this.session;
+				if (!session || this.topics.size === 0) {
+					resolve();
+					return;
+				}
+				const topology = {
+					protocol: "questpie-realtime-topology",
+					version: 1,
+					revision: ++this.desiredRevision,
+					topics: [...this.topics.entries()].map(([id, entry]) => ({
+						id,
+						topic: entry.topic,
+					})),
+					channels: [],
+				};
+				this.controlOperation = this.controlOperation
+					.catch(() => {})
+					.then(async () => {
+						const authHeaders = await this.options.getAuthHeaders?.();
+						const response = await this.options.fetcher(
+							`${this.options.baseUrl}/realtime`,
+							{
+								method: "POST",
+								headers: {
+									"Content-Type": "application/json",
+									...authHeaders,
+								},
+								body: JSON.stringify({
+									sessionId: session.sessionId,
+									token: session.token,
+									topology,
+								}),
+								credentials: "include",
+							},
+						);
+						if (!response.ok) {
+							throw new Error(`Realtime control failed: ${response.status}`);
+						}
+					});
+				this.controlOperation.then(resolve, reject);
+			});
+		}).finally(() => {
+			this.desiredFlushPromise = null;
+		});
+		return this.desiredFlushPromise;
 	}
 
 	private scheduleRefresh(): void {
@@ -364,6 +433,7 @@ export class PusherRealtimeTransport implements RealtimeClientTransport {
 		this.pusher = null;
 		this.channel = null;
 		this.session = null;
+		this.desiredRevision = 0;
 	}
 
 	destroy(): void {

--- a/packages/questpie/src/client/realtime/pusher.ts
+++ b/packages/questpie/src/client/realtime/pusher.ts
@@ -70,6 +70,8 @@ export class PusherRealtimeTransport implements RealtimeClientTransport {
 	private controlOperation: Promise<void> = Promise.resolve();
 	private desiredRevision = 0;
 	private desiredFlushPromise: Promise<void> | null = null;
+	private desiredTopologyGeneration = 0;
+	private desiredFlushedGeneration = 0;
 	private refreshPromise: Promise<void> | null = null;
 	private refreshPending = false;
 	private destroyed = false;
@@ -122,11 +124,16 @@ export class PusherRealtimeTransport implements RealtimeClientTransport {
 			if (onError) current.errorCallbacks.delete(onError);
 			if (current.subscribers.size > 0) return;
 			this.topics.delete(topicId);
+			if (this.supportsDesiredTopology()) {
+				const closeAfterFlush = this.topics.size === 0;
+				void this.sendControl([{ type: "remove_topic", topicId }]).finally(
+					() => {
+						if (closeAfterFlush && this.topics.size === 0) this.disconnect();
+					},
+				);
+				return;
+			}
 			if (current.registered) {
-				if (this.supportsDesiredTopology() && this.topics.size === 0) {
-					this.disconnect();
-					return;
-				}
 				void this.sendControl([{ type: "remove_topic", topicId }]).finally(
 					() => {
 						if (this.topics.size === 0) this.disconnect();
@@ -148,6 +155,7 @@ export class PusherRealtimeTransport implements RealtimeClientTransport {
 				await this.sendControl([
 					{ type: "add_topic", topicId, topic: entry.topic },
 				]);
+				if (this.destroyed || this.topics.get(topicId) !== entry) return;
 				entry.registered = true;
 			}
 			await this.refetchEntry(entry);
@@ -253,6 +261,10 @@ export class PusherRealtimeTransport implements RealtimeClientTransport {
 			}));
 		if (removed.length || added.length)
 			await this.sendControl([...removed, ...added]);
+		if (this.topics.size === 0) {
+			this.disconnect();
+			return;
+		}
 		for (const frame of added) {
 			const entry = this.topics.get(frame.topicId);
 			if (entry) entry.registered = true;
@@ -338,14 +350,14 @@ export class PusherRealtimeTransport implements RealtimeClientTransport {
 	}
 
 	private sendDesiredTopology(): Promise<void> {
+		this.desiredTopologyGeneration += 1;
 		if (this.desiredFlushPromise) return this.desiredFlushPromise;
-		this.desiredFlushPromise = new Promise<void>((resolve, reject) => {
-			queueMicrotask(() => {
+		this.desiredFlushPromise = (async () => {
+			await Promise.resolve();
+			while (this.desiredFlushedGeneration < this.desiredTopologyGeneration) {
+				const generation = this.desiredTopologyGeneration;
 				const session = this.session;
-				if (!session || this.topics.size === 0) {
-					resolve();
-					return;
-				}
+				if (!session) return;
 				const topology = {
 					protocol: "questpie-realtime-topology",
 					version: 1,
@@ -356,7 +368,7 @@ export class PusherRealtimeTransport implements RealtimeClientTransport {
 					})),
 					channels: [],
 				};
-				this.controlOperation = this.controlOperation
+				const operation = this.controlOperation
 					.catch(() => {})
 					.then(async () => {
 						const authHeaders = await this.options.getAuthHeaders?.();
@@ -380,9 +392,12 @@ export class PusherRealtimeTransport implements RealtimeClientTransport {
 							throw new Error(`Realtime control failed: ${response.status}`);
 						}
 					});
-				this.controlOperation.then(resolve, reject);
-			});
-		}).finally(() => {
+				this.controlOperation = operation;
+				await operation;
+				if (this.session !== session) return;
+				this.desiredFlushedGeneration = generation;
+			}
+		})().finally(() => {
 			this.desiredFlushPromise = null;
 		});
 		return this.desiredFlushPromise;
@@ -434,6 +449,8 @@ export class PusherRealtimeTransport implements RealtimeClientTransport {
 		this.channel = null;
 		this.session = null;
 		this.desiredRevision = 0;
+		this.desiredTopologyGeneration = 0;
+		this.desiredFlushedGeneration = 0;
 	}
 
 	destroy(): void {
@@ -442,9 +459,14 @@ export class PusherRealtimeTransport implements RealtimeClientTransport {
 		const frames = [...this.topics.entries()]
 			.filter(([, entry]) => entry.registered)
 			.map(([topicId]) => ({ type: "remove_topic", topicId }));
-		if (frames.length) void this.sendControl(frames).catch(() => {});
 		this.topics.clear();
-		this.disconnect();
+		if (frames.length) {
+			void this.sendControl(frames)
+				.catch(() => {})
+				.finally(() => this.disconnect());
+		} else {
+			this.disconnect();
+		}
 	}
 
 	get topicCount(): number {

--- a/packages/questpie/src/server/adapters/routes/realtime.ts
+++ b/packages/questpie/src/server/adapters/routes/realtime.ts
@@ -5,6 +5,8 @@
  * Accepts multiple topics via POST and streams updates for all of them.
  */
 
+import type { RealtimeTopicRejectedPayload } from "#questpie/shared/realtime-error.js";
+
 import {
 	ChannelsService,
 	type ChannelServiceContext,
@@ -18,6 +20,8 @@ import {
 	admitRealtimeTopic,
 	createConcurrencyLimiter,
 	getRealtimeAdmissionRegistry,
+	RealtimeTopicAdmissionError,
+	realtimeTopicRejectedPayload,
 	realtimePrincipalKey,
 	resolveRealtimeAdmissionConfig,
 } from "../../modules/core/integrated/realtime/admission.js";
@@ -320,7 +324,11 @@ async function resolveIncrementalTopic(
 	}
 	const normalizedTopic = normalizeTopicOperation(rawTopic);
 	const topicAdmission = admitRealtimeTopic(normalizedTopic, admission);
-	if (!topicAdmission.accepted) throw new Error(topicAdmission.message);
+	if (!topicAdmission.accepted) {
+		throw new RealtimeTopicAdmissionError(
+			realtimeTopicRejectedPayload(normalizedTopic, topicAdmission),
+		);
+	}
 	const topic = topicAdmission.topic;
 
 	if (topic.resourceType === "collection") {
@@ -476,7 +484,26 @@ export async function realtimeSubscribe(
 			| "relation_depth"
 			| "snapshot_bytes"
 			| "access",
-	) => app.realtime!.record({ type: "admission.rejected", reason });
+		details: Partial<
+			Pick<RealtimeTopicRejectedPayload, "resource" | "operation"> & {
+				requestedLimit?: number;
+				configuredLimit?: number;
+			}
+		> = {},
+	) =>
+		app.realtime!.record({
+			type: "admission.rejected",
+			reason,
+			...details,
+			rolloutMode: app.config?.realtime?.rollout?.mode ?? "v2",
+		});
+	const observeTopicRejection = (error: RealtimeTopicAdmissionError) =>
+		observeAdmission(error.payload.details.reason, {
+			resource: error.payload.resource,
+			operation: error.payload.operation,
+			requestedLimit: error.payload.details.requestedLimit,
+			configuredLimit: error.payload.details.configuredLimit,
+		});
 
 	// Resolve context (auth, locale, etc.)
 	const resolved = await resolveContext(app, request, config, context);
@@ -611,7 +638,11 @@ export async function realtimeSubscribe(
 				},
 				{ status: result.status === "accepted" ? 202 : 200 },
 			);
-		} catch {
+		} catch (error) {
+			if (error instanceof RealtimeTopicAdmissionError) {
+				observeTopicRejection(error);
+				return Response.json({ error: error.payload }, { status: 400 });
+			}
 			return Response.json(
 				{
 					error: {
@@ -685,7 +716,11 @@ export async function realtimeSubscribe(
 
 	// Validate and resolve all topics upfront
 	const validatedTopics: ValidatedTopic[] = [];
-	const topicErrors: Array<{ id: string; message: string }> = [];
+	const topicErrors: Array<{
+		id: string;
+		message: string;
+		rejection?: RealtimeTopicRejectedPayload;
+	}> = [];
 	const collectionCruds = new Map<string, any>();
 	const globalCruds = new Map<string, any>();
 	const collectionApi = app.collections as Record<string, any>;
@@ -752,12 +787,18 @@ export async function realtimeSubscribe(
 
 		const topicAdmission = admitRealtimeTopic(topic, admission);
 		if (!topicAdmission.accepted) {
-			observeAdmission(
-				topicAdmission.message.includes("relation depth")
-					? "relation_depth"
-					: "query_limit",
-			);
-			topicErrors.push({ id: topic.id, message: topicAdmission.message });
+			const rejection = realtimeTopicRejectedPayload(topic, topicAdmission);
+			observeAdmission(rejection.details.reason, {
+				resource: rejection.resource,
+				operation: rejection.operation,
+				requestedLimit: rejection.details.requestedLimit,
+				configuredLimit: rejection.details.configuredLimit,
+			});
+			topicErrors.push({
+				id: topic.id,
+				message: topicAdmission.message,
+				rejection,
+			});
 			continue;
 		}
 		topic = topicAdmission.topic;
@@ -864,6 +905,16 @@ export async function realtimeSubscribe(
 	}
 
 	if (accessValidatedTopics.length === 0 && validatedChannelsById.size === 0) {
+		const rejectionErrors = topicErrors.flatMap((error) =>
+			error.rejection ? [error.rejection] : [],
+		);
+		if (
+			rejectionErrors.length > 0 &&
+			rejectionErrors.length === topicErrors.length &&
+			channelErrors.length === 0
+		) {
+			return Response.json({ errors: rejectionErrors }, { status: 400 });
+		}
 		const errors = [...topicErrors, ...channelErrors]
 			.map((error) => `${error.id}: ${error.message}`)
 			.join("; ");
@@ -1208,8 +1259,12 @@ export async function realtimeSubscribe(
 				};
 
 				// Send per-topic error
-				const sendTopicError = (topicId: string, message: string) => {
-					return send("error", { topicId, message });
+				const sendTopicError = (
+					topicId: string,
+					message: string,
+					rejection?: RealtimeTopicRejectedPayload,
+				) => {
+					return send("error", rejection ?? { topicId, message });
 				};
 				const sendChannelError = (subscriptionId: string, message: string) =>
 					send("error", { channelSubscriptionId: subscriptionId, message });
@@ -1485,6 +1540,15 @@ export async function realtimeSubscribe(
 								);
 								await subscribeTopic(topic, topicContext);
 							} catch (error) {
+								if (error instanceof RealtimeTopicAdmissionError) {
+									observeTopicRejection(error);
+									await sendTopicError(
+										error.payload.topicId,
+										error.message,
+										error.payload,
+									);
+									continue;
+								}
 								await sendTopicError(
 									desired.id,
 									error instanceof Error ? error.message : "Topic rejected",
@@ -1524,7 +1588,7 @@ export async function realtimeSubscribe(
 
 				// Send initial errors for invalid topics
 				for (const error of topicErrors) {
-					await sendTopicError(error.id, error.message);
+					await sendTopicError(error.id, error.message, error.rejection);
 				}
 				for (const error of channelErrors) {
 					await sendChannelError(error.id, error.message);

--- a/packages/questpie/src/server/adapters/routes/realtime.ts
+++ b/packages/questpie/src/server/adapters/routes/realtime.ts
@@ -32,11 +32,9 @@ import {
 	SseClientTransport,
 	SseLatestSnapshotWriter,
 } from "../../modules/core/integrated/realtime/sse-client-transport.js";
-import {
-	getRealtimeSseControlRegistry,
-	type RealtimeControlFrame,
-} from "../../modules/core/integrated/realtime/sse-control.js";
+import type { RealtimeControlFrame } from "../../modules/core/integrated/realtime/sse-control.js";
 import { sharedSseKeepAliveTicker } from "../../modules/core/integrated/realtime/sse-keep-alive.js";
+import type { RealtimeDesiredTopology } from "../../modules/core/integrated/realtime/topology-coordinator.js";
 import type { ClientSink } from "../../modules/core/integrated/realtime/transport.js";
 import type { AdapterConfig, AdapterContext } from "../types.js";
 import { resolveContext } from "../utils/context.js";
@@ -119,6 +117,42 @@ type ValidatedChannelSubscription = {
 	lastEventId?: string;
 	presence?: Record<string, unknown>;
 };
+
+function createInitialTopology(
+	topics: TopicInput[],
+	channels: ChannelSubscriptionInput[],
+	validTopicIds: ReadonlySet<string>,
+	validChannelIds: ReadonlySet<string>,
+): RealtimeDesiredTopology {
+	return {
+		protocol: "questpie-realtime-topology",
+		version: 1,
+		revision: 0,
+		topics: topics
+			.filter((topic) => validTopicIds.has(topic.id))
+			.map(({ id, sinceSeq, ...topic }) => ({
+				id,
+				topic,
+				...(sinceSeq === undefined ? {} : { sinceSeq }),
+			})),
+		channels: channels
+			.filter(
+				(
+					channel,
+				): channel is Required<
+					Pick<ChannelSubscriptionInput, "id" | "channel" | "params">
+				> &
+					ChannelSubscriptionInput =>
+					Boolean(channel.id && validChannelIds.has(channel.id)),
+			)
+			.map(({ id, channel, params, lastEventId }) => ({
+				id,
+				channel,
+				params,
+				...(lastEventId === undefined ? {} : { lastEventId }),
+			})),
+	};
+}
 
 function normalizeTopicOperation(topic: TopicInput): NormalizedTopicInput {
 	if (topic.resourceType !== "collection" && topic.resourceType !== "global") {
@@ -489,15 +523,24 @@ export async function realtimeSubscribe(
 			);
 		}
 		try {
-			const dispatched = await getRealtimeSseControlRegistry<any>(app).dispatch(
-				body.sessionId,
-				body.token,
-				body.frames,
-				resolved.appContext,
-			);
-			if (!dispatched) {
+			const result = await app.realtime.submitLegacyTopology({
+				sessionId: body.sessionId,
+				token: body.token,
+				identity: realtimeControlIdentity(resolved.appContext),
+				frames: body.frames,
+			});
+			if (result.status === "unavailable") {
 				return errorResponse(
 					ApiError.badRequest("Realtime control session is unavailable"),
+					request,
+					resolved.appContext.locale,
+				);
+			}
+			if (result.status === "conflict") {
+				return errorResponse(
+					ApiError.badRequest(
+						"Realtime control id conflicts with its current value",
+					),
 					request,
 					resolved.appContext.locale,
 				);
@@ -784,6 +827,13 @@ export async function realtimeSubscribe(
 		let unregisterControl = () => {};
 		let sink: ClientSink | null = null;
 		let closed = false;
+		let applyingTopology = false;
+		let appliedTopology = createInitialTopology(
+			topics ?? [],
+			[],
+			new Set(validatedTopicsById.keys()),
+			new Set(),
+		);
 		try {
 			sink = await app.realtime.openClientSession({
 				sessionId: edgeSessionId,
@@ -814,7 +864,7 @@ export async function realtimeSubscribe(
 				if (!unsubscribe) return;
 				topicUnsubscribers.delete(topicId);
 				unsubscribe();
-				if (topicUnsubscribers.size === 0) close();
+				if (topicUnsubscribers.size === 0 && !applyingTopology) close();
 			};
 			const subscribeTopic = async (
 				topic: ValidatedTopic,
@@ -874,23 +924,31 @@ export async function realtimeSubscribe(
 			};
 
 			const originalIdentity = realtimeControlIdentity(resolved.appContext);
-			unregisterControl = getRealtimeSseControlRegistry<any>(app).register(
-				edgeSessionId,
-				controlToken,
-				async (frames, controlContext) => {
+			const topologySession = await app.realtime.openTopologySession({
+				sessionId: edgeSessionId,
+				token: controlToken,
+				identity: originalIdentity,
+				topology: appliedTopology,
+				apply: async (topology) => {
 					if (closed) throw new Error("Realtime session is closed");
-					if (realtimeControlIdentity(controlContext) !== originalIdentity) {
-						close();
-						throw new Error("Realtime session identity changed");
+					applyingTopology = true;
+					const current = new Map(
+						appliedTopology.topics.map((topic) => [topic.id, topic]),
+					);
+					const desiredIds = new Set(topology.topics.map((topic) => topic.id));
+					for (const topicId of topicUnsubscribers.keys()) {
+						const desired = topology.topics.find(
+							(topic) => topic.id === topicId,
+						);
+						if (
+							!desiredIds.has(topicId) ||
+							JSON.stringify(current.get(topicId)) !== JSON.stringify(desired)
+						) {
+							teardownTopic(topicId);
+						}
 					}
-					for (const frame of frames) {
-						if (frame.type === "remove_topic") {
-							teardownTopic(frame.topicId);
-							continue;
-						}
-						if (frame.type !== "add_topic") {
-							throw new Error("Unknown realtime control frame");
-						}
+					for (const desired of topology.topics) {
+						if (topicUnsubscribers.has(desired.id)) continue;
 						if (topicUnsubscribers.size >= admission.maxTopicsPerConnection) {
 							observeAdmission("subscription_limit");
 							throw new Error(
@@ -898,24 +956,29 @@ export async function realtimeSubscribe(
 							);
 						}
 						const rawTopic = {
-							...frame.topic,
-							...(frame.topic.resourceType === "collection" &&
-							frame.topic.operation === "get"
-								? { recordId: frame.topic.id }
+							...desired.topic,
+							...(desired.topic.resourceType === "collection" &&
+							desired.topic.operation === "get"
+								? { recordId: desired.topic.id }
 								: {}),
-							id: frame.topicId,
-							sinceSeq: frame.sinceSeq,
+							id: desired.id,
+							sinceSeq: desired.sinceSeq,
 						} as TopicInput;
 						const topic = await resolveIncrementalTopic(
 							app,
 							rawTopic,
-							controlContext,
+							resolved.appContext,
 							admission,
 						);
-						await subscribeTopic(topic, controlContext);
+						await subscribeTopic(topic, resolved.appContext);
 					}
+					appliedTopology = topology;
+					applyingTopology = false;
+					if (topicUnsubscribers.size === 0) close();
 				},
-			);
+				onClose: close,
+			});
+			unregisterControl = () => void topologySession.close();
 			for (const topic of validatedTopicsById.values()) {
 				await subscribeTopic(topic, resolved.appContext);
 			}
@@ -953,6 +1016,13 @@ export async function realtimeSubscribe(
 				const channelUnsubscribers = new Map<string, () => void>();
 				let closed = false;
 				let closeRequested = false;
+				let applyingTopology = false;
+				let appliedTopology = createInitialTopology(
+					topics ?? [],
+					channelInputs ?? [],
+					new Set(validatedTopicsById.keys()),
+					new Set(validatedChannelsById.keys()),
+				);
 
 				const requestClose = () => {
 					closeRequested = true;
@@ -1026,6 +1096,7 @@ export async function realtimeSubscribe(
 					send("error", { channelSubscriptionId: subscriptionId, message });
 
 				const closeIfEmpty = () => {
+					if (applyingTopology) return;
 					if (
 						topicUnsubscribers.size === 0 &&
 						channelUnsubscribers.size === 0
@@ -1182,85 +1253,111 @@ export async function realtimeSubscribe(
 
 				const originalIdentity = realtimeControlIdentity(resolved.appContext);
 				const controlToken = globalThis.crypto.randomUUID();
-				unregisterControl = getRealtimeSseControlRegistry<any>(app).register(
-					edgeSessionId,
-					controlToken,
-					async (frames, controlContext) => {
+				const topologySession = await app.realtime.openTopologySession({
+					sessionId: edgeSessionId,
+					token: controlToken,
+					identity: originalIdentity,
+					topology: appliedTopology,
+					apply: async (topology) => {
 						if (closed) throw new Error("Realtime session is closed");
-						if (realtimeControlIdentity(controlContext) !== originalIdentity) {
-							requestClose();
-							throw new Error("Realtime session identity changed");
+						applyingTopology = true;
+						const currentTopics = new Map(
+							appliedTopology.topics.map((topic) => [topic.id, topic]),
+						);
+						const currentChannels = new Map(
+							appliedTopology.channels.map((channel) => [channel.id, channel]),
+						);
+						const desiredTopicIds = new Set(
+							topology.topics.map((topic) => topic.id),
+						);
+						const desiredChannelIds = new Set(
+							topology.channels.map((channel) => channel.id),
+						);
+						for (const topicId of topicUnsubscribers.keys()) {
+							const desired = topology.topics.find(
+								(topic) => topic.id === topicId,
+							);
+							if (
+								!desiredTopicIds.has(topicId) ||
+								JSON.stringify(currentTopics.get(topicId)) !==
+									JSON.stringify(desired)
+							) {
+								teardownTopic(topicId);
+							}
+						}
+						for (const channelId of channelUnsubscribers.keys()) {
+							const desired = topology.channels.find(
+								(channel) => channel.id === channelId,
+							);
+							if (
+								!desiredChannelIds.has(channelId) ||
+								JSON.stringify(currentChannels.get(channelId)) !==
+									JSON.stringify(desired)
+							) {
+								teardownChannel(channelId);
+							}
 						}
 
-						for (const frame of frames) {
-							if (frame.type === "unsubscribe_channel") {
-								teardownChannel(frame.subscriptionId);
+						for (const desired of topology.channels) {
+							if (channelUnsubscribers.has(desired.id)) continue;
+							if (
+								topicUnsubscribers.size + channelUnsubscribers.size >=
+								admission.maxTopicsPerConnection
+							) {
+								observeAdmission("subscription_limit");
+								await sendChannelError(
+									desired.id,
+									`Connection accepts at most ${admission.maxTopicsPerConnection} subscriptions`,
+								);
 								continue;
 							}
-							if (frame.type === "subscribe_channel") {
-								if (
-									topicUnsubscribers.size + channelUnsubscribers.size >=
-									admission.maxTopicsPerConnection
-								) {
-									observeAdmission("subscription_limit");
-									await sendChannelError(
-										frame.subscriptionId,
-										`Connection accepts at most ${admission.maxTopicsPerConnection} subscriptions`,
-									);
-									continue;
-								}
-								try {
-									const channel = await resolveChannelSubscription(
-										app,
-										{
-											id: frame.subscriptionId,
-											channel: frame.channel,
-											params: frame.params,
-											lastEventId: frame.lastEventId,
-										},
-										controlContext,
-									);
-									await subscribeChannel(channel);
-								} catch (error) {
-									await sendChannelError(
-										frame.subscriptionId,
-										error instanceof Error ? error.message : "Channel rejected",
-									);
-								}
-								continue;
+							try {
+								const channel = await resolveChannelSubscription(
+									app,
+									{
+										id: desired.id,
+										channel: desired.channel,
+										params: desired.params,
+										lastEventId: desired.lastEventId,
+									},
+									resolved.appContext,
+								);
+								await subscribeChannel(channel);
+							} catch (error) {
+								await sendChannelError(
+									desired.id,
+									error instanceof Error ? error.message : "Channel rejected",
+								);
 							}
-							if (frame.type === "remove_topic") {
-								teardownTopic(frame.topicId);
-								continue;
-							}
-							if (frame.type !== "add_topic") {
-								throw new Error("Unknown realtime control frame");
-							}
+						}
+						for (const desired of topology.topics) {
+							if (topicUnsubscribers.has(desired.id)) continue;
 							if (
 								topicUnsubscribers.size + channelUnsubscribers.size >=
 								admission.maxTopicsPerConnection
 							) {
 								observeAdmission("subscription_limit");
 								await sendTopicError(
-									frame.topicId,
+									desired.id,
 									`Connection accepts at most ${admission.maxTopicsPerConnection} topics`,
 								);
 								continue;
 							}
 							try {
 								const rawTopic = {
-									...frame.topic,
-									...(frame.topic.resourceType === "collection" &&
-									frame.topic.operation === "get"
-										? { recordId: frame.topic.id }
+									...desired.topic,
+									...(desired.topic.resourceType === "collection" &&
+									desired.topic.operation === "get"
+										? { recordId: desired.topic.id }
 										: {}),
-									id: frame.topicId,
-									sinceSeq: frame.sinceSeq,
+									id: desired.id,
+									sinceSeq: desired.sinceSeq,
 								} as TopicInput;
 								const topicContext =
-									rawTopic.locale && rawTopic.locale !== controlContext.locale
-										? { ...controlContext, locale: rawTopic.locale }
-										: controlContext;
+									rawTopic.locale &&
+									rawTopic.locale !== resolved.appContext.locale
+										? { ...resolved.appContext, locale: rawTopic.locale }
+										: resolved.appContext;
 								const topic = await resolveIncrementalTopic(
 									app,
 									rawTopic,
@@ -1270,13 +1367,18 @@ export async function realtimeSubscribe(
 								await subscribeTopic(topic, topicContext);
 							} catch (error) {
 								await sendTopicError(
-									frame.topicId,
+									desired.id,
 									error instanceof Error ? error.message : "Topic rejected",
 								);
 							}
 						}
+						appliedTopology = topology;
+						applyingTopology = false;
+						closeIfEmpty();
 					},
-				);
+					onClose: requestClose,
+				});
+				unregisterControl = () => void topologySession.close();
 				await send("session", {
 					sessionId: edgeSessionId,
 					token: controlToken,

--- a/packages/questpie/src/server/adapters/routes/realtime.ts
+++ b/packages/questpie/src/server/adapters/routes/realtime.ts
@@ -489,6 +489,7 @@ export async function realtimeSubscribe(
 		sessionId?: string;
 		token?: string;
 		frames?: RealtimeControlFrame[];
+		topology?: RealtimeDesiredTopology;
 	};
 	try {
 		body = await request.json();
@@ -508,6 +509,120 @@ export async function realtimeSubscribe(
 	const admission = resolveRealtimeAdmissionConfig(
 		app.config?.realtime?.admission,
 	);
+	if (body.topology !== undefined) {
+		if (
+			!body.sessionId ||
+			!body.token ||
+			body.topology.protocol !== "questpie-realtime-topology" ||
+			body.topology.version !== 1 ||
+			!Number.isSafeInteger(body.topology.revision) ||
+			body.topology.revision < 1 ||
+			!Array.isArray(body.topology.topics) ||
+			!Array.isArray(body.topology.channels) ||
+			body.topology.topics.length + body.topology.channels.length >
+				admission.maxTopicsPerConnection
+		) {
+			return Response.json(
+				{
+					error: {
+						code: "REALTIME_TOPOLOGY_INVALID",
+						message: "Invalid realtime topology request",
+					},
+				},
+				{ status: 400 },
+			);
+		}
+		try {
+			for (const desired of body.topology.topics) {
+				await resolveIncrementalTopic(
+					app,
+					{
+						...desired.topic,
+						id: desired.id,
+						sinceSeq: desired.sinceSeq,
+					} as TopicInput,
+					resolved.appContext,
+					admission,
+				);
+			}
+			for (const desired of body.topology.channels) {
+				await resolveChannelSubscription(
+					app,
+					{
+						id: desired.id,
+						channel: desired.channel,
+						params: desired.params,
+						lastEventId: desired.lastEventId,
+					},
+					resolved.appContext,
+				);
+			}
+			let result;
+			try {
+				result = await app.realtime.submitTopology({
+					sessionId: body.sessionId,
+					token: body.token,
+					identity: realtimeControlIdentity(resolved.appContext),
+					topology: body.topology,
+				});
+			} catch {
+				return Response.json(
+					{
+						error: {
+							code: "REALTIME_TOPOLOGY_STORAGE_UNAVAILABLE",
+							message: "Realtime topology storage is unavailable",
+						},
+					},
+					{ status: 503 },
+				);
+			}
+			if (result.status === "unavailable") {
+				return Response.json(
+					{
+						error: {
+							code: "REALTIME_CONTROL_UNAVAILABLE",
+							message: "Realtime control session is unavailable",
+						},
+					},
+					{ status: 404 },
+				);
+			}
+			if (
+				result.status === "stale" ||
+				result.status === "conflict" ||
+				result.status === "unsupported"
+			) {
+				const code =
+					result.status === "stale"
+						? "REALTIME_TOPOLOGY_STALE"
+						: result.status === "conflict"
+							? "REALTIME_TOPOLOGY_REVISION_CONFLICT"
+							: "REALTIME_TOPOLOGY_VERSION_UNSUPPORTED";
+				return Response.json(
+					{ error: { code, message: "Realtime topology was rejected" } },
+					{ status: 409 },
+				);
+			}
+			return Response.json(
+				{
+					protocol: "questpie-realtime-topology",
+					version: 1,
+					...result,
+				},
+				{ status: result.status === "accepted" ? 202 : 200 },
+			);
+		} catch {
+			return Response.json(
+				{
+					error: {
+						code: "REALTIME_TOPOLOGY_INVALID",
+						message: "Invalid realtime topology request",
+					},
+				},
+				{ status: 400 },
+			);
+		}
+	}
 	if (body.sessionId || body.frames) {
 		if (
 			!body.sessionId ||
@@ -989,6 +1104,10 @@ export async function realtimeSubscribe(
 					sessionId: edgeSessionId,
 					token: controlToken,
 					channel: activeSink.clientChannel,
+					control: {
+						protocol: "questpie-realtime-topology",
+						versions: [1],
+					},
 					...(topicErrors.length ? { errors: topicErrors } : {}),
 				},
 				{ headers: { "Cache-Control": "no-store" } },
@@ -1382,6 +1501,10 @@ export async function realtimeSubscribe(
 				await send("session", {
 					sessionId: edgeSessionId,
 					token: controlToken,
+					control: {
+						protocol: "questpie-realtime-topology",
+						versions: [1],
+					},
 				});
 
 				// Subscribe to each initial topic.

--- a/packages/questpie/src/server/adapters/routes/realtime.ts
+++ b/packages/questpie/src/server/adapters/routes/realtime.ts
@@ -669,6 +669,31 @@ export async function realtimeSubscribe(
 			);
 		}
 		try {
+			for (const frame of body.frames) {
+				if (frame.type === "add_topic") {
+					await resolveIncrementalTopic(
+						app,
+						{
+							...frame.topic,
+							id: frame.topicId,
+							sinceSeq: frame.sinceSeq,
+						} as TopicInput,
+						resolved.appContext,
+						admission,
+					);
+				} else if (frame.type === "subscribe_channel") {
+					await resolveChannelSubscription(
+						app,
+						{
+							id: frame.subscriptionId,
+							channel: frame.channel,
+							params: frame.params,
+							lastEventId: frame.lastEventId,
+						},
+						resolved.appContext,
+					);
+				}
+			}
 			const result = await app.realtime.submitLegacyTopology({
 				sessionId: body.sessionId,
 				token: body.token,
@@ -693,6 +718,10 @@ export async function realtimeSubscribe(
 			}
 			return new Response(null, { status: 204 });
 		} catch (error) {
+			if (error instanceof RealtimeTopicAdmissionError) {
+				observeTopicRejection(error);
+				return Response.json({ error: error.payload }, { status: 400 });
+			}
 			return errorResponse(error, request, resolved.appContext.locale);
 		}
 	}
@@ -1483,7 +1512,9 @@ export async function realtimeSubscribe(
 									desired.id,
 									`Connection accepts at most ${admission.maxTopicsPerConnection} subscriptions`,
 								);
-								continue;
+								throw new Error(
+									`Connection accepts at most ${admission.maxTopicsPerConnection} subscriptions`,
+								);
 							}
 							try {
 								const channel = await resolveChannelSubscription(
@@ -1502,6 +1533,7 @@ export async function realtimeSubscribe(
 									desired.id,
 									error instanceof Error ? error.message : "Channel rejected",
 								);
+								throw error;
 							}
 						}
 						for (const desired of topology.topics) {
@@ -1515,7 +1547,9 @@ export async function realtimeSubscribe(
 									desired.id,
 									`Connection accepts at most ${admission.maxTopicsPerConnection} topics`,
 								);
-								continue;
+								throw new Error(
+									`Connection accepts at most ${admission.maxTopicsPerConnection} topics`,
+								);
 							}
 							try {
 								const rawTopic = {
@@ -1547,12 +1581,13 @@ export async function realtimeSubscribe(
 										error.message,
 										error.payload,
 									);
-									continue;
+									throw error;
 								}
 								await sendTopicError(
 									desired.id,
 									error instanceof Error ? error.message : "Topic rejected",
 								);
+								throw error;
 							}
 						}
 						appliedTopology = topology;

--- a/packages/questpie/src/server/adapters/routes/realtime.ts
+++ b/packages/questpie/src/server/adapters/routes/realtime.ts
@@ -541,7 +541,6 @@ export async function realtimeSubscribe(
 			!body.sessionId ||
 			!body.token ||
 			body.topology.protocol !== "questpie-realtime-topology" ||
-			body.topology.version !== 1 ||
 			!Number.isSafeInteger(body.topology.revision) ||
 			body.topology.revision < 1 ||
 			!Array.isArray(body.topology.topics) ||
@@ -614,20 +613,23 @@ export async function realtimeSubscribe(
 					{ status: 404 },
 				);
 			}
-			if (
-				result.status === "stale" ||
-				result.status === "conflict" ||
-				result.status === "unsupported"
-			) {
+			if (result.status !== "accepted" && result.status !== "duplicate") {
 				const code =
 					result.status === "stale"
 						? "REALTIME_TOPOLOGY_STALE"
 						: result.status === "conflict"
 							? "REALTIME_TOPOLOGY_REVISION_CONFLICT"
-							: "REALTIME_TOPOLOGY_VERSION_UNSUPPORTED";
+							: result.status === "unsupported"
+								? "REALTIME_TOPOLOGY_VERSION_UNSUPPORTED"
+								: "REALTIME_TOPOLOGY_INVALID";
 				return Response.json(
 					{ error: { code, message: "Realtime topology was rejected" } },
-					{ status: 409 },
+					{
+						status:
+							result.status === "unsupported" || result.status === "invalid"
+								? 400
+								: 409,
+					},
 				);
 			}
 			return Response.json(

--- a/packages/questpie/src/server/config/questpie.ts
+++ b/packages/questpie/src/server/config/questpie.ts
@@ -44,6 +44,7 @@ import {
 	questpieChannelHeadTable,
 	questpieChannelPresenceTable,
 	questpieRealtimeLogTable,
+	questpieRealtimeTopologyTable,
 } from "#questpie/server/modules/core/integrated/realtime/collection.js";
 import type { RealtimeService } from "#questpie/server/modules/core/integrated/realtime/service.js";
 import type { SearchService } from "#questpie/server/modules/core/integrated/search/types.js";
@@ -1226,6 +1227,7 @@ export class Questpie<TConfig extends QuestpieConfig = QuestpieConfig> {
 		schema.questpie_channel_event = questpieChannelEventTable;
 		schema.questpie_channel_dispatch = questpieChannelDispatchTable;
 		schema.questpie_channel_presence = questpieChannelPresenceTable;
+		schema.questpie_realtime_topology = questpieRealtimeTopologyTable;
 
 		// 4. Add search tables if adapter provides local storage schemas
 		// Local adapters (Postgres, PgVector) return their tables for migration generation.

--- a/packages/questpie/src/server/modules/core/integrated/realtime/TRANSPORT.md
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/TRANSPORT.md
@@ -376,6 +376,19 @@ bounded concurrency pool. Per-principal counters are released by every teardown
 path. A batch with some rejected topics keeps admitted topics alive and emits
 per-topic errors; a request with no admitted topics fails before opening a sink.
 
+`maxFindLimit` is a per-snapshot limit: it applies to the initial `find` and to
+every later refresh. The default remains `100`. Rejection is explicit; the
+runtime must not clamp or split a query because either changes ordering,
+pagination, completeness, and topic-budget semantics. Configuration changes
+require measurements of query cost, serialized size, fan-out, and slow-client
+behavior. Large or paginated read models are not one realtime snapshot.
+
+Topic admission failures use the safe `REALTIME_TOPIC_REJECTED` payload with
+`topicId`, `resource`, `operation`, `retryable: false`, and bounded details.
+Never attach `where`, session data, tokens, or arbitrary input. The edge sends
+the error only to the rejected subscriber; adapters must expose a visible error
+state and must not retry a non-retryable rejection.
+
 The initial defaults are normative and may be changed only with benchmark and
 compatibility evidence:
 
@@ -389,6 +402,18 @@ compatibility evidence:
 | queued latest-snapshot bytes per edge session       |   1 MiB |
 | queued ordered channel events per edge session      |     100 |
 | queued ordered channel-event bytes per edge session |   1 MiB |
+
+## Future deep module: invalidation mode (not implemented)
+
+A future, separately specified `realtime: { mode: "invalidate" }` module may
+publish a bounded invalidation signal and let a read adapter refetch its own
+page instead of streaming complete snapshots. That is a different delivery
+contract: it needs explicit ownership of cache keys, pagination semantics,
+dedupe, authorization revalidation, retry policy, and stale-data behavior.
+
+It must not be added as a flag inside the snapshot pipeline or used to delay HA
+topology work. No invalidate mode is implemented by this design; it requires a
+separate spec and acceptance suite.
 
 The connection count is explicitly per app instance; exact distributed rate
 limiting is outside this program. Provider account/channel limits and RT2.0

--- a/packages/questpie/src/server/modules/core/integrated/realtime/TRANSPORT.md
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/TRANSPORT.md
@@ -733,6 +733,42 @@ write failures, or an increasing admission-rejection rate are warning signals;
 single access denials and rate-limit rejections are structured audit warnings,
 not paging conditions by themselves.
 
+## Distributed desired-topology control
+
+Realtime topology control follows the same durable-state/wake/reconcile rule as
+the outbox. `questpie_realtime_topology` is authoritative for the complete
+desired topology, its monotonic revision, the applied revision, owner lease,
+and fencing generation. The live sink and its apply/close callbacks remain in
+the owner process and are never serialized.
+
+An opening SSE or shared-provider session advertises
+`questpie-realtime-topology` version `1`. New clients then submit a complete
+bounded topology with one positive revision; unchanged topics/channels stay
+mounted while the owner applies only additions and removals. The accepting
+replica commits the desired revision before acknowledging it, then publishes a
+metadata-only `topology-maybe-advanced` wake. The owner re-reads the durable
+row and a one-second reconciliation loop heals a lost wake. The default lease
+is 30 seconds with a 10-second heartbeat, both using database time and fenced
+updates.
+
+Session ids, control tokens, and identities are stored as SHA-256 hashes. Wakes
+contain only the session hash, owner id/generation, desired revision, and a
+bounded reason. A missing/expired row or token/identity mismatch has the same
+unavailable response. Owner death never transfers a live stream; the client
+reconnects and opens a new fenced session after transport/watchdog failure.
+
+Postgres apps construct `PgNotifyChangeBroker` automatically. Redis deployments
+can select `redisStreamsChangeBroker`; neither broker is the durable topology
+store. Generic KV is not a coordinator and load-balancer affinity is not part
+of the correctness contract.
+
+QuestPie 3.x continues accepting legacy delta frames and maps them into durable
+desired state. `RealtimeAdapter`, `realtime.adapter`, `pgNotifyAdapter`,
+`redisStreamsAdapter`, and `legacy`/`dual` rollout modes are deprecated through
+3.x and removed in QuestPie 4. Mixed-version fleets may reconnect; the
+cross-replica no-reconnect guarantee begins only after the topology migration
+and every request-handling replica supports desired-topology v1.
+
 ## Defect mapping
 
 | Defect | Design element that removes it                                                                                                                                  |
@@ -751,23 +787,23 @@ not paging conditions by themselves.
 
 ## Fifteen-invariant gate
 
-| Invariant | Concrete mechanism                                                                                                         | Required proof                                                                         |
-| --------- | -------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
-| H1        | Both seams start/stop with app lifecycle; no subscriber-gated broker start.                                                | Write-only instance wakes a separate subscriber instance.                              |
-| H2        | Lossy wake contract plus unconditional poll, reconnect drain, lag-window rescan, and seq dedupe.                           | Drop/reorder wakes and expose an out-of-order commit; state still converges.           |
-| H3        | Logical-operation batch guard; one in-tx append; caught post-commit publish.                                               | Exact event/insert/notify counts and response-path latency assertion.                  |
-| H4        | Scheduler keyed by topic and access equivalence; immutable byte fan-out; hash suppression; pre/post match.                 | N equivalent sinks cause one query and unchanged results emit no frame.                |
-| H5        | Admission config, pre-registration access execution, bounded concurrency, finite limits.                                   | Cap matrix and denied-topic teardown tests.                                            |
-| H6        | `ClientSink.write()` busy/throw contract, latest-wins replacement, bounded ordered queue, shared ticker, terminal cleanup. | Slow and failed sink tests prove bounded memory and zero listeners/timers after close. |
-| H7        | `sinceSeq`, add/remove control frames, jittered reconnect, ping watchdog, forced reset outside retention.                  | Resume inside/outside retention and incremental mount tests with no reconnect storm.   |
-| H8        | Discriminated `find`/`count`/`get` topic union.                                                                            | Live count runs count and transfers O(1) data.                                         |
-| H9        | Notice-only broker and per-session private WS live-query channel with authorized refetch.                                  | Cross-session WS test proves no ACL snapshot reaches a shared channel.                 |
-| H10       | Default time retention, no local watermark deletion, bounded replay infrastructure.                                        | Cleanup with zero subscribers and multiple instances.                                  |
-| H11       | Caught async, isolated listeners, 42P01-only silence, client error/close, coarse session refresh.                          | Failure-injection matrix produces no unhandled rejection or hanging client.            |
-| H12       | Non-throwing observer events for broker, drain, refresh, buffers, admission, resume, and failures.                         | Observer contract tests plus sensitive-label audit.                                    |
-| H13       | Mutation and outbox append share the transaction; wake is post-commit.                                                     | Crash-window rollback/commit/reconcile tests.                                          |
-| H14       | Separate `ChangeBroker` and `ClientTransport`; latest-snapshot and ordered-event QoS have different queue/replay rules.    | Interface compile test and cross-driver QoS matrix.                                    |
-| H15       | Session-scoped default access key; cross-principal sharing only by explicit deterministic resolver.                        | Adversarial row, field, and `afterRead` isolation tests.                               |
+| Invariant | Concrete mechanism                                                                                                                              | Required proof                                                                         |
+| --------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| H1        | Both seams start/stop with app lifecycle; no subscriber-gated broker start.                                                                     | Write-only instance wakes a separate subscriber instance.                              |
+| H2        | Lossy wake contract plus unconditional poll, reconnect drain, lag-window rescan, and seq dedupe.                                                | Drop/reorder wakes and expose an out-of-order commit; state still converges.           |
+| H3        | Logical-operation batch guard; one in-tx append; caught post-commit publish.                                                                    | Exact event/insert/notify counts and response-path latency assertion.                  |
+| H4        | Scheduler keyed by topic and access equivalence; immutable byte fan-out; hash suppression; pre/post match.                                      | N equivalent sinks cause one query and unchanged results emit no frame.                |
+| H5        | Admission config, pre-registration access execution, bounded concurrency, finite limits.                                                        | Cap matrix and denied-topic teardown tests.                                            |
+| H6        | `ClientSink.write()` busy/throw contract, latest-wins replacement, bounded ordered queue, shared ticker, terminal cleanup.                      | Slow and failed sink tests prove bounded memory and zero listeners/timers after close. |
+| H7        | `sinceSeq`, revisioned complete desired topology, durable ownership/fencing, jittered reconnect, ping watchdog, forced reset outside retention. | Cross-replica topology, resume, reconciliation, and incremental mount tests.           |
+| H8        | Discriminated `find`/`count`/`get` topic union.                                                                                                 | Live count runs count and transfers O(1) data.                                         |
+| H9        | Notice-only broker and per-session private WS live-query channel with authorized refetch.                                                       | Cross-session WS test proves no ACL snapshot reaches a shared channel.                 |
+| H10       | Default time retention, no local watermark deletion, bounded replay infrastructure.                                                             | Cleanup with zero subscribers and multiple instances.                                  |
+| H11       | Caught async, isolated listeners, 42P01-only silence, client error/close, coarse session refresh.                                               | Failure-injection matrix produces no unhandled rejection or hanging client.            |
+| H12       | Non-throwing observer events for broker, drain, refresh, buffers, admission, resume, and failures.                                              | Observer contract tests plus sensitive-label audit.                                    |
+| H13       | Mutation and outbox append share the transaction; wake is post-commit.                                                                          | Crash-window rollback/commit/reconcile tests.                                          |
+| H14       | Separate `ChangeBroker` and `ClientTransport`; latest-snapshot and ordered-event QoS have different queue/replay rules.                         | Interface compile test and cross-driver QoS matrix.                                    |
+| H15       | Session-scoped default access key; cross-principal sharing only by explicit deterministic resolver.                                             | Adversarial row, field, and `afterRead` isolation tests.                               |
 
 Dependent implementation tasks may start only after this table is reviewed
 15/15 and any blocker found by the grill is represented on the board.

--- a/packages/questpie/src/server/modules/core/integrated/realtime/adapter.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/adapter.ts
@@ -4,6 +4,8 @@ export type RealtimeAdapterState = "connected" | "disconnected";
 
 /**
  * Transport adapter for realtime change notifications.
+ * @deprecated Use a notice-only ChangeBroker. RealtimeAdapter remains available
+ * through QuestPie 3.x and is scheduled for removal in QuestPie 4.
  */
 export interface RealtimeAdapter {
 	/** Prepare the publish side without requiring a local subscription. */

--- a/packages/questpie/src/server/modules/core/integrated/realtime/adapters/pg-notify.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/adapters/pg-notify.ts
@@ -1,6 +1,12 @@
 import type { Client, ClientConfig, Notification } from "pg";
 
 import type { RealtimeAdapter, RealtimeAdapterState } from "../adapter.js";
+import type {
+	ChangeBroker,
+	ChangeBrokerState,
+	ChangeWake,
+} from "../transport.js";
+import { normalizeChangeWake } from "../transport.js";
 import type { RealtimeChangeEvent, RealtimeNotice } from "../types.js";
 
 export type PgNotifyAdapterOptions = {
@@ -16,6 +22,13 @@ export type PgNotifyAdapterOptions = {
 	reconnectInitialDelayMs?: number;
 	reconnectMaxDelayMs?: number;
 };
+
+export type PgNotifyChangeBrokerOptions = Omit<
+	PgNotifyAdapterOptions,
+	"onError"
+>;
+
+type ChangeBrokerStartInput = Parameters<ChangeBroker["start"]>[0];
 
 const PG_NOTIFY_MAX_PAYLOAD_BYTES = 8_000;
 
@@ -182,16 +195,20 @@ export class PgNotifyAdapter implements RealtimeAdapter {
 	}
 
 	async notify(event: RealtimeChangeEvent): Promise<void> {
-		const payload = JSON.stringify({
+		await this.publishPayload({
 			seq: event.seq,
 			resourceType: event.resourceType,
 			resource: event.resource,
 			operation: event.operation,
 		});
+	}
+
+	protected async publishPayload(value: unknown): Promise<void> {
+		const payload = JSON.stringify(value);
 		const payloadBytes = new TextEncoder().encode(payload).byteLength;
 		if (payloadBytes >= PG_NOTIFY_MAX_PAYLOAD_BYTES) {
 			const error = new Error(
-				`PgNotifyAdapter payload must be smaller than ${PG_NOTIFY_MAX_PAYLOAD_BYTES} bytes (received ${payloadBytes}).`,
+				`${this.constructor.name} payload must be smaller than ${PG_NOTIFY_MAX_PAYLOAD_BYTES} bytes (received ${payloadBytes}).`,
 			);
 			this.reportError("payload", error);
 			throw error;
@@ -394,3 +411,91 @@ export class PgNotifyAdapter implements RealtimeAdapter {
 
 export const pgNotifyAdapter = (options: PgNotifyAdapterOptions = {}) =>
 	new PgNotifyAdapter(options);
+
+/** Postgres LISTEN/NOTIFY implementation of the Realtime v2 notice-only seam. */
+export class PgNotifyChangeBroker
+	extends PgNotifyAdapter
+	implements ChangeBroker
+{
+	private brokerActive = false;
+	private brokerOnStateChange?: (state: ChangeBrokerState) => void;
+	private unsubscribeWake?: () => void;
+	private unsubscribeState?: () => void;
+	private readonly setDriverErrorHandler: (
+		handler: (error: unknown) => void,
+	) => void;
+
+	constructor(options: PgNotifyChangeBrokerOptions = {}) {
+		let driverErrorHandler = (_error: unknown) => {};
+		super({
+			...options,
+			channel: options.channel ?? "questpie_realtime_v2",
+			onError: (error) => driverErrorHandler(error),
+		});
+		this.setDriverErrorHandler = (handler) => {
+			driverErrorHandler = handler;
+		};
+	}
+
+	override async start(input?: ChangeBrokerStartInput): Promise<void> {
+		if (this.brokerActive) return;
+		if (!input) {
+			throw new Error("PgNotifyChangeBroker.start requires broker callbacks");
+		}
+
+		this.brokerActive = true;
+		this.brokerOnStateChange = input.onStateChange;
+		this.setDriverErrorHandler(input.onError);
+		this.unsubscribeWake = super.subscribe((notice) => {
+			const wake = normalizeChangeWake(notice);
+			if (wake) input.onWake(wake);
+			else input.onError(new Error("Invalid pg-notify ChangeWake payload"));
+		});
+		this.unsubscribeState = super.onStateChange((state) => {
+			input.onStateChange?.(
+				state === "connected" ? "connected" : "unavailable",
+			);
+		});
+		input.onStateChange?.("connecting");
+
+		try {
+			await super.start();
+		} catch (error) {
+			input.onError(error);
+			input.onStateChange?.("failed");
+			this.resetBrokerCallbacks();
+			await super.stop();
+			throw error;
+		}
+	}
+
+	async publish(wake: ChangeWake): Promise<void> {
+		if (!this.brokerActive) {
+			throw new Error("PgNotifyChangeBroker is not started");
+		}
+		const normalized = normalizeChangeWake(wake);
+		if (!normalized) throw new Error("Invalid ChangeWake payload");
+		await this.publishPayload(normalized);
+	}
+
+	override async stop(): Promise<void> {
+		const onStateChange = this.brokerOnStateChange;
+		await super.stop();
+		this.resetBrokerCallbacks();
+		if (onStateChange) onStateChange("disconnected");
+	}
+
+	private resetBrokerCallbacks(): void {
+		this.unsubscribeWake?.();
+		this.unsubscribeState?.();
+		this.unsubscribeWake = undefined;
+		this.unsubscribeState = undefined;
+		this.brokerOnStateChange = undefined;
+		this.brokerActive = false;
+		this.setDriverErrorHandler(() => {});
+	}
+}
+
+export const pgNotifyChangeBroker = (
+	options: PgNotifyChangeBrokerOptions = {},
+) => new PgNotifyChangeBroker(options);

--- a/packages/questpie/src/server/modules/core/integrated/realtime/adapters/pg-notify.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/adapters/pg-notify.ts
@@ -409,6 +409,10 @@ export class PgNotifyAdapter implements RealtimeAdapter {
 	}
 }
 
+/**
+ * @deprecated Use `pgNotifyChangeBroker`, or omit `realtime.changeBroker` on a
+ * Postgres app to use the automatic v2 default. Removed in QuestPie 4.
+ */
 export const pgNotifyAdapter = (options: PgNotifyAdapterOptions = {}) =>
 	new PgNotifyAdapter(options);
 

--- a/packages/questpie/src/server/modules/core/integrated/realtime/adapters/redis-streams.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/adapters/redis-streams.ts
@@ -1,4 +1,10 @@
 import type { RealtimeAdapter } from "../adapter.js";
+import {
+	type ChangeBroker,
+	type ChangeBrokerState,
+	type ChangeWake,
+	normalizeChangeWake,
+} from "../transport.js";
 import type { RealtimeChangeEvent, RealtimeNotice } from "../types.js";
 
 export type RedisStreamsClient = {
@@ -44,6 +50,7 @@ export type RedisStreamsAdapterOptions = {
 	onError?: (error: unknown) => void;
 };
 
+/** @deprecated Use `RedisStreamsChangeBroker`. Removed in QuestPie 4. */
 export class RedisStreamsAdapter implements RealtimeAdapter {
 	private client: RedisStreamsClient;
 	private providedReader?: RedisStreamsClient;
@@ -320,5 +327,93 @@ export class RedisStreamsAdapter implements RealtimeAdapter {
 	}
 }
 
+/** @deprecated Use `redisStreamsChangeBroker`. Removed in QuestPie 4. */
 export const redisStreamsAdapter = (options: RedisStreamsAdapterOptions) =>
 	new RedisStreamsAdapter(options);
+
+/** Redis Streams implementation of the Realtime v2 notice-only seam. */
+export class RedisStreamsChangeBroker implements ChangeBroker {
+	private readonly adapter: RedisStreamsAdapter;
+	private setErrorHandler: (handler: (error: unknown) => void) => void;
+	private unsubscribe?: () => void;
+	private active = false;
+
+	constructor(options: RedisStreamsAdapterOptions) {
+		let errorHandler = (_error: unknown) => {};
+		this.adapter = new RedisStreamsAdapter({
+			...options,
+			stream: options.stream ?? "questpie:realtime:v2",
+			onError: (error) => errorHandler(error),
+		});
+		this.setErrorHandler = (handler) => {
+			errorHandler = handler;
+		};
+	}
+
+	async start(input: {
+		onWake: (wake: ChangeWake) => void;
+		onError: (error: unknown) => void;
+		onStateChange?: (state: ChangeBrokerState) => void;
+	}): Promise<void> {
+		if (this.active) return;
+		this.active = true;
+		this.setErrorHandler(input.onError);
+		this.unsubscribe = this.adapter.subscribe((notice) => {
+			let wake: ChangeWake | null = null;
+			try {
+				wake = normalizeChangeWake(JSON.parse(notice.resource));
+			} catch {
+				// Invalid messages are reported through the broker error seam below.
+			}
+			if (wake) input.onWake(wake);
+			else input.onError(new Error("Invalid Redis Streams ChangeWake payload"));
+		});
+		input.onStateChange?.("connecting");
+
+		try {
+			await this.adapter.start();
+			input.onStateChange?.("connected");
+		} catch (error) {
+			input.onError(error);
+			input.onStateChange?.("failed");
+			this.reset();
+			throw error;
+		}
+	}
+
+	async publish(wake: ChangeWake): Promise<void> {
+		if (!this.active) {
+			throw new Error("RedisStreamsChangeBroker is not started");
+		}
+		const normalized = normalizeChangeWake(wake);
+		if (!normalized) throw new Error("Invalid ChangeWake payload");
+		await this.adapter.notify({
+			seq:
+				normalized.kind === "outbox-maybe-advanced"
+					? (normalized.highWaterSeq ?? 0)
+					: normalized.kind === "topology-maybe-advanced"
+						? normalized.desiredRevision
+						: 0,
+			resourceType: "global",
+			resource: JSON.stringify(normalized),
+			operation: "update",
+			createdAt: new Date(),
+		});
+	}
+
+	async stop(): Promise<void> {
+		if (!this.active) return;
+		await this.adapter.stop();
+		this.reset();
+	}
+
+	private reset(): void {
+		this.unsubscribe?.();
+		this.unsubscribe = undefined;
+		this.active = false;
+		this.setErrorHandler(() => {});
+	}
+}
+
+export const redisStreamsChangeBroker = (options: RedisStreamsAdapterOptions) =>
+	new RedisStreamsChangeBroker(options);

--- a/packages/questpie/src/server/modules/core/integrated/realtime/admission.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/admission.ts
@@ -1,3 +1,8 @@
+import type {
+	RealtimeTopicRejectedPayload,
+	RealtimeTopicRejectionReason,
+} from "#questpie/shared/realtime-error.js";
+
 export type RealtimeAdmissionConfig = {
 	maxTopicsPerConnection: number;
 	maxConnectionsPerPrincipal: number;
@@ -67,7 +72,44 @@ type AdmissionTopic = {
 
 export type TopicAdmissionResult<TTopic extends AdmissionTopic> =
 	| { accepted: true; topic: TTopic & { limit?: number } }
-	| { accepted: false; message: string };
+	| {
+			accepted: false;
+			message: string;
+			reason: RealtimeTopicRejectionReason;
+			requestedLimit?: number;
+			configuredLimit?: number;
+	  };
+
+export class RealtimeTopicAdmissionError extends Error {
+	constructor(readonly payload: RealtimeTopicRejectedPayload) {
+		super(payload.message);
+		this.name = "RealtimeTopicAdmissionError";
+	}
+}
+
+export function realtimeTopicRejectedPayload(
+	topic: AdmissionTopic,
+	rejection: Extract<TopicAdmissionResult<AdmissionTopic>, { accepted: false }>,
+): RealtimeTopicRejectedPayload {
+	return {
+		code: "REALTIME_TOPIC_REJECTED",
+		message: rejection.message,
+		topicId: topic.id,
+		resource: topic.resource,
+		operation:
+			topic.resourceType === "global" ? "get" : (topic.operation ?? "find"),
+		retryable: false,
+		details: {
+			reason: rejection.reason,
+			...(rejection.requestedLimit !== undefined
+				? { requestedLimit: rejection.requestedLimit }
+				: {}),
+			...(rejection.configuredLimit !== undefined
+				? { configuredLimit: rejection.configuredLimit }
+				: {}),
+		},
+	};
+}
 
 function withDepth(withConfig: Record<string, unknown> | undefined): number {
 	if (!withConfig) return 0;
@@ -92,6 +134,8 @@ export function admitRealtimeTopic<TTopic extends AdmissionTopic>(
 		return {
 			accepted: false,
 			message: `Topic exceeds maximum relation depth of ${config.maxWithDepth}`,
+			reason: "relation_depth",
+			configuredLimit: config.maxWithDepth,
 		};
 	}
 	if ((topic.operation ?? "find") !== "find") {
@@ -103,6 +147,9 @@ export function admitRealtimeTopic<TTopic extends AdmissionTopic>(
 		return {
 			accepted: false,
 			message: `Topic limit must be between 1 and ${config.maxFindLimit}`,
+			reason: "query_limit",
+			requestedLimit: limit,
+			configuredLimit: config.maxFindLimit,
 		};
 	}
 

--- a/packages/questpie/src/server/modules/core/integrated/realtime/collection.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/collection.ts
@@ -99,3 +99,38 @@ export const questpieChannelPresenceTable = pgTable(
 		index("idx_channel_presence_expiry").on(table.expiresAt),
 	],
 );
+
+/** Durable ownership and desired state for HA realtime control sessions. */
+export const questpieRealtimeTopologyTable = pgTable(
+	"questpie_realtime_topology",
+	{
+		sessionKey: text("session_key").primaryKey(),
+		ownerId: text("owner_id").notNull(),
+		ownerGeneration: bigserial("owner_generation", {
+			mode: "number",
+		}).notNull(),
+		protocolVersion: integer("protocol_version").notNull(),
+		tokenHash: text("token_hash").notNull(),
+		identityHash: text("identity_hash").notNull(),
+		leaseExpiresAt: timestamp("lease_expires_at", {
+			withTimezone: true,
+			mode: "date",
+		}).notNull(),
+		desiredRevision: bigint("desired_revision", { mode: "number" })
+			.default(0)
+			.notNull(),
+		appliedRevision: bigint("applied_revision", { mode: "number" })
+			.default(0)
+			.notNull(),
+		desiredTopology: jsonb("desired_topology").notNull(),
+		createdAt: systemTimestamp("created_at").defaultNow().notNull(),
+		updatedAt: systemTimestamp("updated_at").defaultNow().notNull(),
+	},
+	(table) => [
+		index("idx_realtime_topology_owner_lease").on(
+			table.ownerId,
+			table.leaseExpiresAt,
+		),
+		index("idx_realtime_topology_lease").on(table.leaseExpiresAt),
+	],
+);

--- a/packages/questpie/src/server/modules/core/integrated/realtime/observer.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/observer.ts
@@ -81,6 +81,26 @@ export type RealtimeObservation =
 			rolloutMode?: "legacy" | "dual" | "v2";
 	  }
 	| {
+			type: "topology.lifecycle";
+			phase: "open" | "submit" | "reconcile" | "apply" | "lease" | "close";
+			outcome:
+				| "accepted"
+				| "duplicate"
+				| "stale"
+				| "conflict"
+				| "unsupported"
+				| "invalid"
+				| "unavailable"
+				| "started"
+				| "applied"
+				| "failed"
+				| "expired"
+				| "fenced"
+				| "closed";
+			desiredRevision?: number;
+			appliedRevision?: number;
+	  }
+	| {
 			type: "resume";
 			outcome: "replay" | "reset" | "current" | "gap" | "dedupe";
 	  }
@@ -155,6 +175,8 @@ function metricKey(event: RealtimeObservation): string {
 			return `${event.type}|reason=${event.reason}|transport=${event.transport}`;
 		case "admission.rejected":
 			return `${event.type}|reason=${event.reason}|resource=${event.resource ?? "unknown"}|rollout_mode=${event.rolloutMode ?? "v2"}`;
+		case "topology.lifecycle":
+			return `${event.type}|outcome=${event.outcome}|phase=${event.phase}`;
 		case "resume":
 			return `${event.type}|outcome=${event.outcome}`;
 		case "channel.security":
@@ -171,12 +193,20 @@ function alertLevel(
 		(event.type === "outbox.capture" && event.outcome === "failed") ||
 		event.type === "drain.failed" ||
 		event.type === "refresh.failed" ||
-		(event.type === "sink.write" && event.outcome === "failed")
+		(event.type === "sink.write" && event.outcome === "failed") ||
+		(event.type === "topology.lifecycle" && event.outcome === "failed")
 	) {
 		return "error";
 	}
 	if (
 		event.type === "admission.rejected" ||
+		(event.type === "topology.lifecycle" &&
+			(event.outcome === "conflict" ||
+				event.outcome === "unsupported" ||
+				event.outcome === "invalid" ||
+				event.outcome === "unavailable" ||
+				event.outcome === "expired" ||
+				event.outcome === "fenced")) ||
 		(event.type === "channel.security" && event.outcome === "denied") ||
 		(event.type === "session.closed" && event.reason !== "normal") ||
 		(event.type === "drain.completed" && event.lagMs > drainLagAlertMs)

--- a/packages/questpie/src/server/modules/core/integrated/realtime/observer.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/observer.ts
@@ -74,6 +74,11 @@ export type RealtimeObservation =
 				| "relation_depth"
 				| "snapshot_bytes"
 				| "access";
+			resource?: string;
+			operation?: "find" | "count" | "get";
+			requestedLimit?: number;
+			configuredLimit?: number;
+			rolloutMode?: "legacy" | "dual" | "v2";
 	  }
 	| {
 			type: "resume";
@@ -149,7 +154,7 @@ function metricKey(event: RealtimeObservation): string {
 		case "session.closed":
 			return `${event.type}|reason=${event.reason}|transport=${event.transport}`;
 		case "admission.rejected":
-			return `${event.type}|reason=${event.reason}`;
+			return `${event.type}|reason=${event.reason}|resource=${event.resource ?? "unknown"}|rollout_mode=${event.rolloutMode ?? "v2"}`;
 		case "resume":
 			return `${event.type}|outcome=${event.outcome}`;
 		case "channel.security":

--- a/packages/questpie/src/server/modules/core/integrated/realtime/pusher-transport.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/pusher-transport.ts
@@ -2,18 +2,19 @@ import { createHmac, createHash } from "node:crypto";
 
 import type { Principal } from "#questpie/server/config/context.js";
 
-import type {
-	ChangeBroker,
-	ChangeBrokerState,
-	ChangeWake,
-	ClientConfigInput,
-	ClientSink,
-	ClientTransportConfig,
-	DeliveryClass,
-	EdgeSessionInput,
-	OrderedChannelDelivery,
-	SharedProviderClientTransport,
-	SinkWriteResult,
+import {
+	normalizeChangeWake,
+	type ChangeBroker,
+	type ChangeBrokerState,
+	type ChangeWake,
+	type ClientConfigInput,
+	type ClientSink,
+	type ClientTransportConfig,
+	type DeliveryClass,
+	type EdgeSessionInput,
+	type OrderedChannelDelivery,
+	type SharedProviderClientTransport,
+	type SinkWriteResult,
 } from "./transport.js";
 
 const CHANNEL_PATTERN = /^[A-Za-z0-9_\-=@,.;]+$/;
@@ -87,44 +88,6 @@ export type PusherChangeBrokerOptions = {
 	channel: string;
 };
 
-function normalizeChangeWake(value: unknown): ChangeWake | null {
-	if (!value || typeof value !== "object") return null;
-	const fields = value as Record<string, unknown>;
-	const wake = value as Partial<ChangeWake>;
-	if (
-		wake.kind !== "outbox-maybe-advanced" &&
-		wake.kind !== "channel-events-maybe-advanced"
-	) {
-		return null;
-	}
-	if (
-		wake.reason !== "publish" &&
-		wake.reason !== "reconnect" &&
-		wake.reason !== "reconcile"
-	) {
-		return null;
-	}
-	if (wake.kind === "outbox-maybe-advanced") {
-		return {
-			kind: wake.kind,
-			...(typeof wake.highWaterSeq === "number"
-				? { highWaterSeq: wake.highWaterSeq }
-				: {}),
-			reason: wake.reason,
-		};
-	}
-	return {
-		kind: wake.kind,
-		...(typeof fields.channelHash === "string"
-			? { channelHash: fields.channelHash }
-			: {}),
-		...(typeof fields.highWaterEventId === "string"
-			? { highWaterEventId: fields.highWaterEventId }
-			: {}),
-		reason: wake.reason,
-	};
-}
-
 export function assertPusherChannelName(channel: string): void {
 	if (
 		channel.length === 0 ||
@@ -161,9 +124,11 @@ function byteLength(value: unknown): number {
 }
 
 function wakeKey(wake: ChangeWake): string {
-	return wake.kind === "outbox-maybe-advanced"
-		? wake.kind
-		: `${wake.kind}:${wake.channelHash ?? "*"}`;
+	if (wake.kind === "outbox-maybe-advanced") return wake.kind;
+	if (wake.kind === "channel-events-maybe-advanced") {
+		return `${wake.kind}:${wake.channelHash ?? "*"}`;
+	}
+	return `${wake.kind}:${wake.sessionKey}`;
 }
 
 /** Pusher-protocol cross-instance wake broker. Payloads are notice-only. */

--- a/packages/questpie/src/server/modules/core/integrated/realtime/service.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/service.ts
@@ -600,6 +600,17 @@ export class RealtimeService {
 		return this.topologyCoordinator.submitLegacy(input);
 	}
 
+	/** @internal Commit one complete versioned desired topology. */
+	async submitTopology(input: {
+		sessionId: string;
+		token: string;
+		identity: string;
+		topology: RealtimeDesiredTopology;
+	}): Promise<RealtimeTopologyResult> {
+		await this.initialize();
+		return this.topologyCoordinator.submit(input);
+	}
+
 	async getClientTransportConfig(
 		input: ClientConfigInput,
 	): Promise<ClientTransportConfig> {

--- a/packages/questpie/src/server/modules/core/integrated/realtime/service.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/service.ts
@@ -2,6 +2,7 @@ import { asc, desc, gt, lt } from "drizzle-orm";
 
 import type { DrizzleClientFromQuestpieConfig } from "#questpie/server/config/types.js";
 import type { LoggerAdapter } from "#questpie/server/modules/core/integrated/logger/types.js";
+import { getNodeEnv } from "#questpie/server/utils/env.js";
 
 import type { RealtimeAdapter } from "./adapter.js";
 import { PgNotifyAdapter, PgNotifyChangeBroker } from "./adapters/pg-notify.js";
@@ -62,6 +63,28 @@ type AppendChangeOptions = {
 
 const DEFAULT_RETENTION_DAYS = 3;
 const DEFAULT_ADAPTER_RECONCILIATION_INTERVAL_MS = 15_000;
+let warnedLegacyRealtimeRuntime = false;
+
+function warnLegacyRealtimeRuntime(
+	config: RealtimeConfig,
+	logger?: Pick<LoggerAdapter, "warn">,
+): void {
+	if (
+		warnedLegacyRealtimeRuntime ||
+		getNodeEnv() === "test" ||
+		(!config.adapter &&
+			config.rollout?.mode !== "legacy" &&
+			config.rollout?.mode !== "dual" &&
+			!config.rollout?.onComparison)
+	) {
+		return;
+	}
+	warnedLegacyRealtimeRuntime = true;
+	const message =
+		"[Realtime] Legacy adapter/rollout configuration is deprecated in QuestPie 3.x and will be removed in QuestPie 4. Use realtime.changeBroker or the automatic Postgres v2 default.";
+	if (logger) logger.warn(message);
+	else console.warn(message);
+}
 
 type ListenerEntry = {
 	listener: RealtimeListener;
@@ -195,6 +218,7 @@ export class RealtimeService {
 		private pgConnectionString?: string,
 		private logger?: Pick<LoggerAdapter, "error" | "warn">,
 	) {
+		warnLegacyRealtimeRuntime(config, this.logger);
 		this.transportMode = config.rollout?.mode ?? "v2";
 		this.onDualRunComparison = config.rollout?.onComparison;
 		if (

--- a/packages/questpie/src/server/modules/core/integrated/realtime/service.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/service.ts
@@ -4,7 +4,7 @@ import type { DrizzleClientFromQuestpieConfig } from "#questpie/server/config/ty
 import type { LoggerAdapter } from "#questpie/server/modules/core/integrated/logger/types.js";
 
 import type { RealtimeAdapter } from "./adapter.js";
-import { PgNotifyAdapter } from "./adapters/pg-notify.js";
+import { PgNotifyAdapter, PgNotifyChangeBroker } from "./adapters/pg-notify.js";
 import {
 	type AppendChannelEventInput,
 	type AppendChannelEventOptions,
@@ -203,13 +203,20 @@ export class RealtimeService {
 		if (
 			!compatibleAdapter &&
 			this.pgConnectionString &&
-			(this.transportMode === "legacy" || !config.changeBroker)
+			this.transportMode === "legacy"
 		) {
 			compatibleAdapter = new PgNotifyAdapter({
 				connectionString: this.pgConnectionString,
 				channel: "questpie_realtime",
 			});
 		}
+		const compatibleBroker =
+			config.changeBroker ??
+			(!config.adapter && this.pgConnectionString && this.transportMode === "v2"
+				? new PgNotifyChangeBroker({
+						connectionString: this.pgConnectionString,
+					})
+				: undefined);
 
 		if (this.transportMode === "legacy") {
 			this.adapter = compatibleAdapter;
@@ -218,7 +225,7 @@ export class RealtimeService {
 			this.changeBroker = config.changeBroker;
 			this.clientTransport = config.clientTransport;
 		} else {
-			this.changeBroker = config.changeBroker;
+			this.changeBroker = compatibleBroker;
 			this.adapter = this.changeBroker ? undefined : compatibleAdapter;
 			this.clientTransport = config.clientTransport;
 		}
@@ -491,6 +498,7 @@ export class RealtimeService {
 			await this.adapter?.startPublisher?.();
 			await this.changeBroker?.start({
 				onWake: (wake) => {
+					if (wake.kind === "topology-maybe-advanced") return;
 					if (wake.kind === "channel-events-maybe-advanced") {
 						void this.channelEventLedger
 							.drain(wake.channelHash)

--- a/packages/questpie/src/server/modules/core/integrated/realtime/service.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/service.ts
@@ -279,6 +279,7 @@ export class RealtimeService {
 			this.db,
 			{
 				broker: this.changeBroker,
+				observer: this.observability,
 				onError: (error) =>
 					this.reportTransportFailure(
 						"[Realtime] Topology coordinator failed",

--- a/packages/questpie/src/server/modules/core/integrated/realtime/service.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/service.ts
@@ -983,8 +983,8 @@ export class RealtimeService {
 		}
 
 		this.startPromise = (async () => {
-			await this.initialize();
 			const latestSeq = await this.getLatestSeq();
+			await this.initialize();
 
 			if (this.adapter) {
 				await this.adapter.start();

--- a/packages/questpie/src/server/modules/core/integrated/realtime/service.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/service.ts
@@ -22,6 +22,12 @@ import {
 	type RegisterChannelPresenceInput,
 	SseChannelPresenceRegistry,
 } from "./sse-channel-presence.js";
+import {
+	createPostgresRealtimeTopologyCoordinator,
+	type RealtimeDesiredTopology,
+	RealtimeTopologyCoordinator,
+	type RealtimeTopologyResult,
+} from "./topology-coordinator.js";
 import type {
 	ChangeBroker,
 	ClientAuthInput,
@@ -177,6 +183,7 @@ export class RealtimeService {
 	private retentionCleanupInProgress = false;
 	private readonly channelEventLedger: ChannelEventLedger;
 	private readonly channelPresenceRegistry: SseChannelPresenceRegistry;
+	private readonly topologyCoordinator: RealtimeTopologyCoordinator;
 	private channelPollTimer: ReturnType<typeof setInterval> | null = null;
 	private nextChannelCleanupAt = 0;
 	private readonly observability: RealtimeObservability;
@@ -244,6 +251,17 @@ export class RealtimeService {
 					? this.configuredPollIntervalMs
 					: Number.POSITIVE_INFINITY,
 		});
+		this.topologyCoordinator = createPostgresRealtimeTopologyCoordinator(
+			this.db,
+			{
+				broker: this.changeBroker,
+				onError: (error) =>
+					this.reportTransportFailure(
+						"[Realtime] Topology coordinator failed",
+						error,
+					),
+			},
+		);
 		this.channelEventLedger = new ChannelEventLedger(
 			this.db,
 			this.changeBroker,
@@ -498,7 +516,10 @@ export class RealtimeService {
 			await this.adapter?.startPublisher?.();
 			await this.changeBroker?.start({
 				onWake: (wake) => {
-					if (wake.kind === "topology-maybe-advanced") return;
+					if (wake.kind === "topology-maybe-advanced") {
+						this.topologyCoordinator.onWake(wake);
+						return;
+					}
 					if (wake.kind === "channel-events-maybe-advanced") {
 						void this.channelEventLedger
 							.drain(wake.channelHash)
@@ -538,6 +559,7 @@ export class RealtimeService {
 					}
 				},
 			});
+			await this.topologyCoordinator.start();
 			await this.clientTransport?.start({
 				onError: (error) =>
 					this.reportTransportFailure(
@@ -552,6 +574,30 @@ export class RealtimeService {
 			this.publisherStartPromise = null;
 		});
 		await this.publisherStartPromise;
+	}
+
+	/** @internal Register the local owner before exposing session capability data. */
+	async openTopologySession(input: {
+		sessionId: string;
+		token: string;
+		identity: string;
+		topology: RealtimeDesiredTopology;
+		apply: (topology: RealtimeDesiredTopology) => Promise<void>;
+		onClose: () => Promise<void> | void;
+	}): Promise<{ generation: number; close(): Promise<void> }> {
+		await this.initialize();
+		return this.topologyCoordinator.open(input);
+	}
+
+	/** @internal Translate a 3.x delta request through durable topology state. */
+	async submitLegacyTopology(input: {
+		sessionId: string;
+		token: string;
+		identity: string;
+		frames: import("./sse-control.js").RealtimeControlFrame[];
+	}): Promise<RealtimeTopologyResult> {
+		await this.initialize();
+		return this.topologyCoordinator.submitLegacy(input);
 	}
 
 	async getClientTransportConfig(
@@ -964,6 +1010,7 @@ export class RealtimeService {
 	}
 
 	async destroy(): Promise<void> {
+		await this.topologyCoordinator.stop();
 		await this.channelPresenceRegistry.destroy();
 		await this.stop();
 	}

--- a/packages/questpie/src/server/modules/core/integrated/realtime/topology-coordinator.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/topology-coordinator.ts
@@ -2,6 +2,8 @@ import { createHash, randomUUID, timingSafeEqual } from "node:crypto";
 
 import { and, eq, gt, lt, sql } from "drizzle-orm";
 
+import type { AnyDrizzleClient } from "#questpie/server/config/types.js";
+
 import { questpieRealtimeTopologyTable } from "./collection.js";
 import type { RealtimeObservation, RealtimeObserver } from "./observer.js";
 import type { RealtimeControlFrame } from "./sse-control.js";
@@ -371,7 +373,7 @@ export class MemoryRealtimeTopologyStore implements RealtimeTopologyStore {
 }
 
 export class PostgresRealtimeTopologyStore implements RealtimeTopologyStore {
-	constructor(private readonly db: any) {}
+	constructor(private readonly db: AnyDrizzleClient<any>) {}
 
 	private leaseDeadline(leaseMs: number) {
 		return sql`now() + (${leaseMs} * interval '1 millisecond')`;
@@ -408,7 +410,7 @@ export class PostgresRealtimeTopologyStore implements RealtimeTopologyStore {
 		identityHash: string;
 		mutate: (row: TopologyRow) => TopologyMutation;
 	}): Promise<TopologyMutationResult> {
-		return this.db.transaction(async (tx: any) => {
+		return this.db.transaction(async (tx) => {
 			const [row] = await tx
 				.select()
 				.from(questpieRealtimeTopologyTable)
@@ -903,7 +905,7 @@ export class RealtimeTopologyCoordinator {
 }
 
 export function createPostgresRealtimeTopologyCoordinator(
-	db: any,
+	db: AnyDrizzleClient<any>,
 	options: ConstructorParameters<typeof RealtimeTopologyCoordinator>[1] = {},
 ): RealtimeTopologyCoordinator {
 	return new RealtimeTopologyCoordinator(

--- a/packages/questpie/src/server/modules/core/integrated/realtime/topology-coordinator.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/topology-coordinator.ts
@@ -1,8 +1,9 @@
-import { createHash, randomUUID } from "node:crypto";
+import { createHash, randomUUID, timingSafeEqual } from "node:crypto";
 
 import { and, eq, gt, lt, sql } from "drizzle-orm";
 
 import { questpieRealtimeTopologyTable } from "./collection.js";
+import type { RealtimeObservation, RealtimeObserver } from "./observer.js";
 import type { RealtimeControlFrame } from "./sse-control.js";
 import type { ChangeBroker, ChangeWake } from "./transport.js";
 
@@ -45,7 +46,9 @@ type TopologyRow = {
 
 type TopologyMutation =
 	| { status: "accepted"; topology: RealtimeDesiredTopology }
-	| { status: "duplicate" | "stale" | "conflict" | "unsupported" };
+	| {
+			status: "duplicate" | "stale" | "conflict" | "unsupported" | "invalid";
+	  };
 
 type TopologyMutationResult =
 	| { status: "unavailable" }
@@ -96,6 +99,18 @@ interface RealtimeTopologyStore {
 
 function hash(value: string): string {
 	return createHash("sha256").update(value).digest("hex");
+}
+
+function hashEquals(left: string, right: string): boolean {
+	if (!/^[0-9a-f]{64}$/i.test(left) || !/^[0-9a-f]{64}$/i.test(right)) {
+		return false;
+	}
+	const leftBytes = Buffer.from(left, "hex");
+	const rightBytes = Buffer.from(right, "hex");
+	return (
+		leftBytes.byteLength === rightBytes.byteLength &&
+		timingSafeEqual(leftBytes, rightBytes)
+	);
 }
 
 function stableValue(value: unknown): unknown {
@@ -280,8 +295,8 @@ export class MemoryRealtimeTopologyStore implements RealtimeTopologyStore {
 		if (
 			!row ||
 			row.leaseExpiresAt <= this.now() ||
-			row.tokenHash !== input.tokenHash ||
-			row.identityHash !== input.identityHash
+			!hashEquals(row.tokenHash, input.tokenHash) ||
+			!hashEquals(row.identityHash, input.identityHash)
 		) {
 			return { status: "unavailable" };
 		}
@@ -406,8 +421,8 @@ export class PostgresRealtimeTopologyStore implements RealtimeTopologyStore {
 				.for("update");
 			if (
 				!row ||
-				row.tokenHash !== input.tokenHash ||
-				row.identityHash !== input.identityHash
+				!hashEquals(row.tokenHash, input.tokenHash) ||
+				!hashEquals(row.identityHash, input.identityHash)
 			) {
 				return { status: "unavailable" };
 			}
@@ -534,7 +549,13 @@ export class PostgresRealtimeTopologyStore implements RealtimeTopologyStore {
 export type RealtimeTopologyResult =
 	| { status: "unavailable" }
 	| {
-			status: "accepted" | "duplicate" | "stale" | "conflict" | "unsupported";
+			status:
+				| "accepted"
+				| "duplicate"
+				| "stale"
+				| "conflict"
+				| "unsupported"
+				| "invalid";
 			revision: number;
 			desiredRevision: number;
 			appliedRevision: number;
@@ -555,6 +576,7 @@ export class RealtimeTopologyCoordinator {
 	private readonly heartbeatMs: number;
 	private readonly reconcileMs: number;
 	private readonly onError: (error: unknown) => void;
+	private readonly observer?: RealtimeObserver;
 	private readonly handlers = new Map<string, LocalHandler>();
 	private heartbeatTimer?: ReturnType<typeof setInterval>;
 	private reconcileTimer?: ReturnType<typeof setInterval>;
@@ -570,6 +592,7 @@ export class RealtimeTopologyCoordinator {
 			heartbeatMs?: number;
 			reconcileMs?: number;
 			onError?: (error: unknown) => void;
+			observer?: RealtimeObserver;
 		} = {},
 	) {
 		this.ownerId = options.ownerId ?? randomUUID();
@@ -578,6 +601,15 @@ export class RealtimeTopologyCoordinator {
 		this.heartbeatMs = options.heartbeatMs ?? 10_000;
 		this.reconcileMs = options.reconcileMs ?? 1_000;
 		this.onError = options.onError ?? (() => {});
+		this.observer = options.observer;
+	}
+
+	private observe(event: RealtimeObservation): void {
+		try {
+			this.observer?.record(event);
+		} catch {
+			// Topology observations cannot break control or lease handling.
+		}
 	}
 
 	async start(): Promise<void> {
@@ -623,6 +655,13 @@ export class RealtimeTopologyCoordinator {
 			onClose: input.onClose,
 			operation: Promise.resolve(),
 		});
+		this.observe({
+			type: "topology.lifecycle",
+			phase: "open",
+			outcome: "accepted",
+			desiredRevision: topology.revision,
+			appliedRevision: topology.revision,
+		});
 		return {
 			generation: row.ownerGeneration,
 			close: () => this.closeLocal(sessionKey, true, false),
@@ -639,8 +678,14 @@ export class RealtimeTopologyCoordinator {
 		try {
 			topology = canonicalizeTopology(input.topology);
 		} catch {
+			const status = input.topology.version === 1 ? "invalid" : "unsupported";
+			this.observe({
+				type: "topology.lifecycle",
+				phase: "submit",
+				outcome: status,
+			});
 			return {
-				status: "unsupported",
+				status,
 				revision: 0,
 				desiredRevision: 0,
 				appliedRevision: 0,
@@ -678,13 +723,27 @@ export class RealtimeTopologyCoordinator {
 			identityHash: hash(input.identity),
 			mutate,
 		});
-		if (result.status === "unavailable") return result;
+		if (result.status === "unavailable") {
+			this.observe({
+				type: "topology.lifecycle",
+				phase: "submit",
+				outcome: "unavailable",
+			});
+			return result;
+		}
 		const response = {
 			status: result.status,
 			revision: result.row.desiredRevision,
 			desiredRevision: result.row.desiredRevision,
 			appliedRevision: result.row.appliedRevision,
 		} as RealtimeTopologyResult;
+		this.observe({
+			type: "topology.lifecycle",
+			phase: "submit",
+			outcome: result.status,
+			desiredRevision: result.row.desiredRevision,
+			appliedRevision: result.row.appliedRevision,
+		});
 		if (result.status !== "accepted") return response;
 		const wake: ChangeWake = {
 			kind: "topology-maybe-advanced",
@@ -728,12 +787,22 @@ export class RealtimeTopologyCoordinator {
 		handler.operation = handler.operation
 			.catch(() => {})
 			.then(async () => {
+				this.observe({
+					type: "topology.lifecycle",
+					phase: "reconcile",
+					outcome: "started",
+				});
 				const row = await this.store.getOwned({
 					sessionKey,
 					ownerId: this.ownerId,
 					ownerGeneration: handler.generation,
 				});
 				if (!row) {
+					this.observe({
+						type: "topology.lifecycle",
+						phase: "lease",
+						outcome: "expired",
+					});
 					await this.closeLocal(sessionKey, false, true);
 					return;
 				}
@@ -741,6 +810,13 @@ export class RealtimeTopologyCoordinator {
 				try {
 					await handler.apply(row.desiredTopology);
 				} catch (error) {
+					this.observe({
+						type: "topology.lifecycle",
+						phase: "apply",
+						outcome: "failed",
+						desiredRevision: row.desiredRevision,
+						appliedRevision: handler.appliedRevision,
+					});
 					this.onError(error);
 					await this.closeLocal(sessionKey, true, true);
 					return;
@@ -752,10 +828,22 @@ export class RealtimeTopologyCoordinator {
 					revision: row.desiredRevision,
 				});
 				if (!marked) {
+					this.observe({
+						type: "topology.lifecycle",
+						phase: "apply",
+						outcome: "fenced",
+					});
 					await this.closeLocal(sessionKey, false, true);
 					return;
 				}
 				handler.appliedRevision = row.desiredRevision;
+				this.observe({
+					type: "topology.lifecycle",
+					phase: "apply",
+					outcome: "applied",
+					desiredRevision: row.desiredRevision,
+					appliedRevision: row.desiredRevision,
+				});
 			});
 		await handler.operation;
 	}
@@ -768,7 +856,14 @@ export class RealtimeTopologyCoordinator {
 				ownerGeneration: handler.generation,
 				leaseMs: this.leaseMs,
 			});
-			if (!renewed) await this.closeLocal(sessionKey, false, true);
+			if (!renewed) {
+				this.observe({
+					type: "topology.lifecycle",
+					phase: "lease",
+					outcome: "expired",
+				});
+				await this.closeLocal(sessionKey, false, true);
+			}
 		}
 	}
 
@@ -788,6 +883,11 @@ export class RealtimeTopologyCoordinator {
 			});
 		}
 		if (notify) await handler.onClose();
+		this.observe({
+			type: "topology.lifecycle",
+			phase: "close",
+			outcome: "closed",
+		});
 	}
 
 	async stop(): Promise<void> {

--- a/packages/questpie/src/server/modules/core/integrated/realtime/topology-coordinator.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/topology-coordinator.ts
@@ -1,0 +1,803 @@
+import { createHash, randomUUID } from "node:crypto";
+
+import { and, eq, gt, lt, sql } from "drizzle-orm";
+
+import { questpieRealtimeTopologyTable } from "./collection.js";
+import type { RealtimeControlFrame } from "./sse-control.js";
+import type { ChangeBroker, ChangeWake } from "./transport.js";
+
+export const REALTIME_TOPOLOGY_PROTOCOL = "questpie-realtime-topology" as const;
+export const MAX_REALTIME_TOPOLOGY_BYTES = 262_144;
+
+export type RealtimeTopologyTopic = {
+	id: string;
+	topic: Record<string, unknown>;
+	sinceSeq?: number;
+};
+
+export type RealtimeTopologyChannel = {
+	id: string;
+	channel: string;
+	params: Record<string, string>;
+	lastEventId?: string;
+};
+
+export type RealtimeDesiredTopology = {
+	protocol: typeof REALTIME_TOPOLOGY_PROTOCOL;
+	version: 1;
+	revision: number;
+	topics: RealtimeTopologyTopic[];
+	channels: RealtimeTopologyChannel[];
+};
+
+type TopologyRow = {
+	sessionKey: string;
+	ownerId: string;
+	ownerGeneration: number;
+	protocolVersion: number;
+	tokenHash: string;
+	identityHash: string;
+	leaseExpiresAt: Date;
+	desiredRevision: number;
+	appliedRevision: number;
+	desiredTopology: RealtimeDesiredTopology;
+};
+
+type TopologyMutation =
+	| { status: "accepted"; topology: RealtimeDesiredTopology }
+	| { status: "duplicate" | "stale" | "conflict" | "unsupported" };
+
+type TopologyMutationResult =
+	| { status: "unavailable" }
+	| {
+			status: TopologyMutation["status"];
+			row: TopologyRow;
+	  };
+
+interface RealtimeTopologyStore {
+	open(input: {
+		sessionKey: string;
+		ownerId: string;
+		tokenHash: string;
+		identityHash: string;
+		topology: RealtimeDesiredTopology;
+		leaseMs: number;
+	}): Promise<TopologyRow>;
+	mutate(input: {
+		sessionKey: string;
+		tokenHash: string;
+		identityHash: string;
+		mutate: (row: TopologyRow) => TopologyMutation;
+	}): Promise<TopologyMutationResult>;
+	getOwned(input: {
+		sessionKey: string;
+		ownerId: string;
+		ownerGeneration: number;
+	}): Promise<TopologyRow | null>;
+	markApplied(input: {
+		sessionKey: string;
+		ownerId: string;
+		ownerGeneration: number;
+		revision: number;
+	}): Promise<boolean>;
+	renew(input: {
+		sessionKey: string;
+		ownerId: string;
+		ownerGeneration: number;
+		leaseMs: number;
+	}): Promise<boolean>;
+	removeOwned(input: {
+		sessionKey: string;
+		ownerId: string;
+		ownerGeneration: number;
+	}): Promise<void>;
+	cleanupExpired(): Promise<void>;
+}
+
+function hash(value: string): string {
+	return createHash("sha256").update(value).digest("hex");
+}
+
+function stableValue(value: unknown): unknown {
+	if (Array.isArray(value)) return value.map(stableValue);
+	if (!value || typeof value !== "object") return value;
+	return Object.fromEntries(
+		Object.entries(value as Record<string, unknown>)
+			.sort(([left], [right]) => left.localeCompare(right))
+			.map(([key, entry]) => [key, stableValue(entry)]),
+	);
+}
+
+function canonicalizeTopology(
+	topology: RealtimeDesiredTopology,
+): RealtimeDesiredTopology {
+	const ids = new Set<string>();
+	const topics = topology.topics
+		.map((entry) => ({
+			id: entry.id,
+			topic: stableValue(entry.topic) as Record<string, unknown>,
+			...(entry.sinceSeq === undefined ? {} : { sinceSeq: entry.sinceSeq }),
+		}))
+		.sort((left, right) => left.id.localeCompare(right.id));
+	const channels = topology.channels
+		.map((entry) => ({
+			id: entry.id,
+			channel: entry.channel,
+			params: stableValue(entry.params) as Record<string, string>,
+			...(entry.lastEventId === undefined
+				? {}
+				: { lastEventId: entry.lastEventId }),
+		}))
+		.sort((left, right) => left.id.localeCompare(right.id));
+	for (const entry of [...topics, ...channels]) {
+		if (!entry.id || ids.has(entry.id)) {
+			throw new Error("Realtime topology ids must be non-empty and unique");
+		}
+		ids.add(entry.id);
+	}
+	if (
+		topology.protocol !== REALTIME_TOPOLOGY_PROTOCOL ||
+		topology.version !== 1 ||
+		!Number.isSafeInteger(topology.revision) ||
+		topology.revision < 0
+	) {
+		throw new Error("Invalid realtime topology envelope");
+	}
+	const canonical: RealtimeDesiredTopology = {
+		protocol: REALTIME_TOPOLOGY_PROTOCOL,
+		version: 1,
+		revision: topology.revision,
+		topics,
+		channels,
+	};
+	if (
+		new TextEncoder().encode(JSON.stringify(canonical)).byteLength >
+		MAX_REALTIME_TOPOLOGY_BYTES
+	) {
+		throw new Error("Realtime topology exceeds 262144 bytes");
+	}
+	return canonical;
+}
+
+function topologyEquals(
+	left: RealtimeDesiredTopology,
+	right: RealtimeDesiredTopology,
+): boolean {
+	return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function applyLegacyFrames(
+	current: RealtimeDesiredTopology,
+	frames: RealtimeControlFrame[],
+): TopologyMutation {
+	const topics = new Map(current.topics.map((entry) => [entry.id, entry]));
+	const channels = new Map(current.channels.map((entry) => [entry.id, entry]));
+	for (const frame of frames) {
+		if (frame.type === "remove_topic") {
+			topics.delete(frame.topicId);
+			continue;
+		}
+		if (frame.type === "unsubscribe_channel") {
+			channels.delete(frame.subscriptionId);
+			continue;
+		}
+		if (frame.type === "add_topic") {
+			const next = canonicalizeTopology({
+				...current,
+				topics: [
+					{
+						id: frame.topicId,
+						topic: frame.topic,
+						...(frame.sinceSeq === undefined
+							? {}
+							: { sinceSeq: frame.sinceSeq }),
+					},
+				],
+				channels: [],
+			}).topics[0]!;
+			const existing = topics.get(frame.topicId);
+			if (existing && JSON.stringify(existing) !== JSON.stringify(next)) {
+				return { status: "conflict" };
+			}
+			topics.set(frame.topicId, next);
+			continue;
+		}
+		const next = canonicalizeTopology({
+			...current,
+			topics: [],
+			channels: [
+				{
+					id: frame.subscriptionId,
+					channel: frame.channel,
+					params: frame.params,
+					...(frame.lastEventId === undefined
+						? {}
+						: { lastEventId: frame.lastEventId }),
+				},
+			],
+		}).channels[0]!;
+		const existing = channels.get(frame.subscriptionId);
+		if (existing && JSON.stringify(existing) !== JSON.stringify(next)) {
+			return { status: "conflict" };
+		}
+		channels.set(frame.subscriptionId, next);
+	}
+	const topology = canonicalizeTopology({
+		...current,
+		revision: current.revision + 1,
+		topics: [...topics.values()],
+		channels: [...channels.values()],
+	});
+	const withoutRevision = { ...topology, revision: current.revision };
+	if (topologyEquals(current, withoutRevision)) return { status: "duplicate" };
+	return { status: "accepted", topology };
+}
+
+export class MemoryRealtimeTopologyStore implements RealtimeTopologyStore {
+	private readonly rows = new Map<string, TopologyRow>();
+	private generation = 0;
+
+	constructor(private readonly now: () => Date = () => new Date()) {}
+
+	async open(input: {
+		sessionKey: string;
+		ownerId: string;
+		tokenHash: string;
+		identityHash: string;
+		topology: RealtimeDesiredTopology;
+		leaseMs: number;
+	}): Promise<TopologyRow> {
+		const row: TopologyRow = {
+			sessionKey: input.sessionKey,
+			ownerId: input.ownerId,
+			ownerGeneration: ++this.generation,
+			protocolVersion: 1,
+			tokenHash: input.tokenHash,
+			identityHash: input.identityHash,
+			leaseExpiresAt: new Date(this.now().getTime() + input.leaseMs),
+			desiredRevision: input.topology.revision,
+			appliedRevision: input.topology.revision,
+			desiredTopology: input.topology,
+		};
+		this.rows.set(row.sessionKey, row);
+		return structuredClone(row);
+	}
+
+	async mutate(input: {
+		sessionKey: string;
+		tokenHash: string;
+		identityHash: string;
+		mutate: (row: TopologyRow) => TopologyMutation;
+	}): Promise<TopologyMutationResult> {
+		const row = this.rows.get(input.sessionKey);
+		if (
+			!row ||
+			row.leaseExpiresAt <= this.now() ||
+			row.tokenHash !== input.tokenHash ||
+			row.identityHash !== input.identityHash
+		) {
+			return { status: "unavailable" };
+		}
+		const mutation = input.mutate(structuredClone(row));
+		if (mutation.status === "accepted") {
+			row.desiredTopology = mutation.topology;
+			row.desiredRevision = mutation.topology.revision;
+		}
+		return { status: mutation.status, row: structuredClone(row) };
+	}
+
+	async getOwned(input: {
+		sessionKey: string;
+		ownerId: string;
+		ownerGeneration: number;
+	}): Promise<TopologyRow | null> {
+		const row = this.rows.get(input.sessionKey);
+		return row &&
+			row.ownerId === input.ownerId &&
+			row.ownerGeneration === input.ownerGeneration &&
+			row.leaseExpiresAt > this.now()
+			? structuredClone(row)
+			: null;
+	}
+
+	async markApplied(input: {
+		sessionKey: string;
+		ownerId: string;
+		ownerGeneration: number;
+		revision: number;
+	}): Promise<boolean> {
+		const row = await this.getOwned(input);
+		if (!row) return false;
+		const stored = this.rows.get(input.sessionKey)!;
+		stored.appliedRevision = input.revision;
+		return true;
+	}
+
+	async renew(input: {
+		sessionKey: string;
+		ownerId: string;
+		ownerGeneration: number;
+		leaseMs: number;
+	}): Promise<boolean> {
+		const row = await this.getOwned(input);
+		if (!row) return false;
+		this.rows.get(input.sessionKey)!.leaseExpiresAt = new Date(
+			this.now().getTime() + input.leaseMs,
+		);
+		return true;
+	}
+
+	async removeOwned(input: {
+		sessionKey: string;
+		ownerId: string;
+		ownerGeneration: number;
+	}): Promise<void> {
+		const row = this.rows.get(input.sessionKey);
+		if (
+			row?.ownerId === input.ownerId &&
+			row.ownerGeneration === input.ownerGeneration
+		) {
+			this.rows.delete(input.sessionKey);
+		}
+	}
+
+	async cleanupExpired(): Promise<void> {
+		for (const [key, row] of this.rows) {
+			if (row.leaseExpiresAt <= this.now()) this.rows.delete(key);
+		}
+	}
+}
+
+export class PostgresRealtimeTopologyStore implements RealtimeTopologyStore {
+	constructor(private readonly db: any) {}
+
+	private leaseDeadline(leaseMs: number) {
+		return sql`now() + (${leaseMs} * interval '1 millisecond')`;
+	}
+
+	async open(input: {
+		sessionKey: string;
+		ownerId: string;
+		tokenHash: string;
+		identityHash: string;
+		topology: RealtimeDesiredTopology;
+		leaseMs: number;
+	}): Promise<TopologyRow> {
+		const [row] = await this.db
+			.insert(questpieRealtimeTopologyTable)
+			.values({
+				sessionKey: input.sessionKey,
+				ownerId: input.ownerId,
+				protocolVersion: 1,
+				tokenHash: input.tokenHash,
+				identityHash: input.identityHash,
+				leaseExpiresAt: this.leaseDeadline(input.leaseMs),
+				desiredRevision: input.topology.revision,
+				appliedRevision: input.topology.revision,
+				desiredTopology: input.topology,
+			})
+			.returning();
+		return row as TopologyRow;
+	}
+
+	async mutate(input: {
+		sessionKey: string;
+		tokenHash: string;
+		identityHash: string;
+		mutate: (row: TopologyRow) => TopologyMutation;
+	}): Promise<TopologyMutationResult> {
+		return this.db.transaction(async (tx: any) => {
+			const [row] = await tx
+				.select()
+				.from(questpieRealtimeTopologyTable)
+				.where(
+					and(
+						eq(questpieRealtimeTopologyTable.sessionKey, input.sessionKey),
+						gt(questpieRealtimeTopologyTable.leaseExpiresAt, sql`now()`),
+					),
+				)
+				.for("update");
+			if (
+				!row ||
+				row.tokenHash !== input.tokenHash ||
+				row.identityHash !== input.identityHash
+			) {
+				return { status: "unavailable" };
+			}
+			const typedRow = row as TopologyRow;
+			const mutation = input.mutate(typedRow);
+			if (mutation.status === "accepted") {
+				const [updated] = await tx
+					.update(questpieRealtimeTopologyTable)
+					.set({
+						desiredRevision: mutation.topology.revision,
+						desiredTopology: mutation.topology,
+						updatedAt: sql`now()`,
+					})
+					.where(eq(questpieRealtimeTopologyTable.sessionKey, input.sessionKey))
+					.returning();
+				return { status: mutation.status, row: updated as TopologyRow };
+			}
+			return { status: mutation.status, row: typedRow };
+		});
+	}
+
+	async getOwned(input: {
+		sessionKey: string;
+		ownerId: string;
+		ownerGeneration: number;
+	}): Promise<TopologyRow | null> {
+		const [row] = await this.db
+			.select()
+			.from(questpieRealtimeTopologyTable)
+			.where(
+				and(
+					eq(questpieRealtimeTopologyTable.sessionKey, input.sessionKey),
+					eq(questpieRealtimeTopologyTable.ownerId, input.ownerId),
+					eq(
+						questpieRealtimeTopologyTable.ownerGeneration,
+						input.ownerGeneration,
+					),
+					gt(questpieRealtimeTopologyTable.leaseExpiresAt, sql`now()`),
+				),
+			);
+		return (row as TopologyRow | undefined) ?? null;
+	}
+
+	async markApplied(input: {
+		sessionKey: string;
+		ownerId: string;
+		ownerGeneration: number;
+		revision: number;
+	}): Promise<boolean> {
+		const rows = await this.db
+			.update(questpieRealtimeTopologyTable)
+			.set({ appliedRevision: input.revision, updatedAt: sql`now()` })
+			.where(
+				and(
+					eq(questpieRealtimeTopologyTable.sessionKey, input.sessionKey),
+					eq(questpieRealtimeTopologyTable.ownerId, input.ownerId),
+					eq(
+						questpieRealtimeTopologyTable.ownerGeneration,
+						input.ownerGeneration,
+					),
+					gt(questpieRealtimeTopologyTable.leaseExpiresAt, sql`now()`),
+				),
+			)
+			.returning({ sessionKey: questpieRealtimeTopologyTable.sessionKey });
+		return rows.length === 1;
+	}
+
+	async renew(input: {
+		sessionKey: string;
+		ownerId: string;
+		ownerGeneration: number;
+		leaseMs: number;
+	}): Promise<boolean> {
+		const rows = await this.db
+			.update(questpieRealtimeTopologyTable)
+			.set({
+				leaseExpiresAt: this.leaseDeadline(input.leaseMs),
+				updatedAt: sql`now()`,
+			})
+			.where(
+				and(
+					eq(questpieRealtimeTopologyTable.sessionKey, input.sessionKey),
+					eq(questpieRealtimeTopologyTable.ownerId, input.ownerId),
+					eq(
+						questpieRealtimeTopologyTable.ownerGeneration,
+						input.ownerGeneration,
+					),
+					gt(questpieRealtimeTopologyTable.leaseExpiresAt, sql`now()`),
+				),
+			)
+			.returning({ sessionKey: questpieRealtimeTopologyTable.sessionKey });
+		return rows.length === 1;
+	}
+
+	async removeOwned(input: {
+		sessionKey: string;
+		ownerId: string;
+		ownerGeneration: number;
+	}): Promise<void> {
+		await this.db
+			.delete(questpieRealtimeTopologyTable)
+			.where(
+				and(
+					eq(questpieRealtimeTopologyTable.sessionKey, input.sessionKey),
+					eq(questpieRealtimeTopologyTable.ownerId, input.ownerId),
+					eq(
+						questpieRealtimeTopologyTable.ownerGeneration,
+						input.ownerGeneration,
+					),
+				),
+			);
+	}
+
+	async cleanupExpired(): Promise<void> {
+		await this.db
+			.delete(questpieRealtimeTopologyTable)
+			.where(lt(questpieRealtimeTopologyTable.leaseExpiresAt, sql`now()`));
+	}
+}
+
+export type RealtimeTopologyResult =
+	| { status: "unavailable" }
+	| {
+			status: "accepted" | "duplicate" | "stale" | "conflict" | "unsupported";
+			revision: number;
+			desiredRevision: number;
+			appliedRevision: number;
+	  };
+
+type LocalHandler = {
+	generation: number;
+	appliedRevision: number;
+	apply: (topology: RealtimeDesiredTopology) => Promise<void>;
+	onClose: () => Promise<void> | void;
+	operation: Promise<void>;
+};
+
+export class RealtimeTopologyCoordinator {
+	private readonly ownerId: string;
+	private readonly broker?: ChangeBroker;
+	private readonly leaseMs: number;
+	private readonly heartbeatMs: number;
+	private readonly reconcileMs: number;
+	private readonly onError: (error: unknown) => void;
+	private readonly handlers = new Map<string, LocalHandler>();
+	private heartbeatTimer?: ReturnType<typeof setInterval>;
+	private reconcileTimer?: ReturnType<typeof setInterval>;
+	private started = false;
+
+	constructor(
+		private readonly store: RealtimeTopologyStore,
+		options: {
+			broker?: ChangeBroker;
+			ownerId?: string;
+			now?: () => Date;
+			leaseMs?: number;
+			heartbeatMs?: number;
+			reconcileMs?: number;
+			onError?: (error: unknown) => void;
+		} = {},
+	) {
+		this.ownerId = options.ownerId ?? randomUUID();
+		this.broker = options.broker;
+		this.leaseMs = options.leaseMs ?? 30_000;
+		this.heartbeatMs = options.heartbeatMs ?? 10_000;
+		this.reconcileMs = options.reconcileMs ?? 1_000;
+		this.onError = options.onError ?? (() => {});
+	}
+
+	async start(): Promise<void> {
+		if (this.started) return;
+		this.started = true;
+		if (this.heartbeatMs > 0) {
+			this.heartbeatTimer = setInterval(
+				() => void this.heartbeat().catch(this.onError),
+				this.heartbeatMs,
+			);
+		}
+		if (this.reconcileMs > 0) {
+			this.reconcileTimer = setInterval(
+				() => void this.reconcile().catch(this.onError),
+				this.reconcileMs,
+			);
+		}
+	}
+
+	async open(input: {
+		sessionId: string;
+		token: string;
+		identity: string;
+		topology: RealtimeDesiredTopology;
+		apply: (topology: RealtimeDesiredTopology) => Promise<void>;
+		onClose: () => Promise<void> | void;
+	}): Promise<{ generation: number; close(): Promise<void> }> {
+		await this.start();
+		const topology = canonicalizeTopology(input.topology);
+		const sessionKey = hash(input.sessionId);
+		const row = await this.store.open({
+			sessionKey,
+			ownerId: this.ownerId,
+			tokenHash: hash(input.token),
+			identityHash: hash(input.identity),
+			topology,
+			leaseMs: this.leaseMs,
+		});
+		this.handlers.set(sessionKey, {
+			generation: row.ownerGeneration,
+			appliedRevision: topology.revision,
+			apply: input.apply,
+			onClose: input.onClose,
+			operation: Promise.resolve(),
+		});
+		return {
+			generation: row.ownerGeneration,
+			close: () => this.closeLocal(sessionKey, true, false),
+		};
+	}
+
+	async submit(input: {
+		sessionId: string;
+		token: string;
+		identity: string;
+		topology: RealtimeDesiredTopology;
+	}): Promise<RealtimeTopologyResult> {
+		let topology: RealtimeDesiredTopology;
+		try {
+			topology = canonicalizeTopology(input.topology);
+		} catch {
+			return {
+				status: "unsupported",
+				revision: 0,
+				desiredRevision: 0,
+				appliedRevision: 0,
+			};
+		}
+		return this.commit(input, (row) => {
+			if (topology.revision < row.desiredRevision) return { status: "stale" };
+			if (topology.revision === row.desiredRevision) {
+				return topologyEquals(topology, row.desiredTopology)
+					? { status: "duplicate" }
+					: { status: "conflict" };
+			}
+			return { status: "accepted", topology };
+		});
+	}
+
+	async submitLegacy(input: {
+		sessionId: string;
+		token: string;
+		identity: string;
+		frames: RealtimeControlFrame[];
+	}): Promise<RealtimeTopologyResult> {
+		return this.commit(input, (row) =>
+			applyLegacyFrames(row.desiredTopology, input.frames),
+		);
+	}
+
+	private async commit(
+		input: { sessionId: string; token: string; identity: string },
+		mutate: (row: TopologyRow) => TopologyMutation,
+	): Promise<RealtimeTopologyResult> {
+		const result = await this.store.mutate({
+			sessionKey: hash(input.sessionId),
+			tokenHash: hash(input.token),
+			identityHash: hash(input.identity),
+			mutate,
+		});
+		if (result.status === "unavailable") return result;
+		const response = {
+			status: result.status,
+			revision: result.row.desiredRevision,
+			desiredRevision: result.row.desiredRevision,
+			appliedRevision: result.row.appliedRevision,
+		} as RealtimeTopologyResult;
+		if (result.status !== "accepted") return response;
+		const wake: ChangeWake = {
+			kind: "topology-maybe-advanced",
+			sessionKey: result.row.sessionKey,
+			ownerId: result.row.ownerId,
+			ownerGeneration: result.row.ownerGeneration,
+			desiredRevision: result.row.desiredRevision,
+			reason: "submit",
+		};
+		try {
+			await this.broker?.publish(wake);
+		} catch (error) {
+			this.onError(error);
+		}
+		if (result.row.ownerId === this.ownerId) {
+			await this.reconcileSession(result.row.sessionKey);
+		}
+		return response;
+	}
+
+	onWake(wake: ChangeWake): void {
+		if (
+			wake.kind !== "topology-maybe-advanced" ||
+			wake.ownerId !== this.ownerId
+		) {
+			return;
+		}
+		void this.reconcileSession(wake.sessionKey).catch(this.onError);
+	}
+
+	async reconcile(): Promise<void> {
+		await Promise.all(
+			[...this.handlers.keys()].map((key) => this.reconcileSession(key)),
+		);
+		await this.store.cleanupExpired();
+	}
+
+	private async reconcileSession(sessionKey: string): Promise<void> {
+		const handler = this.handlers.get(sessionKey);
+		if (!handler) return;
+		handler.operation = handler.operation
+			.catch(() => {})
+			.then(async () => {
+				const row = await this.store.getOwned({
+					sessionKey,
+					ownerId: this.ownerId,
+					ownerGeneration: handler.generation,
+				});
+				if (!row) {
+					await this.closeLocal(sessionKey, false, true);
+					return;
+				}
+				if (row.desiredRevision <= handler.appliedRevision) return;
+				try {
+					await handler.apply(row.desiredTopology);
+				} catch (error) {
+					this.onError(error);
+					await this.closeLocal(sessionKey, true, true);
+					return;
+				}
+				const marked = await this.store.markApplied({
+					sessionKey,
+					ownerId: this.ownerId,
+					ownerGeneration: handler.generation,
+					revision: row.desiredRevision,
+				});
+				if (!marked) {
+					await this.closeLocal(sessionKey, false, true);
+					return;
+				}
+				handler.appliedRevision = row.desiredRevision;
+			});
+		await handler.operation;
+	}
+
+	private async heartbeat(): Promise<void> {
+		for (const [sessionKey, handler] of this.handlers) {
+			const renewed = await this.store.renew({
+				sessionKey,
+				ownerId: this.ownerId,
+				ownerGeneration: handler.generation,
+				leaseMs: this.leaseMs,
+			});
+			if (!renewed) await this.closeLocal(sessionKey, false, true);
+		}
+	}
+
+	private async closeLocal(
+		sessionKey: string,
+		removeOwned: boolean,
+		notify: boolean,
+	): Promise<void> {
+		const handler = this.handlers.get(sessionKey);
+		if (!handler) return;
+		this.handlers.delete(sessionKey);
+		if (removeOwned) {
+			await this.store.removeOwned({
+				sessionKey,
+				ownerId: this.ownerId,
+				ownerGeneration: handler.generation,
+			});
+		}
+		if (notify) await handler.onClose();
+	}
+
+	async stop(): Promise<void> {
+		if (this.heartbeatTimer) clearInterval(this.heartbeatTimer);
+		if (this.reconcileTimer) clearInterval(this.reconcileTimer);
+		this.heartbeatTimer = undefined;
+		this.reconcileTimer = undefined;
+		for (const key of this.handlers.keys()) {
+			await this.closeLocal(key, true, true);
+		}
+		this.started = false;
+	}
+}
+
+export function createPostgresRealtimeTopologyCoordinator(
+	db: any,
+	options: ConstructorParameters<typeof RealtimeTopologyCoordinator>[1] = {},
+): RealtimeTopologyCoordinator {
+	return new RealtimeTopologyCoordinator(
+		new PostgresRealtimeTopologyStore(db),
+		options,
+	);
+}

--- a/packages/questpie/src/server/modules/core/integrated/realtime/topology-coordinator.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/topology-coordinator.ts
@@ -166,6 +166,13 @@ function topologyEquals(
 	return JSON.stringify(left) === JSON.stringify(right);
 }
 
+function normalizeTopologyRow(row: TopologyRow): TopologyRow {
+	return {
+		...row,
+		desiredTopology: canonicalizeTopology(row.desiredTopology),
+	};
+}
+
 function applyLegacyFrames(
 	current: RealtimeDesiredTopology,
 	frames: RealtimeControlFrame[],
@@ -377,7 +384,7 @@ export class PostgresRealtimeTopologyStore implements RealtimeTopologyStore {
 				desiredTopology: input.topology,
 			})
 			.returning();
-		return row as TopologyRow;
+		return normalizeTopologyRow(row as TopologyRow);
 	}
 
 	async mutate(input: {
@@ -404,7 +411,7 @@ export class PostgresRealtimeTopologyStore implements RealtimeTopologyStore {
 			) {
 				return { status: "unavailable" };
 			}
-			const typedRow = row as TopologyRow;
+			const typedRow = normalizeTopologyRow(row as TopologyRow);
 			const mutation = input.mutate(typedRow);
 			if (mutation.status === "accepted") {
 				const [updated] = await tx
@@ -416,7 +423,10 @@ export class PostgresRealtimeTopologyStore implements RealtimeTopologyStore {
 					})
 					.where(eq(questpieRealtimeTopologyTable.sessionKey, input.sessionKey))
 					.returning();
-				return { status: mutation.status, row: updated as TopologyRow };
+				return {
+					status: mutation.status,
+					row: normalizeTopologyRow(updated as TopologyRow),
+				};
 			}
 			return { status: mutation.status, row: typedRow };
 		});
@@ -441,7 +451,7 @@ export class PostgresRealtimeTopologyStore implements RealtimeTopologyStore {
 					gt(questpieRealtimeTopologyTable.leaseExpiresAt, sql`now()`),
 				),
 			);
-		return (row as TopologyRow | undefined) ?? null;
+		return row ? normalizeTopologyRow(row as TopologyRow) : null;
 	}
 
 	async markApplied(input: {

--- a/packages/questpie/src/server/modules/core/integrated/realtime/transport.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/transport.ts
@@ -12,7 +12,100 @@ export type ChangeWake =
 			channelHash?: string;
 			highWaterEventId?: string;
 			reason: "publish" | "reconnect" | "reconcile";
+	  }
+	| {
+			kind: "topology-maybe-advanced";
+			sessionKey: string;
+			ownerId: string;
+			ownerGeneration: number;
+			desiredRevision: number;
+			reason: "submit" | "reconnect" | "reconcile";
 	  };
+
+function isNonNegativeSafeInteger(value: unknown): value is number {
+	return Number.isSafeInteger(value) && Number(value) >= 0;
+}
+
+/** Validate and strip a broker wake down to its bounded metadata contract. */
+export function normalizeChangeWake(value: unknown): ChangeWake | null {
+	if (!value || typeof value !== "object") return null;
+	const wake = value as Record<string, unknown>;
+
+	if (wake.kind === "outbox-maybe-advanced") {
+		if (
+			wake.reason !== "publish" &&
+			wake.reason !== "reconnect" &&
+			wake.reason !== "reconcile"
+		) {
+			return null;
+		}
+		if (
+			wake.highWaterSeq !== undefined &&
+			!isNonNegativeSafeInteger(wake.highWaterSeq)
+		) {
+			return null;
+		}
+		return {
+			kind: wake.kind,
+			reason: wake.reason,
+			...(wake.highWaterSeq === undefined
+				? {}
+				: { highWaterSeq: wake.highWaterSeq }),
+		};
+	}
+
+	if (wake.kind === "channel-events-maybe-advanced") {
+		if (
+			wake.reason !== "publish" &&
+			wake.reason !== "reconnect" &&
+			wake.reason !== "reconcile"
+		) {
+			return null;
+		}
+		if (
+			(wake.channelHash !== undefined &&
+				typeof wake.channelHash !== "string") ||
+			(wake.highWaterEventId !== undefined &&
+				typeof wake.highWaterEventId !== "string")
+		) {
+			return null;
+		}
+		return {
+			kind: wake.kind,
+			reason: wake.reason,
+			...(wake.channelHash === undefined
+				? {}
+				: { channelHash: wake.channelHash }),
+			...(wake.highWaterEventId === undefined
+				? {}
+				: { highWaterEventId: wake.highWaterEventId }),
+		};
+	}
+
+	if (
+		wake.kind !== "topology-maybe-advanced" ||
+		typeof wake.sessionKey !== "string" ||
+		wake.sessionKey.length === 0 ||
+		typeof wake.ownerId !== "string" ||
+		wake.ownerId.length === 0 ||
+		!isNonNegativeSafeInteger(wake.ownerGeneration) ||
+		!isNonNegativeSafeInteger(wake.desiredRevision) ||
+		(wake.reason !== "submit" &&
+			wake.reason !== "reconnect" &&
+			wake.reason !== "reconcile")
+	) {
+		return null;
+	}
+
+	return {
+		kind: wake.kind,
+		sessionKey: wake.sessionKey,
+		ownerId: wake.ownerId,
+		ownerGeneration: wake.ownerGeneration,
+		desiredRevision: wake.desiredRevision,
+		reason: wake.reason,
+	};
+}
 
 /** Cross-instance invalidation seam. It never carries snapshots or records. */
 export interface ChangeBroker {

--- a/packages/questpie/src/server/modules/core/integrated/realtime/types.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/types.ts
@@ -49,8 +49,11 @@ export type RealtimeNotice = Pick<
 	"seq" | "resourceType" | "resource" | "operation"
 >;
 
-export type RealtimeTransportMode = "legacy" | "v2" | "dual";
+/** @deprecated `legacy` and `dual` are 3.x rollback aids removed in QuestPie 4. */
+export type LegacyRealtimeTransportMode = "legacy" | "dual";
+export type RealtimeTransportMode = "v2" | LegacyRealtimeTransportMode;
 
+/** @deprecated Dual-run comparison is a 3.x migration aid removed in QuestPie 4. */
 export type RealtimeDualRunComparison = {
 	/** Durable outbox sequence published through both invalidation paths. */
 	seq: number;
@@ -69,7 +72,7 @@ export type RealtimeRolloutConfig = {
 	 * @default "v2"
 	 */
 	mode?: RealtimeTransportMode;
-	/** Observes one comparison per dual-run outbox publish. */
+	/** @deprecated Dual-run comparison hooks are removed in QuestPie 4. */
 	onComparison?: (comparison: RealtimeDualRunComparison) => void;
 };
 
@@ -124,6 +127,8 @@ export interface RealtimeConfig {
 	connectionAcceptPacingMs?: number;
 	/**
 	 * Optional transport adapter (pg_notify, redis streams, etc.).
+	 * @deprecated Use `changeBroker`. This compatibility path remains in 3.x and
+	 * is removed in QuestPie 4.
 	 */
 	adapter?: RealtimeAdapter;
 	/** Cross-instance notice seam used by Realtime v2 transports. */

--- a/packages/questpie/src/shared/realtime-error.ts
+++ b/packages/questpie/src/shared/realtime-error.ts
@@ -1,0 +1,40 @@
+export type RealtimeTopicOperation = "find" | "count" | "get";
+
+export type RealtimeTopicRejectionReason = "query_limit" | "relation_depth";
+
+export type RealtimeTopicRejectedDetails = {
+	reason: RealtimeTopicRejectionReason;
+	requestedLimit?: number;
+	configuredLimit?: number;
+};
+
+/** Public, payload-safe rejection emitted for one realtime topic. */
+export type RealtimeTopicRejectedPayload = {
+	code: "REALTIME_TOPIC_REJECTED";
+	message: string;
+	topicId: string;
+	resource: string;
+	operation: RealtimeTopicOperation;
+	retryable: false;
+	details: RealtimeTopicRejectedDetails;
+};
+
+export function isRealtimeTopicRejectedPayload(
+	value: unknown,
+): value is RealtimeTopicRejectedPayload {
+	if (!value || typeof value !== "object") return false;
+	const payload = value as Partial<RealtimeTopicRejectedPayload>;
+	return (
+		payload.code === "REALTIME_TOPIC_REJECTED" &&
+		typeof payload.message === "string" &&
+		typeof payload.topicId === "string" &&
+		typeof payload.resource === "string" &&
+		(payload.operation === "find" ||
+			payload.operation === "count" ||
+			payload.operation === "get") &&
+		payload.retryable === false &&
+		Boolean(payload.details) &&
+		(payload.details?.reason === "query_limit" ||
+			payload.details?.reason === "relation_depth")
+	);
+}

--- a/packages/questpie/test/adapters/redis-streams.test.ts
+++ b/packages/questpie/test/adapters/redis-streams.test.ts
@@ -1,10 +1,14 @@
 import { afterEach, describe, expect, it } from "bun:test";
 
 import {
+	RedisStreamsChangeBroker,
 	RedisStreamsAdapter,
 	type RedisStreamsClient,
 } from "../../src/exports/adapters/redis-streams.js";
-import type { RealtimeChangeEvent } from "../../src/exports/realtime.js";
+import type {
+	ChangeWake,
+	RealtimeChangeEvent,
+} from "../../src/exports/realtime.js";
 import { buildMockApp } from "../utils/mocks/mock-app-builder.js";
 import { createTestDb, runTestDbMigrations } from "../utils/test-db.js";
 
@@ -272,4 +276,105 @@ describe("redis streams realtime matrix adapter", () => {
 		releases.shift()?.();
 		await finalStop;
 	});
+});
+
+describe("redis streams change broker", () => {
+	const brokers: RedisStreamsChangeBroker[] = [];
+
+	afterEach(async () => {
+		await Promise.all(brokers.splice(0).map((broker) => broker.stop()));
+	});
+
+	it("fans metadata-only topology wakes out to every instance", async () => {
+		const redis = new FakeRedisStream();
+		const first = new RedisStreamsChangeBroker({
+			client: redis.createClient(),
+			blockMs: 10,
+		});
+		const second = new RedisStreamsChangeBroker({
+			client: redis.createClient(),
+			blockMs: 10,
+		});
+		brokers.push(first, second);
+		const received: ChangeWake[] = [];
+		const wake: ChangeWake = {
+			kind: "topology-maybe-advanced",
+			sessionKey: "hashed-session",
+			ownerId: "owner-one",
+			ownerGeneration: 3,
+			desiredRevision: 4,
+			reason: "submit",
+		};
+
+		await Promise.all([
+			first.start({
+				onWake: (value) => received.push(value),
+				onError: () => {},
+			}),
+			second.start({
+				onWake: (value) => received.push(value),
+				onError: () => {},
+			}),
+		]);
+		await first.publish(wake);
+
+		for (let attempt = 0; received.length < 2 && attempt < 100; attempt++) {
+			await new Promise((resolve) => setTimeout(resolve, 1));
+		}
+		expect(received).toEqual([wake, wake]);
+	});
+
+	it("drives the v2 service seam across two app instances", async () => {
+		const redis = new FakeRedisStream();
+		const firstBroker = new RedisStreamsChangeBroker({
+			client: redis.createClient(),
+			blockMs: 10,
+		});
+		const secondBroker = new RedisStreamsChangeBroker({
+			client: redis.createClient(),
+			blockMs: 10,
+		});
+		brokers.push(firstBroker, secondBroker);
+		const db = await createTestDb();
+		const first = await buildMockApp(
+			{},
+			{ db: { pglite: db }, realtime: { changeBroker: firstBroker } },
+		);
+		const second = await buildMockApp(
+			{},
+			{ db: { pglite: db }, realtime: { changeBroker: secondBroker } },
+		);
+
+		try {
+			await runTestDbMigrations(first.app);
+			const received = Promise.all([
+				new Promise((resolve) =>
+					first.app.realtime.subscribe(resolve, {
+						resourceType: "collection",
+						resource: "posts",
+					}),
+				),
+				new Promise((resolve) =>
+					second.app.realtime.subscribe(resolve, {
+						resourceType: "collection",
+						resource: "posts",
+					}),
+				),
+			]);
+			for (let attempt = 0; redis.waiterCount < 2 && attempt < 100; attempt++) {
+				await new Promise((resolve) => setTimeout(resolve, 1));
+			}
+
+			const event = await first.app.realtime.appendChange(change);
+			await first.app.realtime.notify(event);
+
+			expect(await received).toEqual([
+				expect.objectContaining({ seq: event.seq, resource: "posts" }),
+				expect.objectContaining({ seq: event.seq, resource: "posts" }),
+			]);
+		} finally {
+			await Promise.all([first.cleanup(), second.cleanup()]);
+			await db.close();
+		}
+	}, 10_000);
 });

--- a/packages/questpie/test/client/client-channels.test.ts
+++ b/packages/questpie/test/client/client-channels.test.ts
@@ -112,6 +112,8 @@ describe("channels client", () => {
 				});
 			}
 			if (url.endsWith("/realtime")) {
+				const payload = JSON.parse(String(init?.body));
+				if (payload.sessionId) return new Response(null, { status: 204 });
 				const stream = new ReadableStream<Uint8Array>({
 					start(controller) {
 						streamController = controller;
@@ -196,7 +198,109 @@ describe("channels client", () => {
 		});
 
 		stopPresence();
+		await waitFor(() =>
+			requests.some(({ url, init }) => {
+				if (!url.endsWith("/realtime")) return false;
+				const payload = JSON.parse(String(init?.body));
+				return payload.frames?.some(
+					(frame: { type: string }) => frame.type === "unsubscribe_channel",
+				);
+			}),
+		);
+		const controlCount = requests.filter(({ url, init }) => {
+			if (!url.endsWith("/realtime")) return false;
+			return Boolean(JSON.parse(String(init?.body)).sessionId);
+		}).length;
 		stop();
+		await new Promise((resolve) => setTimeout(resolve, 10));
+		expect(
+			requests.filter(({ url, init }) => {
+				if (!url.endsWith("/realtime")) return false;
+				return Boolean(JSON.parse(String(init?.body)).sessionId);
+			}).length,
+		).toBe(controlCount);
+		client.channels.destroy();
+	});
+
+	test("coalesces advertised v1 channel topology and closes the last channel locally", async () => {
+		const controls: Array<{
+			revision: number;
+			channels: Array<{ id: string }>;
+		}> = [];
+		let streamReady = false;
+		let aborted = false;
+		const encoder = new TextEncoder();
+		const fetcher: typeof fetch = async (input, init) => {
+			const url = String(input);
+			if (url.endsWith("/channels/config")) {
+				return Response.json({
+					transport: "sse",
+					channels: {
+						news: { pattern: "news", visibility: "public" },
+						room: {
+							pattern: "room-[roomId]",
+							visibility: "public",
+						},
+					},
+				});
+			}
+			if (url.endsWith("/realtime")) {
+				const payload = JSON.parse(String(init?.body));
+				if (payload.topology) {
+					controls.push(payload.topology);
+					return Response.json({ status: "accepted" }, { status: 202 });
+				}
+				const stream = new ReadableStream<Uint8Array>({
+					start(controller) {
+						streamReady = true;
+						controller.enqueue(
+							encoder.encode(
+								`event: session\ndata: ${JSON.stringify({
+									sessionId: "channels-v1",
+									token: "token-v1",
+									control: {
+										protocol: "questpie-realtime-topology",
+										versions: [1],
+									},
+								})}\n\n`,
+							),
+						);
+						init?.signal?.addEventListener("abort", () => {
+							aborted = true;
+							try {
+								controller.close();
+							} catch {}
+						});
+					},
+				});
+				return new Response(stream, {
+					headers: { "Content-Type": "text/event-stream" },
+				});
+			}
+			throw new Error(`Unexpected request: ${url}`);
+		};
+		const client = createClient<any>({
+			baseURL: "http://localhost:3000",
+			fetch: fetcher,
+		});
+		const stopNews = client.channels.news.subscribe(() => {});
+		await waitFor(() => streamReady);
+		const stopOne = client.channels.room.subscribe({ roomId: "one" }, () => {});
+		const stopTwo = client.channels.room.subscribe({ roomId: "two" }, () => {});
+		await waitFor(() => controls.length === 1);
+		expect(controls[0]).toMatchObject({ revision: 1 });
+		expect(controls[0].channels).toHaveLength(3);
+
+		stopOne();
+		stopTwo();
+		await waitFor(() => controls.length === 2);
+		expect(controls[1]).toMatchObject({ revision: 2 });
+		expect(controls[1].channels).toHaveLength(1);
+
+		stopNews();
+		await waitFor(() => aborted);
+		await new Promise((resolve) => setTimeout(resolve, 10));
+		expect(controls).toHaveLength(2);
 		client.channels.destroy();
 	});
 

--- a/packages/questpie/test/client/client-live.test.ts
+++ b/packages/questpie/test/client/client-live.test.ts
@@ -245,6 +245,89 @@ describe("client live queries", () => {
 		stopPosts();
 	});
 
+	it("coalesces advertised v1 desired topology and closes the last topic locally", async () => {
+		const controls: Array<Record<string, any>> = [];
+		let streamController!: ReadableStreamDefaultController<Uint8Array>;
+		let aborted = false;
+		const fetcher: typeof fetch = async (_input, init) => {
+			const payload = JSON.parse(String(init?.body));
+			if (payload.sessionId) {
+				controls.push(payload);
+				return Response.json(
+					{
+						protocol: "questpie-realtime-topology",
+						version: 1,
+						status: "accepted",
+						revision: payload.topology.revision,
+						desiredRevision: payload.topology.revision,
+						appliedRevision: payload.topology.revision - 1,
+					},
+					{ status: 202 },
+				);
+			}
+			const stream = new ReadableStream<Uint8Array>({
+				start(controller) {
+					streamController = controller;
+					controller.enqueue(
+						encoder.encode(
+							`event: session\ndata: ${JSON.stringify({
+								sessionId: "session-v1",
+								token: "token-v1",
+								control: {
+									protocol: "questpie-realtime-topology",
+									versions: [1],
+								},
+							})}\n\n`,
+						),
+					);
+				},
+			});
+			init?.signal?.addEventListener("abort", () => {
+				aborted = true;
+				streamController.close();
+			});
+			return new Response(stream, {
+				headers: { "Content-Type": "text/event-stream" },
+			});
+		};
+		const multiplexer = new RealtimeMultiplexer(
+			"http://localhost:3000",
+			true,
+			0,
+			{},
+			undefined,
+			fetcher,
+		);
+		const stopPosts = multiplexer.subscribe(
+			{ resourceType: "collection", resource: "posts" },
+			() => {},
+		);
+		await new Promise((resolve) => setTimeout(resolve, 10));
+		const stopPages = multiplexer.subscribe(
+			{ resourceType: "collection", resource: "pages" },
+			() => {},
+		);
+		const stopUsers = multiplexer.subscribe(
+			{ resourceType: "collection", resource: "users" },
+			() => {},
+		);
+
+		await waitFor(() => controls.length === 1);
+		expect(controls[0].topology.revision).toBe(1);
+		expect(controls[0].topology.topics).toHaveLength(3);
+		expect(controls[0].frames).toBeUndefined();
+
+		stopPages();
+		stopUsers();
+		await waitFor(() => controls.length === 2);
+		expect(controls[1].topology.revision).toBe(2);
+		expect(controls[1].topology.topics).toHaveLength(1);
+		stopPosts();
+		await waitFor(() => aborted);
+		expect(controls).toHaveLength(2);
+		multiplexer.destroy();
+	});
+
 	it("reconnects a clean close with sinceSeq and skips duplicate delivery", async () => {
 		const multiplexer = new RealtimeMultiplexer(
 			"http://localhost:3000",

--- a/packages/questpie/test/client/client-live.test.ts
+++ b/packages/questpie/test/client/client-live.test.ts
@@ -333,7 +333,7 @@ describe("client live queries", () => {
 		multiplexer.destroy();
 	});
 
-	it("reconnects a clean close with sinceSeq and skips duplicate delivery", async () => {
+	it("reconnects with the exact active topic set and per-topic sinceSeq", async () => {
 		const multiplexer = new RealtimeMultiplexer(
 			"http://localhost:3000",
 			true,
@@ -352,17 +352,31 @@ describe("client live queries", () => {
 			undefined,
 			"resume-posts",
 		);
+		multiplexer.subscribe(
+			{ resourceType: "collection", resource: "pages" },
+			(snapshot) => snapshots.push(snapshot),
+			undefined,
+			"resume-pages",
+		);
 		await waitFor(() => connections.length === 1);
 		connections[0].sendSnapshot("resume-posts", 7, { docs: [{ id: "7" }] });
-		await waitFor(() => snapshots.length === 1);
+		connections[0].sendSnapshot("resume-pages", 11, { docs: [{ id: "11" }] });
+		await waitFor(() => snapshots.length === 2);
 
 		connections[0].close();
 		await new Promise((resolve) => setTimeout(resolve, 1));
 		expect(connections).toHaveLength(1);
 		await waitFor(() => connections.length === 2);
-		expect(connections[1].topics[0].sinceSeq).toBe(7);
+		expect(
+			connections[1].topics
+				.map(({ id, resource, sinceSeq }) => ({ id, resource, sinceSeq }))
+				.sort((left, right) => left.id.localeCompare(right.id)),
+		).toEqual([
+			{ id: "resume-pages", resource: "pages", sinceSeq: 11 },
+			{ id: "resume-posts", resource: "posts", sinceSeq: 7 },
+		]);
 		await new Promise((resolve) => setTimeout(resolve, 20));
-		expect(snapshots).toHaveLength(1);
+		expect(snapshots).toHaveLength(2);
 		multiplexer.destroy();
 	});
 

--- a/packages/questpie/test/client/client-live.test.ts
+++ b/packages/questpie/test/client/client-live.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 import { createClient } from "../../src/client/index.js";
 import {
 	RealtimeMultiplexer,
+	RealtimeTopicRejectedError,
 	realtimeReconnectDelay,
 } from "../../src/client/realtime/multiplexer.js";
 import { sseSnapshotStream } from "../../src/client/realtime/stream.js";
@@ -31,7 +32,11 @@ type SSEConnection = {
 		sinceSeq?: number;
 	}>;
 	sendSnapshot: (topicId: string, seq: number, data: unknown) => void;
-	sendError: (topicId: string, message: string) => void;
+	sendError: (
+		topicId: string,
+		message: string,
+		payload?: Record<string, unknown>,
+	) => void;
 	close: () => void;
 	aborted: boolean;
 };
@@ -94,10 +99,10 @@ describe("client live queries", () => {
 						// Stream already closed
 					}
 				},
-				sendError(topicId, message) {
+				sendError(topicId, message, payload = {}) {
 					controller.enqueue(
 						encoder.encode(
-							`event: error\ndata: ${JSON.stringify({ topicId, message })}\n\n`,
+							`event: error\ndata: ${JSON.stringify({ topicId, message, ...payload })}\n\n`,
 						),
 					);
 				},
@@ -424,13 +429,89 @@ describe("client live queries", () => {
 		);
 		await waitFor(() => connections.length === 1);
 
-		connections[0].sendError("posts-topic", "posts denied");
+		connections[0].sendError(
+			"posts-topic",
+			"Topic limit must be between 1 and 100",
+			{
+				code: "REALTIME_TOPIC_REJECTED",
+				resource: "posts",
+				operation: "find",
+				retryable: false,
+				details: {
+					reason: "query_limit",
+					requestedLimit: 240,
+					configuredLimit: 100,
+				},
+			},
+		);
 		await waitFor(() => postErrors.length === 1);
-		expect(postErrors[0].message).toBe("posts denied");
+		expect(postErrors[0]).toBeInstanceOf(RealtimeTopicRejectedError);
+		expect(postErrors[0]).toMatchObject({
+			code: "REALTIME_TOPIC_REJECTED",
+			topicId: "posts-topic",
+			resource: "posts",
+			operation: "find",
+			retryable: false,
+			details: {
+				reason: "query_limit",
+				requestedLimit: 240,
+				configuredLimit: 100,
+			},
+		});
 		expect(pageErrors).toHaveLength(0);
+		expect(client.realtime.topicCount).toBe(1);
 
 		stopPosts();
 		stopPages();
+	});
+
+	it("delivers an initial admission response once and removes the rejected topic", async () => {
+		let calls = 0;
+		const fetcher = (async () => {
+			calls += 1;
+			return Response.json(
+				{
+					errors: [
+						{
+							code: "REALTIME_TOPIC_REJECTED",
+							message: "Topic limit must be between 1 and 100",
+							topicId: "media-topic",
+							resource: "media",
+							operation: "find",
+							retryable: false,
+							details: {
+								reason: "query_limit",
+								requestedLimit: 240,
+								configuredLimit: 100,
+							},
+						},
+					],
+				},
+				{ status: 400 },
+			);
+		}) as typeof fetch;
+		const multiplexer = new RealtimeMultiplexer(
+			"http://localhost",
+			true,
+			0,
+			{ retryBaseMs: 1, maxRetryMs: 1 },
+			undefined,
+			fetcher,
+		);
+		const errors: Error[] = [];
+		multiplexer.subscribe(
+			{ resourceType: "collection", resource: "media", limit: 240 },
+			() => {},
+			undefined,
+			"media-topic",
+			(error) => errors.push(error),
+		);
+
+		await waitFor(() => errors.length === 1);
+		expect(errors[0]).toBeInstanceOf(RealtimeTopicRejectedError);
+		expect(calls).toBe(1);
+		expect(multiplexer.topicCount).toBe(0);
+		multiplexer.destroy();
 	});
 
 	it("liveIter() yields snapshots and terminates on abort", async () => {

--- a/packages/questpie/test/client/client-pusher-realtime.test.ts
+++ b/packages/questpie/test/client/client-pusher-realtime.test.ts
@@ -186,4 +186,91 @@ describe("Pusher realtime client transport", () => {
 		expect(FakePusher.instances[0].disconnected).toBe(true);
 		expect(authVersion).toBeGreaterThanOrEqual(4);
 	});
+
+	test("flushes the newest desired topology and closes the final server session", async () => {
+		const controls: Array<{
+			revision: number;
+			topics: Array<{ id: string }>;
+		}> = [];
+		let releaseFirstControl!: () => void;
+		const firstControlGate = new Promise<void>((resolve) => {
+			releaseFirstControl = resolve;
+		});
+		const fetcher: typeof fetch = async (input, init) => {
+			const url = String(input);
+			if (url.endsWith("/realtime/config")) {
+				return Response.json({
+					transport: "shared-provider",
+					config: { provider: "pusher", key: "public-key" },
+				});
+			}
+			if (url.endsWith("/realtime/auth")) {
+				return Response.json({ auth: "signed" });
+			}
+			if (url.endsWith("/realtime") && init?.method === "POST") {
+				const body = JSON.parse(String(init.body));
+				if (body.transport === "shared-provider") {
+					return Response.json({
+						transport: "shared-provider",
+						sessionId: "session-v1",
+						token: "control-v1",
+						channel: "private-questpie-rt-session-v1",
+						control: {
+							protocol: "questpie-realtime-topology",
+							versions: [1],
+						},
+					});
+				}
+				if (body.topology) {
+					controls.push(body.topology);
+					if (controls.length === 1) await firstControlGate;
+					return Response.json({ status: "accepted" }, { status: 202 });
+				}
+			}
+			if (url.includes("/posts") || url.includes("/pages")) {
+				return Response.json({ docs: [], totalDocs: 0 });
+			}
+			throw new Error(`Unexpected request: ${url}`);
+		};
+		const client = createClient<any>({
+			baseURL: "http://localhost:3000",
+			fetch: fetcher,
+		});
+		const errors: Error[] = [];
+		let postSnapshots = 0;
+		const stopPosts = client.collections.posts.live(
+			{},
+			() => {
+				postSnapshots += 1;
+			},
+			{ onError: (error) => errors.push(error) },
+		);
+		await waitFor(
+			() => FakePusher.instances.length === 1 && postSnapshots === 1,
+		);
+		const stopPages = client.collections.pages.live({}, () => {}, {
+			onError: (error) => errors.push(error),
+		});
+		await waitFor(() => controls.length === 1 || errors.length > 0);
+		expect(errors).toHaveLength(0);
+		expect(controls[0].topics.map((topic) => topic.id)).toHaveLength(2);
+
+		stopPages();
+		releaseFirstControl();
+		await waitFor(() => controls.length === 2);
+		expect(controls[1]).toMatchObject({ revision: 2 });
+		expect(controls[1].topics).toHaveLength(1);
+
+		stopPosts();
+		await waitFor(() => controls.length === 3);
+		expect(controls[2]).toEqual({
+			protocol: "questpie-realtime-topology",
+			version: 1,
+			revision: 3,
+			topics: [],
+			channels: [],
+		});
+		await waitFor(() => FakePusher.instances[0].disconnected);
+		client.realtime.destroy();
+	});
 });

--- a/packages/questpie/test/integration/realtime-pusher-routes.test.ts
+++ b/packages/questpie/test/integration/realtime-pusher-routes.test.ts
@@ -1,13 +1,50 @@
 import { afterEach, describe, expect, test } from "bun:test";
 
-import { createFetchHandler } from "../../src/server/adapters/http.js";
+import {
+	createAdapterRoutes,
+	createFetchHandler,
+} from "../../src/server/adapters/http.js";
 import { collection } from "../../src/server/collection/builder/collection-builder.js";
 import {
 	PusherClientTransport,
 	type PusherProvider,
 } from "../../src/server/modules/core/integrated/realtime/pusher-transport.js";
+import type {
+	ChangeBroker,
+	ChangeWake,
+} from "../../src/server/modules/core/integrated/realtime/transport.js";
 import { buildMockApp } from "../utils/mocks/mock-app-builder";
-import { runTestDbMigrations } from "../utils/test-db.js";
+import { createTestDb, runTestDbMigrations } from "../utils/test-db.js";
+
+class SharedChangeBus {
+	private readonly listeners = new Set<(wake: ChangeWake) => void>();
+
+	createBroker(): ChangeBroker {
+		let listener: ((wake: ChangeWake) => void) | undefined;
+		return {
+			start: async ({ onWake, onStateChange }) => {
+				listener = onWake;
+				this.listeners.add(onWake);
+				onStateChange?.("connected");
+			},
+			publish: async (wake) => {
+				for (const onWake of this.listeners) onWake(wake);
+			},
+			stop: async () => {
+				if (listener) this.listeners.delete(listener);
+			},
+		};
+	}
+}
+
+async function waitFor(assertion: () => boolean, timeoutMs = 2_000) {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (assertion()) return;
+		await new Promise((resolve) => setTimeout(resolve, 5));
+	}
+	throw new Error("Timed out waiting for cross-instance Pusher topology");
+}
 
 const provider: PusherProvider = {
 	trigger: async () => {},
@@ -23,10 +60,11 @@ const provider: PusherProvider = {
 };
 
 describe("pusher channel matrix module routes", () => {
-	let setup: Awaited<ReturnType<typeof buildMockApp>>;
+	let setup: Awaited<ReturnType<typeof buildMockApp>> | undefined;
 
 	afterEach(async () => {
-		await setup.cleanup();
+		await setup?.cleanup();
+		setup = undefined;
 	});
 
 	test("exposes secret-free config and no-store session-bound auth", async () => {
@@ -155,8 +193,13 @@ describe("pusher channel matrix module routes", () => {
 			sessionId: string;
 			token: string;
 			channel: string;
+			control: {
+				protocol: "questpie-realtime-topology";
+				versions: number[];
+			};
 		};
 		expect(session.channel).toMatch(/^private-questpie-rt-/);
+		expect(session.control.versions).toContain(1);
 
 		const auth = new URLSearchParams({
 			socket_id: "123.456",
@@ -179,11 +222,17 @@ describe("pusher channel matrix module routes", () => {
 				body: JSON.stringify({
 					sessionId: session.sessionId,
 					token: session.token,
-					frames: [{ type: "remove_topic", topicId: "posts-topic" }],
+					topology: {
+						protocol: "questpie-realtime-topology",
+						version: 1,
+						revision: 1,
+						topics: [],
+						channels: [],
+					},
 				}),
 			}),
 		);
-		expect(removeResponse.status).toBe(204);
+		expect(removeResponse.status).toBe(202);
 
 		const staleAuthResponse = await handler(
 			new Request("http://localhost/realtime/auth", {
@@ -193,5 +242,133 @@ describe("pusher channel matrix module routes", () => {
 			}),
 		);
 		expect(staleAuthResponse.status).toBe(403);
+	});
+
+	test("applies and closes a Pusher live-query topology through another app instance", async () => {
+		const database = await createTestDb();
+		const bus = new SharedChangeBus();
+		const transport = new PusherClientTransport({
+			provider,
+			key: "public-key",
+			identityKey: "test-secret",
+		});
+		const posts = () =>
+			collection("posts")
+				.fields(({ f }) => ({ title: f.text().required() }))
+				.access({ read: true });
+		const second = await buildMockApp(
+			{ name: "pusher-control", collections: { posts: posts() } },
+			{
+				db: { pglite: database },
+				realtime: {
+					changeBroker: bus.createBroker(),
+					retentionDays: 0,
+				},
+			},
+		);
+		const first = await buildMockApp(
+			{ name: "pusher-owner", collections: { posts: posts() } },
+			{
+				db: { pglite: database },
+				realtime: {
+					changeBroker: bus.createBroker(),
+					clientTransport: transport,
+					retentionDays: 0,
+				},
+			},
+		);
+		try {
+			await runTestDbMigrations(first.app);
+			const firstRoutes = createAdapterRoutes(first.app, {
+				accessMode: "user",
+			});
+			const secondRoutes = createAdapterRoutes(second.app, {
+				accessMode: "user",
+			});
+			const opened = await firstRoutes.realtime.subscribe(
+				new Request("http://localhost/realtime", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({
+						transport: "shared-provider",
+						topics: [
+							{
+								id: "posts-base",
+								resourceType: "collection",
+								resource: "posts",
+								operation: "find",
+							},
+						],
+					}),
+				}),
+				{},
+				undefined,
+			);
+			if (opened.status !== 200) {
+				throw new Error(`Pusher session failed: ${await opened.text()}`);
+			}
+			const session = (await opened.json()) as {
+				sessionId: string;
+				token: string;
+				channel: string;
+			};
+			await waitFor(() => first.app.realtime.listeners.size === 1);
+
+			const control = (revision: number, topics: unknown[]) =>
+				secondRoutes.realtime.subscribe(
+					new Request("http://localhost/realtime", {
+						method: "POST",
+						headers: { "Content-Type": "application/json" },
+						body: JSON.stringify({
+							sessionId: session.sessionId,
+							token: session.token,
+							topology: {
+								protocol: "questpie-realtime-topology",
+								version: 1,
+								revision,
+								topics,
+								channels: [],
+							},
+						}),
+					}),
+					{},
+					undefined,
+				);
+			const added = await control(1, [
+				{
+					id: "posts-base",
+					topic: {
+						resourceType: "collection",
+						resource: "posts",
+						operation: "find",
+					},
+				},
+				{
+					id: "posts-added",
+					topic: {
+						resourceType: "collection",
+						resource: "posts",
+						operation: "find",
+						where: { title: "added" },
+					},
+				},
+			]);
+			expect(added.status).toBe(202);
+			await waitFor(() => first.app.realtime.listeners.size === 2);
+
+			const closed = await control(2, []);
+			expect(closed.status).toBe(202);
+			await waitFor(() => first.app.realtime.listeners.size === 0);
+			await expect(
+				transport.generateAuth({
+					socketId: "123.456",
+					channel: session.channel,
+					principal: null,
+				}),
+			).rejects.toThrow("Realtime session is not authorized");
+		} finally {
+			await Promise.all([first.cleanup(), second.cleanup()]);
+			await database.close();
+		}
 	});
 });

--- a/packages/questpie/test/integration/realtime-reconciliation.test.ts
+++ b/packages/questpie/test/integration/realtime-reconciliation.test.ts
@@ -6,7 +6,7 @@ import {
 	type RealtimeChangeEvent,
 	type RealtimeNotice,
 } from "../../src/exports/index.js";
-import { PgNotifyAdapter } from "../../src/server/modules/core/integrated/realtime/adapters/pg-notify.js";
+import { PgNotifyChangeBroker } from "../../src/server/modules/core/integrated/realtime/adapters/pg-notify.js";
 import { RealtimeService } from "../../src/server/modules/core/integrated/realtime/service.js";
 import { buildMockApp } from "../utils/mocks/mock-app-builder";
 import { runTestDbMigrations } from "../utils/test-db";
@@ -202,14 +202,14 @@ describe("realtime matrix reconciliation", () => {
 		await cleanup?.();
 	});
 
-	it("G1: implicit pg publisher notifies with zero local subscribers", async () => {
-		const startPublisherSpy = spyOn(
-			PgNotifyAdapter.prototype,
-			"startPublisher",
+	it("G1: implicit pg broker publishes with zero local subscribers", async () => {
+		const startSpy = spyOn(
+			PgNotifyChangeBroker.prototype,
+			"start",
 		).mockResolvedValue();
-		const notifySpy = spyOn(
-			PgNotifyAdapter.prototype,
-			"notify",
+		const publishSpy = spyOn(
+			PgNotifyChangeBroker.prototype,
+			"publish",
 		).mockResolvedValue();
 		const realtime = new RealtimeService(
 			new ControlledRealtimeReadDb() as never,
@@ -230,11 +230,15 @@ describe("realtime matrix reconciliation", () => {
 
 		try {
 			await realtime.notify(change);
-			expect(notifySpy).toHaveBeenCalledTimes(1);
-			expect(notifySpy).toHaveBeenCalledWith(change);
+			expect(publishSpy).toHaveBeenCalledTimes(1);
+			expect(publishSpy).toHaveBeenCalledWith({
+				kind: "outbox-maybe-advanced",
+				highWaterSeq: 1,
+				reason: "publish",
+			});
 		} finally {
-			notifySpy.mockRestore();
-			startPublisherSpy.mockRestore();
+			publishSpy.mockRestore();
+			startSpy.mockRestore();
 		}
 	});
 

--- a/packages/questpie/test/integration/realtime-topology-ha.test.ts
+++ b/packages/questpie/test/integration/realtime-topology-ha.test.ts
@@ -220,6 +220,29 @@ test("applies topic additions and removals through a different app instance", as
 			);
 		}
 		await waitFor(() => first.app.realtime.listeners.size === 1);
+
+		const swap = await secondRoutes.realtime.subscribe(
+			controlRequest(session, [
+				{ type: "remove_topic", topicId: "items-base" },
+				{
+					type: "add_topic",
+					topicId: "items-replacement",
+					topic: {
+						resourceType: "collection",
+						resource: "items",
+						where: { name: "replacement" },
+					},
+				},
+			]),
+			{},
+			undefined,
+		);
+		expect(swap.status).toBe(204);
+		await withTimeout(
+			reader.read("snapshot", "items-replacement"),
+			"cross-instance replacement snapshot",
+		);
+		await waitFor(() => first.app.realtime.listeners.size === 1);
 		expect(session.sessionId).toBeTruthy();
 	} finally {
 		await reader?.close().catch(() => {});

--- a/packages/questpie/test/integration/realtime-topology-ha.test.ts
+++ b/packages/questpie/test/integration/realtime-topology-ha.test.ts
@@ -1,0 +1,229 @@
+import { expect, test } from "bun:test";
+
+import {
+	collection,
+	createAdapterRoutes,
+	type ChangeBroker,
+	type ChangeWake,
+} from "../../src/exports/index.js";
+import { buildMockApp } from "../utils/mocks/mock-app-builder.js";
+import { createTestDb, runTestDbMigrations } from "../utils/test-db.js";
+
+class SharedChangeBus {
+	private readonly listeners = new Set<(wake: ChangeWake) => void>();
+
+	createBroker(): ChangeBroker {
+		let listener: ((wake: ChangeWake) => void) | undefined;
+		return {
+			start: async ({ onWake, onStateChange }) => {
+				listener = onWake;
+				this.listeners.add(onWake);
+				onStateChange?.("connected");
+			},
+			publish: async (wake) => {
+				for (const onWake of this.listeners) onWake(wake);
+			},
+			stop: async () => {
+				if (listener) this.listeners.delete(listener);
+				listener = undefined;
+			},
+		};
+	}
+}
+
+function createSseReader(stream: ReadableStream<Uint8Array>) {
+	const reader = stream.getReader();
+	const decoder = new TextDecoder();
+	let buffer = "";
+
+	const readEvent = async (): Promise<{
+		event: string;
+		data: Record<string, unknown>;
+	}> => {
+		while (true) {
+			const separator = buffer.indexOf("\n\n");
+			if (separator >= 0) {
+				const block = buffer.slice(0, separator);
+				buffer = buffer.slice(separator + 2);
+				let event = "message";
+				let data = "";
+				for (const line of block.split("\n")) {
+					if (line.startsWith("event:")) event = line.slice(6).trim();
+					if (line.startsWith("data:")) data += line.slice(5).trim();
+				}
+				if (!data) continue;
+				return {
+					event,
+					data: JSON.parse(data) as Record<string, unknown>,
+				};
+			}
+
+			const { done, value } = await reader.read();
+			if (done) throw new Error("Realtime stream closed before expected event");
+			buffer += decoder.decode(value, { stream: true });
+		}
+	};
+
+	const read = async (eventType: string, topicId?: string) => {
+		while (true) {
+			const event = await readEvent();
+			if (event.event === "error") {
+				throw new Error(`Realtime stream error: ${JSON.stringify(event.data)}`);
+			}
+			if (event.event !== eventType) continue;
+			if (topicId && event.data.topicId !== topicId) continue;
+			return event.data;
+		}
+	};
+
+	return { read, close: () => reader.cancel() };
+}
+
+async function waitFor(assertion: () => boolean, timeoutMs = 2_000) {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (assertion()) return;
+		await new Promise((resolve) => setTimeout(resolve, 5));
+	}
+	throw new Error("Timed out waiting for cross-instance topology application");
+}
+
+async function withTimeout<T>(promise: Promise<T>, label: string): Promise<T> {
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	try {
+		return await Promise.race([
+			promise,
+			new Promise<never>((_, reject) => {
+				timer = setTimeout(
+					() => reject(new Error(`Timed out waiting for ${label}`)),
+					2_000,
+				);
+			}),
+		]);
+	} finally {
+		if (timer) clearTimeout(timer);
+	}
+}
+
+function controlRequest(
+	session: { sessionId: unknown; token: unknown },
+	frames: Array<Record<string, unknown>>,
+) {
+	return new Request("http://localhost/realtime", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({
+			sessionId: session.sessionId,
+			token: session.token,
+			frames,
+		}),
+	});
+}
+
+test("applies topic additions and removals through a different app instance", async () => {
+	const database = await createTestDb();
+	const bus = new SharedChangeBus();
+	const items = () =>
+		collection("items")
+			.fields(({ f }) => ({ name: f.text().required() }))
+			.access({ read: true });
+	const first = await buildMockApp(
+		{ name: "topology-first", collections: { items: items() } },
+		{
+			app: { url: "http://topology-first.localhost" },
+			db: { pglite: database },
+			realtime: { changeBroker: bus.createBroker() },
+		},
+	);
+	const second = await buildMockApp(
+		{ name: "topology-second", collections: { items: items() } },
+		{
+			app: { url: "http://topology-second.localhost" },
+			db: { pglite: database },
+			realtime: { changeBroker: bus.createBroker() },
+		},
+	);
+	let reader: ReturnType<typeof createSseReader> | undefined;
+
+	try {
+		await runTestDbMigrations(first.app);
+		const firstRoutes = createAdapterRoutes(first.app, { accessMode: "user" });
+		const secondRoutes = createAdapterRoutes(second.app, {
+			accessMode: "user",
+		});
+		const initial = await firstRoutes.realtime.subscribe(
+			new Request("http://localhost/realtime", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({
+					topics: [
+						{
+							id: "items-base",
+							resourceType: "collection",
+							resource: "items",
+							where: { name: "base" },
+						},
+					],
+				}),
+			}),
+			{},
+			undefined,
+		);
+		expect(initial.status).toBe(200);
+		reader = createSseReader(initial.body!);
+		const session = await withTimeout(
+			reader.read("session"),
+			"session metadata",
+		);
+		await withTimeout(
+			reader.read("snapshot", "items-base"),
+			"initial base snapshot",
+		);
+		expect(first.app.realtime.listeners.size).toBe(1);
+
+		const add = await secondRoutes.realtime.subscribe(
+			controlRequest(session, [
+				{
+					type: "add_topic",
+					topicId: "items-added",
+					topic: {
+						resourceType: "collection",
+						resource: "items",
+						where: { name: "added" },
+					},
+				},
+			]),
+			{},
+			undefined,
+		);
+		if (!add.ok) {
+			throw new Error(
+				`Cross-instance add was rejected (${add.status}): ${await add.text()}`,
+			);
+		}
+		await withTimeout(
+			reader.read("snapshot", "items-added"),
+			"cross-instance added snapshot",
+		);
+		await waitFor(() => first.app.realtime.listeners.size === 2);
+
+		const remove = await secondRoutes.realtime.subscribe(
+			controlRequest(session, [
+				{ type: "remove_topic", topicId: "items-added" },
+			]),
+			{},
+			undefined,
+		);
+		if (!remove.ok) {
+			throw new Error(
+				`Cross-instance remove was rejected (${remove.status}): ${await remove.text()}`,
+			);
+		}
+		await waitFor(() => first.app.realtime.listeners.size === 1);
+		expect(session.sessionId).toBeTruthy();
+	} finally {
+		await reader?.close().catch(() => {});
+		await Promise.all([first.cleanup(), second.cleanup()]);
+		await database.close();
+	}
+}, 20_000);

--- a/packages/questpie/test/integration/realtime-topology-ha.test.ts
+++ b/packages/questpie/test/integration/realtime-topology-ha.test.ts
@@ -150,6 +150,10 @@ test("applies topic additions and removals through a different app instance", as
 		collection("items")
 			.fields(({ f }) => ({ name: f.text().required() }))
 			.access({ read: true });
+	const controlOnly = () =>
+		collection("controlOnly")
+			.fields(({ f }) => ({ name: f.text().required() }))
+			.access({ read: true });
 	const first = await buildMockApp(
 		{
 			name: "topology-first",
@@ -165,7 +169,7 @@ test("applies topic additions and removals through a different app instance", as
 	const second = await buildMockApp(
 		{
 			name: "topology-second",
-			collections: { items: items() },
+			collections: { items: items(), controlOnly: controlOnly() },
 			channels: { room: channel("room-[id]").authorize({ subscribe: true }) },
 		},
 		{
@@ -380,6 +384,30 @@ test("applies topic additions and removals through a different app instance", as
 				(first.app.realtime as any).channelEventLedger.localSubscriptions
 					.size === 0,
 		);
+
+		const ownerApplyFailure = await secondRoutes.realtime.subscribe(
+			desiredRequest(session, 6, [
+				{
+					id: "items-replacement",
+					topic: {
+						resourceType: "collection",
+						resource: "items",
+						where: { name: "replacement" },
+					},
+				},
+				{
+					id: "control-only",
+					topic: {
+						resourceType: "collection",
+						resource: "controlOnly",
+					},
+				},
+			]),
+			{},
+			undefined,
+		);
+		expect(ownerApplyFailure.status).toBe(202);
+		await waitFor(() => first.app.realtime.listeners.size === 0);
 		expect(session.sessionId).toBeTruthy();
 	} finally {
 		await reader?.close().catch(() => {});

--- a/packages/questpie/test/integration/realtime-topology-ha.test.ts
+++ b/packages/questpie/test/integration/realtime-topology-ha.test.ts
@@ -120,6 +120,28 @@ function controlRequest(
 	});
 }
 
+function desiredRequest(
+	session: { sessionId: unknown; token: unknown },
+	revision: number,
+	topics: Array<{ id: string; topic: Record<string, unknown> }>,
+) {
+	return new Request("http://localhost/realtime", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({
+			sessionId: session.sessionId,
+			token: session.token,
+			topology: {
+				protocol: "questpie-realtime-topology",
+				version: 1,
+				revision,
+				topics,
+				channels: [],
+			},
+		}),
+	});
+}
+
 test("applies topic additions and removals through a different app instance", async () => {
 	const database = await createTestDb();
 	const bus = new SharedChangeBus();
@@ -182,10 +204,17 @@ test("applies topic additions and removals through a different app instance", as
 		expect(first.app.realtime.listeners.size).toBe(1);
 
 		const add = await secondRoutes.realtime.subscribe(
-			controlRequest(session, [
+			desiredRequest(session, 1, [
 				{
-					type: "add_topic",
-					topicId: "items-added",
+					id: "items-base",
+					topic: {
+						resourceType: "collection",
+						resource: "items",
+						where: { name: "base" },
+					},
+				},
+				{
+					id: "items-added",
 					topic: {
 						resourceType: "collection",
 						resource: "items",
@@ -196,11 +225,34 @@ test("applies topic additions and removals through a different app instance", as
 			{},
 			undefined,
 		);
-		if (!add.ok) {
+		if (add.status !== 202) {
 			throw new Error(
 				`Cross-instance add was rejected (${add.status}): ${await add.text()}`,
 			);
 		}
+		const duplicate = await secondRoutes.realtime.subscribe(
+			desiredRequest(session, 1, [
+				{
+					id: "items-base",
+					topic: {
+						resourceType: "collection",
+						resource: "items",
+						where: { name: "base" },
+					},
+				},
+				{
+					id: "items-added",
+					topic: {
+						resourceType: "collection",
+						resource: "items",
+						where: { name: "added" },
+					},
+				},
+			]),
+			{},
+			undefined,
+		);
+		expect(duplicate.status).toBe(200);
 		await withTimeout(
 			reader.read("snapshot", "items-added"),
 			"cross-instance added snapshot",

--- a/packages/questpie/test/integration/realtime-topology-ha.test.ts
+++ b/packages/questpie/test/integration/realtime-topology-ha.test.ts
@@ -6,6 +6,7 @@ import {
 	type ChangeBroker,
 	type ChangeWake,
 } from "../../src/exports/index.js";
+import { channel } from "../../src/server/channels/channel-builder.js";
 import { buildMockApp } from "../utils/mocks/mock-app-builder.js";
 import { createTestDb, runTestDbMigrations } from "../utils/test-db.js";
 
@@ -150,7 +151,11 @@ test("applies topic additions and removals through a different app instance", as
 			.fields(({ f }) => ({ name: f.text().required() }))
 			.access({ read: true });
 	const first = await buildMockApp(
-		{ name: "topology-first", collections: { items: items() } },
+		{
+			name: "topology-first",
+			collections: { items: items() },
+			channels: { room: channel("room-[id]").authorize({ subscribe: true }) },
+		},
 		{
 			app: { url: "http://topology-first.localhost" },
 			db: { pglite: database },
@@ -158,7 +163,11 @@ test("applies topic additions and removals through a different app instance", as
 		},
 	);
 	const second = await buildMockApp(
-		{ name: "topology-second", collections: { items: items() } },
+		{
+			name: "topology-second",
+			collections: { items: items() },
+			channels: { room: channel("room-[id]").authorize({ subscribe: true }) },
+		},
 		{
 			app: { url: "http://topology-second.localhost" },
 			db: { pglite: database },
@@ -295,6 +304,82 @@ test("applies topic additions and removals through a different app instance", as
 			"cross-instance replacement snapshot",
 		);
 		await waitFor(() => first.app.realtime.listeners.size === 1);
+
+		const addChannel = await secondRoutes.realtime.subscribe(
+			new Request("http://localhost/realtime", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({
+					sessionId: session.sessionId,
+					token: session.token,
+					topology: {
+						protocol: "questpie-realtime-topology",
+						version: 1,
+						revision: 4,
+						topics: [
+							{
+								id: "items-replacement",
+								topic: {
+									resourceType: "collection",
+									resource: "items",
+									where: { name: "replacement" },
+								},
+							},
+						],
+						channels: [
+							{
+								id: "room-one",
+								channel: "room",
+								params: { id: "one" },
+							},
+						],
+					},
+				}),
+			}),
+			{},
+			undefined,
+		);
+		expect(addChannel.status).toBe(202);
+		await waitFor(
+			() =>
+				(first.app.realtime as any).channelEventLedger.localSubscriptions
+					.size === 1,
+		);
+		const localChannel = [
+			...(
+				first.app.realtime as any
+			).channelEventLedger.localSubscriptions.values(),
+		][0].channel as string;
+		await first.app.realtime.appendChannelEvent({
+			channel: localChannel,
+			event: "message",
+			schemaIdentity: "ha-test",
+			data: { text: "cross-instance" },
+		});
+		expect(
+			await withTimeout(reader.read("channel_event"), "typed channel event"),
+		).toMatchObject({ data: { text: "cross-instance" } });
+
+		const removeChannel = await secondRoutes.realtime.subscribe(
+			desiredRequest(session, 5, [
+				{
+					id: "items-replacement",
+					topic: {
+						resourceType: "collection",
+						resource: "items",
+						where: { name: "replacement" },
+					},
+				},
+			]),
+			{},
+			undefined,
+		);
+		expect(removeChannel.status).toBe(202);
+		await waitFor(
+			() =>
+				(first.app.realtime as any).channelEventLedger.localSubscriptions
+					.size === 0,
+		);
 		expect(session.sessionId).toBeTruthy();
 	} finally {
 		await reader?.close().catch(() => {});

--- a/packages/questpie/test/integration/realtime.test.ts
+++ b/packages/questpie/test/integration/realtime.test.ts
@@ -1923,6 +1923,7 @@ describe("realtime matrix", () => {
 	describe("admission control", () => {
 		it("enforces topic, query, and initial-concurrency caps for a mixed batch", async () => {
 			const adapter = new MockRealtimeAdapter();
+			const observations: unknown[] = [];
 			let activeReads = 0;
 			let maximumActiveReads = 0;
 			const observedLimits: number[] = [];
@@ -1940,7 +1941,12 @@ describe("realtime matrix", () => {
 				.access({ read: true });
 			setup = await buildMockApp(
 				{ collections: { items } },
-				{ realtime: { adapter } },
+				{
+					realtime: {
+						adapter,
+						observer: { record: (event) => observations.push(event) },
+					},
+				},
 			);
 			await runTestDbMigrations(setup.app);
 
@@ -1976,6 +1982,33 @@ describe("realtime matrix", () => {
 					.filter((event) => event.event === "error")
 					.map((event) => event.data.topicId),
 			).toEqual(expect.arrayContaining(["items-1", "items-2", "items-20"]));
+			const limitError = events.find(
+				(event) => event.event === "error" && event.data.topicId === "items-1",
+			);
+			expect(limitError?.data).toEqual({
+				code: "REALTIME_TOPIC_REJECTED",
+				message: "Topic limit must be between 1 and 100",
+				topicId: "items-1",
+				resource: "items",
+				operation: "find",
+				retryable: false,
+				details: {
+					reason: "query_limit",
+					requestedLimit: 101,
+					configuredLimit: 100,
+				},
+			});
+			expect(JSON.stringify(limitError?.data)).not.toContain("where");
+			expect(observations).toContainEqual({
+				type: "admission.rejected",
+				reason: "query_limit",
+				resource: "items",
+				operation: "find",
+				requestedLimit: 101,
+				configuredLimit: 100,
+				rolloutMode: "v2",
+			});
+			expect(JSON.stringify(observations)).not.toContain("item-1");
 			expect(observedLimits).toHaveLength(18);
 			expect(observedLimits.every((limit) => limit === 100)).toBe(true);
 			expect(maximumActiveReads).toBe(4);
@@ -1983,6 +2016,53 @@ describe("realtime matrix", () => {
 
 			await reader.close();
 			expect(setup.app.realtime.listeners.size).toBe(0);
+		});
+
+		it("returns a structured non-retryable error when every initial topic is rejected", async () => {
+			const adapter = new MockRealtimeAdapter();
+			const items = collection("items")
+				.fields(({ f }) => ({ name: f.textarea().required() }))
+				.access({ read: true });
+			setup = await buildMockApp(
+				{ collections: { items } },
+				{ realtime: { adapter } },
+			);
+			await runTestDbMigrations(setup.app);
+
+			const routes = createAdapterRoutes(setup.app, { accessMode: "user" });
+			const response = await routes.realtime.subscribe(
+				createRealtimeRequest([
+					{
+						...collectionTopic("items"),
+						id: "oversized-items",
+						limit: 240,
+						where: { name: "must-not-leak" },
+					},
+				]),
+				{},
+				undefined,
+			);
+
+			expect(response.status).toBe(400);
+			const payload = await response.json();
+			expect(payload).toEqual({
+				errors: [
+					{
+						code: "REALTIME_TOPIC_REJECTED",
+						message: "Topic limit must be between 1 and 100",
+						topicId: "oversized-items",
+						resource: "items",
+						operation: "find",
+						retryable: false,
+						details: {
+							reason: "query_limit",
+							requestedLimit: 240,
+							configuredLimit: 100,
+						},
+					},
+				],
+			});
+			expect(JSON.stringify(payload)).not.toContain("must-not-leak");
 		});
 
 		it("preserves the access where constraint alongside the requested filter", async () => {
@@ -2132,6 +2212,54 @@ describe("realtime matrix", () => {
 			expect(session.event).toBe("session");
 			await reader.readSnapshot(2000, "col-items");
 
+			const desiredRejected = await routes.realtime.subscribe(
+				new Request("http://localhost/realtime", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({
+						sessionId: session.data.sessionId,
+						token: session.data.token,
+						topology: {
+							protocol: "questpie-realtime-topology",
+							version: 1,
+							revision: 1,
+							topics: [
+								{
+									id: "items-desired-rejected",
+									topic: {
+										resourceType: "collection",
+										resource: "items",
+										limit: 2000,
+										where: { name: "must-not-leak" },
+									},
+								},
+							],
+							channels: [],
+						},
+					}),
+				}),
+				{},
+				undefined,
+			);
+			expect(desiredRejected.status).toBe(400);
+			const desiredError = await desiredRejected.json();
+			expect(desiredError).toEqual({
+				error: {
+					code: "REALTIME_TOPIC_REJECTED",
+					message: "Topic limit must be between 1 and 100",
+					topicId: "items-desired-rejected",
+					resource: "items",
+					operation: "find",
+					retryable: false,
+					details: {
+						reason: "query_limit",
+						requestedLimit: 2000,
+						configuredLimit: 100,
+					},
+				},
+			});
+			expect(JSON.stringify(desiredError)).not.toContain("must-not-leak");
+
 			const control = (frames: unknown[]) =>
 				routes.realtime.subscribe(
 					new Request("http://localhost/realtime", {
@@ -2161,6 +2289,39 @@ describe("realtime matrix", () => {
 			expect((await reader.readSnapshot(2000, "items-added")).event).toBe(
 				"snapshot",
 			);
+			expect(setup.app.realtime.listeners.size).toBe(2);
+
+			const rejected = await control([
+				{
+					type: "add_topic",
+					topicId: "items-rejected",
+					topic: {
+						resourceType: "collection",
+						resource: "items",
+						limit: 500,
+						where: { name: "must-not-leak" },
+					},
+				},
+			]);
+			expect(rejected.status).toBe(204);
+			const rejection = await reader.readEvent(2000);
+			expect(rejection).toEqual({
+				event: "error",
+				data: {
+					code: "REALTIME_TOPIC_REJECTED",
+					message: "Topic limit must be between 1 and 100",
+					topicId: "items-rejected",
+					resource: "items",
+					operation: "find",
+					retryable: false,
+					details: {
+						reason: "query_limit",
+						requestedLimit: 500,
+						configuredLimit: 100,
+					},
+				},
+			});
+			expect(JSON.stringify(rejection)).not.toContain("must-not-leak");
 			expect(setup.app.realtime.listeners.size).toBe(2);
 
 			const removed = await control([

--- a/packages/questpie/test/integration/realtime.test.ts
+++ b/packages/questpie/test/integration/realtime.test.ts
@@ -2260,6 +2260,75 @@ describe("realtime matrix", () => {
 			});
 			expect(JSON.stringify(desiredError)).not.toContain("must-not-leak");
 
+			const unsupportedVersion = await routes.realtime.subscribe(
+				new Request("http://localhost/realtime", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({
+						sessionId: session.data.sessionId,
+						token: session.data.token,
+						topology: {
+							protocol: "questpie-realtime-topology",
+							version: 2,
+							revision: 1,
+							topics: [],
+							channels: [],
+						},
+					}),
+				}),
+				{},
+				undefined,
+			);
+			expect(unsupportedVersion.status).toBe(400);
+			expect(await unsupportedVersion.json()).toEqual({
+				error: {
+					code: "REALTIME_TOPOLOGY_VERSION_UNSUPPORTED",
+					message: "Realtime topology was rejected",
+				},
+			});
+
+			const invalidTopology = await routes.realtime.subscribe(
+				new Request("http://localhost/realtime", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({
+						sessionId: session.data.sessionId,
+						token: session.data.token,
+						topology: {
+							protocol: "questpie-realtime-topology",
+							version: 1,
+							revision: 1,
+							topics: [
+								{
+									id: "duplicate",
+									topic: {
+										resourceType: "collection",
+										resource: "items",
+									},
+								},
+								{
+									id: "duplicate",
+									topic: {
+										resourceType: "collection",
+										resource: "items",
+									},
+								},
+							],
+							channels: [],
+						},
+					}),
+				}),
+				{},
+				undefined,
+			);
+			expect(invalidTopology.status).toBe(400);
+			expect(await invalidTopology.json()).toEqual({
+				error: {
+					code: "REALTIME_TOPOLOGY_INVALID",
+					message: "Realtime topology was rejected",
+				},
+			});
+
 			const control = (frames: unknown[]) =>
 				routes.realtime.subscribe(
 					new Request("http://localhost/realtime", {

--- a/packages/questpie/test/integration/realtime.test.ts
+++ b/packages/questpie/test/integration/realtime.test.ts
@@ -2303,11 +2303,10 @@ describe("realtime matrix", () => {
 					},
 				},
 			]);
-			expect(rejected.status).toBe(204);
-			const rejection = await reader.readEvent(2000);
+			expect(rejected.status).toBe(400);
+			const rejection = await rejected.json();
 			expect(rejection).toEqual({
-				event: "error",
-				data: {
+				error: {
 					code: "REALTIME_TOPIC_REJECTED",
 					message: "Topic limit must be between 1 and 100",
 					topicId: "items-rejected",

--- a/packages/questpie/test/migration/migrations.test.ts
+++ b/packages/questpie/test/migration/migrations.test.ts
@@ -394,6 +394,49 @@ describe("Migration System - DrizzleMigrationGenerator", () => {
 		).toBe(true);
 	});
 
+	test("generates the framework-owned realtime topology schema", async () => {
+		const { DrizzleMigrationGenerator } =
+			await import("../../src/server/migration/generator.js");
+		const app = await createApp(module({ name: "realtime-topology-schema" }), {
+			app: { url: "http://localhost:3000" },
+			db: { pglite: pgClient },
+			email: { adapter: new MockMailAdapter() },
+			queue: { adapter: new MockQueueAdapter() },
+			kv: { adapter: new MockKVAdapter() },
+			logger: { adapter: new MockLogger() },
+		});
+		const schema = app.getSchema();
+		expect(schema.questpie_realtime_topology).toBeDefined();
+
+		const result = await new DrizzleMigrationGenerator().generateMigration({
+			migrationName: "realtimeTopology20250108",
+			fileBaseName: "20250108_realtime_topology",
+			schema,
+			migrationDir: testMigrationDir,
+		});
+
+		expect(result.skipped).toBe(false);
+		const migrationSource = readFileSync(
+			join(testMigrationDir, "20250108_realtime_topology.ts"),
+			"utf8",
+		);
+		for (const fragment of [
+			'CREATE TABLE "questpie_realtime_topology"',
+			'"session_key" text PRIMARY KEY',
+			'"owner_generation" bigserial',
+			'"token_hash" text NOT NULL',
+			'"identity_hash" text NOT NULL',
+			'"lease_expires_at" timestamp with time zone NOT NULL',
+			'"desired_revision" bigint DEFAULT 0 NOT NULL',
+			'"applied_revision" bigint DEFAULT 0 NOT NULL',
+			'"desired_topology" jsonb NOT NULL',
+			'CREATE INDEX "idx_realtime_topology_owner_lease"',
+			'CREATE INDEX "idx_realtime_topology_lease"',
+		]) {
+			expect(migrationSource).toContain(fragment);
+		}
+	});
+
 	test("should skip if no schema changes", async () => {
 		const { DrizzleMigrationGenerator } =
 			await import("../../src/server/migration/generator.js");

--- a/packages/questpie/test/units/realtime-admission.test.ts
+++ b/packages/questpie/test/units/realtime-admission.test.ts
@@ -9,6 +9,7 @@ import {
 
 describe("realtime admission", () => {
 	it("applies the finite default limit and rejects query caps", () => {
+		expect(DEFAULT_REALTIME_ADMISSION.maxFindLimit).toBe(100);
 		expect(
 			admitRealtimeTopic(
 				{ id: "posts", resourceType: "collection", resource: "posts" },
@@ -25,7 +26,13 @@ describe("realtime admission", () => {
 				},
 				DEFAULT_REALTIME_ADMISSION,
 			),
-		).toMatchObject({ accepted: false });
+		).toEqual({
+			accepted: false,
+			message: "Topic limit must be between 1 and 100",
+			reason: "query_limit",
+			requestedLimit: 101,
+			configuredLimit: 100,
+		});
 		expect(
 			admitRealtimeTopic(
 				{
@@ -40,7 +47,12 @@ describe("realtime admission", () => {
 				},
 				DEFAULT_REALTIME_ADMISSION,
 			),
-		).toMatchObject({ accepted: false });
+		).toEqual({
+			accepted: false,
+			message: "Topic exceeds maximum relation depth of 3",
+			reason: "relation_depth",
+			configuredLimit: 3,
+		});
 		expect(
 			admitRealtimeTopic(
 				{

--- a/packages/questpie/test/units/realtime-observability.test.ts
+++ b/packages/questpie/test/units/realtime-observability.test.ts
@@ -51,6 +51,32 @@ describe("realtime matrix observability", () => {
 		expect(JSON.stringify(warnings)).not.toContain("where");
 	});
 
+	test("records bounded topology lifecycle metrics and warnings", () => {
+		const warnings: unknown[] = [];
+		const observability = new RealtimeObservability({
+			logger: {
+				warn: (_message, fields) => warnings.push(fields),
+				error: () => {},
+			},
+		});
+
+		observability.record({
+			type: "topology.lifecycle",
+			phase: "submit",
+			outcome: "conflict",
+			desiredRevision: 4,
+			appliedRevision: 3,
+		});
+
+		expect(observability.snapshot().counters).toMatchObject({
+			"topology.lifecycle|outcome=conflict|phase=submit": 1,
+		});
+		expect(warnings).toHaveLength(1);
+		expect(JSON.stringify(warnings)).not.toContain("sessionId");
+		expect(JSON.stringify(warnings)).not.toContain("token");
+		expect(JSON.stringify(warnings)).not.toContain("identity");
+	});
+
 	test("isolates observer and logger failures while exposing bounded metrics", () => {
 		const events: RealtimeObservation[] = [];
 		const observability = new RealtimeObservability({

--- a/packages/questpie/test/units/realtime-observability.test.ts
+++ b/packages/questpie/test/units/realtime-observability.test.ts
@@ -13,6 +13,44 @@ import type { RealtimeChangeEvent } from "../../src/server/modules/core/integrat
 const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
 
 describe("realtime matrix observability", () => {
+	test("records bounded rejected-topic dimensions without query payloads", () => {
+		const events: RealtimeObservation[] = [];
+		const warnings: unknown[] = [];
+		const observability = new RealtimeObservability({
+			observer: { record: (event) => events.push(event) },
+			logger: {
+				warn: (_message, fields) => warnings.push(fields),
+				error: () => {},
+			},
+		});
+
+		observability.record({
+			type: "admission.rejected",
+			reason: "query_limit",
+			resource: "media",
+			operation: "find",
+			requestedLimit: 240,
+			configuredLimit: 100,
+			rolloutMode: "v2",
+		});
+
+		expect(events).toEqual([
+			{
+				type: "admission.rejected",
+				reason: "query_limit",
+				resource: "media",
+				operation: "find",
+				requestedLimit: 240,
+				configuredLimit: 100,
+				rolloutMode: "v2",
+			},
+		]);
+		expect(observability.snapshot().counters).toMatchObject({
+			"admission.rejected|reason=query_limit|resource=media|rollout_mode=v2": 1,
+		});
+		expect(JSON.stringify(warnings)).not.toContain("where");
+	});
+
 	test("isolates observer and logger failures while exposing bounded metrics", () => {
 		const events: RealtimeObservation[] = [];
 		const observability = new RealtimeObservability({

--- a/packages/questpie/test/units/realtime-pg-change-broker.test.ts
+++ b/packages/questpie/test/units/realtime-pg-change-broker.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, spyOn, test } from "bun:test";
+
+import { PgNotifyChangeBroker } from "../../src/server/modules/core/integrated/realtime/adapters/pg-notify.js";
+import type {
+	ChangeBrokerState,
+	ChangeWake,
+} from "../../src/server/modules/core/integrated/realtime/transport.js";
+
+class FakePgClient {
+	connectCalls = 0;
+	endCalls = 0;
+	queries: Array<{ text: string; params?: unknown[] }> = [];
+	private handlers = new Map<string, Set<(...args: any[]) => void>>();
+
+	async connect(): Promise<void> {
+		this.connectCalls += 1;
+	}
+
+	async query(text: string, params?: unknown[]): Promise<void> {
+		this.queries.push({ text, params });
+	}
+
+	on(event: string, handler: (...args: any[]) => void): this {
+		const handlers = this.handlers.get(event) ?? new Set();
+		handlers.add(handler);
+		this.handlers.set(event, handlers);
+		return this;
+	}
+
+	off(event: string, handler: (...args: any[]) => void): this {
+		this.handlers.get(event)?.delete(handler);
+		return this;
+	}
+
+	async end(): Promise<void> {
+		this.endCalls += 1;
+	}
+
+	emit(event: string, ...args: any[]): void {
+		for (const handler of this.handlers.get(event) ?? []) handler(...args);
+	}
+}
+
+const topologyWake: ChangeWake = {
+	kind: "topology-maybe-advanced",
+	sessionKey: "sha256-session-key",
+	ownerId: "owner-a",
+	ownerGeneration: 12,
+	desiredRevision: 4,
+	reason: "submit",
+};
+
+describe("pg-notify change broker", () => {
+	test("publishes and receives metadata-only topology wakes", async () => {
+		const listener = new FakePgClient();
+		const publisher = new FakePgClient();
+		const wakes: ChangeWake[] = [];
+		const states: ChangeBrokerState[] = [];
+		const broker = new PgNotifyChangeBroker({
+			client: listener as any,
+			publisherClient: publisher as any,
+		});
+
+		await broker.start({
+			onWake: (wake) => wakes.push(wake),
+			onError: (error) => {
+				throw error;
+			},
+			onStateChange: (state) => states.push(state),
+		});
+		await broker.publish({
+			...topologyWake,
+			token: "must-not-cross-the-broker",
+			topics: [{ resource: "posts" }],
+		} as ChangeWake);
+
+		expect(listener.queries).toEqual([{ text: "LISTEN questpie_realtime_v2" }]);
+		expect(publisher.queries).toEqual([
+			{
+				text: "select pg_notify($1, $2)",
+				params: ["questpie_realtime_v2", JSON.stringify(topologyWake)],
+			},
+		]);
+		expect(JSON.parse(String(publisher.queries[0]!.params![1]))).toEqual(
+			topologyWake,
+		);
+
+		listener.emit("notification", {
+			channel: "questpie_realtime_v2",
+			payload: JSON.stringify(topologyWake),
+		});
+		expect(wakes).toEqual([topologyWake]);
+		expect(states).toEqual(["connecting", "connected"]);
+
+		await broker.stop();
+		expect(states).toEqual(["connecting", "connected", "disconnected"]);
+	});
+
+	test("reports unavailable and reconnects the LISTEN connection", async () => {
+		const listener = new FakePgClient();
+		const publisher = new FakePgClient();
+		const states: ChangeBrokerState[] = [];
+		const errors: unknown[] = [];
+		let reconnect: (() => void) | undefined;
+		let resolveConnected = () => {};
+		const connectedAgain = new Promise<void>((resolve) => {
+			resolveConnected = resolve;
+		});
+		const timeoutSpy = spyOn(globalThis, "setTimeout").mockImplementation(
+			(handler) => {
+				reconnect = () => {
+					if (typeof handler === "function") handler();
+				};
+				return 1 as unknown as ReturnType<typeof setTimeout>;
+			},
+		);
+		const broker = new PgNotifyChangeBroker({
+			client: listener as any,
+			publisherClient: publisher as any,
+		});
+
+		try {
+			await broker.start({
+				onWake: () => {},
+				onError: (error) => errors.push(error),
+				onStateChange: (state) => {
+					states.push(state);
+					if (state === "connected" && states.includes("unavailable")) {
+						resolveConnected();
+					}
+				},
+			});
+			listener.emit("error", new Error("listener lost"));
+			expect(reconnect).toBeDefined();
+			reconnect?.();
+			await connectedAgain;
+
+			expect(states).toEqual([
+				"connecting",
+				"connected",
+				"unavailable",
+				"connected",
+			]);
+			expect(errors).toHaveLength(1);
+			expect(
+				listener.queries.filter(({ text }) => text.startsWith("LISTEN")),
+			).toHaveLength(2);
+		} finally {
+			timeoutSpy.mockRestore();
+			await broker.stop();
+		}
+	});
+
+	test("ignores payloads that are not valid ChangeWake metadata", async () => {
+		const listener = new FakePgClient();
+		const publisher = new FakePgClient();
+		const wakes: ChangeWake[] = [];
+		const errors: unknown[] = [];
+		const broker = new PgNotifyChangeBroker({
+			client: listener as any,
+			publisherClient: publisher as any,
+		});
+
+		await broker.start({
+			onWake: (wake) => wakes.push(wake),
+			onError: (error) => errors.push(error),
+		});
+		listener.emit("notification", {
+			channel: "questpie_realtime_v2",
+			payload: JSON.stringify({
+				kind: "topology-maybe-advanced",
+				token: "must-not-cross-the-broker",
+				topics: [{ resource: "posts" }],
+			}),
+		});
+
+		expect(wakes).toEqual([]);
+		expect(errors).toHaveLength(1);
+		await broker.stop();
+	});
+});

--- a/packages/questpie/test/units/realtime-pusher-transport.test.ts
+++ b/packages/questpie/test/units/realtime-pusher-transport.test.ts
@@ -166,6 +166,43 @@ describe("pusher channel matrix change broker", () => {
 		expect(states).toEqual(["connected"]);
 	});
 
+	test("keeps topology wakes metadata-only on the provider path", async () => {
+		const { provider, triggers } = createProvider();
+		let onMessage: ((value: unknown) => void) | undefined;
+		const wakes: unknown[] = [];
+		const broker = new PusherChangeBroker({
+			provider,
+			subscriber: {
+				start: async (input) => {
+					onMessage = input.onMessage;
+				},
+				stop: async () => {},
+			},
+			channel: "questpie-broker-test",
+		});
+		const wake = {
+			kind: "topology-maybe-advanced" as const,
+			sessionKey: "sha256-session-key",
+			ownerId: "owner-a",
+			ownerGeneration: 2,
+			desiredRevision: 7,
+			reason: "submit" as const,
+		};
+
+		await broker.start({
+			onWake: (value) => wakes.push(value),
+			onError: () => {},
+		});
+		await broker.publish({
+			...wake,
+			token: "must-be-stripped",
+		} as ChangeWake);
+		expect(triggers[0]?.data).toEqual(wake);
+
+		onMessage?.({ ...wake, topics: [{ resource: "posts" }] });
+		expect(wakes).toEqual([wake]);
+	});
+
 	test("reports provider failures while publish remains off the caller path", async () => {
 		const errors: unknown[] = [];
 		const provider = createProvider().provider;

--- a/packages/questpie/test/units/realtime-pusher-transport.test.ts
+++ b/packages/questpie/test/units/realtime-pusher-transport.test.ts
@@ -305,9 +305,9 @@ describe("pusher channel matrix change broker", () => {
 			});
 			await tick();
 			broker.emitState("unavailable");
-			expect(delays).toEqual([15_000, 2000]);
+			expect(delays.slice(-2)).toEqual([15_000, 2000]);
 			broker.emitState("connected");
-			expect(delays).toEqual([15_000, 2000, 15_000]);
+			expect(delays.slice(-3)).toEqual([15_000, 2000, 15_000]);
 		} finally {
 			intervalSpy.mockRestore();
 			await realtime.destroy();

--- a/packages/questpie/test/units/realtime-rollout.test.ts
+++ b/packages/questpie/test/units/realtime-rollout.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 
 import { sseHeaders } from "../../src/server/adapters/utils/response.js";
 import type { RealtimeAdapter } from "../../src/server/modules/core/integrated/realtime/adapter.js";
+import { PgNotifyChangeBroker } from "../../src/server/modules/core/integrated/realtime/adapters/pg-notify.js";
 import { RealtimeService } from "../../src/server/modules/core/integrated/realtime/service.js";
 import type {
 	ChangeBroker,
@@ -122,6 +123,22 @@ function createService(
 }
 
 describe("realtime compatibility rollout", () => {
+	it("auto-selects the v2 Postgres broker for clean Postgres config", async () => {
+		const realtime = new RealtimeService(
+			new EmptyRealtimeDb() as never,
+			{ pollIntervalMs: 0, retentionDays: 0 },
+			"postgres://questpie.test/realtime",
+		);
+		try {
+			expect((realtime as any).changeBroker).toBeInstanceOf(
+				PgNotifyChangeBroker,
+			);
+			expect((realtime as any).adapter).toBeUndefined();
+		} finally {
+			await realtime.destroy();
+		}
+	});
+
 	it("keeps adapter-only config working as the v2 compatibility fallback", async () => {
 		const adapter = new RecordingAdapter();
 		const realtime = createService({ adapter });
@@ -132,6 +149,22 @@ describe("realtime compatibility rollout", () => {
 			expect(await realtime.getClientTransportConfig({})).toEqual({
 				transport: "sse",
 			});
+		} finally {
+			await realtime.destroy();
+		}
+	});
+
+	it("does not replace an explicit compatibility adapter with the Postgres default", async () => {
+		const adapter = new RecordingAdapter();
+		const realtime = new RealtimeService(
+			new EmptyRealtimeDb() as never,
+			{ adapter, pollIntervalMs: 0, retentionDays: 0 },
+			"postgres://questpie.test/realtime",
+		);
+		try {
+			await realtime.notify(change);
+			expect(adapter.notifications).toEqual([change]);
+			expect((realtime as any).changeBroker).toBeUndefined();
 		} finally {
 			await realtime.destroy();
 		}

--- a/packages/questpie/test/units/realtime-rollout.test.ts
+++ b/packages/questpie/test/units/realtime-rollout.test.ts
@@ -123,6 +123,43 @@ function createService(
 }
 
 describe("realtime compatibility rollout", () => {
+	it("warns once outside tests without removing the 3.x runtime", async () => {
+		const previous = process.env.NODE_ENV;
+		process.env.NODE_ENV = "production";
+		const warnings: unknown[][] = [];
+		const logger = {
+			warn: (...args: unknown[]) => warnings.push(args),
+			error: () => {},
+		};
+		const first = new RealtimeService(
+			new EmptyRealtimeDb() as never,
+			{ adapter: new RecordingAdapter(), pollIntervalMs: 0, retentionDays: 0 },
+			undefined,
+			logger,
+		);
+		const second = new RealtimeService(
+			new EmptyRealtimeDb() as never,
+			{
+				adapter: new RecordingAdapter(),
+				rollout: { mode: "legacy" },
+				pollIntervalMs: 0,
+				retentionDays: 0,
+			},
+			undefined,
+			logger,
+		);
+		try {
+			expect(warnings).toHaveLength(1);
+			expect(String(warnings[0]?.[0])).toContain("QuestPie 4");
+			await expect(first.notify(change)).resolves.toBeUndefined();
+			await expect(second.notify(change)).resolves.toBeUndefined();
+		} finally {
+			await Promise.all([first.destroy(), second.destroy()]);
+			if (previous === undefined) delete process.env.NODE_ENV;
+			else process.env.NODE_ENV = previous;
+		}
+	});
+
 	it("auto-selects the v2 Postgres broker for clean Postgres config", async () => {
 		const realtime = new RealtimeService(
 			new EmptyRealtimeDb() as never,

--- a/packages/questpie/test/units/realtime-topology-coordinator.test.ts
+++ b/packages/questpie/test/units/realtime-topology-coordinator.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+	MemoryRealtimeTopologyStore,
+	RealtimeTopologyCoordinator,
+	type RealtimeDesiredTopology,
+} from "../../src/server/modules/core/integrated/realtime/topology-coordinator.js";
+import type {
+	ChangeBroker,
+	ChangeWake,
+} from "../../src/server/modules/core/integrated/realtime/transport.js";
+
+class RecordingBroker implements ChangeBroker {
+	wakes: ChangeWake[] = [];
+
+	async start(): Promise<void> {}
+
+	async publish(wake: ChangeWake): Promise<void> {
+		this.wakes.push(wake);
+	}
+
+	async stop(): Promise<void> {}
+}
+
+const emptyTopology = (revision = 0): RealtimeDesiredTopology => ({
+	protocol: "questpie-realtime-topology",
+	version: 1,
+	revision,
+	topics: [],
+	channels: [],
+});
+
+describe("realtime topology coordinator", () => {
+	test("applies, deduplicates, rejects stale revisions, and detects conflicts", async () => {
+		let now = new Date("2026-07-15T20:00:00.000Z");
+		const broker = new RecordingBroker();
+		const coordinator = new RealtimeTopologyCoordinator(
+			new MemoryRealtimeTopologyStore(() => now),
+			{
+				broker,
+				ownerId: "owner-a",
+				now: () => now,
+				leaseMs: 30_000,
+				heartbeatMs: 0,
+				reconcileMs: 0,
+			},
+		);
+		const applied: RealtimeDesiredTopology[] = [];
+		const session = await coordinator.open({
+			sessionId: "session-a",
+			token: "token-a",
+			identity: "anonymous",
+			topology: emptyTopology(),
+			apply: async (topology) => applied.push(topology),
+			onClose: async () => {},
+		});
+		const revisionOne: RealtimeDesiredTopology = {
+			...emptyTopology(1),
+			topics: [
+				{
+					id: "posts",
+					topic: { resourceType: "collection", resource: "posts" },
+				},
+			],
+		};
+
+		expect(
+			await coordinator.submit({
+				sessionId: "session-a",
+				token: "token-a",
+				identity: "anonymous",
+				topology: revisionOne,
+			}),
+		).toMatchObject({ status: "accepted", desiredRevision: 1 });
+		await coordinator.reconcile();
+		expect(applied).toEqual([revisionOne]);
+
+		expect(
+			await coordinator.submit({
+				sessionId: "session-a",
+				token: "token-a",
+				identity: "anonymous",
+				topology: revisionOne,
+			}),
+		).toMatchObject({ status: "duplicate", desiredRevision: 1 });
+		expect(
+			await coordinator.submit({
+				sessionId: "session-a",
+				token: "token-a",
+				identity: "anonymous",
+				topology: emptyTopology(0),
+			}),
+		).toMatchObject({ status: "stale", desiredRevision: 1 });
+		expect(
+			await coordinator.submit({
+				sessionId: "session-a",
+				token: "token-a",
+				identity: "anonymous",
+				topology: { ...emptyTopology(1), channels: [] },
+			}),
+		).toMatchObject({ status: "conflict", desiredRevision: 1 });
+		expect(broker.wakes).toHaveLength(1);
+
+		await session.close();
+		await coordinator.stop();
+	});
+
+	test("fences an expired owner and rejects its capability uniformly", async () => {
+		let now = new Date("2026-07-15T20:00:00.000Z");
+		let closed = 0;
+		const coordinator = new RealtimeTopologyCoordinator(
+			new MemoryRealtimeTopologyStore(() => now),
+			{
+				ownerId: "owner-a",
+				now: () => now,
+				leaseMs: 30_000,
+				heartbeatMs: 0,
+				reconcileMs: 0,
+			},
+		);
+		await coordinator.open({
+			sessionId: "session-a",
+			token: "token-a",
+			identity: "anonymous",
+			topology: emptyTopology(),
+			apply: async () => {},
+			onClose: async () => {
+				closed += 1;
+			},
+		});
+		now = new Date(now.getTime() + 30_001);
+		await coordinator.reconcile();
+
+		expect(closed).toBe(1);
+		expect(
+			await coordinator.submit({
+				sessionId: "session-a",
+				token: "wrong-token",
+				identity: "someone-else",
+				topology: emptyTopology(1),
+			}),
+		).toEqual({ status: "unavailable" });
+		await coordinator.stop();
+	});
+
+	test("heals a dropped cross-instance wake from durable state", async () => {
+		const store = new MemoryRealtimeTopologyStore();
+		const owner = new RealtimeTopologyCoordinator(store, {
+			ownerId: "owner-a",
+			heartbeatMs: 0,
+			reconcileMs: 0,
+		});
+		const handler = new RealtimeTopologyCoordinator(store, {
+			ownerId: "owner-b",
+			heartbeatMs: 0,
+			reconcileMs: 0,
+		});
+		const applied: RealtimeDesiredTopology[] = [];
+		await owner.open({
+			sessionId: "session-a",
+			token: "token-a",
+			identity: "anonymous",
+			topology: emptyTopology(),
+			apply: async (topology) => applied.push(topology),
+			onClose: async () => {},
+		});
+		const desired = {
+			...emptyTopology(1),
+			topics: [
+				{
+					id: "posts",
+					topic: { resourceType: "collection", resource: "posts" },
+				},
+			],
+		};
+
+		expect(
+			await handler.submit({
+				sessionId: "session-a",
+				token: "token-a",
+				identity: "anonymous",
+				topology: desired,
+			}),
+		).toMatchObject({ status: "accepted" });
+		expect(applied).toEqual([]);
+		await owner.reconcile();
+		expect(applied).toEqual([desired]);
+
+		await Promise.all([owner.stop(), handler.stop()]);
+	});
+});

--- a/packages/questpie/test/units/realtime-topology-coordinator.test.ts
+++ b/packages/questpie/test/units/realtime-topology-coordinator.test.ts
@@ -159,6 +159,58 @@ describe("realtime topology coordinator", () => {
 		await coordinator.stop();
 	});
 
+	test("closes the session without marking a failed owner apply", async () => {
+		const coordinator = new RealtimeTopologyCoordinator(
+			new MemoryRealtimeTopologyStore(),
+			{
+				ownerId: "owner-a",
+				heartbeatMs: 0,
+				reconcileMs: 0,
+			},
+		);
+		let closed = 0;
+		await coordinator.open({
+			sessionId: "session-a",
+			token: "token-a",
+			identity: "anonymous",
+			topology: emptyTopology(),
+			apply: async () => {
+				throw new Error("owner apply failed");
+			},
+			onClose: () => {
+				closed += 1;
+			},
+		});
+		const desired = {
+			...emptyTopology(1),
+			topics: [
+				{
+					id: "posts",
+					topic: { resourceType: "collection", resource: "posts" },
+				},
+			],
+		};
+
+		expect(
+			await coordinator.submit({
+				sessionId: "session-a",
+				token: "token-a",
+				identity: "anonymous",
+				topology: desired,
+			}),
+		).toMatchObject({ status: "accepted", appliedRevision: 0 });
+		expect(closed).toBe(1);
+		expect(
+			await coordinator.submit({
+				sessionId: "session-a",
+				token: "token-a",
+				identity: "anonymous",
+				topology: desired,
+			}),
+		).toEqual({ status: "unavailable" });
+		await coordinator.stop();
+	});
+
 	test("heals a dropped cross-instance wake from durable state", async () => {
 		const store = new MemoryRealtimeTopologyStore();
 		const owner = new RealtimeTopologyCoordinator(store, {

--- a/packages/questpie/test/units/realtime-topology-coordinator.test.ts
+++ b/packages/questpie/test/units/realtime-topology-coordinator.test.ts
@@ -128,6 +128,22 @@ describe("realtime topology coordinator", () => {
 				closed += 1;
 			},
 		});
+		expect(
+			await coordinator.submit({
+				sessionId: "session-a",
+				token: "wrong-token",
+				identity: "anonymous",
+				topology: emptyTopology(1),
+			}),
+		).toEqual({ status: "unavailable" });
+		expect(
+			await coordinator.submit({
+				sessionId: "session-a",
+				token: "token-a",
+				identity: "someone-else",
+				topology: emptyTopology(1),
+			}),
+		).toEqual({ status: "unavailable" });
 		now = new Date(now.getTime() + 30_001);
 		await coordinator.reconcile();
 

--- a/packages/questpie/test/units/realtime-topology-coordinator.test.ts
+++ b/packages/questpie/test/units/realtime-topology-coordinator.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
+import type { RealtimeObservation } from "../../src/server/modules/core/integrated/realtime/observer.js";
 import {
 	MemoryRealtimeTopologyStore,
 	RealtimeTopologyCoordinator,
@@ -34,6 +35,7 @@ describe("realtime topology coordinator", () => {
 	test("applies, deduplicates, rejects stale revisions, and detects conflicts", async () => {
 		let now = new Date("2026-07-15T20:00:00.000Z");
 		const broker = new RecordingBroker();
+		const observations: RealtimeObservation[] = [];
 		const coordinator = new RealtimeTopologyCoordinator(
 			new MemoryRealtimeTopologyStore(() => now),
 			{
@@ -43,6 +45,7 @@ describe("realtime topology coordinator", () => {
 				leaseMs: 30_000,
 				heartbeatMs: 0,
 				reconcileMs: 0,
+				observer: { record: (event) => observations.push(event) },
 			},
 		);
 		const applied: RealtimeDesiredTopology[] = [];
@@ -74,6 +77,15 @@ describe("realtime topology coordinator", () => {
 		).toMatchObject({ status: "accepted", desiredRevision: 1 });
 		await coordinator.reconcile();
 		expect(applied).toEqual([revisionOne]);
+		expect(observations).toContainEqual({
+			type: "topology.lifecycle",
+			phase: "apply",
+			outcome: "applied",
+			desiredRevision: 1,
+			appliedRevision: 1,
+		});
+		expect(JSON.stringify(observations)).not.toContain("session-a");
+		expect(JSON.stringify(observations)).not.toContain("token-a");
 
 		expect(
 			await coordinator.submit({
@@ -100,6 +112,28 @@ describe("realtime topology coordinator", () => {
 			}),
 		).toMatchObject({ status: "conflict", desiredRevision: 1 });
 		expect(broker.wakes).toHaveLength(1);
+		expect(
+			await coordinator.submit({
+				sessionId: "session-a",
+				token: "token-a",
+				identity: "anonymous",
+				topology: { ...emptyTopology(2), version: 2 } as never,
+			}),
+		).toMatchObject({ status: "unsupported" });
+		expect(
+			await coordinator.submit({
+				sessionId: "session-a",
+				token: "token-a",
+				identity: "anonymous",
+				topology: {
+					...emptyTopology(2),
+					topics: [
+						{ id: "duplicate", topic: {} },
+						{ id: "duplicate", topic: {} },
+					],
+				},
+			}),
+		).toMatchObject({ status: "invalid" });
 
 		await session.close();
 		await coordinator.stop();

--- a/packages/questpie/test/units/realtime-topology-coordinator.test.ts
+++ b/packages/questpie/test/units/realtime-topology-coordinator.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import type { RealtimeObservation } from "../../src/server/modules/core/integrated/realtime/observer.js";
 import {
+	MAX_REALTIME_TOPOLOGY_BYTES,
 	MemoryRealtimeTopologyStore,
 	RealtimeTopologyCoordinator,
 	type RealtimeDesiredTopology,
@@ -75,6 +76,20 @@ describe("realtime topology coordinator", () => {
 				topology: revisionOne,
 			}),
 		).toMatchObject({ status: "accepted", desiredRevision: 1 });
+		expect(broker.wakes).toEqual([
+			{
+				kind: "topology-maybe-advanced",
+				sessionKey: expect.any(String),
+				ownerId: "owner-a",
+				ownerGeneration: 1,
+				desiredRevision: 1,
+				reason: "submit",
+			},
+		]);
+		expect(JSON.stringify(broker.wakes)).not.toContain("session-a");
+		expect(JSON.stringify(broker.wakes)).not.toContain("token-a");
+		expect(JSON.stringify(broker.wakes)).not.toContain("anonymous");
+		expect(JSON.stringify(broker.wakes)).not.toContain("topics");
 		await coordinator.reconcile();
 		expect(applied).toEqual([revisionOne]);
 		expect(observations).toContainEqual({
@@ -134,6 +149,23 @@ describe("realtime topology coordinator", () => {
 				},
 			}),
 		).toMatchObject({ status: "invalid" });
+		expect(
+			await coordinator.submit({
+				sessionId: "session-a",
+				token: "token-a",
+				identity: "anonymous",
+				topology: {
+					...emptyTopology(2),
+					topics: [
+						{
+							id: "oversized",
+							topic: { value: "x".repeat(MAX_REALTIME_TOPOLOGY_BYTES) },
+						},
+					],
+				},
+			}),
+		).toMatchObject({ status: "invalid" });
+		expect(broker.wakes).toHaveLength(1);
 
 		await session.close();
 		await coordinator.stop();

--- a/packages/tanstack-query/src/index.ts
+++ b/packages/tanstack-query/src/index.ts
@@ -484,6 +484,41 @@ const defaultErrorMap: QuestpieQueryErrorMap = (error) =>
 		? error
 		: new Error(typeof error === "string" ? error : "Unknown error");
 
+const isNonRetryableError = (error: unknown): boolean =>
+	Boolean(
+		error &&
+		typeof error === "object" &&
+		"retryable" in error &&
+		error.retryable === false,
+	);
+
+const mapRealtimeError = (
+	error: unknown,
+	errorMap: QuestpieQueryErrorMap,
+): unknown => {
+	const mapped = errorMap(error);
+	if (
+		isNonRetryableError(error) &&
+		(!mapped || typeof mapped !== "object" || !("retryable" in mapped))
+	) {
+		if (mapped && typeof mapped === "object" && Object.isExtensible(mapped)) {
+			Object.defineProperty(mapped, "retryable", {
+				value: false,
+				enumerable: true,
+			});
+			return mapped;
+		}
+		return Object.assign(new Error("Non-retryable realtime query failed"), {
+			cause: mapped,
+			retryable: false as const,
+		});
+	}
+	return mapped;
+};
+
+const realtimeRetry = (failureCount: number, error: unknown): boolean =>
+	!isNonRetryableError(error) && failureCount < 3;
+
 const buildKey = (prefix: QueryKey, parts: QueryKey): QueryKey =>
 	prefix.length ? [...prefix, ...parts] : parts;
 
@@ -548,7 +583,7 @@ async function* streamRealtimeQuery<TInitialData>(options: {
 			yield snapshot;
 		}
 	} catch (error) {
-		throw errorMap(error);
+		throw mapRealtimeError(error, errorMap);
 	}
 }
 
@@ -613,6 +648,7 @@ export function createQuestpieQueryOptions<
 							const topic = buildCollectionTopic(collectionName, options);
 							return queryOptions({
 								queryKey: qKey,
+								retry: realtimeRetry,
 								queryFn: streamedQuery({
 									streamFn: ({ signal }) =>
 										streamRealtimeQuery<any>({
@@ -650,6 +686,7 @@ export function createQuestpieQueryOptions<
 							);
 							return queryOptions({
 								queryKey: qKey,
+								retry: realtimeRetry,
 								queryFn: streamedQuery({
 									streamFn: ({ signal }) =>
 										streamRealtimeQuery<number>({
@@ -913,6 +950,7 @@ export function createQuestpieQueryOptions<
 						const topic = buildGlobalTopic(globalName as string, options);
 						return queryOptions({
 							queryKey: qKey,
+							retry: realtimeRetry,
 							queryFn: streamedQuery({
 								streamFn: ({ signal }) =>
 									streamRealtimeQuery({

--- a/packages/tanstack-query/src/realtime-query-options.test.ts
+++ b/packages/tanstack-query/src/realtime-query-options.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "bun:test";
 
 import { QueryClient } from "@tanstack/react-query";
-import type { QuestpieApp, QuestpieClient } from "questpie/client";
+import {
+	RealtimeTopicRejectedError,
+	type QuestpieApp,
+	type QuestpieClient,
+} from "questpie/client";
 
 import {
 	createQuestpieQueryOptions,
@@ -138,5 +142,57 @@ describe("realtime query options", () => {
 			operation: "count",
 		});
 		expect(value).toBe(10_000);
+	});
+
+	it("surfaces non-retryable admission failures as query errors after one attempt", async () => {
+		let streamCalls = 0;
+		const client = {
+			collections: {
+				posts: { find: async () => ({ docs: [], totalDocs: 0 }) },
+			},
+			globals: {},
+			routes: {},
+			realtime: {
+				subscribe: () => () => {},
+				stream: async function* () {
+					streamCalls += 1;
+					yield await Promise.reject(
+						new RealtimeTopicRejectedError({
+							code: "REALTIME_TOPIC_REJECTED",
+							message: "Topic limit must be between 1 and 100",
+							topicId: "posts-topic",
+							resource: "posts",
+							operation: "find",
+							retryable: false,
+							details: {
+								reason: "query_limit",
+								requestedLimit: 240,
+								configuredLimit: 100,
+							},
+						}),
+					);
+				},
+				destroy: () => {},
+				topicCount: 0,
+				subscriberCount: 0,
+			},
+		} as unknown as QuestpieClient<QuestpieApp>;
+		const queryClient = new QueryClient({
+			defaultOptions: { queries: { retry: 3, retryDelay: 0 } },
+		});
+		const options = createQuestpieQueryOptions(client).collections.posts.find(
+			{ limit: 240 },
+			{ realtime: true },
+		);
+
+		await expect(queryClient.fetchQuery(options as any)).rejects.toMatchObject({
+			code: "REALTIME_TOPIC_REJECTED",
+			retryable: false,
+		});
+		expect(streamCalls).toBe(1);
+		expect(queryClient.getQueryState(options.queryKey)).toMatchObject({
+			status: "error",
+			fetchStatus: "idle",
+		});
 	});
 });

--- a/skills/questpie/AGENTS.md
+++ b/skills/questpie/AGENTS.md
@@ -5594,11 +5594,11 @@ const { data } = useQuery(
 
 ## Transport selection
 
-SSE is the default `ClientTransport`; no browser transport config is required. With a normal Postgres URL the server auto-wires `PgNotifyChangeBroker`; otherwise it polls every 2s. Redis Streams and Pusher are supported v2 broker overrides. Cloudflare's adapter remains on the deprecated 3.x compatibility seam. A clean v2 configuration never needs both `RealtimeAdapter` and `ChangeBroker`.
+SSE is the default `ClientTransport`; no browser transport config is required. With a normal Postgres URL the server auto-wires `PgNotifyChangeBroker`; otherwise it polls every 2s. Redis Streams and Pusher are supported v2 broker overrides. A clean v2 configuration uses one `ChangeBroker`.
 
 Realtime topology is durable in `questpie_realtime_topology`. Complete desired topology uses monotonic revisions; a metadata-only broker wake lowers latency and one-second reconciliation heals dropped wakes. This makes companion control HA-safe without sticky routing after the migration is applied and every request-handling replica supports the advertised `questpie-realtime-topology` v1 capability.
 
-Before a production upgrade, run `bunx questpie migrate:create`, review and commit the generated migration, then run `bunx questpie migrate`. Never use `push` for this production schema change. `RealtimeAdapter`, `realtime.adapter`, `pgNotifyAdapter`, and `legacy`/`dual` rollout modes are deprecated in QuestPie 3.x and removed in QuestPie 4.
+Before a production upgrade, run `bunx questpie migrate:create`, review and commit the generated migration, then run `bunx questpie migrate`. Never use `push` for this production schema change. Use the Realtime v2 HA migration guide for the QuestPie 3.x transition and QuestPie 4 removal window.
 
 For managed WebSockets and native presence, select the isolated Pusher/Soketi preset:
 
@@ -6856,7 +6856,7 @@ The preset supplies a notice-only Pusher `ChangeBroker` and a Pusher `ClientTran
 
 ### Cloudflare Durable Objects
 
-`cloudflareRealtimeAdapter()` is the deprecated 3.x `RealtimeAdapter` compatibility path for Workers. It shards Durable Objects by resource type and resource name, and notification work is attached to `waitUntil` so CRUD commits do not wait on the adapter. A dedicated v2 `ChangeBroker` replacement is not part of this release.
+Cloudflare Workers use a Durable Object fan-out path because they do not keep a long-lived process-local poller. Consult the Realtime v2 HA migration guide before selecting the QuestPie 3.x deployment path.
 
 ### When to Use Which
 
@@ -6866,10 +6866,9 @@ The preset supplies a notice-only Pusher `ChangeBroker` and a Pusher `ClientTran
 | Poll + SSE                       | Zero extra infrastructure without a push-capable database                 |
 | `pgNotifyChangeBroker` + SSE     | Explicit Postgres connection/channel                                      |
 | `redisStreamsChangeBroker` + SSE | Cross-instance Redis notice fan-out                                       |
-| `cloudflareRealtimeAdapter`      | Deprecated 3.x Cloudflare compatibility adapter                           |
 | `pusherRealtime`                 | Managed WebSockets, provider-native presence, and shared channel delivery |
 
-`RealtimeAdapter`, `realtime.adapter`, `pgNotifyAdapter`, and the `legacy`/`dual` rollout modes remain deprecated compatibility surfaces through QuestPie 3.x. Migrate to `changeBroker`; they are removed in QuestPie 4. Apply the generated `questpie_realtime_topology` migration before claiming cross-replica no-reconnect control.
+Apply the generated `questpie_realtime_topology` migration before claiming cross-replica no-reconnect control. Use the Realtime v2 HA migration guide for version-transition details.
 
 ## Search
 

--- a/skills/questpie/AGENTS.md
+++ b/skills/questpie/AGENTS.md
@@ -5594,7 +5594,11 @@ const { data } = useQuery(
 
 ## Transport selection
 
-SSE is the default `ClientTransport`; no browser transport config is required. With a normal Postgres URL the server auto-wires `pg_notify`; otherwise it polls every 2s. Explicit pg, Redis, and Cloudflare adapters remain supported as notice brokers.
+SSE is the default `ClientTransport`; no browser transport config is required. With a normal Postgres URL the server auto-wires `PgNotifyChangeBroker`; otherwise it polls every 2s. Redis Streams and Pusher are supported v2 broker overrides. Cloudflare's adapter remains on the deprecated 3.x compatibility seam. A clean v2 configuration never needs both `RealtimeAdapter` and `ChangeBroker`.
+
+Realtime topology is durable in `questpie_realtime_topology`. Complete desired topology uses monotonic revisions; a metadata-only broker wake lowers latency and one-second reconciliation heals dropped wakes. This makes companion control HA-safe without sticky routing after the migration is applied and every request-handling replica supports the advertised `questpie-realtime-topology` v1 capability.
+
+Before a production upgrade, run `bunx questpie migrate:create`, review and commit the generated migration, then run `bunx questpie migrate`. Never use `push` for this production schema change. `RealtimeAdapter`, `realtime.adapter`, `pgNotifyAdapter`, and `legacy`/`dual` rollout modes are deprecated in QuestPie 3.x and removed in QuestPie 4.
 
 For managed WebSockets and native presence, select the isolated Pusher/Soketi preset:
 
@@ -5750,15 +5754,15 @@ The event subscription accumulates messages. The presence query and live-query `
 
 QUESTPIE uses an adapter-based architecture for all infrastructure. Development defaults work out of the box; production requires explicit adapter configuration in `questpie.config.ts`.
 
-| Service  | Dev Default           | Production Adapter                            |
-| -------- | --------------------- | --------------------------------------------- |
-| Database | PostgreSQL (local)    | PostgreSQL (remote, SSL)                      |
-| Storage  | Local filesystem      | Files SDK provider adapter (`s3`, `r2`, etc.) |
-| Queue    | None (jobs skip)      | pg-boss (`pgBossAdapter`)                     |
-| Realtime | pgNotify              | Redis Streams (`redisStreamsAdapter`)         |
-| Email    | Console (logs output) | SMTP (`SmtpAdapter`)                          |
-| KV Store | In-memory             | Redis (`redisKVAdapter`)                      |
-| Logger   | Pino (console)        | Pino (structured JSON)                        |
+| Service  | Dev Default            | Production Adapter                            |
+| -------- | ---------------------- | --------------------------------------------- |
+| Database | PostgreSQL (local)     | PostgreSQL (remote, SSL)                      |
+| Storage  | Local filesystem       | Files SDK provider adapter (`s3`, `r2`, etc.) |
+| Queue    | None (jobs skip)       | pg-boss (`pgBossAdapter`)                     |
+| Realtime | `PgNotifyChangeBroker` | Redis Streams (`redisStreamsChangeBroker`)    |
+| Email    | Console (logs output)  | SMTP (`SmtpAdapter`)                          |
+| KV Store | In-memory              | Redis (`redisKVAdapter`)                      |
+| Logger   | Pino (console)         | Pino (structured JSON)                        |
 
 Every adapter's exact config shape lives in `references/infrastructure-adapters.md`.
 
@@ -5854,9 +5858,9 @@ Configure migration and seed directories in `questpie.config.ts` under `cli.migr
 
 All adapter config shapes, Storage (local, S3, R2), Queue (pg-boss, BullMQ), Realtime (pgNotify, Redis Streams), Email (SMTP, Console, Resend, Plunk), KV (Redis, custom), Logger, Search, and OpenAPI, live in **`references/infrastructure-adapters.md`**. Each is configured under `runtimeConfig({...})` in `questpie.config.ts`. The deployment-relevant constraints follow.
 
-- **Queue / pg-boss and Realtime / pgNotify** both rely on PostgreSQL `LISTEN/NOTIFY` and silently break behind PgBouncer in transaction pool mode. See [PgBouncer Compatibility](#pgbouncer-compatibility).
+- **Queue / pg-boss and Realtime / PgNotifyChangeBroker** both rely on PostgreSQL `LISTEN/NOTIFY` and silently break behind PgBouncer in transaction pool mode. See [PgBouncer Compatibility](#pgbouncer-compatibility).
 - **Cloudflare Workers** process queues push-based: use `cloudflareQueuesAdapter` from `questpie/adapters/cloudflare` and export the Worker via `createCloudflareWorkerHandlers`, do not run `app.queue.listen()` in a Worker.
-- **Multi-instance realtime** requires `redisStreamsAdapter`; a single instance can use `pgNotifyAdapter`.
+- **Multi-instance realtime** works with the default Postgres `PgNotifyChangeBroker` or an explicit Redis/Pusher/Cloudflare broker. Apply the generated topology migration before enabling HA control.
 
 ## PgBouncer Compatibility
 
@@ -5866,25 +5870,25 @@ Bun SQL (`new SQL({ url })`) already pools connections internally. In single-ins
 
 ### Adapter Compatibility Matrix
 
-| Adapter                          | Direct PG | PgBouncer (transaction)          | PgBouncer (session)         |
-| -------------------------------- | --------- | -------------------------------- | --------------------------- |
-| `pgNotifyAdapter` (realtime)     | works     | broken, listens silently dropped | works (pooling neutralized) |
-| `pgBossAdapter` (queue)          | works     | broken, LISTEN/NOTIFY required   | works (pooling neutralized) |
-| Drizzle queries via Bun SQL      | works     | works                            | works                       |
-| `redisStreamsAdapter` (realtime) | n/a       | n/a                              | n/a                         |
+| Adapter                               | Direct PG | PgBouncer (transaction)          | PgBouncer (session)         |
+| ------------------------------------- | --------- | -------------------------------- | --------------------------- |
+| `PgNotifyChangeBroker` (realtime)     | works     | broken, listens silently dropped | works (pooling neutralized) |
+| `pgBossAdapter` (queue)               | works     | broken, LISTEN/NOTIFY required   | works (pooling neutralized) |
+| Drizzle queries via Bun SQL           | works     | works                            | works                       |
+| `redisStreamsChangeBroker` (realtime) | n/a       | n/a                              | n/a                         |
 
 Prepared statements also break under transaction pooling. If you must use it, ensure your driver disables prepared statements end-to-end.
 
 ### DB Connection Routing
 
 - **Default and recommended:** direct connection to the PG primary. Bun SQL pools internally; you do not need PgBouncer.
-- **If you must use PgBouncer:** put it in `session` pool mode for any process that runs `pgBossAdapter` or `pgNotifyAdapter`. Session mode pins one server connection per client, which neutralizes pooling but keeps `LISTEN/NOTIFY` working.
+- **If you must use PgBouncer:** put it in `session` pool mode for any process that runs `pgBossAdapter` or `PgNotifyChangeBroker`. Session mode pins one server connection per client, which neutralizes pooling but keeps `LISTEN/NOTIFY` working.
 - **Split topology:** route web traffic through PgBouncer (transaction mode) and run workers (pgBoss, pgNotify) on a direct connection. This works, but realtime fired from web handlers still routes through the same `QUESTPIE_DB`, so realtime in web fails. In practice, going direct everywhere is simpler.
 - **TODO / current limitation:** the framework reads a single `QUESTPIE_DB` env var. There is no built-in split between a pooled URL and a direct URL for LISTEN consumers. Track this if you need a mixed topology.
 
 ## Realtime & SSE Keepalive
 
-SSE-based live updates fan out via the `POST /realtime` multiplexed endpoint. Adapter config (`pgNotifyAdapter`, `redisStreamsAdapter`) is in `references/infrastructure-adapters.md`.
+SSE-based live updates fan out via the `POST /realtime` multiplexed endpoint. Broker config (`pgNotifyChangeBroker`, Redis, Pusher, Cloudflare) is in `references/infrastructure-adapters.md`.
 
 ### SSE Keepalive & Timeouts
 
@@ -5951,7 +5955,7 @@ CMD ["bun", "run", ".output/server/index.mjs"]
 - Set `APP_URL` to your public domain
 - Enable HTTPS
 - Configure S3 or persistent storage for uploads
-- Use `redisStreamsAdapter` if running multiple instances
+- Use `redisStreamsChangeBroker` when Redis is the shared notice infrastructure
 - Set up health checks
 
 ### Health Check
@@ -6040,7 +6044,7 @@ queue: {
 
 ### HIGH: PgBouncer transaction pool with pgNotify/pgBoss
 
-Pointing `QUESTPIE_DB` at a PgBouncer in transaction pool mode silently breaks `pgNotifyAdapter` and `pgBossAdapter`. Both rely on PostgreSQL `LISTEN/NOTIFY`, which requires a persistent session. PgBouncer transaction pooling reassigns the session per-transaction, so the listener is dropped right after `LISTEN` returns.
+Pointing `QUESTPIE_DB` at a PgBouncer in transaction pool mode silently breaks `PgNotifyChangeBroker` and `pgBossAdapter`. Both rely on PostgreSQL `LISTEN/NOTIFY`, which requires a persistent session. PgBouncer transaction pooling reassigns the session per-transaction, so the listener is dropped right after `LISTEN` returns.
 
 Symptoms:
 
@@ -6052,17 +6056,17 @@ Fix:
 ```ts
 // WRONG -- QUESTPIE_DB points at PgBouncer (transaction mode)
 realtime: {
-	adapter: pgNotifyAdapter({ connectionString: env.QUESTPIE_DB });
+	changeBroker: pgNotifyChangeBroker({ connectionString: env.QUESTPIE_DB });
 }
 queue: {
 	adapter: pgBossAdapter({ connectionString: env.QUESTPIE_DB });
 }
 
 // CORRECT -- direct PG connection (Bun SQL pools internally), or switch
-// realtime to redisStreamsAdapter, which takes a connected redis client
+// realtime to redisStreamsChangeBroker, which takes a connected redis client
 // (not a URL) for multi-instance deployments:
 realtime: {
-	adapter: redisStreamsAdapter({ client: redis }); // see infrastructure-adapters.md
+	changeBroker: redisStreamsChangeBroker({ client: redis }); // see infrastructure-adapters.md
 }
 ```
 
@@ -6070,7 +6074,7 @@ If your infra mandates PgBouncer, use `session` pool mode for processes that run
 
 ## Realtime and Live Preview
 
-The realtime adapter (`pgNotifyAdapter` or `redisStreamsAdapter`) is relevant for **detached or shared preview sessions**, when the preview runs in a separate browser tab, or multiple collaborators view the same preview.
+The realtime broker (`PgNotifyChangeBroker` or `redisStreamsChangeBroker`) is relevant for **detached or shared preview sessions**, when the preview runs in a separate browser tab, or multiple collaborators view the same preview.
 
 For the default **same-tab preview**, realtime is NOT involved. Current same-tab preview uses `postMessage` for refresh/focus messages between the editor and the iframe.
 
@@ -6786,7 +6790,7 @@ handler: async ({ queue }) => {
 
 The realtime runtime writes its outbox row in the business transaction and always reconciles missed notices. `ChangeBroker` handles notice-only cross-instance wakes; `ClientTransport` handles already-authorized edge frames. SSE is the default client transport.
 
-With `realtime: true`, a normal Postgres URL auto-selects `pg_notify`; without a push broker, the outbox is polled every 2s. With push, reconciliation still runs every 15s so a lost wake cannot permanently stall subscribers.
+With `realtime: true`, a normal Postgres URL auto-selects `PgNotifyChangeBroker`; without a push broker, the outbox is polled every 2s. With push, reconciliation still runs every 15s so a lost outbox wake cannot permanently stall subscribers. Revisioned topology has its own durable `questpie_realtime_topology` state and one-second reconciliation, so a companion control request can land on any upgraded replica without sticky routing.
 
 ### pgNotify
 
@@ -6794,13 +6798,13 @@ Uses PostgreSQL `LISTEN/NOTIFY`. Every listening instance receives the same noti
 
 ```ts
 import { runtimeConfig } from "questpie/app";
-import { pgNotifyAdapter } from "questpie/adapters/pg-notify";
+import { pgNotifyChangeBroker } from "questpie/adapters/pg-notify";
 
 import env from "./env";
 
 export default runtimeConfig({
 	realtime: {
-		adapter: pgNotifyAdapter({
+		changeBroker: pgNotifyChangeBroker({
 			connectionString: env.DATABASE_URL,
 		}),
 	},
@@ -6814,7 +6818,7 @@ Takes a connected Redis-shaped `client` with `xAdd` and `xRead`, not a URL. Ever
 ```ts
 import { createClient } from "redis";
 import { runtimeConfig } from "questpie/app";
-import { redisStreamsAdapter } from "questpie/adapters/redis-streams";
+import { redisStreamsChangeBroker } from "questpie/adapters/redis-streams";
 
 import env from "./env";
 
@@ -6823,7 +6827,7 @@ await redis.connect();
 
 export default runtimeConfig({
 	realtime: {
-		adapter: redisStreamsAdapter({ client: redis }),
+		changeBroker: redisStreamsChangeBroker({ client: redis }),
 	},
 });
 ```
@@ -6852,18 +6856,20 @@ The preset supplies a notice-only Pusher `ChangeBroker` and a Pusher `ClientTran
 
 ### Cloudflare Durable Objects
 
-`cloudflareRealtimeAdapter()` is a notice-only broker for Workers. It shards Durable Objects by resource type and resource name, and notification work is attached to `waitUntil` so CRUD commits do not wait on the broker. The Worker still reads the durable outbox, re-runs access-controlled snapshots, and performs reconciliation.
+`cloudflareRealtimeAdapter()` is the deprecated 3.x `RealtimeAdapter` compatibility path for Workers. It shards Durable Objects by resource type and resource name, and notification work is attached to `waitUntil` so CRUD commits do not wait on the adapter. A dedicated v2 `ChangeBroker` replacement is not part of this release.
 
 ### When to Use Which
 
-| Selection                   | Use case                                                                  |
-| --------------------------- | ------------------------------------------------------------------------- |
-| Implicit pg + SSE           | Default Postgres deployment                                               |
-| Poll + SSE                  | Zero extra infrastructure without a push-capable database                 |
-| `pgNotifyAdapter` + SSE     | Explicit Postgres connection/channel                                      |
-| `redisStreamsAdapter` + SSE | Cross-instance Redis notice fan-out                                       |
-| `cloudflareRealtimeAdapter` | Cloudflare Workers notice fan-out through sharded Durable Objects         |
-| `pusherRealtime`            | Managed WebSockets, provider-native presence, and shared channel delivery |
+| Selection                        | Use case                                                                  |
+| -------------------------------- | ------------------------------------------------------------------------- |
+| Implicit pg + SSE                | Default Postgres deployment                                               |
+| Poll + SSE                       | Zero extra infrastructure without a push-capable database                 |
+| `pgNotifyChangeBroker` + SSE     | Explicit Postgres connection/channel                                      |
+| `redisStreamsChangeBroker` + SSE | Cross-instance Redis notice fan-out                                       |
+| `cloudflareRealtimeAdapter`      | Deprecated 3.x Cloudflare compatibility adapter                           |
+| `pusherRealtime`                 | Managed WebSockets, provider-native presence, and shared channel delivery |
+
+`RealtimeAdapter`, `realtime.adapter`, `pgNotifyAdapter`, and the `legacy`/`dual` rollout modes remain deprecated compatibility surfaces through QuestPie 3.x. Migrate to `changeBroker`; they are removed in QuestPie 4. Apply the generated `questpie_realtime_topology` migration before claiming cross-replica no-reconnect control.
 
 ## Search
 
@@ -7301,7 +7307,7 @@ const spec = generateOpenApiSpec(app, {
 import { createClient } from "redis";
 import { runtimeConfig } from "questpie/app";
 import { pgBossAdapter } from "questpie/adapters/pg-boss";
-import { pgNotifyAdapter } from "questpie/adapters/pg-notify";
+import { pgNotifyChangeBroker } from "questpie/adapters/pg-notify";
 import { redisKVAdapter } from "questpie/adapters/redis-kv";
 import { SmtpAdapter } from "questpie/adapters/smtp";
 import { s3 } from "files-sdk/s3";
@@ -7335,7 +7341,7 @@ export default runtimeConfig({
 		}),
 	},
 	realtime: {
-		adapter: pgNotifyAdapter({
+		changeBroker: pgNotifyChangeBroker({
 			connectionString: env.DATABASE_URL,
 		}),
 	},
@@ -8989,16 +8995,12 @@ const { data } = useQuery(
 );
 ```
 
-Server realtime must be enabled. SSE is the default client transport; a normal Postgres URL auto-wires `pg_notify`, while setups without a push broker reconcile by polling every 2s. An explicit adapter can select a broker:
+Server realtime must be enabled. SSE is the default client transport; a normal Postgres URL auto-wires `PgNotifyChangeBroker`, while setups without a push broker reconcile by polling every 2s. No explicit transport is needed for the Postgres default:
 
 ```ts
-import { runtimeConfig } from "questpie/app";
-import { pgNotifyAdapter } from "questpie/adapters/pg-notify";
-
 export default runtimeConfig({
-	realtime: {
-		adapter: pgNotifyAdapter({ connectionString: process.env.DATABASE_URL }),
-	},
+	db: { url: process.env.DATABASE_URL! },
+	realtime: true,
 });
 ```
 

--- a/skills/questpie/references/infrastructure-adapters.md
+++ b/skills/questpie/references/infrastructure-adapters.md
@@ -255,7 +255,7 @@ handler: async ({ queue }) => {
 
 The realtime runtime writes its outbox row in the business transaction and always reconciles missed notices. `ChangeBroker` handles notice-only cross-instance wakes; `ClientTransport` handles already-authorized edge frames. SSE is the default client transport.
 
-With `realtime: true`, a normal Postgres URL auto-selects `pg_notify`; without a push broker, the outbox is polled every 2s. With push, reconciliation still runs every 15s so a lost wake cannot permanently stall subscribers.
+With `realtime: true`, a normal Postgres URL auto-selects `PgNotifyChangeBroker`; without a push broker, the outbox is polled every 2s. With push, reconciliation still runs every 15s so a lost outbox wake cannot permanently stall subscribers. Revisioned topology has its own durable `questpie_realtime_topology` state and one-second reconciliation, so a companion control request can land on any upgraded replica without sticky routing.
 
 ### pgNotify
 
@@ -263,13 +263,13 @@ Uses PostgreSQL `LISTEN/NOTIFY`. Every listening instance receives the same noti
 
 ```ts
 import { runtimeConfig } from "questpie/app";
-import { pgNotifyAdapter } from "questpie/adapters/pg-notify";
+import { pgNotifyChangeBroker } from "questpie/adapters/pg-notify";
 
 import env from "./env";
 
 export default runtimeConfig({
 	realtime: {
-		adapter: pgNotifyAdapter({
+		changeBroker: pgNotifyChangeBroker({
 			connectionString: env.DATABASE_URL,
 		}),
 	},
@@ -283,7 +283,7 @@ Takes a connected Redis-shaped `client` with `xAdd` and `xRead`, not a URL. Ever
 ```ts
 import { createClient } from "redis";
 import { runtimeConfig } from "questpie/app";
-import { redisStreamsAdapter } from "questpie/adapters/redis-streams";
+import { redisStreamsChangeBroker } from "questpie/adapters/redis-streams";
 
 import env from "./env";
 
@@ -292,7 +292,7 @@ await redis.connect();
 
 export default runtimeConfig({
 	realtime: {
-		adapter: redisStreamsAdapter({ client: redis }),
+		changeBroker: redisStreamsChangeBroker({ client: redis }),
 	},
 });
 ```
@@ -321,18 +321,20 @@ The preset supplies a notice-only Pusher `ChangeBroker` and a Pusher `ClientTran
 
 ### Cloudflare Durable Objects
 
-`cloudflareRealtimeAdapter()` is a notice-only broker for Workers. It shards Durable Objects by resource type and resource name, and notification work is attached to `waitUntil` so CRUD commits do not wait on the broker. The Worker still reads the durable outbox, re-runs access-controlled snapshots, and performs reconciliation.
+`cloudflareRealtimeAdapter()` is the deprecated 3.x `RealtimeAdapter` compatibility path for Workers. It shards Durable Objects by resource type and resource name, and notification work is attached to `waitUntil` so CRUD commits do not wait on the adapter. A dedicated v2 `ChangeBroker` replacement is not part of this release.
 
 ### When to Use Which
 
-| Selection                   | Use case                                                                  |
-| --------------------------- | ------------------------------------------------------------------------- |
-| Implicit pg + SSE           | Default Postgres deployment                                               |
-| Poll + SSE                  | Zero extra infrastructure without a push-capable database                 |
-| `pgNotifyAdapter` + SSE     | Explicit Postgres connection/channel                                      |
-| `redisStreamsAdapter` + SSE | Cross-instance Redis notice fan-out                                       |
-| `cloudflareRealtimeAdapter` | Cloudflare Workers notice fan-out through sharded Durable Objects         |
-| `pusherRealtime`            | Managed WebSockets, provider-native presence, and shared channel delivery |
+| Selection                        | Use case                                                                  |
+| -------------------------------- | ------------------------------------------------------------------------- |
+| Implicit pg + SSE                | Default Postgres deployment                                               |
+| Poll + SSE                       | Zero extra infrastructure without a push-capable database                 |
+| `pgNotifyChangeBroker` + SSE     | Explicit Postgres connection/channel                                      |
+| `redisStreamsChangeBroker` + SSE | Cross-instance Redis notice fan-out                                       |
+| `cloudflareRealtimeAdapter`      | Deprecated 3.x Cloudflare compatibility adapter                           |
+| `pusherRealtime`                 | Managed WebSockets, provider-native presence, and shared channel delivery |
+
+`RealtimeAdapter`, `realtime.adapter`, `pgNotifyAdapter`, and the `legacy`/`dual` rollout modes remain deprecated compatibility surfaces through QuestPie 3.x. Migrate to `changeBroker`; they are removed in QuestPie 4. Apply the generated `questpie_realtime_topology` migration before claiming cross-replica no-reconnect control.
 
 ## Search
 
@@ -770,7 +772,7 @@ const spec = generateOpenApiSpec(app, {
 import { createClient } from "redis";
 import { runtimeConfig } from "questpie/app";
 import { pgBossAdapter } from "questpie/adapters/pg-boss";
-import { pgNotifyAdapter } from "questpie/adapters/pg-notify";
+import { pgNotifyChangeBroker } from "questpie/adapters/pg-notify";
 import { redisKVAdapter } from "questpie/adapters/redis-kv";
 import { SmtpAdapter } from "questpie/adapters/smtp";
 import { s3 } from "files-sdk/s3";
@@ -804,7 +806,7 @@ export default runtimeConfig({
 		}),
 	},
 	realtime: {
-		adapter: pgNotifyAdapter({
+		changeBroker: pgNotifyChangeBroker({
 			connectionString: env.DATABASE_URL,
 		}),
 	},

--- a/skills/questpie/references/infrastructure-adapters.md
+++ b/skills/questpie/references/infrastructure-adapters.md
@@ -321,7 +321,7 @@ The preset supplies a notice-only Pusher `ChangeBroker` and a Pusher `ClientTran
 
 ### Cloudflare Durable Objects
 
-`cloudflareRealtimeAdapter()` is the deprecated 3.x `RealtimeAdapter` compatibility path for Workers. It shards Durable Objects by resource type and resource name, and notification work is attached to `waitUntil` so CRUD commits do not wait on the adapter. A dedicated v2 `ChangeBroker` replacement is not part of this release.
+Cloudflare Workers use a Durable Object fan-out path because they do not keep a long-lived process-local poller. Consult the Realtime v2 HA migration guide before selecting the QuestPie 3.x deployment path.
 
 ### When to Use Which
 
@@ -331,10 +331,9 @@ The preset supplies a notice-only Pusher `ChangeBroker` and a Pusher `ClientTran
 | Poll + SSE                       | Zero extra infrastructure without a push-capable database                 |
 | `pgNotifyChangeBroker` + SSE     | Explicit Postgres connection/channel                                      |
 | `redisStreamsChangeBroker` + SSE | Cross-instance Redis notice fan-out                                       |
-| `cloudflareRealtimeAdapter`      | Deprecated 3.x Cloudflare compatibility adapter                           |
 | `pusherRealtime`                 | Managed WebSockets, provider-native presence, and shared channel delivery |
 
-`RealtimeAdapter`, `realtime.adapter`, `pgNotifyAdapter`, and the `legacy`/`dual` rollout modes remain deprecated compatibility surfaces through QuestPie 3.x. Migrate to `changeBroker`; they are removed in QuestPie 4. Apply the generated `questpie_realtime_topology` migration before claiming cross-replica no-reconnect control.
+Apply the generated `questpie_realtime_topology` migration before claiming cross-replica no-reconnect control. Use the Realtime v2 HA migration guide for version-transition details.
 
 ## Search
 

--- a/skills/questpie/references/production.md
+++ b/skills/questpie/references/production.md
@@ -24,15 +24,15 @@ This skill builds on questpie-core. It is the **deployment/ops** doc: auth, acce
 
 QUESTPIE uses an adapter-based architecture for all infrastructure. Development defaults work out of the box; production requires explicit adapter configuration in `questpie.config.ts`.
 
-| Service  | Dev Default           | Production Adapter                            |
-| -------- | --------------------- | --------------------------------------------- |
-| Database | PostgreSQL (local)    | PostgreSQL (remote, SSL)                      |
-| Storage  | Local filesystem      | Files SDK provider adapter (`s3`, `r2`, etc.) |
-| Queue    | None (jobs skip)      | pg-boss (`pgBossAdapter`)                     |
-| Realtime | pgNotify              | Redis Streams (`redisStreamsAdapter`)         |
-| Email    | Console (logs output) | SMTP (`SmtpAdapter`)                          |
-| KV Store | In-memory             | Redis (`redisKVAdapter`)                      |
-| Logger   | Pino (console)        | Pino (structured JSON)                        |
+| Service  | Dev Default            | Production Adapter                            |
+| -------- | ---------------------- | --------------------------------------------- |
+| Database | PostgreSQL (local)     | PostgreSQL (remote, SSL)                      |
+| Storage  | Local filesystem       | Files SDK provider adapter (`s3`, `r2`, etc.) |
+| Queue    | None (jobs skip)       | pg-boss (`pgBossAdapter`)                     |
+| Realtime | `PgNotifyChangeBroker` | Redis Streams (`redisStreamsChangeBroker`)    |
+| Email    | Console (logs output)  | SMTP (`SmtpAdapter`)                          |
+| KV Store | In-memory              | Redis (`redisKVAdapter`)                      |
+| Logger   | Pino (console)         | Pino (structured JSON)                        |
 
 Every adapter's exact config shape lives in `references/infrastructure-adapters.md`.
 
@@ -128,9 +128,9 @@ Configure migration and seed directories in `questpie.config.ts` under `cli.migr
 
 All adapter config shapes, Storage (local, S3, R2), Queue (pg-boss, BullMQ), Realtime (pgNotify, Redis Streams), Email (SMTP, Console, Resend, Plunk), KV (Redis, custom), Logger, Search, and OpenAPI, live in **`references/infrastructure-adapters.md`**. Each is configured under `runtimeConfig({...})` in `questpie.config.ts`. The deployment-relevant constraints follow.
 
-- **Queue / pg-boss and Realtime / pgNotify** both rely on PostgreSQL `LISTEN/NOTIFY` and silently break behind PgBouncer in transaction pool mode. See [PgBouncer Compatibility](#pgbouncer-compatibility).
+- **Queue / pg-boss and Realtime / PgNotifyChangeBroker** both rely on PostgreSQL `LISTEN/NOTIFY` and silently break behind PgBouncer in transaction pool mode. See [PgBouncer Compatibility](#pgbouncer-compatibility).
 - **Cloudflare Workers** process queues push-based: use `cloudflareQueuesAdapter` from `questpie/adapters/cloudflare` and export the Worker via `createCloudflareWorkerHandlers`, do not run `app.queue.listen()` in a Worker.
-- **Multi-instance realtime** requires `redisStreamsAdapter`; a single instance can use `pgNotifyAdapter`.
+- **Multi-instance realtime** works with the default Postgres `PgNotifyChangeBroker` or an explicit Redis/Pusher/Cloudflare broker. Apply the generated topology migration before enabling HA control.
 
 ## PgBouncer Compatibility
 
@@ -140,25 +140,25 @@ Bun SQL (`new SQL({ url })`) already pools connections internally. In single-ins
 
 ### Adapter Compatibility Matrix
 
-| Adapter                          | Direct PG | PgBouncer (transaction)          | PgBouncer (session)         |
-| -------------------------------- | --------- | -------------------------------- | --------------------------- |
-| `pgNotifyAdapter` (realtime)     | works     | broken, listens silently dropped | works (pooling neutralized) |
-| `pgBossAdapter` (queue)          | works     | broken, LISTEN/NOTIFY required   | works (pooling neutralized) |
-| Drizzle queries via Bun SQL      | works     | works                            | works                       |
-| `redisStreamsAdapter` (realtime) | n/a       | n/a                              | n/a                         |
+| Adapter                               | Direct PG | PgBouncer (transaction)          | PgBouncer (session)         |
+| ------------------------------------- | --------- | -------------------------------- | --------------------------- |
+| `PgNotifyChangeBroker` (realtime)     | works     | broken, listens silently dropped | works (pooling neutralized) |
+| `pgBossAdapter` (queue)               | works     | broken, LISTEN/NOTIFY required   | works (pooling neutralized) |
+| Drizzle queries via Bun SQL           | works     | works                            | works                       |
+| `redisStreamsChangeBroker` (realtime) | n/a       | n/a                              | n/a                         |
 
 Prepared statements also break under transaction pooling. If you must use it, ensure your driver disables prepared statements end-to-end.
 
 ### DB Connection Routing
 
 - **Default and recommended:** direct connection to the PG primary. Bun SQL pools internally; you do not need PgBouncer.
-- **If you must use PgBouncer:** put it in `session` pool mode for any process that runs `pgBossAdapter` or `pgNotifyAdapter`. Session mode pins one server connection per client, which neutralizes pooling but keeps `LISTEN/NOTIFY` working.
+- **If you must use PgBouncer:** put it in `session` pool mode for any process that runs `pgBossAdapter` or `PgNotifyChangeBroker`. Session mode pins one server connection per client, which neutralizes pooling but keeps `LISTEN/NOTIFY` working.
 - **Split topology:** route web traffic through PgBouncer (transaction mode) and run workers (pgBoss, pgNotify) on a direct connection. This works, but realtime fired from web handlers still routes through the same `QUESTPIE_DB`, so realtime in web fails. In practice, going direct everywhere is simpler.
 - **TODO / current limitation:** the framework reads a single `QUESTPIE_DB` env var. There is no built-in split between a pooled URL and a direct URL for LISTEN consumers. Track this if you need a mixed topology.
 
 ## Realtime & SSE Keepalive
 
-SSE-based live updates fan out via the `POST /realtime` multiplexed endpoint. Adapter config (`pgNotifyAdapter`, `redisStreamsAdapter`) is in `references/infrastructure-adapters.md`.
+SSE-based live updates fan out via the `POST /realtime` multiplexed endpoint. Broker config (`pgNotifyChangeBroker`, Redis, Pusher, Cloudflare) is in `references/infrastructure-adapters.md`.
 
 ### SSE Keepalive & Timeouts
 
@@ -225,7 +225,7 @@ CMD ["bun", "run", ".output/server/index.mjs"]
 - Set `APP_URL` to your public domain
 - Enable HTTPS
 - Configure S3 or persistent storage for uploads
-- Use `redisStreamsAdapter` if running multiple instances
+- Use `redisStreamsChangeBroker` when Redis is the shared notice infrastructure
 - Set up health checks
 
 ### Health Check
@@ -314,7 +314,7 @@ queue: {
 
 ### HIGH: PgBouncer transaction pool with pgNotify/pgBoss
 
-Pointing `QUESTPIE_DB` at a PgBouncer in transaction pool mode silently breaks `pgNotifyAdapter` and `pgBossAdapter`. Both rely on PostgreSQL `LISTEN/NOTIFY`, which requires a persistent session. PgBouncer transaction pooling reassigns the session per-transaction, so the listener is dropped right after `LISTEN` returns.
+Pointing `QUESTPIE_DB` at a PgBouncer in transaction pool mode silently breaks `PgNotifyChangeBroker` and `pgBossAdapter`. Both rely on PostgreSQL `LISTEN/NOTIFY`, which requires a persistent session. PgBouncer transaction pooling reassigns the session per-transaction, so the listener is dropped right after `LISTEN` returns.
 
 Symptoms:
 
@@ -326,17 +326,17 @@ Fix:
 ```ts
 // WRONG -- QUESTPIE_DB points at PgBouncer (transaction mode)
 realtime: {
-	adapter: pgNotifyAdapter({ connectionString: env.QUESTPIE_DB });
+	changeBroker: pgNotifyChangeBroker({ connectionString: env.QUESTPIE_DB });
 }
 queue: {
 	adapter: pgBossAdapter({ connectionString: env.QUESTPIE_DB });
 }
 
 // CORRECT -- direct PG connection (Bun SQL pools internally), or switch
-// realtime to redisStreamsAdapter, which takes a connected redis client
+// realtime to redisStreamsChangeBroker, which takes a connected redis client
 // (not a URL) for multi-instance deployments:
 realtime: {
-	adapter: redisStreamsAdapter({ client: redis }); // see infrastructure-adapters.md
+	changeBroker: redisStreamsChangeBroker({ client: redis }); // see infrastructure-adapters.md
 }
 ```
 
@@ -344,7 +344,7 @@ If your infra mandates PgBouncer, use `session` pool mode for processes that run
 
 ## Realtime and Live Preview
 
-The realtime adapter (`pgNotifyAdapter` or `redisStreamsAdapter`) is relevant for **detached or shared preview sessions**, when the preview runs in a separate browser tab, or multiple collaborators view the same preview.
+The realtime broker (`PgNotifyChangeBroker` or `redisStreamsChangeBroker`) is relevant for **detached or shared preview sessions**, when the preview runs in a separate browser tab, or multiple collaborators view the same preview.
 
 For the default **same-tab preview**, realtime is NOT involved. Current same-tab preview uses `postMessage` for refresh/focus messages between the editor and the iframe.
 

--- a/skills/questpie/references/realtime.md
+++ b/skills/questpie/references/realtime.md
@@ -61,11 +61,11 @@ const { data } = useQuery(
 
 ## Transport selection
 
-SSE is the default `ClientTransport`; no browser transport config is required. With a normal Postgres URL the server auto-wires `PgNotifyChangeBroker`; otherwise it polls every 2s. Redis Streams and Pusher are supported v2 broker overrides. Cloudflare's adapter remains on the deprecated 3.x compatibility seam. A clean v2 configuration never needs both `RealtimeAdapter` and `ChangeBroker`.
+SSE is the default `ClientTransport`; no browser transport config is required. With a normal Postgres URL the server auto-wires `PgNotifyChangeBroker`; otherwise it polls every 2s. Redis Streams and Pusher are supported v2 broker overrides. A clean v2 configuration uses one `ChangeBroker`.
 
 Realtime topology is durable in `questpie_realtime_topology`. Complete desired topology uses monotonic revisions; a metadata-only broker wake lowers latency and one-second reconciliation heals dropped wakes. This makes companion control HA-safe without sticky routing after the migration is applied and every request-handling replica supports the advertised `questpie-realtime-topology` v1 capability.
 
-Before a production upgrade, run `bunx questpie migrate:create`, review and commit the generated migration, then run `bunx questpie migrate`. Never use `push` for this production schema change. `RealtimeAdapter`, `realtime.adapter`, `pgNotifyAdapter`, and `legacy`/`dual` rollout modes are deprecated in QuestPie 3.x and removed in QuestPie 4.
+Before a production upgrade, run `bunx questpie migrate:create`, review and commit the generated migration, then run `bunx questpie migrate`. Never use `push` for this production schema change. Use the Realtime v2 HA migration guide for the QuestPie 3.x transition and QuestPie 4 removal window.
 
 For managed WebSockets and native presence, select the isolated Pusher/Soketi preset:
 

--- a/skills/questpie/references/realtime.md
+++ b/skills/questpie/references/realtime.md
@@ -61,7 +61,11 @@ const { data } = useQuery(
 
 ## Transport selection
 
-SSE is the default `ClientTransport`; no browser transport config is required. With a normal Postgres URL the server auto-wires `pg_notify`; otherwise it polls every 2s. Explicit pg, Redis, and Cloudflare adapters remain supported as notice brokers.
+SSE is the default `ClientTransport`; no browser transport config is required. With a normal Postgres URL the server auto-wires `PgNotifyChangeBroker`; otherwise it polls every 2s. Redis Streams and Pusher are supported v2 broker overrides. Cloudflare's adapter remains on the deprecated 3.x compatibility seam. A clean v2 configuration never needs both `RealtimeAdapter` and `ChangeBroker`.
+
+Realtime topology is durable in `questpie_realtime_topology`. Complete desired topology uses monotonic revisions; a metadata-only broker wake lowers latency and one-second reconciliation heals dropped wakes. This makes companion control HA-safe without sticky routing after the migration is applied and every request-handling replica supports the advertised `questpie-realtime-topology` v1 capability.
+
+Before a production upgrade, run `bunx questpie migrate:create`, review and commit the generated migration, then run `bunx questpie migrate`. Never use `push` for this production schema change. `RealtimeAdapter`, `realtime.adapter`, `pgNotifyAdapter`, and `legacy`/`dual` rollout modes are deprecated in QuestPie 3.x and removed in QuestPie 4.
 
 For managed WebSockets and native presence, select the isolated Pusher/Soketi preset:
 

--- a/skills/questpie/references/tanstack-query.md
+++ b/skills/questpie/references/tanstack-query.md
@@ -422,16 +422,12 @@ const { data } = useQuery(
 );
 ```
 
-Server realtime must be enabled. SSE is the default client transport; a normal Postgres URL auto-wires `pg_notify`, while setups without a push broker reconcile by polling every 2s. An explicit adapter can select a broker:
+Server realtime must be enabled. SSE is the default client transport; a normal Postgres URL auto-wires `PgNotifyChangeBroker`, while setups without a push broker reconcile by polling every 2s. No explicit transport is needed for the Postgres default:
 
 ```ts
-import { runtimeConfig } from "questpie/app";
-import { pgNotifyAdapter } from "questpie/adapters/pg-notify";
-
 export default runtimeConfig({
-	realtime: {
-		adapter: pgNotifyAdapter({ connectionString: process.env.DATABASE_URL }),
-	},
+	db: { url: process.env.DATABASE_URL! },
+	realtime: true,
 });
 ```
 


### PR DESCRIPTION
## Summary

- replace process-local realtime companion control with durable desired-topology coordination backed by Postgres leases, fencing, revisions, metadata-only broker wakes, and reconciliation
- propagate safe subscriber-scoped `REALTIME_TOPIC_REJECTED` admission failures through SSE/Pusher multiplexers and make TanStack live queries enter a visible non-retryable error state
- add bounded topology/admission observability, Postgres and Redis v2 broker coverage, migration assertions, multi-instance HA tests, and rollout documentation

## Why

Realtime v2 incremental `add_topic` / `remove_topic` control previously depended on the process that owned the live stream. A control request routed to another replica could not find the callback, forcing reconnects or temporary sticky affinity.

A confirmed Jubli production capture also showed a separate compatibility case: session establishment and snapshots were healthy, while realtime `find` topics requested limits above the framework default `maxFindLimit = 100`. The framework correctly rejected those topics. This PR keeps the default at 100 and does not clamp or split queries; it makes the correct rejection safe, observable, subscriber-scoped, and non-retryable. Jubli query topology is outside this PR.

## Contract decisions

- `maxFindLimit` remains 100 per realtime snapshot.
- No automatic clamp or query splitting.
- Durable coordinator state contains topology metadata only; live sinks and authorization context stay process-local.
- Generic KV is not the coordinator contract.
- Sticky affinity remains a temporary rollout aid and must be removed after cross-pod rollout verification.
- An invalidation-only realtime mode requires a separate spec and is not implemented here.

## Validation

- `bun test --cwd packages/questpie`: 2082 pass, 5 explicit external-infrastructure skips, 0 fail
- `bun run check-types`: 16/16 workspaces
- `bun run build`: 19/19 workspaces
- docs validation: 0 errors, 0 warnings
- changed-source oxlint: 0 errors
- changed-source oxfmt and `git diff --check`: clean
- focused HA/admission/client/coordinator/observability suites and generated migration assertions: green

Repository-wide lint and format checks still report unrelated baseline debt (87 lint errors / 1460 warnings and 466 formatting files). The files in this realtime series pass their scoped gates.

## Release and rollout

- includes `.changeset/tidy-rivers-coordinate.md` for a minor fixed-group release
- production must apply the generated `questpie_realtime_topology` migration with `questpie migrate`; `push` is not a production rollout mechanism
- rollout verification must exercise initial connect, cross-pod `add_topic` / `remove_topic`, reconnect/resume, lease expiry, bounded cleanup, and admission telemetry before sticky affinity is removed
- no Jubli application change is included or claimed
