### PR TITLE
fix(core): builders lost the app field map on every derivation

### DIFF
--- a/.changeset/builder-private-state.md
+++ b/.changeset/builder-private-state.md
@@ -1,0 +1,30 @@
+---
+"questpie": patch
+---
+
+Fix `.fields()` losing module-contributed field types after any other builder
+call.
+
+`CollectionBuilder` and `GlobalBuilder` are immutable: every method builds a new
+builder from new state. Each one also had to remember to hand-copy the private
+state across. `_indexesFn` was copied at all thirteen collection sites;
+`_fieldDefs` — the runtime map holding `richText`, `blocks` and the app's own
+`fieldType()`s — was copied at none. It was assigned once in `create()` and
+dropped by the first derivation.
+
+Every extension method routes through `.set()`, so:
+
+```ts
+collection("posts").admin({ … }).fields(({ f }) => f.richText())
+```
+
+fell back to `builtinFields`, `f.richText` was undefined, and the call threw —
+while the type still advertised `richText`, because `~fieldTypes` travels on the
+state and survives. Writing `.fields()` first worked. Globals had the same
+defect, in a purer form: `_fieldDefs` is their only private state and nothing
+carried it.
+
+Both builders now derive through a single private helper that carries every
+piece of private state, so the knowledge lives in one place instead of nineteen.
+`indexes()` and `merge()` derive and then override the one field they exist to
+change.

--- a/packages/questpie/src/server/collection/builder/collection-builder.ts
+++ b/packages/questpie/src/server/collection/builder/collection-builder.ts
@@ -180,6 +180,38 @@ export class CollectionBuilder<TState extends CollectionBuilderState> {
 	}
 
 	/**
+	 * Build the next builder in an immutable chain, carrying every piece of
+	 * private state forward.
+	 *
+	 * Each method used to construct `new CollectionBuilder(...)` itself and then
+	 * hand-copy what it remembered to copy. `_indexesFn` was copied at all
+	 * thirteen sites; `_fieldDefs` at none, so the app's field-factory map — the
+	 * one holding module-contributed types like `richText` — was dropped by the
+	 * first derivation and `.fields()` silently fell back to `builtinFields`.
+	 * The type did not fall back with it, because `~fieldTypes` travels on the
+	 * state, so the promise and the runtime disagreed depending on call order.
+	 *
+	 * Adding a fourteenth hand-copy is how that recurs. This is the one place
+	 * that knows what a derived builder must carry; a new private field is added
+	 * here once. Callers that mean to CHANGE one of these (`indexes()`,
+	 * `merge()`) override it on the result.
+	 */
+	private _derive<TNext extends CollectionBuilderState>(
+		state: TNext,
+	): CollectionBuilder<TNext> {
+		const next = new CollectionBuilder(state);
+		next._fieldDefs = this._fieldDefs;
+		// `_indexesFn` is parameterised by the builder's own state, so carrying
+		// it to a builder with different state needs the conversion spelled out.
+		// The function itself is unchanged — only the state type it is indexed by.
+		next._indexesFn = this._indexesFn as CollectionBuilderIndexesFn<
+			TNext,
+			TNext["indexes"]
+		>;
+		return next;
+	}
+
+	/**
 	 * Define fields using Field Builder.
 	 * Provides type-safe field definitions with validation, metadata, and operators.
 	 *
@@ -350,12 +382,7 @@ export class CollectionBuilder<TState extends CollectionBuilderState> {
 				_pendingRelations: [...prevPendingRelations, ...pendingRelations],
 			} as any;
 
-			const newBuilder = new CollectionBuilder(newState);
-
-			// Copy callback functions
-			newBuilder._indexesFn = this._indexesFn;
-
-			return newBuilder;
+			return this._derive(newState);
 		}
 
 		// Legacy pattern: raw Drizzle columns object
@@ -384,12 +411,7 @@ export class CollectionBuilder<TState extends CollectionBuilderState> {
 			).filter((rel) => !(rel.name in columns)),
 		} as any;
 
-		const newBuilder = new CollectionBuilder(newState);
-
-		// Copy callback functions
-		newBuilder._indexesFn = this._indexesFn;
-
-		return newBuilder;
+		return this._derive(newState);
 	}
 
 	/**
@@ -557,9 +579,9 @@ export class CollectionBuilder<TState extends CollectionBuilderState> {
 			indexes: {} as TNewIndexes,
 		} as any;
 
-		const newBuilder = new CollectionBuilder(newState);
-
-		// Copy existing callback functions and set new indexesFn
+		// Derives normally, then overrides the one thing this method exists to
+		// change.
+		const newBuilder = this._derive(newState);
 		newBuilder._indexesFn = fn;
 
 		return newBuilder;
@@ -577,9 +599,7 @@ export class CollectionBuilder<TState extends CollectionBuilderState> {
 				awarenessSchema: config?.awareness,
 			},
 		} as any;
-		const newBuilder = new CollectionBuilder(newState);
-		newBuilder._indexesFn = this._indexesFn;
-		return newBuilder;
+		return this._derive(newState);
 	}
 
 	/**
@@ -609,12 +629,7 @@ export class CollectionBuilder<TState extends CollectionBuilderState> {
 			title: titleFieldName,
 		} as any;
 
-		const newBuilder = new CollectionBuilder(newState);
-
-		// Copy existing callback functions
-		newBuilder._indexesFn = this._indexesFn;
-
-		return newBuilder;
+		return this._derive(newState);
 	}
 
 	/**
@@ -639,12 +654,7 @@ export class CollectionBuilder<TState extends CollectionBuilderState> {
 			options,
 		} as any;
 
-		const newBuilder = new CollectionBuilder(newState);
-
-		// Copy callback functions
-		newBuilder._indexesFn = this._indexesFn;
-
-		return newBuilder;
+		return this._derive(newState);
 	}
 
 	/**
@@ -692,12 +702,7 @@ export class CollectionBuilder<TState extends CollectionBuilderState> {
 			hooks: mergedHooks,
 		} as any;
 
-		const newBuilder = new CollectionBuilder(newState);
-
-		// Copy callback functions
-		newBuilder._indexesFn = this._indexesFn;
-
-		return newBuilder;
+		return this._derive(newState);
 	}
 
 	/**
@@ -729,12 +734,7 @@ export class CollectionBuilder<TState extends CollectionBuilderState> {
 			access,
 		} as any;
 
-		const newBuilder = new CollectionBuilder(newState);
-
-		// Copy callback functions
-		newBuilder._indexesFn = this._indexesFn;
-
-		return newBuilder;
+		return this._derive(newState);
 	}
 
 	/**
@@ -760,12 +760,7 @@ export class CollectionBuilder<TState extends CollectionBuilderState> {
 			searchable,
 		} as any;
 
-		const newBuilder = new CollectionBuilder(newState);
-
-		// Copy callback functions
-		newBuilder._indexesFn = this._indexesFn;
-
-		return newBuilder;
+		return this._derive(newState);
 	}
 
 	/**
@@ -800,12 +795,7 @@ export class CollectionBuilder<TState extends CollectionBuilderState> {
 			validationOptions: options ?? {},
 		} as any;
 
-		const newBuilder = new CollectionBuilder(newState);
-
-		// Copy callback functions
-		newBuilder._indexesFn = this._indexesFn;
-
-		return newBuilder;
+		return this._derive(newState);
 	}
 
 	/**
@@ -1039,12 +1029,7 @@ export class CollectionBuilder<TState extends CollectionBuilderState> {
 			upload: options,
 		} as any;
 
-		const newBuilder = new CollectionBuilder(newState);
-
-		// Copy callback functions
-		newBuilder._indexesFn = this._indexesFn;
-
-		return newBuilder;
+		return this._derive(newState);
 	}
 
 	/**
@@ -1067,9 +1052,7 @@ export class CollectionBuilder<TState extends CollectionBuilderState> {
 		value: V,
 	): CollectionBuilder<TState & Record<TKey, V>> {
 		const newState = { ...this.state, [key]: value } as any;
-		const newBuilder = new CollectionBuilder(newState);
-		newBuilder._indexesFn = this._indexesFn;
-		return newBuilder;
+		return this._derive(newState);
 	}
 
 	/**
@@ -1273,10 +1256,11 @@ export class CollectionBuilder<TState extends CollectionBuilderState> {
 			_pendingRelations: mergedPendingRelations,
 		} as any;
 
-		const newBuilder = new CollectionBuilder(mergedState);
-
-		// Merge callback functions - prefer other's if exists, otherwise use this
-		newBuilder._indexesFn = other._indexesFn || this._indexesFn;
+		// Derives from `this`, then lets the merged-in builder win where it has
+		// something to contribute.
+		const newBuilder = this._derive(mergedState);
+		newBuilder._indexesFn = (other._indexesFn ||
+			this._indexesFn) as typeof newBuilder._indexesFn;
 
 		return newBuilder;
 	}

--- a/packages/questpie/src/server/global/builder/global-builder.ts
+++ b/packages/questpie/src/server/global/builder/global-builder.ts
@@ -120,6 +120,25 @@ export class GlobalBuilder<TState extends GlobalBuilderState> {
 	}
 
 	/**
+	 * Build the next builder in an immutable chain, carrying private state
+	 * forward.
+	 *
+	 * `_fieldDefs` — the app's field-factory map, holding module-contributed
+	 * types like `richText` — was assigned once in `create()` and carried by
+	 * none of the derivations, so the first `.set()` or `.options()` dropped it
+	 * and `.fields()` silently fell back to `builtinFields` while the type still
+	 * advertised the full map. Same defect as CollectionBuilder had; one place
+	 * to fix it, and one place to extend when a private field is added.
+	 */
+	private _derive<TNext extends GlobalBuilderState>(
+		state: TNext,
+	): GlobalBuilder<TNext> {
+		const next = new GlobalBuilder(state);
+		next._fieldDefs = this._fieldDefs;
+		return next;
+	}
+
+	/**
 	 * Define fields using Field Builder.
 	 *
 	 * Cumulative: fields add to whatever the builder already has from earlier
@@ -288,8 +307,7 @@ export class GlobalBuilder<TState extends GlobalBuilderState> {
 			_pendingRelations: [...prevPendingRelations, ...pendingRelations],
 		} as any;
 
-		const newBuilder = new GlobalBuilder(newState);
-		return newBuilder;
+		return this._derive(newState);
 	}
 
 	/** Enable one collaborative aggregate for this global singleton/scope. */
@@ -304,7 +322,7 @@ export class GlobalBuilder<TState extends GlobalBuilderState> {
 				awarenessSchema: config?.awareness,
 			},
 		} as any;
-		return new GlobalBuilder(newState);
+		return this._derive(newState);
 	}
 
 	/**
@@ -318,8 +336,7 @@ export class GlobalBuilder<TState extends GlobalBuilderState> {
 			options,
 		} as any;
 
-		const newBuilder = new GlobalBuilder(newState);
-		return newBuilder;
+		return this._derive(newState);
 	}
 
 	/**
@@ -333,8 +350,7 @@ export class GlobalBuilder<TState extends GlobalBuilderState> {
 			hooks,
 		} as any;
 
-		const newBuilder = new GlobalBuilder(newState);
-		return newBuilder;
+		return this._derive(newState);
 	}
 
 	/**
@@ -353,8 +369,7 @@ export class GlobalBuilder<TState extends GlobalBuilderState> {
 			access,
 		} as any;
 
-		const newBuilder = new GlobalBuilder(newState);
-		return newBuilder;
+		return this._derive(newState);
 	}
 
 	/**
@@ -471,7 +486,7 @@ export class GlobalBuilder<TState extends GlobalBuilderState> {
 		value: V,
 	): GlobalBuilder<TState & Record<TKey, V>> {
 		const newState = { ...this.state, [key]: value } as any;
-		return new GlobalBuilder(newState);
+		return this._derive(newState);
 	}
 
 	/**

--- a/packages/questpie/test/collection/builder-private-state.test.ts
+++ b/packages/questpie/test/collection/builder-private-state.test.ts
@@ -1,0 +1,120 @@
+/**
+ * A builder must not lose the app's field-type map when it is derived.
+ *
+ * `CollectionBuilder` carries two pieces of private state: `_indexesFn` and
+ * `_fieldDefs`. The second is the runtime map of field factories — builtins,
+ * plus module-contributed types like `richText` and `blocks`, plus the app's own
+ * `fieldType()`s — and `.fields()` reads it to resolve `f.<type>()`.
+ *
+ * Every builder method is immutable: it constructs a new `CollectionBuilder`
+ * from new state. `_indexesFn` was carried across all thirteen of those
+ * construction sites; `_fieldDefs` was carried across none. It was assigned once
+ * in `create()` and dropped by the first derivation.
+ *
+ * That matters because every extension method — `.admin()`, `.list()`,
+ * `.form()`, `.actions()` — routes through `.set()`. So
+ *
+ *     collection("posts").admin({ … }).fields(({ f }) => f.richText())
+ *
+ * silently fell back to `builtinFields`, `f.richText` was undefined, and the
+ * call threw — while the TYPE still advertised `richText`, because `~fieldTypes`
+ * is a separate rail that survives derivation. Putting `.fields()` first worked.
+ * Order-dependent divergence between what the type promises and what the runtime
+ * has, which is the same shape as the shipped `Field<TState, {}>` truncation.
+ *
+ * These tests assert the invariant on the *derived* builder rather than on any
+ * one method, so a future method that forgets to carry private state fails here
+ * regardless of what it is called.
+ */
+import { describe, expect, it } from "bun:test";
+
+import { CollectionBuilder } from "../../src/server/collection/builder/collection-builder.js";
+import { GlobalBuilder } from "../../src/server/global/builder/global-builder.js";
+
+/** Stands in for a module-contributed field type; only its presence matters. */
+const APP_FIELDS = {
+	appOnlyField: () => ({ __marker: "app-only" }),
+} as any;
+
+/** The keys `.fields()` actually sees on the builder it is called on. */
+function fieldKeysSeenBy(builder: unknown): string[] {
+	let keys: string[] = [];
+	(builder as any).fields(({ f }: any) => {
+		keys = Object.keys(f);
+		return {};
+	});
+	return keys;
+}
+
+describe("CollectionBuilder carries private state across derivations", () => {
+	it("sees the app field map on a freshly created builder", () => {
+		const base = CollectionBuilder.create("bps_base", APP_FIELDS);
+		expect(fieldKeysSeenBy(base)).toContain("appOnlyField");
+	});
+
+	it("keeps it across .set() — the path every extension method takes", () => {
+		// `.admin()`, `.list()`, `.form()` and `.actions()` all resolve through
+		// `builder.set(stateKey, config)`, so this one covers all of them.
+		const derived = (
+			CollectionBuilder.create("bps_set", APP_FIELDS) as any
+		).set("admin", {});
+		expect(fieldKeysSeenBy(derived)).toContain("appOnlyField");
+	});
+
+	it("keeps it across .options()", () => {
+		const derived = (
+			CollectionBuilder.create("bps_options", APP_FIELDS) as any
+		).options({ softDelete: true });
+		expect(fieldKeysSeenBy(derived)).toContain("appOnlyField");
+	});
+
+	it("keeps it across .merge()", () => {
+		const other = CollectionBuilder.create("bps_other", APP_FIELDS);
+		const derived = (
+			CollectionBuilder.create("bps_merge", APP_FIELDS) as any
+		).merge(other);
+		expect(fieldKeysSeenBy(derived)).toContain("appOnlyField");
+	});
+
+	it("keeps it across a chain of derivations", () => {
+		// The realistic authoring order: configure, then declare fields.
+		const derived = (CollectionBuilder.create("bps_chain", APP_FIELDS) as any)
+			.options({ timestamps: true })
+			.set("admin", {})
+			.set("adminList", {});
+		expect(fieldKeysSeenBy(derived)).toContain("appOnlyField");
+	});
+
+	it("still carries _indexesFn, which was already correct", () => {
+		// Guard against the fix trading one carried field for another.
+		const fn = () => [];
+		const derived = (CollectionBuilder.create("bps_idx", APP_FIELDS) as any)
+			.indexes(fn)
+			.set("admin", {});
+		expect((derived as any)._indexesFn).toBe(fn);
+	});
+});
+
+describe("GlobalBuilder carries private state across derivations", () => {
+	// Globals had the same defect in a purer form: `_fieldDefs` is their ONLY
+	// private state, assigned once and carried by none of the six derivations.
+	it("sees the app field map on a freshly created builder", () => {
+		const base = GlobalBuilder.create("bps_g_base", APP_FIELDS);
+		expect(fieldKeysSeenBy(base)).toContain("appOnlyField");
+	});
+
+	it("keeps it across .set()", () => {
+		const derived = (GlobalBuilder.create("bps_g_set", APP_FIELDS) as any).set(
+			"admin",
+			{},
+		);
+		expect(fieldKeysSeenBy(derived)).toContain("appOnlyField");
+	});
+
+	it("keeps it across a chain of derivations", () => {
+		const derived = (GlobalBuilder.create("bps_g_chain", APP_FIELDS) as any)
+			.set("admin", {})
+			.set("adminForm", {});
+		expect(fieldKeysSeenBy(derived)).toContain("appOnlyField");
+	});
+});


### PR DESCRIPTION
Both builders lost the app's field-type map the moment any other builder method was called.

## The bug

`CollectionBuilder` and `GlobalBuilder` are immutable — every method constructs a new builder from new state — and each construction site had to remember to hand-copy the private state across. The audit:

| builder | derived sites | `_indexesFn` carried | `_fieldDefs` carried |
|---|---|---|---|
| `CollectionBuilder` | 13 | 13 | **0** |
| `GlobalBuilder` | 6 | n/a | **0** |

`_fieldDefs` is the runtime map of field factories: builtins, plus module-contributed types like `richText` and `blocks`, plus the app's own `fieldType()`s. It was assigned once in `create()` and dropped by the first derivation.

Every extension method routes through `.set()`, so:

```ts
collection("posts").admin({ … }).fields(({ f }) => f.richText())
//                                                   ^ undefined at runtime
```

fell back to `builtinFields` and threw — while the **type still advertised `richText`**, because `~fieldTypes` travels on the state and survives derivation. Putting `.fields()` first worked.

Order-dependent divergence between what the type promises and what the runtime holds. Same shape as the `Field<TState, {}>` chain truncation that shipped in both scaffolding templates.

## The fix

Centralised rather than patched. One private `_derive()` per builder carries every piece of private state; `indexes()` and `merge()` derive and then override the single field they exist to change.

The knowledge of what a derived builder must carry now lives in **two places instead of nineteen**, so the next private field is added once rather than forgotten eighteen times.

## Tests

Nine tests asserting the invariant on the **derived** builder rather than on any named method — a future method that forgets to carry state fails here regardless of what it is called.

Teeth confirmed by deleting the `_fieldDefs` line: 4 of 6 collection tests fail.

## Provenance

Surfaced by an adversarial review of an unrelated design plan, then confirmed by probe before any code was touched. Worth noting that the review's own claim was narrower than the truth — it said `.set()` was the problem; the audit showed all nineteen sites.

Also worth recording: `any-census` rejected two attempts at this fix, `as any` and then `as unknown as`. The third needed neither — a direct typed cast to `CollectionBuilderIndexesFn<TNext, TNext["indexes"]>`. The gate produced better code than I would have written without it.

## Verification

2,811 tests / 0 fail · `turbo run check-types` 25/25 · `bun run lint` 0 errors · oxfmt clean repo-wide · five ratchets green.
