### PR TITLE
fix(realtime): harden foundation coordination and delivery

### DIFF
--- a/.changeset/tidy-realtime-storms.md
+++ b/.changeset/tidy-realtime-storms.md
@@ -1,0 +1,10 @@
+---
+"questpie": patch
+---
+
+Harden PostgreSQL realtime coordination and storage.
+
+- Bound and coalesce topology reconciliation work while exposing terminal reconcile outcomes.
+- Fence superseded reconnect streams so admission slots cannot leak or be reused to bypass per-principal limits.
+- Recover pg-notify listeners cleanly after a PostgreSQL connection terminates, and bound serialized NOTIFY work across shutdown.
+- Store realtime payloads, presence data, and desired topology as native JSONB with Bun SQL.

--- a/packages/questpie/src/client/realtime/multiplexer.ts
+++ b/packages/questpie/src/client/realtime/multiplexer.ts
@@ -146,6 +146,39 @@ export function realtimeTopicId(topic: TopicConfig): string {
 }
 
 // ============================================================================
+// Connection identity
+// ============================================================================
+
+const CONNECTION_ID_STORAGE_KEY = "questpie-realtime-connection-id";
+
+/**
+ * A per-tab-stable connection id. The server's admission registry reclaims the
+ * prior slot for the same id, so a tab that reconnects (ping watchdog), hot-
+ * reloads, or refreshes reoccupies its ONE connection slot instead of leaking a
+ * fresh one each time and eventually tripping the per-principal cap while dead
+ * streams still hold it. Persisted in sessionStorage so a reload/HMR reuses the
+ * same id; falls back to a per-instance token when storage or crypto is
+ * unavailable (SSR / privacy mode / non-browser tests).
+ */
+export function resolveRealtimeConnectionId(random: () => number = Math.random): string {
+	const generate = () =>
+		typeof globalThis.crypto?.randomUUID === "function"
+			? globalThis.crypto.randomUUID()
+			: `c-${Math.floor(random() * 1e9).toString(36)}-${Math.floor(random() * 1e9).toString(36)}`;
+	try {
+		const storage = globalThis.sessionStorage;
+		if (!storage) return generate();
+		const stored = storage.getItem(CONNECTION_ID_STORAGE_KEY);
+		if (stored) return stored;
+		const id = generate();
+		storage.setItem(CONNECTION_ID_STORAGE_KEY, id);
+		return id;
+	} catch {
+		return generate();
+	}
+}
+
+// ============================================================================
 // Multiplexer
 // ============================================================================
 
@@ -172,6 +205,7 @@ export class RealtimeMultiplexer implements RealtimeClientTransport {
 	private readonly maxRetryMs: number;
 	private readonly pingWatchdogMs: number;
 	private readonly random: () => number;
+	private readonly connectionId: string;
 
 	constructor(
 		private baseUrl: string,
@@ -188,6 +222,7 @@ export class RealtimeMultiplexer implements RealtimeClientTransport {
 		this.maxRetryMs = runtime.maxRetryMs ?? 30_000;
 		this.pingWatchdogMs = runtime.pingWatchdogMs ?? 25_000;
 		this.random = runtime.random ?? Math.random;
+		this.connectionId = resolveRealtimeConnectionId(this.random);
 	}
 
 	/**
@@ -453,7 +488,10 @@ export class RealtimeMultiplexer implements RealtimeClientTransport {
 			const response = await this.fetcher(`${this.baseUrl}/realtime`, {
 				method: "POST",
 				headers: { "Content-Type": "application/json", ...authHeaders },
-				body: JSON.stringify({ topics: getTopicsPayload() }),
+				body: JSON.stringify({
+					topics: getTopicsPayload(),
+					connectionId: this.connectionId,
+				}),
 				credentials: this.withCredentials ? "include" : "omit",
 				signal: this.abortController.signal,
 			});

--- a/packages/questpie/src/server/adapters/routes/realtime.ts
+++ b/packages/questpie/src/server/adapters/routes/realtime.ts
@@ -514,6 +514,9 @@ export async function realtimeSubscribe(
 		sessionId?: string;
 		token?: string;
 		topology?: RealtimeDesiredTopology;
+		// Stable per-tab id the multiplexer reuses across reconnects/hot-reloads so
+		// admission can reclaim this connection's prior slot instead of leaking it.
+		connectionId?: string;
 	};
 	try {
 		body = await request.json();
@@ -918,6 +921,7 @@ export async function realtimeSubscribe(
 	);
 	const releaseConnection = admissionRegistry.acquire(
 		realtimePrincipalKey(resolved.appContext),
+		typeof body.connectionId === "string" ? body.connectionId : null,
 	);
 	if (!releaseConnection) {
 		observeAdmission("connection_limit");
@@ -993,6 +997,7 @@ export async function realtimeSubscribe(
 				topicUnsubscribers.clear();
 				void activeSink.close("normal").catch(() => {});
 			};
+			releaseConnection.setClose(close);
 			const teardownTopic = (topicId: string) => {
 				const unsubscribe = topicUnsubscribers.get(topicId);
 				if (!unsubscribe) return;
@@ -1213,6 +1218,7 @@ export async function realtimeSubscribe(
 					channelUnsubscribers.clear();
 					void transport?.stop().catch(() => {});
 				};
+				releaseConnection.setClose(close);
 				closeStream = close;
 				if (closeRequested || streamCancelled || request.signal.aborted) {
 					close();

--- a/packages/questpie/src/server/modules/core/integrated/realtime/adapters/pg-notify.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/adapters/pg-notify.ts
@@ -28,6 +28,7 @@ type PgNotifyDriverState = "connected" | "disconnected";
 type ChangeBrokerStartInput = Parameters<ChangeBroker["start"]>[0];
 
 const PG_NOTIFY_MAX_PAYLOAD_BYTES = 8_000;
+const PG_NOTIFY_MAX_PENDING_PUBLISHES = 256;
 
 class PgNotifyDriver {
 	private listenerClient: Client | null = null;
@@ -57,6 +58,8 @@ class PgNotifyDriver {
 	private listenerEndHandler?: () => void;
 	private publisherErrorHandler?: (error: Error) => void;
 	private publisherEndHandler?: () => void;
+	private publishChain: Promise<void> = Promise.resolve();
+	private pendingPublishes = 0;
 
 	constructor(options: PgNotifyDriverOptions = {}) {
 		this.channel = options.channel ?? "questpie_realtime";
@@ -136,6 +139,10 @@ class PgNotifyDriver {
 			clearTimeout(this.reconnectTimer);
 			this.reconnectTimer = null;
 		}
+		// Let the currently executing publish finish and cancel queued publishes
+		// before capturing/closing clients. No queued task may create a new client
+		// after shutdown has started.
+		await this.publishChain;
 		const wasStarted = this.started;
 		this.started = false;
 		const listenerClient = this.listenerClient;
@@ -201,13 +208,34 @@ class PgNotifyDriver {
 			this.reportError("payload", error);
 			throw error;
 		}
-		const client = await this.ensurePublisherClient();
-		await this.ensurePublisherConnected(client);
-		try {
+		if (this.stopping) throw new Error("pg-notify driver is stopping");
+		if (this.pendingPublishes >= PG_NOTIFY_MAX_PENDING_PUBLISHES) {
+			const error = new Error(
+				`pg-notify publish queue is full (${PG_NOTIFY_MAX_PENDING_PUBLISHES})`,
+			);
+			this.reportError("publish_queue", error);
+			throw error;
+		}
+		this.pendingPublishes += 1;
+		// Serialize NOTIFY queries on the dedicated publisher connection. The
+		// bounded queue protects memory during a burst; durable outbox polling
+		// remains the recovery path if admission rejects a notice.
+		const run = async () => {
+			if (this.stopping) throw new Error("pg-notify driver is stopping");
+			const client = await this.ensurePublisherClient();
+			await this.ensurePublisherConnected(client);
+			if (this.stopping) throw new Error("pg-notify driver is stopping");
 			await client.query("select pg_notify($1, $2)", [this.channel, payload]);
+		};
+		const settled = this.publishChain.then(run, run);
+		this.publishChain = settled.catch(() => {});
+		try {
+			await settled;
 		} catch (error) {
 			this.reportError("notify", error);
 			throw error;
+		} finally {
+			this.pendingPublishes -= 1;
 		}
 	}
 
@@ -292,8 +320,16 @@ class PgNotifyDriver {
 			client.off("notification", this.notificationHandler);
 			this.notificationHandler = undefined;
 		}
-		this.detachListenerLifecycle(client);
-		if (this.ownsListenerClient) this.listenerClient = null;
+		if (this.ownsListenerClient) {
+			// A fatal node-postgres disconnect may emit more than one lifecycle
+			// event before the old client fully closes. Keep its handlers attached
+			// so those follow-up errors cannot become unhandled process errors; the
+			// identity guard makes them no-ops after the replacement client is set.
+			this.listenerClient = null;
+			void client.end().catch(() => {});
+		} else {
+			this.detachListenerLifecycle(client);
+		}
 		if (error) this.reportError("listener", error);
 		this.emitState("disconnected");
 		this.scheduleReconnect();

--- a/packages/questpie/src/server/modules/core/integrated/realtime/admission.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/admission.ts
@@ -156,24 +156,84 @@ export function admitRealtimeTopic<TTopic extends AdmissionTopic>(
 	return { accepted: true, topic: { ...topic, limit } };
 }
 
+type AdmissionSlot = {
+	released: boolean;
+	superseded: boolean;
+	close?: () => void;
+};
+
+export type RealtimeAdmissionRelease = (() => void) & {
+	setClose: (close: () => void) => void;
+};
+
+function noopAdmissionRelease(): RealtimeAdmissionRelease {
+	const release = (() => {}) as RealtimeAdmissionRelease;
+	release.setClose = () => {};
+	return release;
+}
+
 export class RealtimeAdmissionRegistry {
-	private readonly counts = new Map<string, number>();
+	// principalKey -> (slotKey -> slot). One live connection per slot. A slot keyed
+	// by the client's connectionId is REPLACED when that same connection reconnects
+	// (ping watchdog, hot-reload, refresh), so a reconnecting tab reoccupies its
+	// single slot instead of leaking a fresh one on every reconnect and eventually
+	// exhausting the per-principal cap while old, already-dead streams still hold it.
+	private readonly principals = new Map<string, Map<string, AdmissionSlot>>();
+	// Connections that supply no id each occupy their own slot (the pre-reclaim
+	// behavior); a monotonic counter keeps those keys distinct.
+	private anonymousSeq = 0;
 
 	constructor(private readonly maximum: number) {}
 
-	acquire(principalKey: string | null): (() => void) | null {
-		if (principalKey === null) return () => {};
-		const count = this.counts.get(principalKey) ?? 0;
-		if (count >= this.maximum) return null;
-		this.counts.set(principalKey, count + 1);
-		let released = false;
-		return () => {
-			if (released) return;
-			released = true;
-			const next = (this.counts.get(principalKey) ?? 1) - 1;
-			if (next === 0) this.counts.delete(principalKey);
-			else this.counts.set(principalKey, next);
+	acquire(
+		principalKey: string | null,
+		connectionId?: string | null,
+	): RealtimeAdmissionRelease | null {
+		if (principalKey === null) return noopAdmissionRelease();
+		let slots = this.principals.get(principalKey);
+		if (!slots) {
+			slots = new Map<string, AdmissionSlot>();
+			this.principals.set(principalKey, slots);
+		}
+
+		const validConnectionId =
+			typeof connectionId === "string" &&
+			/^[A-Za-z0-9_-]{1,128}$/.test(connectionId);
+		const slotKey = validConnectionId
+			? `id:${connectionId}`
+			: `anon:${(this.anonymousSeq += 1)}`;
+
+		// Fence and actively close the prior stream before its slot is reused.
+		// Replacing only the counter would allow arbitrarily many live streams to
+		// share one client-controlled id while counting as one.
+		const prior = slots.get(slotKey);
+		if (prior) {
+			prior.superseded = true;
+			prior.released = true;
+			slots.delete(slotKey);
+			prior.close?.();
+		}
+
+		if (slots.size >= this.maximum) return null;
+
+		const slot: AdmissionSlot = { released: false, superseded: false };
+		slots.set(slotKey, slot);
+		const release = (() => {
+			if (slot.released) return;
+			slot.released = true;
+			// Only vacate the cell if THIS slot still occupies it: a reconnect may
+			// have already replaced it, and this release must not evict the new slot.
+			const current = this.principals.get(principalKey);
+			if (current?.get(slotKey) === slot) {
+				current.delete(slotKey);
+					if (current.size === 0) this.principals.delete(principalKey);
+				}
+		}) as RealtimeAdmissionRelease;
+		release.setClose = (close) => {
+			slot.close = close;
+			if (slot.superseded) close();
 		};
+		return release;
 	}
 }
 

--- a/packages/questpie/src/server/modules/core/integrated/realtime/collection.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/collection.ts
@@ -1,9 +1,9 @@
 import {
 	bigint,
 	bigserial,
+	customType,
 	index,
 	integer,
-	jsonb,
 	pgTable,
 	primaryKey,
 	text,
@@ -12,6 +12,29 @@ import {
 } from "drizzle-orm/pg-core";
 
 import { systemTimestamp } from "#questpie/server/db/system-columns.js";
+
+class JsonDriverValue {
+	constructor(private readonly value: unknown) {}
+
+	toJSON(): unknown {
+		return this.value;
+	}
+
+	toPostgres(): string {
+		return JSON.stringify(this.value);
+	}
+}
+
+const jsonbSafe = customType<{ data: unknown; driverData: unknown }>({
+	dataType: () => "jsonb",
+	// Keep Bun SQL from inferring primitive/array PostgreSQL parameter types while
+	// still allowing each driver to serialize the JSON value exactly once.
+	toDriver: (value) => new JsonDriverValue(value),
+	// Bun SQL, PGlite, and node-postgres already decode native jsonb values.
+	// Parsing strings again corrupts legitimate JSON-looking string payloads
+	// ("123" -> 123, "true" -> true, and so on).
+	fromDriver: (value) => value,
+});
 
 /**
  * Realtime outbox log table
@@ -26,7 +49,7 @@ export const questpieRealtimeLogTable = pgTable(
 		operation: text("operation").notNull(),
 		recordId: text("record_id"),
 		locale: text("locale"),
-		payload: jsonb("payload").default({}),
+		payload: jsonbSafe("payload").default({}),
 		createdAt: systemTimestamp("created_at").defaultNow().notNull(),
 	},
 	(t) => [index("idx_realtime_log_created_at").on(t.createdAt)],
@@ -50,7 +73,7 @@ export const questpieChannelEventTable = pgTable(
 		channel: text("channel").notNull(),
 		event: text("event").notNull(),
 		schemaIdentity: text("schema_identity").notNull(),
-		payload: jsonb("payload").notNull(),
+		payload: jsonbSafe("payload").notNull(),
 		sizeBytes: integer("size_bytes").notNull(),
 		createdAt: systemTimestamp("created_at").defaultNow().notNull(),
 	},
@@ -86,7 +109,7 @@ export const questpieChannelPresenceTable = pgTable(
 		connectionId: text("connection_id").notNull(),
 		principalId: text("principal_id").notNull(),
 		channel: text("channel").notNull(),
-		data: jsonb("data").notNull(),
+		data: jsonbSafe("data").notNull(),
 		expiresAt: timestamp("expires_at", {
 			withTimezone: true,
 			mode: "date",
@@ -122,7 +145,7 @@ export const questpieRealtimeTopologyTable = pgTable(
 		appliedRevision: bigint("applied_revision", { mode: "number" })
 			.default(0)
 			.notNull(),
-		desiredTopology: jsonb("desired_topology").notNull(),
+		desiredTopology: jsonbSafe("desired_topology").notNull(),
 		createdAt: systemTimestamp("created_at").defaultNow().notNull(),
 		updatedAt: systemTimestamp("updated_at").defaultNow().notNull(),
 	},

--- a/packages/questpie/src/server/modules/core/integrated/realtime/observer.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/observer.ts
@@ -92,6 +92,7 @@ export type RealtimeObservation =
 				| "invalid"
 				| "unavailable"
 				| "started"
+				| "current"
 				| "applied"
 				| "failed"
 				| "expired"

--- a/packages/questpie/src/server/modules/core/integrated/realtime/service.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/service.ts
@@ -213,6 +213,7 @@ export class RealtimeService {
 			this.db,
 			{
 				broker: this.changeBroker,
+				reconcileMs: this.configuredPollIntervalMs,
 				observer: this.observability,
 				onError: (error) =>
 					this.reportTransportFailure(
@@ -625,6 +626,7 @@ export class RealtimeService {
 	private setReconciliationPollInterval(intervalMs: number): void {
 		if (this.pollIntervalMs === intervalMs) return;
 		this.pollIntervalMs = intervalMs;
+		this.topologyCoordinator.setReconciliationPollInterval(intervalMs);
 		if (this.channelPollTimer) {
 			clearInterval(this.channelPollTimer);
 			this.channelPollTimer = null;

--- a/packages/questpie/src/server/modules/core/integrated/realtime/topology-coordinator.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/topology-coordinator.ts
@@ -10,6 +10,7 @@ import type { ChangeBroker, ChangeWake } from "./transport.js";
 
 export const REALTIME_TOPOLOGY_PROTOCOL = "questpie-realtime-topology" as const;
 export const MAX_REALTIME_TOPOLOGY_BYTES = 262_144;
+const DEFAULT_RECONCILIATION_INTERVAL_MS = 15_000;
 
 export type RealtimeTopologyTopic = {
 	id: string;
@@ -501,6 +502,8 @@ type LocalHandler = {
 	apply: (topology: RealtimeDesiredTopology) => Promise<void>;
 	onClose: () => Promise<void> | void;
 	operation: Promise<void>;
+	reconciling: boolean;
+	reconcilePending: boolean;
 };
 
 export class RealtimeTopologyCoordinator {
@@ -508,12 +511,13 @@ export class RealtimeTopologyCoordinator {
 	private readonly broker?: ChangeBroker;
 	private readonly leaseMs: number;
 	private readonly heartbeatMs: number;
-	private readonly reconcileMs: number;
+	private reconcileMs: number;
 	private readonly onError: (error: unknown) => void;
 	private readonly observer?: RealtimeObserver;
 	private readonly handlers = new Map<string, LocalHandler>();
 	private heartbeatTimer?: ReturnType<typeof setInterval>;
 	private reconcileTimer?: ReturnType<typeof setInterval>;
+	private reconcileOperation: Promise<void> | null = null;
 	private started = false;
 
 	constructor(
@@ -533,7 +537,8 @@ export class RealtimeTopologyCoordinator {
 		this.broker = options.broker;
 		this.leaseMs = options.leaseMs ?? 30_000;
 		this.heartbeatMs = options.heartbeatMs ?? 10_000;
-		this.reconcileMs = options.reconcileMs ?? 1_000;
+		this.reconcileMs =
+			options.reconcileMs ?? DEFAULT_RECONCILIATION_INTERVAL_MS;
 		this.onError = options.onError ?? (() => {});
 		this.observer = options.observer;
 	}
@@ -555,12 +560,23 @@ export class RealtimeTopologyCoordinator {
 				this.heartbeatMs,
 			);
 		}
-		if (this.reconcileMs > 0) {
-			this.reconcileTimer = setInterval(
-				() => void this.reconcile().catch(this.onError),
-				this.reconcileMs,
-			);
-		}
+		this.startReconcileTimer();
+	}
+
+	setReconciliationPollInterval(intervalMs: number): void {
+		if (this.reconcileMs === intervalMs) return;
+		this.reconcileMs = intervalMs;
+		if (this.reconcileTimer) clearInterval(this.reconcileTimer);
+		this.reconcileTimer = undefined;
+		this.startReconcileTimer();
+	}
+
+	private startReconcileTimer(): void {
+		if (!this.started || this.reconcileMs <= 0 || this.reconcileTimer) return;
+		this.reconcileTimer = setInterval(
+			() => void this.reconcile().catch(this.onError),
+			this.reconcileMs,
+		);
 	}
 
 	async open(input: {
@@ -588,6 +604,8 @@ export class RealtimeTopologyCoordinator {
 			apply: input.apply,
 			onClose: input.onClose,
 			operation: Promise.resolve(),
+			reconciling: false,
+			reconcilePending: false,
 		});
 		this.observe({
 			type: "topology.lifecycle",
@@ -698,77 +716,160 @@ export class RealtimeTopologyCoordinator {
 	}
 
 	async reconcile(): Promise<void> {
-		await Promise.all(
-			[...this.handlers.keys()].map((key) => this.reconcileSession(key)),
-		);
-		await this.store.cleanupExpired();
+		if (this.reconcileOperation) return this.reconcileOperation;
+		this.reconcileOperation = (async () => {
+			await Promise.all(
+				[...this.handlers.keys()].map((key) => this.reconcileSession(key)),
+			);
+			await this.store.cleanupExpired();
+		})().finally(() => {
+			this.reconcileOperation = null;
+		});
+		return this.reconcileOperation;
 	}
 
 	private async reconcileSession(sessionKey: string): Promise<void> {
 		const handler = this.handlers.get(sessionKey);
 		if (!handler) return;
+		if (handler.reconciling) {
+			handler.reconcilePending = true;
+			await handler.operation;
+			return;
+		}
+		handler.reconciling = true;
 		handler.operation = handler.operation
 			.catch(() => {})
 			.then(async () => {
-				this.observe({
-					type: "topology.lifecycle",
-					phase: "reconcile",
-					outcome: "started",
-				});
-				const row = await this.store.getOwned({
-					sessionKey,
-					ownerId: this.ownerId,
-					ownerGeneration: handler.generation,
-				});
-				if (!row) {
-					this.observe({
-						type: "topology.lifecycle",
-						phase: "lease",
-						outcome: "expired",
-					});
-					await this.closeLocal(sessionKey, false, true);
-					return;
-				}
-				if (row.desiredRevision <= handler.appliedRevision) return;
-				try {
-					await handler.apply(row.desiredTopology);
-				} catch (error) {
-					this.observe({
-						type: "topology.lifecycle",
-						phase: "apply",
-						outcome: "failed",
-						desiredRevision: row.desiredRevision,
-						appliedRevision: handler.appliedRevision,
-					});
-					this.onError(error);
-					await this.closeLocal(sessionKey, true, true);
-					return;
-				}
-				const marked = await this.store.markApplied({
-					sessionKey,
-					ownerId: this.ownerId,
-					ownerGeneration: handler.generation,
-					revision: row.desiredRevision,
-				});
-				if (!marked) {
-					this.observe({
-						type: "topology.lifecycle",
-						phase: "apply",
-						outcome: "fenced",
-					});
-					await this.closeLocal(sessionKey, false, true);
-					return;
-				}
-				handler.appliedRevision = row.desiredRevision;
-				this.observe({
-					type: "topology.lifecycle",
-					phase: "apply",
-					outcome: "applied",
-					desiredRevision: row.desiredRevision,
-					appliedRevision: row.desiredRevision,
-				});
+				do {
+					handler.reconcilePending = false;
+					await this.runReconcileSession(sessionKey, handler);
+				} while (
+					handler.reconcilePending &&
+					this.handlers.get(sessionKey) === handler
+				);
+			})
+			.finally(() => {
+				handler.reconciling = false;
 			});
 		await handler.operation;
+	}
+
+	private async runReconcileSession(
+		sessionKey: string,
+		handler: LocalHandler,
+	): Promise<void> {
+		this.observe({
+			type: "topology.lifecycle",
+			phase: "reconcile",
+			outcome: "started",
+		});
+		let row: TopologyRow | null;
+		try {
+			row = await this.store.getOwned({
+				sessionKey,
+				ownerId: this.ownerId,
+				ownerGeneration: handler.generation,
+			});
+		} catch (error) {
+			this.observe({
+				type: "topology.lifecycle",
+				phase: "reconcile",
+				outcome: "failed",
+			});
+			throw error;
+		}
+		if (!row) {
+			this.observe({
+				type: "topology.lifecycle",
+				phase: "reconcile",
+				outcome: "expired",
+			});
+			this.observe({
+				type: "topology.lifecycle",
+				phase: "lease",
+				outcome: "expired",
+			});
+			await this.closeLocal(sessionKey, false, true);
+			return;
+		}
+		if (row.desiredRevision <= handler.appliedRevision) {
+			this.observe({
+				type: "topology.lifecycle",
+				phase: "reconcile",
+				outcome: "current",
+				desiredRevision: row.desiredRevision,
+				appliedRevision: handler.appliedRevision,
+			});
+			return;
+		}
+		try {
+			await handler.apply(row.desiredTopology);
+		} catch (error) {
+			this.observe({
+				type: "topology.lifecycle",
+				phase: "apply",
+				outcome: "failed",
+				desiredRevision: row.desiredRevision,
+				appliedRevision: handler.appliedRevision,
+			});
+			this.observe({
+				type: "topology.lifecycle",
+				phase: "reconcile",
+				outcome: "failed",
+				desiredRevision: row.desiredRevision,
+				appliedRevision: handler.appliedRevision,
+			});
+			this.onError(error);
+			await this.closeLocal(sessionKey, true, true);
+			return;
+		}
+		let marked: boolean;
+		try {
+			marked = await this.store.markApplied({
+				sessionKey,
+				ownerId: this.ownerId,
+				ownerGeneration: handler.generation,
+				revision: row.desiredRevision,
+			});
+		} catch (error) {
+			this.observe({
+				type: "topology.lifecycle",
+				phase: "reconcile",
+				outcome: "failed",
+				desiredRevision: row.desiredRevision,
+				appliedRevision: handler.appliedRevision,
+			});
+			throw error;
+		}
+		if (!marked) {
+			this.observe({
+				type: "topology.lifecycle",
+				phase: "apply",
+				outcome: "fenced",
+			});
+			this.observe({
+				type: "topology.lifecycle",
+				phase: "reconcile",
+				outcome: "fenced",
+			});
+			await this.closeLocal(sessionKey, false, true);
+			return;
+		}
+		handler.appliedRevision = row.desiredRevision;
+		this.observe({
+			type: "topology.lifecycle",
+			phase: "apply",
+			outcome: "applied",
+			desiredRevision: row.desiredRevision,
+			appliedRevision: row.desiredRevision,
+		});
+		this.observe({
+			type: "topology.lifecycle",
+			phase: "reconcile",
+			outcome: "applied",
+			desiredRevision: row.desiredRevision,
+			appliedRevision: row.desiredRevision,
+		});
 	}
 
 	private async heartbeat(): Promise<void> {

--- a/packages/questpie/test/client/realtime-connection-id.test.ts
+++ b/packages/questpie/test/client/realtime-connection-id.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, it } from "bun:test";
+
+import {
+	RealtimeMultiplexer,
+	resolveRealtimeConnectionId,
+} from "../../src/client/realtime/multiplexer";
+
+type Mutable = Record<string, unknown>;
+const originalSessionStorage = (globalThis as Mutable).sessionStorage;
+
+afterEach(() => {
+	(globalThis as Mutable).sessionStorage = originalSessionStorage;
+});
+
+describe("realtime connection identity", () => {
+	it("generates a non-empty id and stays stable per tab via sessionStorage", () => {
+		// No sessionStorage (server / privacy mode) → a fresh, non-empty id.
+		const generated = resolveRealtimeConnectionId(() => 0.42);
+		expect(typeof generated).toBe("string");
+		expect(generated.length).toBeGreaterThan(0);
+
+		// With sessionStorage → the SAME id every call, so a tab that hot-reloads or
+		// refreshes (a NEW multiplexer instance) reuses its id and the server reclaims
+		// its prior admission slot instead of leaking a fresh one.
+		const store = new Map<string, string>();
+		(globalThis as Mutable).sessionStorage = {
+			getItem: (key: string) => store.get(key) ?? null,
+			setItem: (key: string, value: string) => void store.set(key, value),
+		};
+		const first = resolveRealtimeConnectionId();
+		const second = resolveRealtimeConnectionId();
+		expect(first).toBe(second);
+		expect(store.size).toBe(1);
+	});
+
+	it("sends its connectionId on the initial connect POST", async () => {
+		const bodies: Array<{ topics?: unknown; connectionId?: unknown }> = [];
+		const fetcher = ((_url: string, init?: RequestInit) => {
+			bodies.push(JSON.parse(String(init?.body)));
+			// A stream that stays open until the request signal aborts keeps connect()
+			// parked in readStream; we only need the POST body captured, then destroy()
+			// aborts it and the stream closes cleanly (no dangling promise).
+			const signal = init?.signal;
+			return Promise.resolve(
+				new Response(
+					new ReadableStream<Uint8Array>({
+						start(controller) {
+							if (!signal) return;
+							if (signal.aborted) return void controller.close();
+							signal.addEventListener(
+								"abort",
+								() => {
+									try {
+										controller.close();
+									} catch {
+										// Already closed by the runtime.
+									}
+								},
+								{ once: true },
+							);
+						},
+					}),
+					{ status: 200, headers: { "content-type": "text/event-stream" } },
+				),
+			);
+		}) as unknown as typeof fetch;
+
+		const mux = new RealtimeMultiplexer(
+			"http://localhost/api",
+			true,
+			0,
+			{},
+			undefined,
+			fetcher,
+		);
+		mux.subscribe({ resourceType: "collection", resource: "posts" }, () => {});
+		await new Promise((resolve) => setTimeout(resolve, 25));
+		mux.destroy();
+
+		expect(bodies.length).toBeGreaterThan(0);
+		expect(Array.isArray(bodies[0]?.topics)).toBe(true);
+		expect(typeof bodies[0]?.connectionId).toBe("string");
+		expect((bodies[0]?.connectionId as string).length).toBeGreaterThan(0);
+	});
+});

--- a/packages/questpie/test/integration/realtime-driver-services.test.ts
+++ b/packages/questpie/test/integration/realtime-driver-services.test.ts
@@ -1,16 +1,24 @@
 import { afterEach, describe, expect, test } from "bun:test";
 
+import { SQL } from "bun";
+import { sql } from "drizzle-orm";
+import { Client as PgClient } from "pg";
 import { createClient, type RedisClientType } from "redis";
 
+import { collection } from "../../src/exports/index.js";
 import { PgNotifyChangeBroker } from "../../src/server/modules/core/integrated/realtime/adapters/pg-notify.js";
 import {
 	RedisStreamsChangeBroker,
 	type RedisStreamsClient,
 } from "../../src/server/modules/core/integrated/realtime/adapters/redis-streams.js";
+import { questpieChannelEventTable } from "../../src/server/modules/core/integrated/realtime/collection.js";
 import type {
 	ChangeBroker,
 	ChangeWake,
 } from "../../src/server/modules/core/integrated/realtime/transport.js";
+import { buildMockApp } from "../utils/mocks/mock-app-builder.js";
+import { createTestContext } from "../utils/test-context.js";
+import { runTestDbMigrations } from "../utils/test-db.js";
 
 const runDrivers = process.env.QUESTPIE_REALTIME_DRIVER_INTEGRATION === "1";
 const postgresUrl =
@@ -100,6 +108,180 @@ describe.skipIf(!runDrivers)("realtime ChangeBroker driver matrix", () => {
 		).toEqual([wakes, wakes]);
 	});
 
+	test("Postgres reconnects LISTEN after its backend is terminated", async () => {
+		const channel = `questpie_rt_${crypto.randomUUID().replaceAll("-", "")}`;
+		const applicationName = `questpie_rt_listener_${crypto.randomUUID()}`;
+		const states: string[] = [];
+		const errors: unknown[] = [];
+		let connectedCount = 0;
+		let resolveReconnected!: () => void;
+		const reconnected = new Promise<void>((resolve) => {
+			resolveReconnected = resolve;
+		});
+		let resolveWake!: (wake: ChangeWake) => void;
+		const received = new Promise<ChangeWake>((resolve) => {
+			resolveWake = resolve;
+		});
+		const broker = new PgNotifyChangeBroker({
+			connection: {
+				connectionString: postgresUrl,
+				application_name: applicationName,
+			},
+			channel,
+			reconnectInitialDelayMs: 10,
+			reconnectMaxDelayMs: 50,
+		});
+		brokers.push(broker);
+		await broker.start({
+			onWake: resolveWake,
+			onError: (error) => errors.push(error),
+			onStateChange: (state) => {
+				states.push(state);
+				if (state === "connected" && ++connectedCount === 2) {
+					resolveReconnected();
+				}
+			},
+		});
+
+		const admin = new PgClient({ connectionString: postgresUrl });
+		await admin.connect();
+		try {
+			const result = await admin.query<{ pid: number }>(
+				"select pid from pg_stat_activity where application_name = $1 and pid <> pg_backend_pid()",
+				[applicationName],
+			);
+			expect(result.rows).toHaveLength(1);
+			await admin.query("select pg_terminate_backend($1)", [
+				result.rows[0]!.pid,
+			]);
+			await timeout(reconnected, "pg-notify LISTEN reconnect timed out");
+
+			await broker.publish(wakes[0]!);
+			expect(
+				await timeout(received, "pg-notify delivery after reconnect timed out"),
+			).toEqual(wakes[0]);
+			expect(states).toContain("unavailable");
+			expect(errors.length).toBeGreaterThanOrEqual(1);
+		} finally {
+			await admin.end();
+		}
+	}, 20_000);
+
+	test("Bun SQL create reaches a service subscriber through pg-notify", async () => {
+		const schemaName = `questpie_rt_${crypto.randomUUID().replaceAll("-", "")}`;
+		const admin = new SQL(postgresUrl);
+		await admin.unsafe(`create schema "${schemaName}"`);
+		const scopedUrl = new URL(postgresUrl);
+		scopedUrl.searchParams.set("options", `-csearch_path=${schemaName},public`);
+		let setup: Awaited<ReturnType<typeof buildMockApp>> | undefined;
+
+		try {
+			const posts = collection("posts")
+				.fields(({ f }) => ({ title: f.text().required() }))
+				.access({ read: true });
+			let resolveConnected!: () => void;
+			const connected = new Promise<void>((resolve) => {
+				resolveConnected = resolve;
+			});
+			setup = await buildMockApp(
+				{ collections: { posts } },
+				{
+					db: { url: scopedUrl.toString() },
+					realtime: {
+						observer: {
+							record: (event) => {
+								if (
+									event.type === "broker.lifecycle" &&
+									event.state === "connected"
+								) {
+									resolveConnected();
+								}
+							},
+						},
+					},
+				},
+			);
+			await runTestDbMigrations(setup.app);
+			const delivered = new Promise((resolve) => {
+				setup!.app.realtime.subscribe(resolve, {
+					resourceType: "collection",
+					resource: "posts",
+					where: { title: "Real pg-notify" },
+				});
+			});
+			await timeout(connected, "service pg-notify startup timed out");
+
+			const created = await setup.app.collections.posts.create(
+				{ title: "Real pg-notify" },
+				createTestContext({ accessMode: "system" }),
+			);
+			expect(
+				await timeout(delivered, "service create-to-push timed out"),
+			).toMatchObject({
+				operation: "create",
+				recordId: created.id,
+				resource: "posts",
+			});
+			const raw = await setup.app.db.execute(
+				sql`select jsonb_typeof(payload) as payload_type, payload from questpie_realtime_log order by seq desc limit 1`,
+			);
+			const row = (raw.rows ?? raw)[0];
+			expect(row.payload_type).toBe("object");
+			expect(row.payload).toBeObject();
+			await setup.app.db.insert(questpieChannelEventTable).values({
+				channelHash: "channel-hash",
+				seq: 1,
+				eventId: "event-id",
+				channel: "room-1",
+				event: "message",
+				schemaIdentity: "message-v1",
+				payload: "hello",
+				sizeBytes: 7,
+			});
+			const channelRaw = await setup.app.db.execute(
+				sql`select jsonb_typeof(payload) as payload_type, payload from questpie_channel_event limit 1`,
+			);
+			const channelRow = (channelRaw.rows ?? channelRaw)[0];
+				expect(channelRow).toMatchObject({
+					payload_type: "string",
+					payload: "hello",
+				});
+				const scalarPayloads: unknown[] = [
+					"123",
+					"true",
+					"null",
+					'{"x":1}',
+					123,
+					true,
+					{ x: 1 },
+					[1, "two"],
+				];
+				await setup.app.db.insert(questpieChannelEventTable).values(
+					scalarPayloads.map((payload, index) => ({
+						channelHash: "scalar-matrix",
+						seq: index + 2,
+						eventId: `scalar-${index}`,
+						channel: "room-1",
+						event: "message",
+						schemaIdentity: "message-v1",
+						payload,
+						sizeBytes: 16,
+					})),
+				);
+				const scalarRows = await setup.app.db
+					.select({ payload: questpieChannelEventTable.payload })
+					.from(questpieChannelEventTable)
+					.orderBy(questpieChannelEventTable.seq);
+				expect(
+					scalarRows.slice(1).map(({ payload }) => payload),
+				).toEqual(scalarPayloads);
+			} finally {
+			await setup?.cleanup();
+			await admin.unsafe(`drop schema if exists "${schemaName}" cascade`);
+			await admin.close({ timeout: 5 });
+		}
+	}, 30_000);
+
 	test("Redis Streams broadcasts every wake to every broker instance", async () => {
 		const stream = `questpie:realtime:${crypto.randomUUID()}`;
 		const clients = [
@@ -134,5 +316,5 @@ describe.skipIf(!runDrivers)("realtime ChangeBroker driver matrix", () => {
 				"redis streams matrix delivery timed out",
 			),
 		).toEqual([wakes, wakes]);
-	});
+	}, 20_000);
 });

--- a/packages/questpie/test/units/realtime-admission.test.ts
+++ b/packages/questpie/test/units/realtime-admission.test.ts
@@ -133,4 +133,84 @@ describe("realtime admission", () => {
 		).toMatchObject({ accepted: false });
 		for (const release of releases) release?.();
 	});
+
+	it("reclaims a reconnecting connection's prior slot (no leak on reconnect)", () => {
+		const registry = new RealtimeAdmissionRegistry(2);
+		let firstClosed = 0;
+		// A tab reconnecting under the SAME connectionId reoccupies its one slot.
+		const first = registry.acquire("user-1", "tab-A");
+		first?.setClose(() => {
+			firstClosed += 1;
+		});
+		const reconnect = registry.acquire("user-1", "tab-A");
+		expect(first).not.toBeNull();
+		expect(reconnect).not.toBeNull();
+		expect(firstClosed).toBe(1);
+		// Still only ONE slot for user-1 → a second distinct tab fits, a third does not.
+		expect(registry.acquire("user-1", "tab-B")).not.toBeNull();
+		expect(registry.acquire("user-1", "tab-C")).toBeNull();
+		// The dropped pre-reconnect stream closing must NOT evict the live slot.
+		first!();
+		expect(registry.acquire("user-1", "tab-C")).toBeNull();
+		// Releasing the live reconnect slot frees tab-A's cell.
+		reconnect!();
+		expect(registry.acquire("user-1", "tab-C")).not.toBeNull();
+	});
+
+	it("keeps unidentified connections counting independently (backward compatible)", () => {
+		const registry = new RealtimeAdmissionRegistry(2);
+		// No connectionId → each acquire is its own slot, exactly as before.
+		expect(registry.acquire("user-1")).not.toBeNull();
+		expect(registry.acquire("user-1")).not.toBeNull();
+		expect(registry.acquire("user-1")).toBeNull();
+		// Identified and unidentified connections share the same per-principal cap.
+		const mixed = new RealtimeAdmissionRegistry(2);
+		mixed.acquire("user-1", "tab-A");
+		mixed.acquire("user-1");
+		expect(mixed.acquire("user-1", "tab-B")).toBeNull();
+	});
+
+	it("a reconnect flood under one id fences every displaced stream", () => {
+		const registry = new RealtimeAdmissionRegistry(5);
+		let closed = 0;
+		let last: ReturnType<typeof registry.acquire> = null;
+		for (let index = 0; index < 500; index += 1) {
+			last = registry.acquire("user-1", "tab-A");
+			last?.setClose(() => {
+				closed += 1;
+			});
+		}
+		expect(last).not.toBeNull();
+		expect(closed).toBe(499);
+		// Four more distinct tabs still fit (tab-A already holds one), the sixth does not.
+		expect(registry.acquire("user-1", "tab-B")).not.toBeNull();
+		expect(registry.acquire("user-1", "tab-C")).not.toBeNull();
+		expect(registry.acquire("user-1", "tab-D")).not.toBeNull();
+		expect(registry.acquire("user-1", "tab-E")).not.toBeNull();
+		expect(registry.acquire("user-1", "tab-F")).toBeNull();
+	});
+
+	it("closes a superseded stream that registers its close handler late", () => {
+		const registry = new RealtimeAdmissionRegistry(1);
+		const first = registry.acquire("user-1", "tab-A");
+		const reconnect = registry.acquire("user-1", "tab-A");
+		let closed = 0;
+		first?.setClose(() => {
+			closed += 1;
+		});
+		expect(reconnect).not.toBeNull();
+		expect(closed).toBe(1);
+	});
+
+	it("does not let invalid or oversized ids alias an admission slot", () => {
+		const registry = new RealtimeAdmissionRegistry(2);
+		expect(registry.acquire("user-1", "same id")).not.toBeNull();
+		expect(registry.acquire("user-1", "same id")).not.toBeNull();
+		expect(registry.acquire("user-1", "same id")).toBeNull();
+
+		const oversized = new RealtimeAdmissionRegistry(1);
+		const id = "a".repeat(129);
+		expect(oversized.acquire("user-1", id)).not.toBeNull();
+		expect(oversized.acquire("user-1", id)).toBeNull();
+	});
 });

--- a/packages/questpie/test/units/realtime-jsonb-encoding.test.ts
+++ b/packages/questpie/test/units/realtime-jsonb-encoding.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { sql } from "drizzle-orm";
+
+import { collection } from "../../src/exports/index.js";
+import {
+	questpieChannelEventTable,
+	questpieChannelPresenceTable,
+	questpieRealtimeTopologyTable,
+} from "../../src/server/modules/core/integrated/realtime/collection.js";
+import { buildMockApp } from "../utils/mocks/mock-app-builder.js";
+import { createTestContext } from "../utils/test-context.js";
+import { runTestDbMigrations } from "../utils/test-db.js";
+
+describe("realtime jsonb encoding", () => {
+	let setup: Awaited<ReturnType<typeof buildMockApp>>;
+
+	beforeEach(async () => {
+		const posts = collection("posts").fields(({ f }) => ({
+			title: f.text().required(),
+		}));
+		setup = await buildMockApp({ collections: { posts } });
+		await runTestDbMigrations(setup.app);
+	});
+
+	afterEach(async () => {
+		await setup.cleanup();
+	});
+
+	test("stores every realtime JSON document as native jsonb on PGlite", async () => {
+		await setup.app.collections.posts.create(
+			{ title: "PGlite" },
+			createTestContext({ accessMode: "system" }),
+		);
+		await setup.app.db.insert(questpieChannelEventTable).values({
+			channelHash: "channel-hash",
+			seq: 1,
+			eventId: "event-id",
+			channel: "room-1",
+			event: "message",
+			schemaIdentity: "message-v1",
+			payload: "hello",
+			sizeBytes: 16,
+		});
+		await setup.app.db.insert(questpieChannelPresenceTable).values({
+			channelHash: "channel-hash",
+			connectionId: "connection-id",
+			principalId: "principal-id",
+			channel: "room-1",
+			data: { typing: true },
+			expiresAt: new Date(Date.now() + 60_000),
+		});
+		await setup.app.db.insert(questpieRealtimeTopologyTable).values({
+			sessionKey: "session-key",
+			ownerId: "owner-id",
+			protocolVersion: 1,
+			tokenHash: "token-hash",
+			identityHash: "identity-hash",
+			leaseExpiresAt: new Date(Date.now() + 60_000),
+			desiredRevision: 0,
+			appliedRevision: 0,
+			desiredTopology: {
+				protocol: "questpie-realtime-topology",
+				version: 1,
+				revision: 0,
+				topics: [],
+				channels: [],
+			},
+		});
+
+		const result = await setup.app.db.execute(sql`
+			select 'outbox' as source, jsonb_typeof(payload) as value_type
+			from questpie_realtime_log
+			union all
+			select 'channel', jsonb_typeof(payload)
+			from questpie_channel_event
+			union all
+			select 'presence', jsonb_typeof(data)
+			from questpie_channel_presence
+			union all
+			select 'topology', jsonb_typeof(desired_topology)
+			from questpie_realtime_topology
+			order by source
+		`);
+		const rows = result.rows ?? result;
+
+		expect(rows).toEqual([
+			{ source: "channel", value_type: "string" },
+			{ source: "outbox", value_type: "object" },
+			{ source: "presence", value_type: "object" },
+			{ source: "topology", value_type: "object" },
+		]);
+		const [channelEvent] = await setup.app.db
+			.select()
+			.from(questpieChannelEventTable);
+		expect(channelEvent.payload).toBe("hello");
+	});
+
+	test("preserves JSON-looking strings and native scalar types", async () => {
+		const payloads: unknown[] = [
+			"123",
+			"true",
+			"null",
+			'{"x":1}',
+			123,
+			true,
+			{ x: 1 },
+			[1, "two"],
+		];
+		await setup.app.db.insert(questpieChannelEventTable).values(
+			payloads.map((payload, index) => ({
+				channelHash: "scalar-matrix",
+				seq: index + 1,
+				eventId: `event-${index}`,
+				channel: "room-1",
+				event: "message",
+				schemaIdentity: "message-v1",
+				payload,
+				sizeBytes: 16,
+			})),
+		);
+		await setup.app.db.execute(sql`
+			insert into questpie_channel_event (
+				channel_hash, seq, event_id, channel, event, schema_identity, payload, size_bytes
+			) values (
+				'scalar-matrix', 9, 'event-8', 'room-1', 'message', 'message-v1', 'null'::jsonb, 16
+			)
+		`);
+
+		const rows = await setup.app.db
+			.select({ payload: questpieChannelEventTable.payload })
+			.from(questpieChannelEventTable)
+			.orderBy(questpieChannelEventTable.seq);
+		expect(rows.map(({ payload }) => payload)).toEqual([...payloads, null]);
+	});
+});

--- a/packages/questpie/test/units/realtime-pg-change-broker.test.ts
+++ b/packages/questpie/test/units/realtime-pg-change-broker.test.ts
@@ -41,6 +41,27 @@ class FakePgClient {
 	}
 }
 
+class BlockingPublisherClient extends FakePgClient {
+	private releaseNotify = () => {};
+	private resolveNotifyStarted = () => {};
+	readonly notifyStarted = new Promise<void>((resolve) => {
+		this.resolveNotifyStarted = resolve;
+	});
+
+	override async query(text: string, params?: unknown[]): Promise<void> {
+		this.queries.push({ text, params });
+		if (!text.startsWith("select pg_notify")) return;
+		this.resolveNotifyStarted();
+		await new Promise<void>((resolve) => {
+			this.releaseNotify = resolve;
+		});
+	}
+
+	release(): void {
+		this.releaseNotify();
+	}
+}
+
 const topologyWake: ChangeWake = {
 	kind: "topology-maybe-advanced",
 	sessionKey: "sha256-session-key",
@@ -177,5 +198,35 @@ describe("pg-notify change broker", () => {
 		expect(wakes).toEqual([]);
 		expect(errors).toHaveLength(1);
 		await broker.stop();
+	});
+
+	test("drains the active publish and cancels queued work on stop", async () => {
+		const listener = new FakePgClient();
+		const publisher = new BlockingPublisherClient();
+		const errors: unknown[] = [];
+		const broker = new PgNotifyChangeBroker({
+			client: listener as any,
+			publisherClient: publisher as any,
+		});
+		await broker.start({
+			onWake: () => {},
+			onError: (error) => errors.push(error),
+		});
+
+		const active = broker.publish(topologyWake);
+		await publisher.notifyStarted;
+		const queued = broker.publish({
+			...topologyWake,
+			desiredRevision: topologyWake.desiredRevision + 1,
+		});
+		const stopping = broker.stop();
+		publisher.release();
+
+		await active;
+		await expect(queued).rejects.toThrow("stopping");
+		await stopping;
+		expect(
+			publisher.queries.filter(({ text }) => text.startsWith("select pg_notify")),
+		).toHaveLength(1);
 	});
 });

--- a/packages/questpie/test/units/realtime-pusher-transport.test.ts
+++ b/packages/questpie/test/units/realtime-pusher-transport.test.ts
@@ -284,7 +284,7 @@ describe("pusher channel matrix change broker", () => {
 		}
 	});
 
-	test("pusher unavailable state escalates reconciliation cadence", async () => {
+	test("pusher unavailable state escalates outbox and topology reconciliation cadence", async () => {
 		const broker = new DroppingChangeBroker();
 		const delays: number[] = [];
 		const intervalSpy = spyOn(globalThis, "setInterval").mockImplementation(
@@ -305,9 +305,9 @@ describe("pusher channel matrix change broker", () => {
 			});
 			await tick();
 			broker.emitState("unavailable");
-			expect(delays.slice(-2)).toEqual([15_000, 2000]);
+			expect(delays.slice(-2)).toEqual([2000, 2000]);
 			broker.emitState("connected");
-			expect(delays.slice(-3)).toEqual([15_000, 2000, 15_000]);
+			expect(delays.slice(-2)).toEqual([15_000, 15_000]);
 		} finally {
 			intervalSpy.mockRestore();
 			await realtime.destroy();

--- a/packages/questpie/test/units/realtime-topology-coordinator.test.ts
+++ b/packages/questpie/test/units/realtime-topology-coordinator.test.ts
@@ -24,6 +24,33 @@ class RecordingBroker implements ChangeBroker {
 	async stop(): Promise<void> {}
 }
 
+class BlockingTopologyStore extends MemoryRealtimeTopologyStore {
+	getOwnedCalls = 0;
+	private releaseFirstRead!: () => void;
+	private firstReadStartedResolve!: () => void;
+	readonly firstReadStarted = new Promise<void>((resolve) => {
+		this.firstReadStartedResolve = resolve;
+	});
+	private readonly firstReadRelease = new Promise<void>((resolve) => {
+		this.releaseFirstRead = resolve;
+	});
+
+	override async getOwned(
+		input: Parameters<MemoryRealtimeTopologyStore["getOwned"]>[0],
+	) {
+		this.getOwnedCalls += 1;
+		if (this.getOwnedCalls === 1) {
+			this.firstReadStartedResolve();
+			await this.firstReadRelease;
+		}
+		return super.getOwned(input);
+	}
+
+	release(): void {
+		this.releaseFirstRead();
+	}
+}
+
 const emptyTopology = (revision = 0): RealtimeDesiredTopology => ({
 	protocol: "questpie-realtime-topology",
 	version: 1,
@@ -33,6 +60,72 @@ const emptyTopology = (revision = 0): RealtimeDesiredTopology => ({
 });
 
 describe("realtime topology coordinator", () => {
+	test("uses a bounded idle reconciliation cadence by default", async () => {
+		const observations: RealtimeObservation[] = [];
+		const coordinator = new RealtimeTopologyCoordinator(
+			new MemoryRealtimeTopologyStore(),
+			{
+				heartbeatMs: 0,
+				observer: { record: (event) => observations.push(event) },
+			},
+		);
+		await coordinator.open({
+			sessionId: "session-a",
+			token: "token-a",
+			identity: "anonymous",
+			topology: emptyTopology(),
+			apply: async () => {},
+			onClose: async () => {},
+		});
+
+		await Bun.sleep(1_100);
+
+		expect(
+			observations.filter(
+				(event) =>
+					event.type === "topology.lifecycle" &&
+					event.phase === "reconcile" &&
+					event.outcome === "started",
+			),
+		).toHaveLength(0);
+		await coordinator.stop();
+	});
+
+	test("coalesces reconcile requests while a session read is in flight", async () => {
+		const store = new BlockingTopologyStore();
+		const coordinator = new RealtimeTopologyCoordinator(store, {
+			ownerId: "owner-a",
+			heartbeatMs: 0,
+			reconcileMs: 0,
+		});
+		const session = await coordinator.open({
+			sessionId: "session-a",
+			token: "token-a",
+			identity: "anonymous",
+			topology: emptyTopology(),
+			apply: async () => {},
+			onClose: async () => {},
+		});
+		const wake: ChangeWake = {
+			kind: "topology-maybe-advanced",
+			sessionKey:
+				"fa57a52dbf08190218529730a3e99db6946c6c29220fb6e0551e21598b0b05db",
+			ownerId: "owner-a",
+			ownerGeneration: session.generation,
+			desiredRevision: 1,
+			reason: "submit",
+		};
+
+		coordinator.onWake(wake);
+		await store.firstReadStarted;
+		for (let index = 0; index < 20; index += 1) coordinator.onWake(wake);
+		store.release();
+		await coordinator.reconcile();
+
+		expect(store.getOwnedCalls).toBeLessThanOrEqual(2);
+		await coordinator.stop();
+	});
+
 	test("applies, deduplicates, rejects stale revisions, and detects conflicts", async () => {
 		let now = new Date("2026-07-15T20:00:00.000Z");
 		const broker = new RecordingBroker();
@@ -92,6 +185,13 @@ describe("realtime topology coordinator", () => {
 		expect(JSON.stringify(broker.wakes)).not.toContain("topics");
 		await coordinator.reconcile();
 		expect(applied).toEqual([revisionOne]);
+		expect(observations).toContainEqual({
+			type: "topology.lifecycle",
+			phase: "reconcile",
+			outcome: "current",
+			desiredRevision: 1,
+			appliedRevision: 1,
+		});
 		expect(observations).toContainEqual({
 			type: "topology.lifecycle",
 			phase: "apply",


### PR DESCRIPTION
Stacked on #186. This isolates the verified realtime foundation hardening required before Realtime v3:

- coalesce topology reconciliation and follow the configured recovery cadence
- fence superseded reconnect streams without weakening per-principal admission caps
- recover pg-notify listeners and bound serialized publish work across shutdown
- store realtime JSON documents as native JSONB while preserving scalar/string semantics
- add real PostgreSQL/Bun SQL driver coverage and adversarial race/DoS regressions

Validation: questpie typecheck; 109 realtime tests; real PostgreSQL broadcast, backend-termination reconnect, and Bun SQL create-to-push tests.