### PR TITLE
feat(errors): let conflict, notFound, forbidden and internal carry message keys

### DIFF
--- a/.changeset/api-error-message-keys.md
+++ b/.changeset/api-error-message-keys.md
@@ -1,0 +1,60 @@
+---
+"questpie": minor
+---
+
+`ApiError.conflict`, `ApiError.notFound`, `ApiError.forbidden` and
+`ApiError.internal` now accept an optional `messageKey` and `messageParams`, so
+the errors they raise can be localized. Previously only `badRequest` and
+`unauthorized` could carry a caller-supplied key.
+
+Before this change a consumer localizing its UI had no way to localize these
+four. Two of them were worse than merely untranslated: `conflict` and `internal`
+**unconditionally** set the generic keys `error.conflict` and `error.internal`,
+so an app with a translator configured did not just fail to translate the
+specific message — it discarded it. `ApiError.conflict("Post 42 was modified by
+someone else")` reached the client as "Resource conflict". Without a translator
+you got untranslated English; with one you got a generic string. Neither is a
+localized, specific message.
+
+Conflicts are the most visible class of these — optimistic-concurrency
+failures, uniqueness violations, invariant breaches. They are exactly the errors
+a user is most likely to see and least able to act on, and they were the ones
+with no path to the user's language at all.
+
+The framework had already been routing around the gap. The search routes in
+`server/adapters/routes/search.ts` hand-build
+`new ApiError({ code: "FORBIDDEN", ..., messageKey: "search.reindexAccessDenied" })`
+and `new ApiError({ code: "NOT_FOUND", ..., messageKey: "search.serviceNotConfigured" })`
+rather than call the constructors, because the constructors could not carry a
+key. Those call sites are left alone here, but they no longer have to be written
+that way.
+
+```ts
+throw ApiError.conflict(
+	`Post ${id} was modified by someone else`,
+	"post.conflict.staleVersion",
+	{ id },
+);
+```
+
+Both parameters are **appended** and optional — nothing was reordered and
+nothing became required. All 95 existing call sites in `packages/questpie/src`
+compile untouched, and so does any consumer code calling these four. When no key
+is passed, every constructor produces the same `ApiError` it did before: same
+`code`, same `message`, same default `messageKey`, same `messageParams`.
+
+Two details worth knowing:
+
+`forbidden` takes the key as a further parameter rather than as a field on its
+`AccessErrorContext`. That context is serialized verbatim into the client-facing
+`context.access` payload, so putting translation metadata there would change the
+wire shape and ship the key twice. Trailing parameters also match how
+`badRequest` and `unauthorized` already read.
+
+The parameters a constructor already derives stay available to your key and can
+be overridden: `notFound` always exposes `{{resource}}` and `{{id}}`, and
+`forbidden` always exposes `{{reason}}`. So `ApiError.notFound("Post", id,
+"post.notFound")` can interpolate `{{id}}` without you passing it again.
+
+No rendering-side change was needed — `toJSON` and `getTranslatedMessage`
+already translate through whatever `messageKey` an error carries.

--- a/apps/docs/content/docs/concepts/access-control.mdx
+++ b/apps/docs/content/docs/concepts/access-control.mdx
@@ -410,14 +410,16 @@ import { ApiError } from "questpie/errors";
 })
 ```
 
-| Factory                                       | Code                    | HTTP |
-| --------------------------------------------- | ----------------------- | ---- |
-| `ApiError.unauthorized(message?)`             | `UNAUTHORIZED`          | 401  |
-| `ApiError.forbidden(context)`                 | `FORBIDDEN`             | 403  |
-| `ApiError.notFound(resource, id?)`            | `NOT_FOUND`             | 404  |
-| `ApiError.badRequest(message?, fieldErrors?)` | `BAD_REQUEST`           | 400  |
-| `ApiError.conflict(message)`                  | `CONFLICT`              | 409  |
-| `ApiError.internal(message?, cause?)`         | `INTERNAL_SERVER_ERROR` | 500  |
+| Factory                                                                    | Code                    | HTTP |
+| -------------------------------------------------------------------------- | ----------------------- | ---- |
+| `ApiError.unauthorized(message?, messageKey?, messageParams?)`             | `UNAUTHORIZED`          | 401  |
+| `ApiError.forbidden(context, messageKey?, messageParams?)`                 | `FORBIDDEN`             | 403  |
+| `ApiError.notFound(resource, id?, messageKey?, messageParams?)`            | `NOT_FOUND`             | 404  |
+| `ApiError.badRequest(message?, fieldErrors?, messageKey?, messageParams?)` | `BAD_REQUEST`           | 400  |
+| `ApiError.conflict(message, messageKey?, messageParams?)`                  | `CONFLICT`              | 409  |
+| `ApiError.internal(message?, cause?, messageKey?, messageParams?)`         | `INTERNAL_SERVER_ERROR` | 500  |
+
+Every factory takes an optional `messageKey` (plus `messageParams` for interpolation) so the error can be localized for the requesting user instead of reaching the client as the untranslated `message`. Omit it and you get the built-in default key for that code. `notFound` always exposes `{{resource}}` and `{{id}}` to the translation, `forbidden` always exposes `{{reason}}`, and anything you pass in `messageParams` overrides them.
 
 `ApiError.forbidden(context)` takes `{ operation, resource, reason, requiredRole?, userRole?, fieldPath? }`. A `reason` of `"Access denied"` triggers the built-in localized message; any other `reason` is sent to the client verbatim. `401` means _no auth_; `403` means _authenticated but not permitted_, reach for `unauthorized` vs `forbidden` accordingly. Every `ApiError` serializes to a stable JSON shape (`{ code, message, fieldErrors?, context? }`) the typed client surfaces, and the full code set (`BAD_REQUEST`, `UNAUTHORIZED`, `FORBIDDEN`, `NOT_FOUND`, `CONFLICT`, `VALIDATION_ERROR`, `HOOK_ERROR`, …) is exported from `questpie/errors`.
 

--- a/packages/questpie/src/server/errors/base.ts
+++ b/packages/questpie/src/server/errors/base.ts
@@ -177,27 +177,49 @@ export class ApiError extends Error {
 
 	/**
 	 * Create NOT_FOUND error
+	 *
+	 * `resource` and `id` are always available to the translation as
+	 * `{{resource}}` / `{{id}}`; `messageParams` overrides them.
 	 */
-	static notFound(resource: string, id?: string): ApiError {
+	static notFound(
+		resource: string,
+		id?: string,
+		messageKey?: BackendMessageKey,
+		messageParams?: Record<string, unknown>,
+	): ApiError {
 		return new ApiError({
 			code: "NOT_FOUND",
 			message: id ? `${resource} not found: ${id}` : `${resource} not found`,
-			messageKey: id ? "error.notFound.withId" : "error.notFound",
-			messageParams: { resource, id },
+			messageKey:
+				messageKey ?? (id ? "error.notFound.withId" : "error.notFound"),
+			messageParams: { resource, id, ...messageParams },
 		});
 	}
 
 	/**
 	 * Create FORBIDDEN error with access context
+	 *
+	 * The key is a separate parameter rather than a field on
+	 * `AccessErrorContext`, because that context is serialized verbatim into the
+	 * client-facing `context.access` payload.
+	 *
+	 * `context.reason` is always available to the translation as `{{reason}}`;
+	 * `messageParams` overrides it.
 	 */
-	static forbidden(context: AccessErrorContext): ApiError {
+	static forbidden(
+		context: AccessErrorContext,
+		messageKey?: BackendMessageKey,
+		messageParams?: Record<string, unknown>,
+	): ApiError {
 		const useDefaultTranslation = context.reason === "Access denied";
+		const resolvedKey =
+			messageKey ?? (useDefaultTranslation ? "error.forbidden" : undefined);
 		return new ApiError({
 			code: "FORBIDDEN",
 			message: context.reason,
-			messageKey: useDefaultTranslation ? "error.forbidden" : undefined,
-			messageParams: useDefaultTranslation
-				? { reason: context.reason }
+			messageKey: resolvedKey,
+			messageParams: resolvedKey
+				? { reason: context.reason, ...messageParams }
 				: undefined,
 			context: { access: context },
 		});
@@ -264,11 +286,14 @@ export class ApiError extends Error {
 	static internal(
 		message = "Internal server error",
 		cause?: unknown,
+		messageKey?: BackendMessageKey,
+		messageParams?: Record<string, unknown>,
 	): ApiError {
 		return new ApiError({
 			code: "INTERNAL_SERVER_ERROR",
 			message,
-			messageKey: "error.internal",
+			messageKey: messageKey ?? "error.internal",
+			messageParams,
 			cause,
 		});
 	}
@@ -288,11 +313,16 @@ export class ApiError extends Error {
 	/**
 	 * Create CONFLICT error
 	 */
-	static conflict(message: string): ApiError {
+	static conflict(
+		message: string,
+		messageKey?: BackendMessageKey,
+		messageParams?: Record<string, unknown>,
+	): ApiError {
 		return new ApiError({
 			code: "CONFLICT",
 			message,
-			messageKey: "error.conflict",
+			messageKey: messageKey ?? "error.conflict",
+			messageParams,
 		});
 	}
 }

--- a/packages/questpie/test/units/i18n.test.ts
+++ b/packages/questpie/test/units/i18n.test.ts
@@ -595,6 +595,217 @@ describe("i18n", () => {
 		});
 	});
 
+	describe("ApiError constructor message keys", () => {
+		const t = createTranslator({
+			messages: {
+				en: allBackendMessagesEN,
+				sk: {
+					"error.conflict": "Konflikt zdroja",
+					"error.forbidden": "Pristup zamietnuty",
+					"error.internal": "Interna chyba servera",
+					"error.notFound": "Zdroj nenajdeny",
+					"error.notFound.withId": "{{resource}} nenajdeny: {{id}}",
+					"post.conflict.staleVersion": "Prispevok {{id}} bol medzitym zmeneny",
+					"post.forbidden.draft": "Koncept {{id}} nie je pristupny",
+					"post.internal.indexer": "Indexovanie {{collection}} zlyhalo",
+					"post.notFound": "Prispevok {{id}} neexistuje",
+				},
+			},
+			fallbackLocale: "en",
+		});
+
+		describe("conflict", () => {
+			test("should preserve a supplied key and params", () => {
+				const error = ApiError.conflict(
+					"Post 42 was modified by someone else",
+					"post.conflict.staleVersion",
+					{ id: "42" },
+				);
+
+				expect(error.messageKey).toBe("post.conflict.staleVersion");
+				expect(error.messageParams).toEqual({ id: "42" });
+			});
+
+			test("should render a supplied key through a translate function", () => {
+				const error = ApiError.conflict(
+					"Post 42 was modified by someone else",
+					"post.conflict.staleVersion",
+					{ id: "42" },
+				);
+
+				expect(error.toJSON(false, t, "sk").message).toBe(
+					"Prispevok 42 bol medzitym zmeneny",
+				);
+			});
+
+			test("should behave exactly as before when no key is given", () => {
+				const error = ApiError.conflict("Post 42 was modified by someone else");
+
+				expect(error.code).toBe("CONFLICT");
+				expect(error.message).toBe("Post 42 was modified by someone else");
+				expect(error.messageKey).toBe("error.conflict");
+				expect(error.messageParams).toBeUndefined();
+				expect(error.toJSON(false).message).toBe(
+					"Post 42 was modified by someone else",
+				);
+				expect(error.toJSON(false, t, "sk").message).toBe("Konflikt zdroja");
+			});
+		});
+
+		describe("notFound", () => {
+			test("should preserve a supplied key and merge params over resource/id", () => {
+				const error = ApiError.notFound("Post", "42", "post.notFound");
+
+				expect(error.messageKey).toBe("post.notFound");
+				expect(error.messageParams).toEqual({ resource: "Post", id: "42" });
+
+				const overridden = ApiError.notFound("Post", "42", "post.notFound", {
+					id: "99",
+				});
+
+				expect(overridden.messageParams).toEqual({
+					resource: "Post",
+					id: "99",
+				});
+			});
+
+			test("should render a supplied key through a translate function", () => {
+				const error = ApiError.notFound("Post", "42", "post.notFound");
+
+				expect(error.toJSON(false, t, "sk").message).toBe(
+					"Prispevok 42 neexistuje",
+				);
+			});
+
+			test("should behave exactly as before when no key is given", () => {
+				const withId = ApiError.notFound("Post", "42");
+
+				expect(withId.code).toBe("NOT_FOUND");
+				expect(withId.message).toBe("Post not found: 42");
+				expect(withId.messageKey).toBe("error.notFound.withId");
+				expect(withId.messageParams).toEqual({ resource: "Post", id: "42" });
+				expect(withId.toJSON(false, t, "sk").message).toBe(
+					"Post nenajdeny: 42",
+				);
+
+				const withoutId = ApiError.notFound("Post");
+
+				expect(withoutId.message).toBe("Post not found");
+				expect(withoutId.messageKey).toBe("error.notFound");
+				expect(withoutId.toJSON(false, t, "sk").message).toBe(
+					"Zdroj nenajdeny",
+				);
+			});
+		});
+
+		describe("forbidden", () => {
+			const draftContext = {
+				operation: "read",
+				resource: "posts",
+				reason: "Draft is private",
+			} as const;
+
+			test("should preserve a supplied key and merge params over reason", () => {
+				const error = ApiError.forbidden(draftContext, "post.forbidden.draft", {
+					id: "42",
+				});
+
+				expect(error.messageKey).toBe("post.forbidden.draft");
+				expect(error.messageParams).toEqual({
+					reason: "Draft is private",
+					id: "42",
+				});
+			});
+
+			test("should render a supplied key through a translate function", () => {
+				const error = ApiError.forbidden(draftContext, "post.forbidden.draft", {
+					id: "42",
+				});
+
+				expect(error.toJSON(false, t, "sk").message).toBe(
+					"Koncept 42 nie je pristupny",
+				);
+			});
+
+			test("should keep the access context free of translation metadata", () => {
+				const error = ApiError.forbidden(draftContext, "post.forbidden.draft", {
+					id: "42",
+				});
+
+				expect(error.toJSON(false, t, "sk").context?.access).toEqual({
+					operation: "read",
+					resource: "posts",
+					reason: "Draft is private",
+				});
+			});
+
+			test("should behave exactly as before when no key is given", () => {
+				const custom = ApiError.forbidden(draftContext);
+
+				expect(custom.code).toBe("FORBIDDEN");
+				expect(custom.message).toBe("Draft is private");
+				expect(custom.messageKey).toBeUndefined();
+				expect(custom.messageParams).toBeUndefined();
+				expect(custom.toJSON(false, t, "sk").message).toBe("Draft is private");
+
+				const fallback = ApiError.forbidden({
+					operation: "read",
+					resource: "posts",
+					reason: "Access denied",
+				});
+
+				expect(fallback.messageKey).toBe("error.forbidden");
+				expect(fallback.messageParams).toEqual({ reason: "Access denied" });
+				expect(fallback.toJSON(false, t, "sk").message).toBe(
+					"Pristup zamietnuty",
+				);
+			});
+		});
+
+		describe("internal", () => {
+			test("should preserve a supplied key and params alongside the cause", () => {
+				const cause = new Error("connection reset");
+				const error = ApiError.internal(
+					"Indexer crashed",
+					cause,
+					"post.internal.indexer",
+					{ collection: "posts" },
+				);
+
+				expect(error.messageKey).toBe("post.internal.indexer");
+				expect(error.messageParams).toEqual({ collection: "posts" });
+				expect(error.cause).toBe(cause);
+			});
+
+			test("should render a supplied key through a translate function", () => {
+				const error = ApiError.internal(
+					"Indexer crashed",
+					undefined,
+					"post.internal.indexer",
+					{ collection: "posts" },
+				);
+
+				expect(error.toJSON(false, t, "sk").message).toBe(
+					"Indexovanie posts zlyhalo",
+				);
+			});
+
+			test("should behave exactly as before when no key is given", () => {
+				const error = ApiError.internal("Database connection failed");
+
+				expect(error.code).toBe("INTERNAL_SERVER_ERROR");
+				expect(error.message).toBe("Database connection failed");
+				expect(error.messageKey).toBe("error.internal");
+				expect(error.messageParams).toBeUndefined();
+				expect(error.cause).toBeUndefined();
+				expect(error.toJSON(false).message).toBe("Database connection failed");
+				expect(error.toJSON(false, t, "sk").message).toBe(
+					"Interna chyba servera",
+				);
+			});
+		});
+	});
+
 	describe("integration", () => {
 		test("should work with full translation config", () => {
 			const config: TranslationsConfig = {


### PR DESCRIPTION
## The problem

`ApiError.badRequest` and `ApiError.unauthorized` accept a caller-supplied `messageKey`. Four siblings did not, so any error they raised could only reach the client as internal English text:

| constructor | before | carried a caller key |
| --- | --- | --- |
| `badRequest` | `(message, fieldErrors, messageKey, messageParams)` | yes |
| `unauthorized` | `(message, messageKey, messageParams)` | yes |
| `conflict` | `(message)` | no |
| `notFound` | `(resource, id)` | no |
| `forbidden` | `(context)` | no |
| `internal` | `(message, cause)` | no |

Two of them were worse than merely untranslated. `conflict` and `internal` **unconditionally** set the generic keys `error.conflict` / `error.internal`, so an app with a translator configured did not just fail to translate the specific message — it discarded it. `ApiError.conflict("Post 42 was modified by someone else")` reached the client as "Resource conflict". Without a translator you got untranslated English; with one you got a generic string. Neither is a localized, specific message.

Conflicts are the most visible class here — optimistic-concurrency failures, uniqueness violations, invariant breaches. They are the errors a user is most likely to see and least able to act on, and they had no path to the user's language at all.

The framework had already been routing around the gap: `packages/questpie/src/server/adapters/routes/search.ts` hand-builds `new ApiError({ code: "FORBIDDEN", ..., messageKey: "search.reindexAccessDenied" })` and `new ApiError({ code: "NOT_FOUND", ..., messageKey: "search.serviceNotConfigured" })` rather than call the constructors, precisely because the constructors could not carry a key. Those call sites are left alone in this PR, but they no longer have to be written that way.

## The shape

```ts
static conflict(message, messageKey?, messageParams?)
static notFound(resource, id?, messageKey?, messageParams?)
static forbidden(context, messageKey?, messageParams?)
static internal(message?, cause?, messageKey?, messageParams?)
```

Both parameters are **appended** and optional, matching the shape `badRequest` already uses. Nothing was reordered and nothing became required.

Two judgement calls:

**`forbidden` takes the key as a further parameter, not as a field on `AccessErrorContext`.** That context is serialized verbatim into the client-facing `context.access` payload by `toJSON`, so putting translation metadata there would change the wire shape and ship the key twice. Trailing parameters also match how `badRequest` and `unauthorized` already read. A test asserts `context.access` stays free of translation metadata.

**Intrinsic parameters stay available to a custom key and can be overridden.** `notFound` always exposes `{{resource}}` and `{{id}}`; `forbidden` always exposes `{{reason}}`; `messageParams` merges on top. Without this, `ApiError.notFound("Post", id, "post.notFound")` would silently lose `{{id}}` — the caller would have to pass data the constructor already has. `conflict` and `internal` derive nothing, so their `messageParams` passes straight through as `badRequest`'s does.

No rendering-side change was needed. `toJSON` and `getTranslatedMessage` already translate through whatever `messageKey` an error carries; that was verified by reading `base.ts` and then proven by the tests, which render every constructor through a real translator.

## Existing call sites compile unchanged

95 calls to these four constructors live in `packages/questpie/src`, plus 7 in `@questpie/admin`. None were touched. The CI typecheck gate (`turbo run check-types --filter=questpie --filter=@questpie/tanstack-query --filter=@questpie/tanstack-db`) passes, which compiles all 95.

When no key is passed, every constructor produces the same `ApiError` it did before: same `code`, same `message`, same default `messageKey`, same `messageParams`. Four dedicated tests assert this, one per constructor.

## Tests

13 new tests in `packages/questpie/test/units/i18n.test.ts`, in the file's existing style. Per constructor: preserves a supplied key and params, renders through a translate function, and behaves exactly as before when no key is given.

Verified load-bearing by running the new tests against the unmodified `base.ts`: 8 of 13 fail, and the 5 that pass are exactly the "unchanged behavior" assertions, which should pass both before and after.

## Docs

`apps/docs/content/docs/concepts/access-control.mdx` carried a factory-signature table that documented `ApiError.conflict(message)` and friends. It is updated to the real signatures across all six rows — `badRequest` and `unauthorized` already took keys but the table never said so — plus one sentence on localization.

## Gates

Every CI gate from `.github/workflows/ci.yml` was run locally except `audit` and `realtime-matrix` (the latter needs Docker services).

| Gate | Result |
| --- | --- |
| `turbo run check-types` (questpie + tanstack-query + tanstack-db) | pass, 3/3 |
| `turbo run test --filter='./packages/*' --concurrency=1` | pass, 22/22 tasks |
| `turbo run build --filter='./packages/*'` | pass, 14/14 |
| Dist syntax gate (`node --check` on every `dist/*.mjs`) | pass |
| `scripts/check-dist-types.ts` | pass, within source baseline |
| `scripts/type-budget.ts` | pass, +1.0–1.8% within budget |
| `scripts/any-census.ts` | pass, within baseline |
| `scripts/example-errors.ts` | pass, 0/0/0 at baseline |
| `scripts/check-codegen-layers.ts` | pass, 4/4 acyclic |
| `validate:docs --docs-app` | pass, 0 errors, 0 warnings |
| `oxlint` on changed files | 0 warnings, 0 errors |
| `oxfmt --check` on changed files | clean |

The built `packages/questpie/dist/server/errors/base.d.mts` was inspected directly and carries all four widened signatures, so published consumers see them.

Two things that are **not** caused by this branch:

- Repo-wide `bun run lint` and `bun run format:check` already fail on `origin/main` (85 lint errors; 277 files with format issues). Neither is a CI gate — the lint job in `ci.yml` is commented out with "TODO: Enable when lint errors are fixed", and there is no format job. The four changed files are individually clean under both.
- `example-errors` failed on the first local run with `examples/tanstack-barbershop` at 1 error: `vite.config.ts(9,32): error TS2307: Cannot find module '@questpie/vite-plugin-iconify'`. That package's `dist/` was missing in the fresh worktree because turbo restored a cached "successful" build for it from the shared worktree cache. Building it directly cleared the error and the ratchet returned to 0/0/0. Unrelated to the change; CI builds fresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
