### PR TITLE
feat(realtime): provider-neutral subscription revocation

### DIFF
--- a/.changeset/upset-berries-roll.md
+++ b/.changeset/upset-berries-roll.md
@@ -1,0 +1,5 @@
+---
+"questpie": minor
+---
+
+Add durable provider-neutral channel authority revocation with exact SSE fencing and signed-user Pusher reconnect reauthorization.

--- a/apps/docs/content/docs/adapters/realtime.mdx
+++ b/apps/docs/content/docs/adapters/realtime.mdx
@@ -253,6 +253,36 @@ The isolated `questpie/adapters/pusher` export is the only entry that loads the 
 
 Live-query snapshots remain private per edge session because each snapshot has already passed that principal's row/field access and `afterRead` hooks. The shared provider broker carries only wakes. Framework channel events may use provider multicast after subscribe/publish authorization and Zod validation.
 
+Pusher clients also use signed-user authentication. QUESTPIE posts only the
+current `socket_id` to the authenticated `Cache-Control: no-store` realtime auth
+route, signs an opaque HMAC-derived user id, and lets `pusher-js` request fresh
+user authentication after reconnect. Channel authorization waits for that
+sign-in and rejects a released owner or stale socket before returning auth. This
+enables the transport's honest
+channel-authority capability: Pusher can terminate all current connections for
+one user, but it cannot terminate only one logical channel subscription. After
+termination, fresh per-channel authorization admits still-valid bindings and
+denies the revoked one.
+
+`channels.revokeAuthority()` persists the authorization generation in the
+caller's database transaction. For a managed caller transaction, bounded
+provider termination and generation acknowledgement run inline; failure throws
+and rolls the transaction back. A conservative disconnect may survive a later
+database rollback. For a standalone command, failure leaves the already durable
+cut pending and ordered provider dispatch fail-closed so an idempotent retry can
+finish it. A physical frame already accepted by Pusher can arrive during
+termination, so this transport does not claim zero-frame atomic revocation.
+Custom shared transports must declare an explicit revocation scope and
+implementation; QUESTPIE never silently treats an unknown provider as exact
+revocation.
+
+Pusher also qualifies channel authorization as a
+`stateless-signed-grant`: provider `generateAuth` is side-effect-free local
+encoding. QUESTPIE evaluates policy and encoding outside database locks, then
+uses an optimistic generation check before returning the blob. A concurrent cut
+discards it before it reaches the browser. Shared adapters without this explicit
+capability are rejected before policy or provider signing.
+
 Direct provider client events are **off by default** and are not equivalent to `client.channels.*.publish()`. Enabling them requires:
 
 ```ts

--- a/apps/docs/content/docs/client/channels.mdx
+++ b/apps/docs/content/docs/client/channels.mdx
@@ -102,6 +102,47 @@ Use the hook's injected `{ channels }` argument. It carries the same generated t
 
 Do not import the generated `app` into a collection/hook file, and do not resolve channels later through ambient `getContext()`. Contextless update/delete calls do not guarantee an ambient scope; the injected hook argument is the reliable and transaction-aware path.
 
+## Revoke delivery authority after a domain change
+
+When a membership or authorization write removes access, call the request-bound
+service in the same transaction:
+
+```ts
+await channels.revokeAuthority("chatRoom", {
+	params: { roomId },
+	subject: { kind: "user", id: removedUserId },
+	idempotencyKey: `chat-room:${roomId}:${removedUserId}:membership-v2`,
+});
+```
+
+The command advances a durable generation for the exact resolved
+channel/subject and returns `{ generation, scope }`. With SSE,
+`scope: "exact-subscription"` closes only that logical binding with
+`access_revoked`; other channel bindings on the multiplexed stream remain
+active. Fresh request context, subscribe authorization, and the presence
+resolver are evaluated outside database locks, then a short generation check
+publishes the binding, latest freshly resolved presence payload, and optional
+presence lease atomically. A stale result and stale member payload publish
+nothing. Dropped authority notices heal through a demand-driven ledger poll
+that also stops when internal revocation closes the last local binding.
+
+Pusher/Soketi reports `scope: "principal-connections"` because its termination
+API is user-wide. QUESTPIE signs the browser into Pusher with an opaque user id,
+terminates every current connection for that user, and lets reconnect obtain
+fresh user and per-channel authorization. Channel authorization waits for
+signed-user completion and rejects stale sockets or owners. An unrelated
+still-authorized binding can reconnect; the removed binding cannot.
+Provider channel auth is explicitly side-effect-free signed-blob encoding; a
+concurrent authority cut discards the blob before it can reach the browser.
+
+<Callout type="warn" title="Managed providers have an in-flight frame window">
+	Pusher cannot guarantee that a frame already accepted by the physical
+	connection will not arrive while termination is in flight. QUESTPIE's durable
+	fence blocks new ordered provider dispatch across a pending cut, and reconnect
+	plus replay reauthorize against current application state. This is
+	intentionally not described as zero-frame atomic revocation.
+</Callout>
+
 ## Subscribe and publish on the client
 
 `createClient<AppConfig>()` exposes one handle per generated channel:
@@ -209,6 +250,12 @@ export default runtimeConfig({
 ```
 
 The client discovers the selected transport from `/channels/config`; `client.channels.*` call sites do not change. After a managed-provider reconnect, the established subscription reauthorizes a bounded `/channels/replay` drain from its last applied event id. Live provider events arriving during that drain are buffered behind the replay cursor, then deduplicated and released in order.
+
+Pusher signed-user authentication uses the current dynamic auth headers and
+cookies. If login or logout changes identity without replacing the browser
+socket, call both `client.realtime.destroy()` and `client.channels.destroy()`
+(or recreate the client) before subscribing again so the shared provider
+connection is recreated under the new identity.
 
 <Callout type="warn" title="Direct Pusher client events are a separate unsafe capability">
 Provider client events bypass QUESTPIE's publish route, per-verb authorization, Zod schemas, ordered ledger, replay, and rate limits. They are off by default. Enabling `clientEvents` requires `acknowledgeProviderWideRisk: true`; its `allowedChannels` list is only an SDK affordance and a raw provider client can bypass it. Prefer `client.channels.<name>.publish()`.

--- a/examples/city-portal/src/questpie/server/.generated/context.gen.ts
+++ b/examples/city-portal/src/questpie/server/.generated/context.gen.ts
@@ -24,6 +24,7 @@ import _glob_site_settings from "../globals/site-settings";
 // ── Migrations ─────────────────────────────────────────────
 import _mig_20260725T184252_realtimeV3Umbrella from "../migrations/20260725T184252_realtime-v3-umbrella";
 import _mig_20260726T163039_queueTransactionalDispatch from "../migrations/20260726T163039_queue-transactional-dispatch";
+import _mig_20260731T000040_realtimeIdempotency1 from "../migrations/20260731T000040_realtime-idempotency-1";
 
 // ── Blocks ─────────────────────────────────────────────────
 import { accordionBlock as _bloc_accordion } from "../blocks/accordion";

--- a/examples/city-portal/src/questpie/server/.generated/entities.gen.ts
+++ b/examples/city-portal/src/questpie/server/.generated/entities.gen.ts
@@ -25,6 +25,7 @@ import _glob_site_settings from "../globals/site-settings";
 // ── Migrations ─────────────────────────────────────────────
 import _mig_20260725T184252_realtimeV3Umbrella from "../migrations/20260725T184252_realtime-v3-umbrella";
 import _mig_20260726T163039_queueTransactionalDispatch from "../migrations/20260726T163039_queue-transactional-dispatch";
+import _mig_20260731T000040_realtimeIdempotency1 from "../migrations/20260731T000040_realtime-idempotency-1";
 
 // ── Blocks ─────────────────────────────────────────────────
 import { accordionBlock as _bloc_accordion } from "../blocks/accordion";

--- a/examples/city-portal/src/questpie/server/.generated/index.ts
+++ b/examples/city-portal/src/questpie/server/.generated/index.ts
@@ -30,6 +30,7 @@ import _glob_site_settings from "../globals/site-settings";
 // ── Migrations ─────────────────────────────────────────────
 import _mig_20260725T184252_realtimeV3Umbrella from "../migrations/20260725T184252_realtime-v3-umbrella";
 import _mig_20260726T163039_queueTransactionalDispatch from "../migrations/20260726T163039_queue-transactional-dispatch";
+import _mig_20260731T000040_realtimeIdempotency1 from "../migrations/20260731T000040_realtime-idempotency-1";
 
 // ── Blocks ─────────────────────────────────────────────────
 import { accordionBlock as _bloc_accordion } from "../blocks/accordion";
@@ -136,7 +137,7 @@ var _appLease = acquireGeneratedApp("city-portal-example:src/questpie/server:src
 		globals: {
 			site_settings: _glob_site_settings,
 		},
-		migrations: [_mig_20260725T184252_realtimeV3Umbrella, _mig_20260726T163039_queueTransactionalDispatch],
+		migrations: [_mig_20260725T184252_realtimeV3Umbrella, _mig_20260726T163039_queueTransactionalDispatch, _mig_20260731T000040_realtimeIdempotency1],
 		blocks: {
 			[_bloc_accordion.state.name]: _bloc_accordion,
 			[_bloc_announcementBanner.state.name]: _bloc_announcementBanner,

--- a/examples/city-portal/src/questpie/server/migrations/20260731T000040_realtime-idempotency-1.ts
+++ b/examples/city-portal/src/questpie/server/migrations/20260731T000040_realtime-idempotency-1.ts
@@ -1,0 +1,35 @@
+import { migration } from "questpie/services"
+import type { OperationSnapshot } from "questpie/migration"
+import { sql } from "drizzle-orm"
+import snapshotJson from "./snapshots/20260731T000040_realtime-idempotency-1.json"
+
+const snapshot = snapshotJson as OperationSnapshot
+
+export default migration({
+	id: "realtimeIdempotency120260731T000040",
+	async up({ db }) {
+		await db.execute(sql`CREATE TABLE "questpie_channel_authority_fence" (
+	"channel_hash" text,
+	"subject" text,
+	"generation" bigint DEFAULT 0 NOT NULL,
+	"applied_generation" bigint DEFAULT 0 NOT NULL,
+	"updated_at" timestamp(3) DEFAULT now() NOT NULL,
+	CONSTRAINT "questpie_channel_authority_fence_pkey" PRIMARY KEY("channel_hash","subject")
+);`)
+		await db.execute(sql`CREATE TABLE "questpie_channel_authority_revocation" (
+	"idempotency_hash" text PRIMARY KEY,
+	"channel_hash" text NOT NULL,
+	"subject" text NOT NULL,
+	"generation" bigint DEFAULT 0 NOT NULL,
+	"applied" boolean DEFAULT false NOT NULL,
+	"created_at" timestamp(3) DEFAULT now() NOT NULL
+);`)
+		await db.execute(sql`CREATE INDEX "idx_channel_authority_fence_updated" ON "questpie_channel_authority_fence" ("updated_at");`)
+		await db.execute(sql`CREATE INDEX "idx_channel_authority_revocation_target" ON "questpie_channel_authority_revocation" ("channel_hash","subject");`)
+	},
+	async down({ db }) {
+		await db.execute(sql`DROP TABLE "questpie_channel_authority_fence";`)
+		await db.execute(sql`DROP TABLE "questpie_channel_authority_revocation";`)
+	},
+	snapshot,
+})

--- a/examples/city-portal/src/questpie/server/migrations/snapshots/20260731T000040_realtime-idempotency-1.json
+++ b/examples/city-portal/src/questpie/server/migrations/snapshots/20260731T000040_realtime-idempotency-1.json
@@ -1,0 +1,336 @@
+{
+  "operations": [
+    {
+      "type": "set",
+      "path": "ddl.table__COLON__public__DOT__questpie_channel_authority_fence",
+      "value": {
+        "isRlsEnabled": false,
+        "name": "questpie_channel_authority_fence",
+        "entityType": "tables",
+        "schema": "public"
+      },
+      "timestamp": "2026-07-31T00:00:40.572Z",
+      "migrationId": "realtimeIdempotency120260731T000040"
+    },
+    {
+      "type": "set",
+      "path": "ddl.table__COLON__public__DOT__questpie_channel_authority_revocation",
+      "value": {
+        "isRlsEnabled": false,
+        "name": "questpie_channel_authority_revocation",
+        "entityType": "tables",
+        "schema": "public"
+      },
+      "timestamp": "2026-07-31T00:00:40.572Z",
+      "migrationId": "realtimeIdempotency120260731T000040"
+    },
+    {
+      "type": "set",
+      "path": "ddl.column__COLON__public__DOT__questpie_channel_authority_fence__DOT__channel_hash",
+      "value": {
+        "type": "text",
+        "typeSchema": null,
+        "notNull": true,
+        "dimensions": 0,
+        "default": null,
+        "generated": null,
+        "identity": null,
+        "name": "channel_hash",
+        "entityType": "columns",
+        "schema": "public",
+        "table": "questpie_channel_authority_fence"
+      },
+      "timestamp": "2026-07-31T00:00:40.572Z",
+      "migrationId": "realtimeIdempotency120260731T000040"
+    },
+    {
+      "type": "set",
+      "path": "ddl.column__COLON__public__DOT__questpie_channel_authority_fence__DOT__subject",
+      "value": {
+        "type": "text",
+        "typeSchema": null,
+        "notNull": true,
+        "dimensions": 0,
+        "default": null,
+        "generated": null,
+        "identity": null,
+        "name": "subject",
+        "entityType": "columns",
+        "schema": "public",
+        "table": "questpie_channel_authority_fence"
+      },
+      "timestamp": "2026-07-31T00:00:40.572Z",
+      "migrationId": "realtimeIdempotency120260731T000040"
+    },
+    {
+      "type": "set",
+      "path": "ddl.column__COLON__public__DOT__questpie_channel_authority_fence__DOT__generation",
+      "value": {
+        "type": "bigint",
+        "typeSchema": null,
+        "notNull": true,
+        "dimensions": 0,
+        "default": "0",
+        "generated": null,
+        "identity": null,
+        "name": "generation",
+        "entityType": "columns",
+        "schema": "public",
+        "table": "questpie_channel_authority_fence"
+      },
+      "timestamp": "2026-07-31T00:00:40.572Z",
+      "migrationId": "realtimeIdempotency120260731T000040"
+    },
+    {
+      "type": "set",
+      "path": "ddl.column__COLON__public__DOT__questpie_channel_authority_fence__DOT__applied_generation",
+      "value": {
+        "type": "bigint",
+        "typeSchema": null,
+        "notNull": true,
+        "dimensions": 0,
+        "default": "0",
+        "generated": null,
+        "identity": null,
+        "name": "applied_generation",
+        "entityType": "columns",
+        "schema": "public",
+        "table": "questpie_channel_authority_fence"
+      },
+      "timestamp": "2026-07-31T00:00:40.572Z",
+      "migrationId": "realtimeIdempotency120260731T000040"
+    },
+    {
+      "type": "set",
+      "path": "ddl.column__COLON__public__DOT__questpie_channel_authority_fence__DOT__updated_at",
+      "value": {
+        "type": "timestamp(3)",
+        "typeSchema": null,
+        "notNull": true,
+        "dimensions": 0,
+        "default": "now()",
+        "generated": null,
+        "identity": null,
+        "name": "updated_at",
+        "entityType": "columns",
+        "schema": "public",
+        "table": "questpie_channel_authority_fence"
+      },
+      "timestamp": "2026-07-31T00:00:40.572Z",
+      "migrationId": "realtimeIdempotency120260731T000040"
+    },
+    {
+      "type": "set",
+      "path": "ddl.column__COLON__public__DOT__questpie_channel_authority_revocation__DOT__idempotency_hash",
+      "value": {
+        "type": "text",
+        "typeSchema": null,
+        "notNull": true,
+        "dimensions": 0,
+        "default": null,
+        "generated": null,
+        "identity": null,
+        "name": "idempotency_hash",
+        "entityType": "columns",
+        "schema": "public",
+        "table": "questpie_channel_authority_revocation"
+      },
+      "timestamp": "2026-07-31T00:00:40.572Z",
+      "migrationId": "realtimeIdempotency120260731T000040"
+    },
+    {
+      "type": "set",
+      "path": "ddl.column__COLON__public__DOT__questpie_channel_authority_revocation__DOT__channel_hash",
+      "value": {
+        "type": "text",
+        "typeSchema": null,
+        "notNull": true,
+        "dimensions": 0,
+        "default": null,
+        "generated": null,
+        "identity": null,
+        "name": "channel_hash",
+        "entityType": "columns",
+        "schema": "public",
+        "table": "questpie_channel_authority_revocation"
+      },
+      "timestamp": "2026-07-31T00:00:40.572Z",
+      "migrationId": "realtimeIdempotency120260731T000040"
+    },
+    {
+      "type": "set",
+      "path": "ddl.column__COLON__public__DOT__questpie_channel_authority_revocation__DOT__subject",
+      "value": {
+        "type": "text",
+        "typeSchema": null,
+        "notNull": true,
+        "dimensions": 0,
+        "default": null,
+        "generated": null,
+        "identity": null,
+        "name": "subject",
+        "entityType": "columns",
+        "schema": "public",
+        "table": "questpie_channel_authority_revocation"
+      },
+      "timestamp": "2026-07-31T00:00:40.572Z",
+      "migrationId": "realtimeIdempotency120260731T000040"
+    },
+    {
+      "type": "set",
+      "path": "ddl.column__COLON__public__DOT__questpie_channel_authority_revocation__DOT__generation",
+      "value": {
+        "type": "bigint",
+        "typeSchema": null,
+        "notNull": true,
+        "dimensions": 0,
+        "default": "0",
+        "generated": null,
+        "identity": null,
+        "name": "generation",
+        "entityType": "columns",
+        "schema": "public",
+        "table": "questpie_channel_authority_revocation"
+      },
+      "timestamp": "2026-07-31T00:00:40.572Z",
+      "migrationId": "realtimeIdempotency120260731T000040"
+    },
+    {
+      "type": "set",
+      "path": "ddl.column__COLON__public__DOT__questpie_channel_authority_revocation__DOT__applied",
+      "value": {
+        "type": "boolean",
+        "typeSchema": null,
+        "notNull": true,
+        "dimensions": 0,
+        "default": "false",
+        "generated": null,
+        "identity": null,
+        "name": "applied",
+        "entityType": "columns",
+        "schema": "public",
+        "table": "questpie_channel_authority_revocation"
+      },
+      "timestamp": "2026-07-31T00:00:40.572Z",
+      "migrationId": "realtimeIdempotency120260731T000040"
+    },
+    {
+      "type": "set",
+      "path": "ddl.column__COLON__public__DOT__questpie_channel_authority_revocation__DOT__created_at",
+      "value": {
+        "type": "timestamp(3)",
+        "typeSchema": null,
+        "notNull": true,
+        "dimensions": 0,
+        "default": "now()",
+        "generated": null,
+        "identity": null,
+        "name": "created_at",
+        "entityType": "columns",
+        "schema": "public",
+        "table": "questpie_channel_authority_revocation"
+      },
+      "timestamp": "2026-07-31T00:00:40.572Z",
+      "migrationId": "realtimeIdempotency120260731T000040"
+    },
+    {
+      "type": "set",
+      "path": "ddl.index__COLON__public__DOT__questpie_channel_authority_fence__DOT__idx_channel_authority_fence_updated",
+      "value": {
+        "nameExplicit": true,
+        "columns": [
+          {
+            "value": "updated_at",
+            "isExpression": false,
+            "asc": true,
+            "nullsFirst": false,
+            "opclass": null
+          }
+        ],
+        "isUnique": false,
+        "where": null,
+        "with": "",
+        "method": "btree",
+        "concurrently": false,
+        "name": "idx_channel_authority_fence_updated",
+        "entityType": "indexes",
+        "schema": "public",
+        "table": "questpie_channel_authority_fence"
+      },
+      "timestamp": "2026-07-31T00:00:40.572Z",
+      "migrationId": "realtimeIdempotency120260731T000040"
+    },
+    {
+      "type": "set",
+      "path": "ddl.index__COLON__public__DOT__questpie_channel_authority_revocation__DOT__idx_channel_authority_revocation_target",
+      "value": {
+        "nameExplicit": true,
+        "columns": [
+          {
+            "value": "channel_hash",
+            "isExpression": false,
+            "asc": true,
+            "nullsFirst": false,
+            "opclass": null
+          },
+          {
+            "value": "subject",
+            "isExpression": false,
+            "asc": true,
+            "nullsFirst": false,
+            "opclass": null
+          }
+        ],
+        "isUnique": false,
+        "where": null,
+        "with": "",
+        "method": "btree",
+        "concurrently": false,
+        "name": "idx_channel_authority_revocation_target",
+        "entityType": "indexes",
+        "schema": "public",
+        "table": "questpie_channel_authority_revocation"
+      },
+      "timestamp": "2026-07-31T00:00:40.572Z",
+      "migrationId": "realtimeIdempotency120260731T000040"
+    },
+    {
+      "type": "set",
+      "path": "ddl.pk__COLON__public__DOT__questpie_channel_authority_fence__DOT__questpie_channel_authority_fence_pkey",
+      "value": {
+        "columns": [
+          "channel_hash",
+          "subject"
+        ],
+        "nameExplicit": false,
+        "name": "questpie_channel_authority_fence_pkey",
+        "entityType": "pks",
+        "schema": "public",
+        "table": "questpie_channel_authority_fence"
+      },
+      "timestamp": "2026-07-31T00:00:40.572Z",
+      "migrationId": "realtimeIdempotency120260731T000040"
+    },
+    {
+      "type": "set",
+      "path": "ddl.pk__COLON__public__DOT__questpie_channel_authority_revocation__DOT__questpie_channel_authority_revocation_pkey",
+      "value": {
+        "columns": [
+          "idempotency_hash"
+        ],
+        "nameExplicit": false,
+        "name": "questpie_channel_authority_revocation_pkey",
+        "schema": "public",
+        "table": "questpie_channel_authority_revocation",
+        "entityType": "pks"
+      },
+      "timestamp": "2026-07-31T00:00:40.572Z",
+      "migrationId": "realtimeIdempotency120260731T000040"
+    }
+  ],
+  "metadata": {
+    "migrationId": "realtimeIdempotency120260731T000040",
+    "timestamp": "2026-07-31T00:00:40.743Z",
+    "prevId": "00000000-0000-0000-0000-000000000000"
+  }
+}

--- a/examples/tanstack-barbershop/src/questpie/server/.generated/context.gen.ts
+++ b/examples/tanstack-barbershop/src/questpie/server/.generated/context.gen.ts
@@ -59,6 +59,7 @@ import _mig_20260712T094709_bold_red_griffin from "../migrations/20260712T094709
 import _mig_20260712T195414_eager_red_tiger from "../migrations/20260712T195414_eager_red_tiger";
 import _mig_20260725T184252_realtimeV3Umbrella from "../migrations/20260725T184252_realtime-v3-umbrella";
 import _mig_20260726T163042_queueTransactionalDispatch from "../migrations/20260726T163042_queue-transactional-dispatch";
+import _mig_20260731T000041_realtimeIdempotency1 from "../migrations/20260731T000041_realtime-idempotency-1";
 
 // ── Seeds ──────────────────────────────────────────────────
 import _seed_blogPosts from "../seeds/blog-posts";

--- a/examples/tanstack-barbershop/src/questpie/server/.generated/entities.gen.ts
+++ b/examples/tanstack-barbershop/src/questpie/server/.generated/entities.gen.ts
@@ -60,6 +60,7 @@ import _mig_20260712T094709_bold_red_griffin from "../migrations/20260712T094709
 import _mig_20260712T195414_eager_red_tiger from "../migrations/20260712T195414_eager_red_tiger";
 import _mig_20260725T184252_realtimeV3Umbrella from "../migrations/20260725T184252_realtime-v3-umbrella";
 import _mig_20260726T163042_queueTransactionalDispatch from "../migrations/20260726T163042_queue-transactional-dispatch";
+import _mig_20260731T000041_realtimeIdempotency1 from "../migrations/20260731T000041_realtime-idempotency-1";
 
 // ── Seeds ──────────────────────────────────────────────────
 import _seed_blogPosts from "../seeds/blog-posts";

--- a/examples/tanstack-barbershop/src/questpie/server/.generated/index.ts
+++ b/examples/tanstack-barbershop/src/questpie/server/.generated/index.ts
@@ -65,6 +65,7 @@ import _mig_20260712T094709_bold_red_griffin from "../migrations/20260712T094709
 import _mig_20260712T195414_eager_red_tiger from "../migrations/20260712T195414_eager_red_tiger";
 import _mig_20260725T184252_realtimeV3Umbrella from "../migrations/20260725T184252_realtime-v3-umbrella";
 import _mig_20260726T163042_queueTransactionalDispatch from "../migrations/20260726T163042_queue-transactional-dispatch";
+import _mig_20260731T000041_realtimeIdempotency1 from "../migrations/20260731T000041_realtime-idempotency-1";
 
 // ── Seeds ──────────────────────────────────────────────────
 import _seed_blogPosts from "../seeds/blog-posts";
@@ -203,7 +204,7 @@ var _appLease = acquireGeneratedApp("tanstack-barbershop-example:src/questpie/se
 			appointmentConfirmation: _email_appointmentConfirmation,
 			newBlogPost: _email_newBlogPost,
 		},
-		migrations: [_mig_20260206T174642_gentle_azure_eagle, _mig_20260206T180920_fancy_green_tiger, _mig_20260211T100836_calm_blue_phoenix, _mig_20260218T195452_calm_blue_dragon, _mig_20260218T223923_fancy_blue_panda, _mig_20260218T235924_kind_crimson_falcon, _mig_20260307T122102_eager_red_eagle, _mig_20260307T135142_fancy_orange_tiger, _mig_20260424T221327_bold_yellow_phoenix, _mig_20260427T093217_eager_blue_phoenix, _mig_20260429T170546_kind_yellow_eagle, _mig_20260615T084209_swift_orange_eagle, _mig_20260712T094709_bold_red_griffin, _mig_20260712T195414_eager_red_tiger, _mig_20260725T184252_realtimeV3Umbrella, _mig_20260726T163042_queueTransactionalDispatch],
+		migrations: [_mig_20260206T174642_gentle_azure_eagle, _mig_20260206T180920_fancy_green_tiger, _mig_20260211T100836_calm_blue_phoenix, _mig_20260218T195452_calm_blue_dragon, _mig_20260218T223923_fancy_blue_panda, _mig_20260218T235924_kind_crimson_falcon, _mig_20260307T122102_eager_red_eagle, _mig_20260307T135142_fancy_orange_tiger, _mig_20260424T221327_bold_yellow_phoenix, _mig_20260427T093217_eager_blue_phoenix, _mig_20260429T170546_kind_yellow_eagle, _mig_20260615T084209_swift_orange_eagle, _mig_20260712T094709_bold_red_griffin, _mig_20260712T195414_eager_red_tiger, _mig_20260725T184252_realtimeV3Umbrella, _mig_20260726T163042_queueTransactionalDispatch, _mig_20260731T000041_realtimeIdempotency1],
 		seeds: [_seed_blogPosts, _seed_demoData, _seed_siteSettings],
 		fieldTypes: {
 			color: _ftype_color,

--- a/examples/tanstack-barbershop/src/questpie/server/migrations/20260731T000041_realtime-idempotency-1.ts
+++ b/examples/tanstack-barbershop/src/questpie/server/migrations/20260731T000041_realtime-idempotency-1.ts
@@ -1,0 +1,35 @@
+import { migration } from "questpie/services"
+import type { OperationSnapshot } from "questpie/migration"
+import { sql } from "drizzle-orm"
+import snapshotJson from "./snapshots/20260731T000041_realtime-idempotency-1.json"
+
+const snapshot = snapshotJson as OperationSnapshot
+
+export default migration({
+	id: "realtimeIdempotency120260731T000041",
+	async up({ db }) {
+		await db.execute(sql`CREATE TABLE "questpie_channel_authority_fence" (
+	"channel_hash" text,
+	"subject" text,
+	"generation" bigint DEFAULT 0 NOT NULL,
+	"applied_generation" bigint DEFAULT 0 NOT NULL,
+	"updated_at" timestamp(3) DEFAULT now() NOT NULL,
+	CONSTRAINT "questpie_channel_authority_fence_pkey" PRIMARY KEY("channel_hash","subject")
+);`)
+		await db.execute(sql`CREATE TABLE "questpie_channel_authority_revocation" (
+	"idempotency_hash" text PRIMARY KEY,
+	"channel_hash" text NOT NULL,
+	"subject" text NOT NULL,
+	"generation" bigint DEFAULT 0 NOT NULL,
+	"applied" boolean DEFAULT false NOT NULL,
+	"created_at" timestamp(3) DEFAULT now() NOT NULL
+);`)
+		await db.execute(sql`CREATE INDEX "idx_channel_authority_fence_updated" ON "questpie_channel_authority_fence" ("updated_at");`)
+		await db.execute(sql`CREATE INDEX "idx_channel_authority_revocation_target" ON "questpie_channel_authority_revocation" ("channel_hash","subject");`)
+	},
+	async down({ db }) {
+		await db.execute(sql`DROP TABLE "questpie_channel_authority_fence";`)
+		await db.execute(sql`DROP TABLE "questpie_channel_authority_revocation";`)
+	},
+	snapshot,
+})

--- a/examples/tanstack-barbershop/src/questpie/server/migrations/snapshots/20260731T000041_realtime-idempotency-1.json
+++ b/examples/tanstack-barbershop/src/questpie/server/migrations/snapshots/20260731T000041_realtime-idempotency-1.json
@@ -1,0 +1,336 @@
+{
+  "operations": [
+    {
+      "type": "set",
+      "path": "ddl.table__COLON__public__DOT__questpie_channel_authority_fence",
+      "value": {
+        "isRlsEnabled": false,
+        "name": "questpie_channel_authority_fence",
+        "entityType": "tables",
+        "schema": "public"
+      },
+      "timestamp": "2026-07-31T00:00:41.793Z",
+      "migrationId": "realtimeIdempotency120260731T000041"
+    },
+    {
+      "type": "set",
+      "path": "ddl.table__COLON__public__DOT__questpie_channel_authority_revocation",
+      "value": {
+        "isRlsEnabled": false,
+        "name": "questpie_channel_authority_revocation",
+        "entityType": "tables",
+        "schema": "public"
+      },
+      "timestamp": "2026-07-31T00:00:41.793Z",
+      "migrationId": "realtimeIdempotency120260731T000041"
+    },
+    {
+      "type": "set",
+      "path": "ddl.column__COLON__public__DOT__questpie_channel_authority_fence__DOT__channel_hash",
+      "value": {
+        "type": "text",
+        "typeSchema": null,
+        "notNull": true,
+        "dimensions": 0,
+        "default": null,
+        "generated": null,
+        "identity": null,
+        "name": "channel_hash",
+        "entityType": "columns",
+        "schema": "public",
+        "table": "questpie_channel_authority_fence"
+      },
+      "timestamp": "2026-07-31T00:00:41.793Z",
+      "migrationId": "realtimeIdempotency120260731T000041"
+    },
+    {
+      "type": "set",
+      "path": "ddl.column__COLON__public__DOT__questpie_channel_authority_fence__DOT__subject",
+      "value": {
+        "type": "text",
+        "typeSchema": null,
+        "notNull": true,
+        "dimensions": 0,
+        "default": null,
+        "generated": null,
+        "identity": null,
+        "name": "subject",
+        "entityType": "columns",
+        "schema": "public",
+        "table": "questpie_channel_authority_fence"
+      },
+      "timestamp": "2026-07-31T00:00:41.793Z",
+      "migrationId": "realtimeIdempotency120260731T000041"
+    },
+    {
+      "type": "set",
+      "path": "ddl.column__COLON__public__DOT__questpie_channel_authority_fence__DOT__generation",
+      "value": {
+        "type": "bigint",
+        "typeSchema": null,
+        "notNull": true,
+        "dimensions": 0,
+        "default": "0",
+        "generated": null,
+        "identity": null,
+        "name": "generation",
+        "entityType": "columns",
+        "schema": "public",
+        "table": "questpie_channel_authority_fence"
+      },
+      "timestamp": "2026-07-31T00:00:41.793Z",
+      "migrationId": "realtimeIdempotency120260731T000041"
+    },
+    {
+      "type": "set",
+      "path": "ddl.column__COLON__public__DOT__questpie_channel_authority_fence__DOT__applied_generation",
+      "value": {
+        "type": "bigint",
+        "typeSchema": null,
+        "notNull": true,
+        "dimensions": 0,
+        "default": "0",
+        "generated": null,
+        "identity": null,
+        "name": "applied_generation",
+        "entityType": "columns",
+        "schema": "public",
+        "table": "questpie_channel_authority_fence"
+      },
+      "timestamp": "2026-07-31T00:00:41.793Z",
+      "migrationId": "realtimeIdempotency120260731T000041"
+    },
+    {
+      "type": "set",
+      "path": "ddl.column__COLON__public__DOT__questpie_channel_authority_fence__DOT__updated_at",
+      "value": {
+        "type": "timestamp(3)",
+        "typeSchema": null,
+        "notNull": true,
+        "dimensions": 0,
+        "default": "now()",
+        "generated": null,
+        "identity": null,
+        "name": "updated_at",
+        "entityType": "columns",
+        "schema": "public",
+        "table": "questpie_channel_authority_fence"
+      },
+      "timestamp": "2026-07-31T00:00:41.793Z",
+      "migrationId": "realtimeIdempotency120260731T000041"
+    },
+    {
+      "type": "set",
+      "path": "ddl.column__COLON__public__DOT__questpie_channel_authority_revocation__DOT__idempotency_hash",
+      "value": {
+        "type": "text",
+        "typeSchema": null,
+        "notNull": true,
+        "dimensions": 0,
+        "default": null,
+        "generated": null,
+        "identity": null,
+        "name": "idempotency_hash",
+        "entityType": "columns",
+        "schema": "public",
+        "table": "questpie_channel_authority_revocation"
+      },
+      "timestamp": "2026-07-31T00:00:41.793Z",
+      "migrationId": "realtimeIdempotency120260731T000041"
+    },
+    {
+      "type": "set",
+      "path": "ddl.column__COLON__public__DOT__questpie_channel_authority_revocation__DOT__channel_hash",
+      "value": {
+        "type": "text",
+        "typeSchema": null,
+        "notNull": true,
+        "dimensions": 0,
+        "default": null,
+        "generated": null,
+        "identity": null,
+        "name": "channel_hash",
+        "entityType": "columns",
+        "schema": "public",
+        "table": "questpie_channel_authority_revocation"
+      },
+      "timestamp": "2026-07-31T00:00:41.793Z",
+      "migrationId": "realtimeIdempotency120260731T000041"
+    },
+    {
+      "type": "set",
+      "path": "ddl.column__COLON__public__DOT__questpie_channel_authority_revocation__DOT__subject",
+      "value": {
+        "type": "text",
+        "typeSchema": null,
+        "notNull": true,
+        "dimensions": 0,
+        "default": null,
+        "generated": null,
+        "identity": null,
+        "name": "subject",
+        "entityType": "columns",
+        "schema": "public",
+        "table": "questpie_channel_authority_revocation"
+      },
+      "timestamp": "2026-07-31T00:00:41.793Z",
+      "migrationId": "realtimeIdempotency120260731T000041"
+    },
+    {
+      "type": "set",
+      "path": "ddl.column__COLON__public__DOT__questpie_channel_authority_revocation__DOT__generation",
+      "value": {
+        "type": "bigint",
+        "typeSchema": null,
+        "notNull": true,
+        "dimensions": 0,
+        "default": "0",
+        "generated": null,
+        "identity": null,
+        "name": "generation",
+        "entityType": "columns",
+        "schema": "public",
+        "table": "questpie_channel_authority_revocation"
+      },
+      "timestamp": "2026-07-31T00:00:41.793Z",
+      "migrationId": "realtimeIdempotency120260731T000041"
+    },
+    {
+      "type": "set",
+      "path": "ddl.column__COLON__public__DOT__questpie_channel_authority_revocation__DOT__applied",
+      "value": {
+        "type": "boolean",
+        "typeSchema": null,
+        "notNull": true,
+        "dimensions": 0,
+        "default": "false",
+        "generated": null,
+        "identity": null,
+        "name": "applied",
+        "entityType": "columns",
+        "schema": "public",
+        "table": "questpie_channel_authority_revocation"
+      },
+      "timestamp": "2026-07-31T00:00:41.793Z",
+      "migrationId": "realtimeIdempotency120260731T000041"
+    },
+    {
+      "type": "set",
+      "path": "ddl.column__COLON__public__DOT__questpie_channel_authority_revocation__DOT__created_at",
+      "value": {
+        "type": "timestamp(3)",
+        "typeSchema": null,
+        "notNull": true,
+        "dimensions": 0,
+        "default": "now()",
+        "generated": null,
+        "identity": null,
+        "name": "created_at",
+        "entityType": "columns",
+        "schema": "public",
+        "table": "questpie_channel_authority_revocation"
+      },
+      "timestamp": "2026-07-31T00:00:41.793Z",
+      "migrationId": "realtimeIdempotency120260731T000041"
+    },
+    {
+      "type": "set",
+      "path": "ddl.index__COLON__public__DOT__questpie_channel_authority_fence__DOT__idx_channel_authority_fence_updated",
+      "value": {
+        "nameExplicit": true,
+        "columns": [
+          {
+            "value": "updated_at",
+            "isExpression": false,
+            "asc": true,
+            "nullsFirst": false,
+            "opclass": null
+          }
+        ],
+        "isUnique": false,
+        "where": null,
+        "with": "",
+        "method": "btree",
+        "concurrently": false,
+        "name": "idx_channel_authority_fence_updated",
+        "entityType": "indexes",
+        "schema": "public",
+        "table": "questpie_channel_authority_fence"
+      },
+      "timestamp": "2026-07-31T00:00:41.793Z",
+      "migrationId": "realtimeIdempotency120260731T000041"
+    },
+    {
+      "type": "set",
+      "path": "ddl.index__COLON__public__DOT__questpie_channel_authority_revocation__DOT__idx_channel_authority_revocation_target",
+      "value": {
+        "nameExplicit": true,
+        "columns": [
+          {
+            "value": "channel_hash",
+            "isExpression": false,
+            "asc": true,
+            "nullsFirst": false,
+            "opclass": null
+          },
+          {
+            "value": "subject",
+            "isExpression": false,
+            "asc": true,
+            "nullsFirst": false,
+            "opclass": null
+          }
+        ],
+        "isUnique": false,
+        "where": null,
+        "with": "",
+        "method": "btree",
+        "concurrently": false,
+        "name": "idx_channel_authority_revocation_target",
+        "entityType": "indexes",
+        "schema": "public",
+        "table": "questpie_channel_authority_revocation"
+      },
+      "timestamp": "2026-07-31T00:00:41.793Z",
+      "migrationId": "realtimeIdempotency120260731T000041"
+    },
+    {
+      "type": "set",
+      "path": "ddl.pk__COLON__public__DOT__questpie_channel_authority_fence__DOT__questpie_channel_authority_fence_pkey",
+      "value": {
+        "columns": [
+          "channel_hash",
+          "subject"
+        ],
+        "nameExplicit": false,
+        "name": "questpie_channel_authority_fence_pkey",
+        "entityType": "pks",
+        "schema": "public",
+        "table": "questpie_channel_authority_fence"
+      },
+      "timestamp": "2026-07-31T00:00:41.793Z",
+      "migrationId": "realtimeIdempotency120260731T000041"
+    },
+    {
+      "type": "set",
+      "path": "ddl.pk__COLON__public__DOT__questpie_channel_authority_revocation__DOT__questpie_channel_authority_revocation_pkey",
+      "value": {
+        "columns": [
+          "idempotency_hash"
+        ],
+        "nameExplicit": false,
+        "name": "questpie_channel_authority_revocation_pkey",
+        "schema": "public",
+        "table": "questpie_channel_authority_revocation",
+        "entityType": "pks"
+      },
+      "timestamp": "2026-07-31T00:00:41.793Z",
+      "migrationId": "realtimeIdempotency120260731T000041"
+    }
+  ],
+  "metadata": {
+    "migrationId": "realtimeIdempotency120260731T000041",
+    "timestamp": "2026-07-31T00:00:41.978Z",
+    "prevId": "00000000-0000-0000-0000-000000000000"
+  }
+}

--- a/examples/tanstack-barbershop/test/openapi-spec.test.ts
+++ b/examples/tanstack-barbershop/test/openapi-spec.test.ts
@@ -70,7 +70,7 @@ describe("barbershop generated OpenAPI route snapshot", () => {
 		};
 
 		expect(routeSnapshot).toEqual({
-			pathCount: 60,
+			pathCount: 61,
 			methods: {
 				"/api/channels/auth": ["options", "post"],
 				"/api/channels/config": ["get"],

--- a/packages/questpie/src/client/channels/pusher.ts
+++ b/packages/questpie/src/client/channels/pusher.ts
@@ -250,6 +250,36 @@ export class PusherChannelTransport implements ChannelClientTransport {
 		};
 	}
 
+	private async authenticateUser(
+		socketId: string,
+	): Promise<{ auth: string; user_data: string }> {
+		const authHeaders = await this.options.getAuthHeaders?.();
+		const path = this.options.config.authEndpoint ?? "realtime/auth";
+		const authEndpoint = /^https?:\/\//.test(path)
+			? path
+			: `${this.options.baseUrl.replace(/\/$/, "")}/${path.replace(/^\//, "")}`;
+		const response = await this.options.fetcher(authEndpoint, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/x-www-form-urlencoded",
+				...authHeaders,
+			},
+			body: new URLSearchParams({ socket_id: socketId }),
+			credentials: "include",
+		});
+		if (!response.ok) {
+			throw new Error(`Realtime user auth failed: ${response.status}`);
+		}
+		const auth = (await response.json()) as {
+			auth?: unknown;
+			user_data?: unknown;
+		};
+		if (typeof auth.auth !== "string" || typeof auth.user_data !== "string") {
+			throw new Error("Invalid realtime user auth response");
+		}
+		return { auth: auth.auth, user_data: auth.user_data };
+	}
+
 	private async mount(entry: Entry): Promise<void> {
 		try {
 			const subscription = await this.connection.subscribe({
@@ -258,6 +288,12 @@ export class PusherChannelTransport implements ChannelClientTransport {
 				lane: "channel",
 				authorize: (socketId, channelName) =>
 					this.authorize(socketId, channelName),
+				...(this.options.config.userAuthentication === true
+					? {
+							authenticateUser: (socketId: string) =>
+								this.authenticateUser(socketId),
+						}
+					: {}),
 			});
 			if (
 				this.destroyed ||

--- a/packages/questpie/src/client/realtime/pusher-connection.ts
+++ b/packages/questpie/src/client/realtime/pusher-connection.ts
@@ -7,6 +7,7 @@ export type PusherRealtimeConfig = {
 	wssPort?: number;
 	forceTLS?: boolean;
 	authEndpoint?: string;
+	userAuthentication?: boolean;
 };
 
 export type PusherModule = typeof import("pusher-js");
@@ -26,8 +27,14 @@ type ChannelAuthorizer = (
 	channelName: string,
 ) => Promise<PusherAuthResponse>;
 
+type UserAuthenticator = (socketId: string) => Promise<{
+	auth: string;
+	user_data: string;
+}>;
+
 type ChannelOwner = {
 	authorize: ChannelAuthorizer;
+	authenticateUser?: UserAuthenticator;
 	channel?: PusherChannel;
 };
 
@@ -48,6 +55,7 @@ function connectionSignature(config: PusherRealtimeConfig): string {
 		wsPort: config.wsPort ?? null,
 		wssPort: config.wssPort ?? null,
 		forceTLS: config.forceTLS ?? true,
+		userAuthentication: config.userAuthentication === true,
 	});
 }
 
@@ -75,6 +83,7 @@ export class PusherConnectionManager {
 		channelName: string;
 		lane: "edge" | "channel";
 		authorize: ChannelAuthorizer;
+		authenticateUser?: UserAuthenticator;
 	}): Promise<ManagedPusherSubscription> {
 		if (
 			options.lane === "channel" &&
@@ -86,7 +95,10 @@ export class PusherConnectionManager {
 			throw new Error(`Pusher channel already owned: ${options.channelName}`);
 		}
 
-		const owner: ChannelOwner = { authorize: options.authorize };
+		const owner: ChannelOwner = {
+			authorize: options.authorize,
+			authenticateUser: options.authenticateUser,
+		};
 		this.owners.set(options.channelName, owner);
 		try {
 			const pusher = await this.getPusher(options.config);
@@ -141,13 +153,78 @@ export class PusherConnectionManager {
 								);
 								return;
 							}
-							void owner
-								.authorize(request.socketId, request.channelName)
+							void (async () => {
+								if (config.userAuthentication === true) {
+									const assertCurrentSignedInConnection = () => {
+										if (this.owners.get(request.channelName) !== owner) {
+											throw new Error(
+												"Realtime channel authorization owner was released",
+											);
+										}
+										if (
+											pusher.connection.state !== "connected" ||
+											pusher.connection.socket_id !== request.socketId
+										) {
+											throw new Error(
+												"Realtime channel authorization socket is stale",
+											);
+										}
+										if (
+											typeof pusher.user.user_data?.id !== "string" ||
+											pusher.user.user_data.id.length === 0
+										) {
+											throw new Error(
+												"Realtime user authentication did not complete",
+											);
+										}
+									};
+									const signinDone = pusher.user.signinDonePromise;
+									if (!signinDone) {
+										throw new Error(
+											"Realtime user authentication has not started",
+										);
+									}
+									await signinDone;
+									assertCurrentSignedInConnection();
+									const auth = await owner.authorize(
+										request.socketId,
+										request.channelName,
+									);
+									assertCurrentSignedInConnection();
+									return auth;
+								}
+								return owner.authorize(request.socketId, request.channelName);
+							})()
 								.then((auth) => callback(null, auth))
 								.catch((error) => callback(normalizedError(error), null));
 						},
 					},
+					...(config.userAuthentication === true
+						? {
+								userAuthentication: {
+									customHandler: (request, callback) => {
+										const owner = [...this.owners.values()].find(
+											(candidate) => candidate.authenticateUser,
+										);
+										if (!owner?.authenticateUser) {
+											callback(
+												new Error(
+													"Realtime user authentication is unavailable",
+												),
+												null,
+											);
+											return;
+										}
+										void owner
+											.authenticateUser(request.socketId)
+											.then((auth) => callback(null, auth))
+											.catch((error) => callback(normalizedError(error), null));
+									},
+								},
+							}
+						: {}),
 				});
+				if (config.userAuthentication === true) pusher.signin();
 				this.pusher = pusher;
 				return pusher;
 			})().catch((error) => {

--- a/packages/questpie/src/client/realtime/pusher.ts
+++ b/packages/questpie/src/client/realtime/pusher.ts
@@ -351,6 +351,12 @@ export class PusherRealtimeTransport implements RealtimeClientTransport {
 			lane: "edge",
 			authorize: (socketId, channelName) =>
 				this.authorize(authEndpoint, socketId, channelName),
+			...(config.userAuthentication === true
+				? {
+						authenticateUser: (socketId: string) =>
+							this.authenticateUser(authEndpoint, socketId),
+					}
+				: {}),
 		});
 		if (this.destroyed || this.session !== session) {
 			subscription.release();
@@ -427,6 +433,33 @@ export class PusherRealtimeTransport implements RealtimeClientTransport {
 				? { shared_secret: auth.shared_secret }
 				: {}),
 		};
+	}
+
+	private async authenticateUser(
+		authEndpoint: string,
+		socketId: string,
+	): Promise<{ auth: string; user_data: string }> {
+		const authHeaders = await this.options.getAuthHeaders?.();
+		const response = await this.options.fetcher(authEndpoint, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/x-www-form-urlencoded",
+				...authHeaders,
+			},
+			body: new URLSearchParams({ socket_id: socketId }),
+			credentials: "include",
+		});
+		if (!response.ok) {
+			throw new Error(`Realtime user auth failed: ${response.status}`);
+		}
+		const auth = (await response.json()) as {
+			auth?: unknown;
+			user_data?: unknown;
+		};
+		if (typeof auth.auth !== "string" || typeof auth.user_data !== "string") {
+			throw new Error("Invalid realtime user auth response");
+		}
+		return { auth: auth.auth, user_data: auth.user_data };
 	}
 
 	private sendDesiredTopology(): Promise<void> {

--- a/packages/questpie/src/server/adapters/routes/realtime.ts
+++ b/packages/questpie/src/server/adapters/routes/realtime.ts
@@ -10,6 +10,10 @@ import { Buffer } from "node:buffer";
 import type { RealtimeTopicRejectedPayload } from "#questpie/shared/realtime-error.js";
 
 import {
+	opaqueChannelAuthoritySubject,
+	resolveChannelAuthoritySubject,
+} from "../../channels/authority.js";
+import {
 	ChannelsService,
 	type ChannelServiceContext,
 } from "../../channels/service.js";
@@ -69,7 +73,7 @@ import {
 } from "../../modules/core/integrated/realtime/topology-coordinator.js";
 import type { ClientSink } from "../../modules/core/integrated/realtime/transport.js";
 import type { AdapterConfig, AdapterContext } from "../types.js";
-import { resolveContext } from "../utils/context.js";
+import { refreshAdapterContext, resolveContext } from "../utils/context.js";
 import { handleError, sseHeaders } from "../utils/response.js";
 
 // ============================================================================
@@ -186,6 +190,8 @@ type ValidatedChannelSubscription = {
 	channel: string;
 	params: Record<string, string>;
 	resolvedName: string;
+	presenceChannel: boolean;
+	subject?: string;
 	lastEventId?: string;
 	presence?: Record<string, unknown>;
 };
@@ -717,6 +723,7 @@ async function resolveChannelSubscription(
 	);
 	const definition = channels.getDefinition(input.channel);
 	const resolvedName = channels.resolveName(input.channel, params);
+	const authoritySubject = resolveChannelAuthoritySubject(context);
 	let presence: Record<string, unknown> | undefined;
 	if (definition.visibility === "presence") {
 		const value = await channels.resolvePresence(input.channel, params);
@@ -731,6 +738,10 @@ async function resolveChannelSubscription(
 		channel: input.channel,
 		params,
 		resolvedName,
+		presenceChannel: definition.visibility === "presence",
+		...(authoritySubject
+			? { subject: opaqueChannelAuthoritySubject(authoritySubject) }
+			: {}),
 		...(input.lastEventId ? { lastEventId: input.lastEventId } : {}),
 		...(presence ? { presence } : {}),
 	};
@@ -817,6 +828,7 @@ export async function realtimeSubscribe(
 
 	// Resolve context (auth, locale, etc.)
 	const resolved = await resolveContext(app, request, config, context);
+	const resolveFreshRouteContext = () => refreshAdapterContext(resolved);
 	let frozenSubscriptionScope: Promise<string | null> | undefined;
 	const getFrozenSubscriptionScope = () =>
 		(frozenSubscriptionScope ??= resolveRealtimeSubscriptionScope(
@@ -1916,8 +1928,8 @@ export async function realtimeSubscribe(
 					if (!ownerIsActive(bindingGeneration)) {
 						throw new Error("Realtime owner is fenced");
 					}
-					let unsubscribeLedger: (() => void) | undefined;
-					let unsubscribePresence: (() => Promise<void>) | undefined;
+					let unsubscribeLedger: (() => Promise<void>) | undefined;
+					let revocationRequested = false;
 					const bindingInstanceId = globalThis.crypto.randomUUID();
 					const fencedSink = createFencedClientSink(sink, () =>
 						ownerIsActive(bindingGeneration),
@@ -1931,43 +1943,88 @@ export async function realtimeSubscribe(
 						unsubscribeLedger = await app.realtime!.subscribeChannel({
 							subscriptionId: `${edgeSessionId}:${channel.id}:${bindingInstanceId}`,
 							channel: channel.resolvedName,
+							...(channel.subject
+								? {
+										subject: channel.subject,
+										reauthorize: async () => {
+											const fresh = await resolveFreshRouteContext();
+											const channels = new ChannelsService(
+												app.config.channels ?? {},
+												app.realtime!,
+												{
+													...fresh.appContext,
+													accessMode: "user",
+												} as ChannelServiceContext,
+												app.config.realtime?.channelSecurity,
+											);
+											if (channel.presenceChannel) {
+												const presence = await channels.resolvePresence(
+													channel.channel,
+													channel.params,
+												);
+												return {
+													authorized: true,
+													...(presence && typeof presence === "object"
+														? {
+																presence: presence as Record<string, unknown>,
+															}
+														: {}),
+												};
+											}
+											return channels.authorize(
+												channel.channel,
+												channel.params,
+												"subscribe",
+											);
+										},
+										close: async () => {
+											if (edge?.has(channel.id)) {
+												await edge.drop(channel.id);
+												closeIfEmpty();
+												return;
+											}
+											revocationRequested = true;
+										},
+									}
+								: {}),
 							sink: subscriptionSink,
 							lastEventId: channel.lastEventId,
 							encodeFrame: (frame) => transport!.encodeChannelFrame(frame),
+							...(channel.presence
+								? {
+										presence: {
+											channel: channel.resolvedName,
+											connectionId: `${edgeSessionId}:${channel.id}:${bindingInstanceId}`,
+											principalId:
+												realtimePrincipalKey(resolved.appContext) ??
+												(() => {
+													throw new Error(
+														"Presence channel subscription requires a principal",
+													);
+												})(),
+											sink: subscriptionSink,
+											data: channel.presence!,
+										},
+									}
+								: {}),
 						});
-						if (channel.presence) {
-							const principalId = realtimePrincipalKey(resolved.appContext);
-							if (!principalId) {
-								throw new Error(
-									"Presence channel subscription requires a principal",
-								);
-							}
-							unsubscribePresence = await app.realtime!.registerChannelPresence(
-								{
-									channel: channel.resolvedName,
-									connectionId: `${edgeSessionId}:${channel.id}:${bindingInstanceId}`,
-									principalId,
-									sink: subscriptionSink,
-									data: channel.presence,
-								},
-							);
-						}
 						if (!ownerIsActive(bindingGeneration)) {
 							throw new Error("Realtime owner is fenced");
+						}
+						if (revocationRequested) {
+							throw new Error("Channel access was revoked");
 						}
 						if (subscriptionSink.error) throw subscriptionSink.error;
 						return {
 							activate: () => subscriptionSink.activate(),
 							assertReady: () => subscriptionSink.assertReady(),
 							close: async () => {
-								await unsubscribePresence?.().catch(requestClose);
-								unsubscribeLedger?.();
+								await unsubscribeLedger?.().catch(requestClose);
 								await subscriptionSink.dispose();
 							},
 						};
 					} catch (error) {
-						await unsubscribePresence?.();
-						unsubscribeLedger?.();
+						await unsubscribeLedger?.();
 						await subscriptionSink.dispose();
 						throw error;
 					}

--- a/packages/questpie/src/server/adapters/utils/context.ts
+++ b/packages/questpie/src/server/adapters/utils/context.ts
@@ -22,6 +22,40 @@ type BetterAuthSessionApi = {
 	}): Promise<{ user: any; session: any } | null | undefined>;
 };
 
+const FRESH_ADAPTER_CONTEXT = Symbol.for(
+	"questpie.internal.freshAdapterContext",
+);
+
+type RefreshableAdapterContext = AdapterContext & {
+	[FRESH_ADAPTER_CONTEXT]?: () => Promise<AdapterContext>;
+};
+
+function attachFreshAdapterContext(
+	context: AdapterContext,
+	resolveFresh: () => Promise<AdapterContext>,
+): AdapterContext {
+	Object.defineProperty(context, FRESH_ADAPTER_CONTEXT, {
+		value: resolveFresh,
+		enumerable: false,
+		configurable: false,
+		writable: false,
+	});
+	return context;
+}
+
+/** @internal Re-run session resolution and app context derivation for a route. */
+export function refreshAdapterContext(
+	context: AdapterContext,
+): Promise<AdapterContext> {
+	const resolveFresh = (context as RefreshableAdapterContext)[
+		FRESH_ADAPTER_CONTEXT
+	];
+	if (!resolveFresh) {
+		throw new Error("Fresh adapter context is unavailable");
+	}
+	return resolveFresh();
+}
+
 export const resolveSession = async <
 	TConfig extends QuestpieConfig = QuestpieConfig,
 >(
@@ -141,19 +175,29 @@ const createAdapterContextInternal = async <
 		request,
 	});
 
-	return {
-		session: sessionData,
-		locale: appContext.locale,
-		localeFallback: appContext.localeFallback,
-		stage: appContext.stage,
-		appContext,
-		...(typeof appContext.requestId === "string"
-			? { requestId: appContext.requestId }
-			: {}),
-		...(typeof appContext.traceId === "string"
-			? { traceId: appContext.traceId }
-			: {}),
-	};
+	return attachFreshAdapterContext(
+		{
+			session: sessionData,
+			locale: appContext.locale,
+			localeFallback: appContext.localeFallback,
+			stage: appContext.stage,
+			appContext,
+			...(typeof appContext.requestId === "string"
+				? { requestId: appContext.requestId }
+				: {}),
+			...(typeof appContext.traceId === "string"
+				? { traceId: appContext.traceId }
+				: {}),
+		},
+		() =>
+			createAdapterContextInternal(
+				app,
+				request,
+				config,
+				observability,
+				oauthAudience,
+			),
+	);
 };
 
 export const createAdapterContext = <
@@ -226,7 +270,7 @@ function withObservability(
 		return context;
 	}
 
-	return {
+	const refreshed = {
 		...context,
 		...(requestId ? { requestId } : {}),
 		...(traceId ? { traceId } : {}),
@@ -236,4 +280,10 @@ function withObservability(
 			...(traceId ? { traceId } : {}),
 		},
 	};
+	const resolveFresh = (context as RefreshableAdapterContext)[
+		FRESH_ADAPTER_CONTEXT
+	];
+	return resolveFresh
+		? attachFreshAdapterContext(refreshed, resolveFresh)
+		: refreshed;
 }

--- a/packages/questpie/src/server/channels/authority.ts
+++ b/packages/questpie/src/server/channels/authority.ts
@@ -1,0 +1,47 @@
+import { createHash } from "node:crypto";
+
+import type { Principal } from "#questpie/server/config/context.js";
+
+export type ChannelAuthoritySubject = Readonly<{
+	kind: "user" | "oauth" | "session";
+	id: string;
+}>;
+
+type ChannelAuthorityContext = Readonly<{
+	principal?: Principal | null;
+	session?: {
+		user?: { id?: unknown };
+		session?: { id?: unknown };
+	} | null;
+}>;
+
+export function resolveChannelAuthoritySubject(
+	context: ChannelAuthorityContext,
+): ChannelAuthoritySubject | null {
+	const principalUserId =
+		context.principal && context.principal.kind !== "system"
+			? context.principal.user.id
+			: undefined;
+	const userId = principalUserId ?? context.session?.user?.id;
+	if (typeof userId === "string" && userId) {
+		return { kind: "user", id: userId };
+	}
+	const tokenId =
+		context.principal?.kind === "oauth" ? context.principal.tokenId : undefined;
+	if (typeof tokenId === "string" && tokenId) {
+		return { kind: "oauth", id: tokenId };
+	}
+	const sessionId = context.session?.session?.id;
+	return typeof sessionId === "string" && sessionId
+		? { kind: "session", id: sessionId }
+		: null;
+}
+
+/** One-way binding key; raw principal/session ids never enter delivery notices. */
+export function opaqueChannelAuthoritySubject(
+	subject: ChannelAuthoritySubject,
+): string {
+	return createHash("sha256")
+		.update(`${subject.kind}:${subject.id}`)
+		.digest("hex");
+}

--- a/packages/questpie/src/server/channels/service.ts
+++ b/packages/questpie/src/server/channels/service.ts
@@ -8,6 +8,7 @@ import type {
 	ChannelEventReceipt,
 } from "#questpie/server/modules/core/integrated/realtime/channel-event-ledger.js";
 
+import type { ChannelAuthoritySubject } from "./authority.js";
 import {
 	type AnyChannelDefinition,
 	type ChannelAuthorizationRule,
@@ -21,6 +22,8 @@ import {
 	assertUniqueResolvedChannelName,
 	type ChannelSecurityConfig,
 } from "./security.js";
+
+export type { ChannelAuthoritySubject } from "./authority.js";
 
 export type ChannelRuntimeErrorCode =
 	| "channel_not_found"
@@ -46,7 +49,22 @@ export interface ChannelPublisher {
 		input: AppendChannelEventInput,
 		options?: AppendChannelEventOptions,
 	): Promise<ChannelEventReceipt>;
+	revokeChannelAuthority?(
+		input: ChannelAuthorityRevocation,
+		options?: AppendChannelEventOptions,
+	): Promise<ChannelAuthorityRevocationReceipt>;
 }
+
+export type ChannelAuthorityRevocation = Readonly<{
+	channel: string;
+	subject: ChannelAuthoritySubject;
+	idempotencyKey: string;
+}>;
+
+export type ChannelAuthorityRevocationReceipt = Readonly<{
+	scope: "exact-subscription" | "principal-connections";
+	generation: number;
+}>;
 
 export type ChannelServiceContext = AppContext & {
 	accessMode?: string;
@@ -75,6 +93,14 @@ type ParamsInput<TDefinition extends AnyChannelDefinition> =
 
 export type ChannelPublishInput<TDefinition extends AnyChannelDefinition> =
 	EventInput<TDefinition> & ParamsInput<TDefinition>;
+
+export type ChannelAuthorityRevocationInput<
+	TDefinition extends AnyChannelDefinition,
+> = Readonly<{
+	subject: ChannelAuthoritySubject;
+	idempotencyKey: string;
+}> &
+	ParamsInput<TDefinition>;
 
 export type ChannelPublishRequest<TChannels extends ChannelDefinitions> = {
 	[TChannel in keyof TChannels & string]: {
@@ -199,6 +225,35 @@ export class ChannelsService<
 	): Promise<ChannelPublishReceipt> {
 		const prepared = await this.preparePublish(channel, input);
 		return this.publishPrepared(prepared);
+	}
+
+	/**
+	 * Revoke current delivery authority for one subject on one channel identity.
+	 *
+	 * The provider-neutral receipt documents whether the configured transport
+	 * closed the exact logical subscription or conservatively terminated all
+	 * physical connections for that principal.
+	 */
+	revokeAuthority<TChannel extends keyof TChannels & string>(
+		channel: TChannel,
+		input: ChannelAuthorityRevocationInput<TChannels[TChannel]>,
+	): Promise<ChannelAuthorityRevocationReceipt> {
+		if (!input.subject.id || input.subject.id.length > 256) {
+			throw new Error("Channel authority subject is invalid");
+		}
+		const params = (input.params ?? {}) as ChannelParamsOf<TChannels[TChannel]>;
+		const resolvedName = this.resolveName(channel, params);
+		if (!this.publisher.revokeChannelAuthority) {
+			throw new Error("Channel authority revocation is unavailable");
+		}
+		return this.publisher.revokeChannelAuthority(
+			{
+				channel: resolvedName,
+				subject: input.subject,
+				idempotencyKey: input.idempotencyKey,
+			},
+			{ db: this.context.db },
+		);
 	}
 
 	/** Validate a client publish completely without allocating a ledger event id. */

--- a/packages/questpie/src/server/config/questpie.ts
+++ b/packages/questpie/src/server/config/questpie.ts
@@ -47,6 +47,8 @@ import type { ObservabilityService } from "#questpie/server/modules/core/integra
 import { questpieQueueDispatchTable } from "#questpie/server/modules/core/integrated/queue/dispatch-table.js";
 import type { QueueClient } from "#questpie/server/modules/core/integrated/queue/types.js";
 import {
+	questpieChannelAuthorityFenceTable,
+	questpieChannelAuthorityRevocationTable,
 	questpieChannelDispatchTable,
 	questpieChannelEventTable,
 	questpieChannelHeadTable,
@@ -1232,6 +1234,10 @@ export class Questpie<TConfig extends QuestpieConfig = QuestpieConfig> {
 		schema.questpie_channel_head = questpieChannelHeadTable;
 		schema.questpie_channel_event = questpieChannelEventTable;
 		schema.questpie_channel_dispatch = questpieChannelDispatchTable;
+		schema.questpie_channel_authority_fence =
+			questpieChannelAuthorityFenceTable;
+		schema.questpie_channel_authority_revocation =
+			questpieChannelAuthorityRevocationTable;
 		schema.questpie_channel_presence = questpieChannelPresenceTable;
 		schema.questpie_realtime_topology = questpieRealtimeTopologyTable;
 

--- a/packages/questpie/src/server/modules/core/integrated/realtime/TRANSPORT.md
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/TRANSPORT.md
@@ -135,6 +135,13 @@ export interface LocalSessionClientTransport extends ClientTransportBase {
 
 export interface SharedProviderClientTransport extends ClientTransportBase {
 	readonly channelDeliveryScope: "shared-provider";
+	readonly authorityRevocationScope?:
+		| "exact-subscription"
+		| "principal-connections";
+	generateUserAuth?(
+		input: ClientUserAuthInput,
+	): Promise<ClientUserAuthResponse>;
+	revokeAuthority?(input: ClientAuthorityRevocationInput): Promise<void>;
 	publishChannel(input: OrderedChannelDelivery): Promise<SinkWriteResult>;
 }
 
@@ -234,6 +241,57 @@ Direct Pusher client events are outside this QoS class. They are disabled by
 default and, when explicitly enabled by the channel security model, are
 best-effort, unvalidated, non-replayable, and use a distinct event namespace.
 They must never masquerade as framework-validated channel events.
+
+### Channel authority generation fence
+
+A domain membership or authorization command calls the provider-neutral
+`channels.revokeAuthority()` seam with a resolved channel, opaque subject, and
+domain idempotency key. The framework advances
+`questpie_channel_authority_fence` and records the idempotent command in
+`questpie_channel_authority_revocation`. That write uses the caller's database
+transaction.
+
+For `local-sessions`, the committed generation is the enforcement boundary.
+Fresh request-context and subscribe/presence policy run outside database locks.
+A short publication transaction then compares the observed generation, locks
+the channel head before the coordinator and exact subject rows where presence
+is involved, and publishes the tagged binding plus optional freshly resolved
+presence payload and lease. A stale true result and its stale member payload
+publish nothing; the retry resolves both again. Sink writes, snapshots, timers,
+and heartbeats never run under the authority lock. An already-admitted frame
+may finish while a cut closes the binding. Cross-instance wakes are redacted
+hints; a demand-driven ledger poll runs only while local channel bindings exist,
+stops on internal revocation of the last binding, and heals a dropped wake
+without starting topology.
+
+For `shared-provider`, a pending authority cut conflicts with the channel
+dispatch admission, so its durable cursor cannot advance across an unapplied
+cut. Provider I/O happens only after the short admission lock is released.
+Pusher's capability is `principal-connections`: the client signs in with an
+opaque user id before channel authorization. In a framework-managed caller
+transaction, bounded provider termination and generation acknowledgement run
+inline: failure throws and rolls the transaction back instead of returning a
+false success. A conservative provider disconnect may survive a later database
+rollback. For a standalone command, provider failure leaves the already durable
+cut pending and dispatch fail-closed; an idempotent retry may apply it. A custom
+shared transport must explicitly declare `authorityRevocationScope` and
+implement `revokeAuthority`; omission never defaults to exact revocation or
+acknowledges the fence.
+
+Pusher explicitly qualifies channel auth as `stateless-signed-grant`:
+`generateAuth` performs only side-effect-free local grant encoding and never
+mutates provider authorization. Channel policy and encoding run without database
+locks. A short expected-generation admission accepts the response; a concurrent
+cut discards the signed blob before it reaches the client. Unqualified shared
+adapters fail before policy or signing. The browser authorizer waits for
+signed-user completion and checks the owner, socket, connection state, and
+opaque user again before returning auth to `pusher-js`.
+
+Pusher cannot terminate one logical channel binding and does not guarantee that
+a frame already accepted by the physical connection disappears. Therefore the
+contract explicitly allows one in-flight physical frame during termination; it
+does not claim zero-frame atomic revocation. After reconnect, still-authorized
+channels replay from their cursor while the revoked channel is denied.
 
 ## Live-query topic contract
 
@@ -704,8 +762,9 @@ Revocation has three mandatory layers:
 1. revoked/expired sessions receive no new auth or publish grant;
 2. local-session transports close the affected edge sessions immediately;
 3. managed-WS transports user-authenticate with an opaque provider user id and
-   terminate that user's active provider connections on session revocation or
-   expiry, then require full subscribe authorization on reconnect.
+   terminate that user's active provider connections on session revocation,
+   expiry, or a channel-scoped authority cut, then require fresh signed-user and
+   per-channel authorization on reconnect.
 
 A provider driver that cannot terminate established user connections must
 report that capability honestly and cannot advertise immediate revocation. Its

--- a/packages/questpie/src/server/modules/core/integrated/realtime/channel-authority-fence.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/channel-authority-fence.ts
@@ -1,0 +1,353 @@
+import { createHash } from "node:crypto";
+
+import { and, eq, gt, ne, sql } from "drizzle-orm";
+
+import {
+	withTransaction,
+	withTransactionOrExisting,
+} from "#questpie/server/collection/crud/shared/transaction.js";
+import type { AnyDrizzleClient } from "#questpie/server/config/types.js";
+
+import {
+	questpieChannelAuthorityFenceTable,
+	questpieChannelAuthorityRevocationTable,
+} from "./collection.js";
+
+export type ChannelAuthorityFenceKey = Readonly<{
+	channelHash: string;
+	subject: string;
+}>;
+
+export type ChannelAuthorityFenceReceipt = Readonly<{
+	generation: number;
+	applied: boolean;
+}>;
+
+export type ChannelAuthorityAdmission<T> =
+	| Readonly<{ admitted: false }>
+	| Readonly<{ admitted: true; value: T }>;
+
+const CHANNEL_COORDINATOR_SUBJECT = "channel-authority-coordinator";
+
+function assertOpaqueSubject(subject: string): void {
+	if (!subject || subject.length > 256) {
+		throw new Error("Channel authority subject is invalid");
+	}
+}
+
+function idempotencyHash(idempotencyKey: string): string {
+	if (!idempotencyKey || idempotencyKey.length > 256) {
+		throw new Error("Channel authority idempotency key is invalid");
+	}
+	return createHash("sha256").update(idempotencyKey).digest("hex");
+}
+
+/** Durable generation store and database linearization point for channel access. */
+export class ChannelAuthorityFenceStore {
+	constructor(private readonly db: AnyDrizzleClient<any>) {}
+
+	async ensure(input: ChannelAuthorityFenceKey): Promise<number> {
+		assertOpaqueSubject(input.subject);
+		await Promise.all([
+			this.ensureRow(input, this.db),
+			this.ensureChannel(input.channelHash, this.db),
+		]);
+		return this.read(input);
+	}
+
+	async ensureChannel(
+		channelHash: string,
+		db: AnyDrizzleClient<any> = this.db,
+	): Promise<void> {
+		await this.ensureRow(
+			{ channelHash, subject: CHANNEL_COORDINATOR_SUBJECT },
+			db,
+		);
+	}
+
+	async advance(
+		input: ChannelAuthorityFenceKey & { idempotencyKey: string },
+		db: AnyDrizzleClient<any> = this.db,
+	): Promise<ChannelAuthorityFenceReceipt> {
+		assertOpaqueSubject(input.subject);
+		const commandHash = idempotencyHash(input.idempotencyKey);
+		return withTransactionOrExisting(db, async (tx) => {
+			const [inserted] = await tx
+				.insert(questpieChannelAuthorityRevocationTable)
+				.values({
+					idempotencyHash: commandHash,
+					channelHash: input.channelHash,
+					subject: input.subject,
+				})
+				.onConflictDoNothing()
+				.returning({
+					idempotencyHash:
+						questpieChannelAuthorityRevocationTable.idempotencyHash,
+				});
+			if (!inserted) {
+				const [existing] = await tx
+					.select({
+						channelHash: questpieChannelAuthorityRevocationTable.channelHash,
+						subject: questpieChannelAuthorityRevocationTable.subject,
+						generation: questpieChannelAuthorityRevocationTable.generation,
+						applied: questpieChannelAuthorityRevocationTable.applied,
+					})
+					.from(questpieChannelAuthorityRevocationTable)
+					.where(
+						eq(
+							questpieChannelAuthorityRevocationTable.idempotencyHash,
+							commandHash,
+						),
+					)
+					.limit(1);
+				if (
+					!existing ||
+					existing.channelHash !== input.channelHash ||
+					existing.subject !== input.subject
+				) {
+					throw new Error("Channel authority idempotency key conflicts");
+				}
+				return {
+					generation: Number(existing.generation),
+					applied: existing.applied,
+				};
+			}
+
+			await this.ensureChannel(input.channelHash, tx);
+			await this.ensureRow(
+				{ channelHash: input.channelHash, subject: input.subject },
+				tx,
+			);
+			const [coordinator] = await tx
+				.update(questpieChannelAuthorityFenceTable)
+				.set({
+					generation: sql`${questpieChannelAuthorityFenceTable.generation} + 1`,
+					updatedAt: new Date(),
+				})
+				.where(
+					and(
+						eq(
+							questpieChannelAuthorityFenceTable.channelHash,
+							input.channelHash,
+						),
+						eq(
+							questpieChannelAuthorityFenceTable.subject,
+							CHANNEL_COORDINATOR_SUBJECT,
+						),
+					),
+				)
+				.returning({
+					generation: questpieChannelAuthorityFenceTable.generation,
+				});
+			if (!coordinator)
+				throw new Error("Channel authority fence is unavailable");
+			const generation = Number(coordinator.generation);
+			await tx
+				.update(questpieChannelAuthorityFenceTable)
+				.set({ generation, updatedAt: new Date() })
+				.where(
+					and(
+						eq(
+							questpieChannelAuthorityFenceTable.channelHash,
+							input.channelHash,
+						),
+						eq(questpieChannelAuthorityFenceTable.subject, input.subject),
+					),
+				);
+			await tx
+				.update(questpieChannelAuthorityRevocationTable)
+				.set({ generation })
+				.where(
+					eq(
+						questpieChannelAuthorityRevocationTable.idempotencyHash,
+						commandHash,
+					),
+				);
+			return { generation, applied: false };
+		});
+	}
+
+	async acknowledge(
+		input: ChannelAuthorityFenceKey & {
+			idempotencyKey: string;
+			generation: number;
+		},
+		db: AnyDrizzleClient<any> = this.db,
+	): Promise<void> {
+		const commandHash = idempotencyHash(input.idempotencyKey);
+		await withTransactionOrExisting(db, async (tx) => {
+			const [command] = await tx
+				.select()
+				.from(questpieChannelAuthorityRevocationTable)
+				.where(
+					eq(
+						questpieChannelAuthorityRevocationTable.idempotencyHash,
+						commandHash,
+					),
+				)
+				.limit(1)
+				.for("update");
+			if (
+				!command ||
+				command.channelHash !== input.channelHash ||
+				command.subject !== input.subject ||
+				Number(command.generation) !== input.generation
+			) {
+				throw new Error("Channel authority acknowledgement is invalid");
+			}
+			if (command.applied) return;
+			await tx
+				.update(questpieChannelAuthorityFenceTable)
+				.set({
+					appliedGeneration: sql`greatest(
+						${questpieChannelAuthorityFenceTable.appliedGeneration},
+						${input.generation}
+					)`,
+					updatedAt: new Date(),
+				})
+				.where(
+					and(
+						eq(
+							questpieChannelAuthorityFenceTable.channelHash,
+							input.channelHash,
+						),
+						eq(questpieChannelAuthorityFenceTable.subject, input.subject),
+					),
+				);
+			await tx
+				.update(questpieChannelAuthorityRevocationTable)
+				.set({ applied: true })
+				.where(
+					eq(
+						questpieChannelAuthorityRevocationTable.idempotencyHash,
+						commandHash,
+					),
+				);
+		});
+	}
+
+	/** Admit one provider dispatch without holding a database lock across I/O. */
+	async admitSharedDispatch(channelHash: string): Promise<boolean> {
+		return withTransaction(this.db, async (tx) => {
+			await this.ensureChannel(channelHash, tx);
+			await tx
+				.select({ generation: questpieChannelAuthorityFenceTable.generation })
+				.from(questpieChannelAuthorityFenceTable)
+				.where(
+					and(
+						eq(questpieChannelAuthorityFenceTable.channelHash, channelHash),
+						eq(
+							questpieChannelAuthorityFenceTable.subject,
+							CHANNEL_COORDINATOR_SUBJECT,
+						),
+					),
+				)
+				.limit(1)
+				.for("share");
+			const [pending] = await tx
+				.select({ subject: questpieChannelAuthorityFenceTable.subject })
+				.from(questpieChannelAuthorityFenceTable)
+				.where(
+					and(
+						eq(questpieChannelAuthorityFenceTable.channelHash, channelHash),
+						ne(
+							questpieChannelAuthorityFenceTable.subject,
+							CHANNEL_COORDINATOR_SUBJECT,
+						),
+						gt(
+							questpieChannelAuthorityFenceTable.generation,
+							questpieChannelAuthorityFenceTable.appliedGeneration,
+						),
+					),
+				)
+				.limit(1);
+			return !pending;
+		});
+	}
+
+	/**
+	 * Publish framework-owned state only if a fresh, externally evaluated
+	 * policy result still targets the current authority generation.
+	 */
+	async admitExpected<T>(
+		input: ChannelAuthorityFenceKey & { expectedGeneration: number },
+		publication: {
+			/** Optional owned SQL which must lock a resource before the fences. */
+			beforeFence?: (tx: AnyDrizzleClient<any>) => Promise<void>;
+			/** Owned SQL and synchronous handle publication only. */
+			publish: (tx: AnyDrizzleClient<any>) => Promise<T> | T;
+		},
+	): Promise<ChannelAuthorityAdmission<T>> {
+		assertOpaqueSubject(input.subject);
+		return withTransaction(this.db, async (tx) => {
+			await publication.beforeFence?.(tx);
+			const [coordinator] = await tx
+				.select({ generation: questpieChannelAuthorityFenceTable.generation })
+				.from(questpieChannelAuthorityFenceTable)
+				.where(
+					and(
+						eq(
+							questpieChannelAuthorityFenceTable.channelHash,
+							input.channelHash,
+						),
+						eq(
+							questpieChannelAuthorityFenceTable.subject,
+							CHANNEL_COORDINATOR_SUBJECT,
+						),
+					),
+				)
+				.limit(1)
+				.for("share");
+			if (!coordinator) {
+				throw new Error("Channel authority coordinator is unavailable");
+			}
+			const [row] = await tx
+				.select({ generation: questpieChannelAuthorityFenceTable.generation })
+				.from(questpieChannelAuthorityFenceTable)
+				.where(
+					and(
+						eq(
+							questpieChannelAuthorityFenceTable.channelHash,
+							input.channelHash,
+						),
+						eq(questpieChannelAuthorityFenceTable.subject, input.subject),
+					),
+				)
+				.limit(1)
+				.for("share");
+			if (!row) throw new Error("Channel authority fence is unavailable");
+			if (Number(row.generation) !== input.expectedGeneration) {
+				return { admitted: false };
+			}
+			return {
+				admitted: true,
+				value: await publication.publish(tx),
+			};
+		});
+	}
+
+	async read(input: ChannelAuthorityFenceKey): Promise<number> {
+		const [row] = await this.db
+			.select({ generation: questpieChannelAuthorityFenceTable.generation })
+			.from(questpieChannelAuthorityFenceTable)
+			.where(
+				and(
+					eq(questpieChannelAuthorityFenceTable.channelHash, input.channelHash),
+					eq(questpieChannelAuthorityFenceTable.subject, input.subject),
+				),
+			)
+			.limit(1);
+		if (!row) throw new Error("Channel authority fence is unavailable");
+		return Number(row.generation);
+	}
+
+	private async ensureRow(
+		input: ChannelAuthorityFenceKey,
+		db: AnyDrizzleClient<any>,
+	): Promise<void> {
+		await db
+			.insert(questpieChannelAuthorityFenceTable)
+			.values({ ...input, generation: 0, appliedGeneration: 0 })
+			.onConflictDoNothing();
+	}
+}

--- a/packages/questpie/src/server/modules/core/integrated/realtime/channel-event-ledger.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/channel-event-ledger.ts
@@ -7,6 +7,7 @@ import {
 	ChannelSecurityError,
 } from "#questpie/server/channels/security.js";
 import {
+	getCurrentTransaction,
 	onAfterCommit,
 	withTransactionOrExisting,
 } from "#questpie/server/collection/crud/shared/transaction.js";
@@ -17,6 +18,7 @@ import {
 	stringifyCompatibleTypedEventWire,
 } from "#questpie/shared/typed-wire.js";
 
+import { ChannelAuthorityFenceStore } from "./channel-authority-fence.js";
 import {
 	questpieChannelDispatchTable,
 	questpieChannelEventTable,
@@ -26,10 +28,12 @@ import type { RealtimeObservation, RealtimeObserver } from "./observer.js";
 import type {
 	ChannelGapFrame,
 	ChangePublisher,
+	ClientAuthoritySubject,
 	ClientSink,
 	ClientTransport,
 	OrderedChannelDelivery,
 	OrderedChannelEventFrame,
+	SinkWriteResult,
 } from "./transport.js";
 
 const DEFAULT_RETENTION_MS = 24 * 60 * 60 * 1000;
@@ -39,6 +43,7 @@ const DEFAULT_MAX_BUFFERED_BYTES = 1024 * 1024;
 const DEFAULT_LEASE_MS = 30_000;
 const DEFAULT_RETRY_MS = 25;
 const DEFAULT_BATCH_SIZE = 500;
+const PROVIDER_REVOCATION_TIMEOUT_MS = 5_000;
 
 export type ChannelEventLedgerConfig = {
 	/** Maximum age of replayable events. Set to 0 to disable time cleanup. */
@@ -88,10 +93,53 @@ export type ChannelReplayPage =
 			oldestEventId: string | null;
 	  }>;
 
+export type LocalChannelBindingLifecycle = {
+	/** Starts timers and client-visible snapshots after the publication commits. */
+	activate(): Promise<void>;
+	/** Removes every durable and local artifact. Must be idempotent. */
+	deactivate(): Promise<void>;
+	/** Installs a short expected-generation guard for owned heartbeat SQL. */
+	setRenewalGuard?(
+		guard: (
+			operation: (tx: AnyDrizzleClient<any>) => Promise<void>,
+		) => Promise<boolean>,
+	): void;
+};
+
+export type LocalChannelBindingStage = {
+	/** Owned SQL which establishes the lock ordered before authority fences. */
+	beforeFence?(tx: AnyDrizzleClient<any>): Promise<void>;
+	/** Owned SQL publication; no policy, sink, provider, or timer callbacks. */
+	publish(
+		tx: AnyDrizzleClient<any>,
+		authorization?: LocalChannelAuthorization,
+	): Promise<LocalChannelBindingLifecycle>;
+};
+
+export type LocalChannelAuthorization =
+	| boolean
+	| Readonly<{
+			authorized: boolean;
+			presence?: Record<string, unknown>;
+	  }>;
+
 export type LocalChannelSubscriptionInput = {
 	subscriptionId: string;
 	channel: string;
+	/** Opaque stable subject. Raw user/session identifiers are not accepted here. */
+	subject?: string;
+	/** Resolve a fresh request and application context before reauthorizing. */
+	reauthorize?: () => Promise<LocalChannelAuthorization>;
+	/**
+	 * Framework-owned state staged in the same short authority publication.
+	 * @internal
+	 */
+	stage?: LocalChannelBindingStage;
 	sink: ClientSink;
+	/** Close only this logical binding when supplied by a multiplexed session. */
+	close?: (reason: "access_revoked") => Promise<void>;
+	/** @internal Runs exactly once for caller release or an internal close. */
+	onRelease?: () => Promise<void>;
 	lastEventId?: string | null;
 	encodeFrame?: (
 		frame: OrderedChannelEventFrame | ChannelGapFrame,
@@ -113,7 +161,14 @@ type LocalSubscription = {
 	drainPending: boolean;
 	closed: boolean;
 	retryTimer: ReturnType<typeof setTimeout> | null;
+	subject?: string;
+	authorityGeneration?: number;
+	reauthorize?: () => Promise<LocalChannelAuthorization>;
+	close?: LocalChannelSubscriptionInput["close"];
+	onRelease?: LocalChannelSubscriptionInput["onRelease"];
 	encodeFrame?: LocalChannelSubscriptionInput["encodeFrame"];
+	active: boolean;
+	lifecycle?: LocalChannelBindingLifecycle;
 };
 
 export function hashResolvedChannel(channel: string): string {
@@ -164,6 +219,33 @@ function canonicalChannelEnvelope(
 	return { wireJson, sizeBytes };
 }
 
+function isAuthorized(authorization: LocalChannelAuthorization): boolean {
+	return (
+		authorization === true ||
+		(typeof authorization === "object" && authorization.authorized === true)
+	);
+}
+
+async function withProviderRevocationTimeout<T>(
+	operation: Promise<T>,
+): Promise<T> {
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	try {
+		return await Promise.race([
+			operation,
+			new Promise<never>((_, reject) => {
+				timer = setTimeout(
+					() =>
+						reject(new Error("Shared provider authority revocation timed out")),
+					PROVIDER_REVOCATION_TIMEOUT_MS,
+				);
+			}),
+		]);
+	} finally {
+		if (timer) clearTimeout(timer);
+	}
+}
+
 function hasPostgresErrorCode(error: unknown, code: string): boolean {
 	let current = error;
 	const seen = new Set<object>();
@@ -185,6 +267,7 @@ export class ChannelEventLedger {
 	private readonly config: ChannelEventLedgerConfig;
 	private readonly instanceId = crypto.randomUUID();
 	private readonly encoder = new TextEncoder();
+	private readonly authorityFences: ChannelAuthorityFenceStore;
 	private readonly localSubscriptions = new Map<string, LocalSubscription>();
 	private readonly subscriptionsByChannel = new Map<
 		string,
@@ -203,6 +286,7 @@ export class ChannelEventLedger {
 		private readonly ensureDeliveryStarted?: () => Promise<void>,
 		private readonly observer?: RealtimeObserver,
 	) {
+		this.authorityFences = new ChannelAuthorityFenceStore(this.db);
 		this.config = {
 			retentionMs: config.retentionMs ?? DEFAULT_RETENTION_MS,
 			retentionBytes: config.retentionBytes ?? DEFAULT_RETENTION_BYTES,
@@ -271,6 +355,7 @@ export class ChannelEventLedger {
 				.insert(questpieChannelDispatchTable)
 				.values({ channelHash })
 				.onConflictDoNothing();
+			await this.authorityFences.ensureChannel(channelHash, tx);
 
 			onAfterCommit(async () => {
 				void this.notifyAfterCommit(channelHash, eventId).catch((error) => {
@@ -303,7 +388,7 @@ export class ChannelEventLedger {
 
 	async subscribeLocal(
 		input: LocalChannelSubscriptionInput,
-	): Promise<() => void> {
+	): Promise<() => Promise<void>> {
 		if (
 			this.clientTransport &&
 			this.clientTransport.channelDeliveryScope !== "local-sessions"
@@ -312,6 +397,14 @@ export class ChannelEventLedger {
 		}
 		if (this.localSubscriptions.has(input.subscriptionId)) {
 			throw new Error(`Channel subscription "${input.subscriptionId}" exists`);
+		}
+		if (Boolean(input.subject) !== Boolean(input.reauthorize)) {
+			throw new Error(
+				"Channel authority subject and reauthorizer must be provided together",
+			);
+		}
+		if (input.stage && !input.subject) {
+			throw new Error("Channel binding staging requires an authority subject");
 		}
 
 		const channelHash = hashResolvedChannel(input.channel);
@@ -343,7 +436,7 @@ export class ChannelEventLedger {
 			if (outsideRetention) {
 				this.observe({ type: "resume", outcome: "gap" });
 				await this.writeGap(input, oldest?.eventId ?? null);
-				return () => {};
+				return async () => {};
 			}
 			cursor = parsed.seq;
 			this.observe({
@@ -365,16 +458,258 @@ export class ChannelEventLedger {
 			drainPending: false,
 			closed: false,
 			retryTimer: null,
+			subject: input.subject,
+			authorityGeneration: undefined,
+			reauthorize: input.reauthorize,
+			close: input.close,
+			onRelease: input.onRelease,
 			encodeFrame: input.encodeFrame,
+			active: false,
 		};
-		this.localSubscriptions.set(subscription.id, subscription);
-		const channelSubscriptions =
-			this.subscriptionsByChannel.get(channelHash) ?? new Set();
-		channelSubscriptions.add(subscription);
-		this.subscriptionsByChannel.set(channelHash, channelSubscriptions);
+		const register = (
+			generation?: number,
+			lifecycle?: LocalChannelBindingLifecycle,
+		) => {
+			if (this.localSubscriptions.has(subscription.id)) {
+				throw new Error(`Channel subscription "${subscription.id}" exists`);
+			}
+			subscription.authorityGeneration = generation;
+			subscription.lifecycle = lifecycle;
+			this.localSubscriptions.set(subscription.id, subscription);
+			const channelSubscriptions =
+				this.subscriptionsByChannel.get(channelHash) ?? new Set();
+			channelSubscriptions.add(subscription);
+			this.subscriptionsByChannel.set(channelHash, channelSubscriptions);
+		};
+
+		try {
+			if (input.subject && input.reauthorize) {
+				await this.authorityFences.ensure({
+					channelHash,
+					subject: input.subject,
+				});
+				while (!subscription.closed && !subscription.active) {
+					const generation = await this.authorityFences.read({
+						channelHash,
+						subject: input.subject,
+					});
+					let authorization: LocalChannelAuthorization = false;
+					try {
+						authorization = await input.reauthorize();
+					} catch {
+						authorization = false;
+					}
+					if (!isAuthorized(authorization)) {
+						if (input.close) await input.close("access_revoked");
+						else await input.sink.close("access_revoked");
+						return async () => {};
+					}
+					const admission = await this.authorityFences.admitExpected(
+						{
+							channelHash,
+							subject: input.subject,
+							expectedGeneration: generation,
+						},
+						{
+							beforeFence: input.stage?.beforeFence,
+							publish: async (tx) => {
+								const lifecycle = await input.stage?.publish(tx, authorization);
+								register(generation, lifecycle);
+								lifecycle?.setRenewalGuard?.(async (operation) => {
+									if (
+										subscription.closed ||
+										subscription.authorityGeneration === undefined
+									) {
+										return false;
+									}
+									const renewal = await this.authorityFences.admitExpected(
+										{
+											channelHash,
+											subject: input.subject!,
+											expectedGeneration: subscription.authorityGeneration,
+										},
+										{
+											beforeFence: input.stage?.beforeFence,
+											publish: operation,
+										},
+									);
+									return renewal.admitted;
+								});
+								return lifecycle;
+							},
+						},
+					);
+					if (!admission.admitted) continue;
+					if (subscription.closed) {
+						await admission.value?.deactivate();
+						break;
+					}
+					subscription.active = true;
+					await admission.value?.activate();
+				}
+			} else {
+				register();
+				subscription.active = true;
+			}
+		} catch (error) {
+			await this.releaseLocalSubscription(subscription);
+			throw error;
+		}
+		if (subscription.closed) return async () => {};
 		await this.drainLocalSubscription(subscription);
 
-		return () => this.removeLocalSubscription(subscription);
+		return () => this.releaseLocalSubscription(subscription);
+	}
+
+	/** @internal Whether a successful admission installed the local binding. */
+	hasLocalSubscription(subscriptionId: string): boolean {
+		return this.localSubscriptions.has(subscriptionId);
+	}
+
+	/**
+	 * Apply one durable authority cut, then reconcile every exact local binding.
+	 *
+	 * Duplicate calls are safe: a closed binding is removed before another cut
+	 * can find it, and notice payloads carry only the resolved channel hash.
+	 */
+	async revokeAuthority(
+		input: {
+			channel: string;
+			subject: string;
+			transportSubject?: ClientAuthoritySubject;
+			idempotencyKey: string;
+		},
+		options: AppendChannelEventOptions = {},
+	): Promise<
+		Readonly<{
+			generation: number;
+			scope: "exact-subscription" | "principal-connections";
+		}>
+	> {
+		const channelHash = hashResolvedChannel(input.channel);
+		const db = options.db ?? this.db;
+		const managedCallerTransaction = Boolean(getCurrentTransaction());
+		const sharedProvider =
+			this.clientTransport?.channelDeliveryScope === "shared-provider"
+				? this.clientTransport
+				: undefined;
+		if (sharedProvider) {
+			if (!input.transportSubject) {
+				throw new Error(
+					"Shared-provider channel authority revocation is unavailable",
+				);
+			}
+			sharedProvider.validateAuthorityRevocation?.(input.transportSubject);
+		}
+		const receipt = await this.authorityFences.advance(
+			{
+				channelHash,
+				subject: input.subject,
+				idempotencyKey: input.idempotencyKey,
+			},
+			db,
+		);
+		const scope = sharedProvider
+			? sharedProvider.authorityRevocationScope
+			: "exact-subscription";
+		if (sharedProvider && (!scope || !sharedProvider.revokeAuthority)) {
+			// Keep the newly advanced fence pending. Shared dispatch remains
+			// blocked until a transport with an explicit capability applies it.
+			throw new Error(
+				"Shared provider channel authority revocation capability is unavailable",
+			);
+		}
+		const reconcileLocal = async () => {
+			const subscriptions = [
+				...(this.subscriptionsByChannel.get(channelHash) ?? []),
+			].filter((subscription) => subscription.subject === input.subject);
+			await Promise.all(
+				subscriptions.map((subscription) =>
+					this.reconcileLocalAuthority(subscription),
+				),
+			);
+		};
+		const publishWake = async () => {
+			await this.changeBroker?.publish({
+				kind: "channel-authority-maybe-advanced",
+				channelHash,
+				reason: "revoke",
+			});
+		};
+
+		if (sharedProvider) {
+			if (!receipt.applied) {
+				if (!input.transportSubject) {
+					throw new Error(
+						"Shared-provider channel authority revocation is unavailable",
+					);
+				}
+				const applyProviderCut = async () => {
+					await withProviderRevocationTimeout(
+						sharedProvider.revokeAuthority!({
+							channel: input.channel,
+							subject: input.transportSubject!,
+						}),
+					);
+					await this.authorityFences.acknowledge(
+						{
+							channelHash,
+							subject: input.subject,
+							idempotencyKey: input.idempotencyKey,
+							generation: receipt.generation,
+						},
+						managedCallerTransaction ? db : undefined,
+					);
+				};
+				if (managedCallerTransaction) {
+					// A conservative disconnect may survive a later database rollback.
+					// That is safer than returning success for an unapplied generation.
+					await applyProviderCut();
+				} else if (
+					"rollback" in db &&
+					typeof (db as { transaction?: unknown }).transaction !== "function"
+				) {
+					throw new Error(
+						"Shared-provider revocation requires a managed transaction",
+					);
+				} else await applyProviderCut();
+			}
+		} else if (!receipt.applied) {
+			// The committed generation is the exact-session enforcement boundary.
+			await this.authorityFences.acknowledge(
+				{
+					channelHash,
+					subject: input.subject,
+					idempotencyKey: input.idempotencyKey,
+					generation: receipt.generation,
+				},
+				db,
+			);
+		}
+
+		const afterDurableCut = async () => {
+			if (scope === "exact-subscription") await reconcileLocal();
+			await publishWake().catch((error) => {
+				this.logger?.warn("[Realtime] Channel authority wake failed", error);
+			});
+		};
+		if (getCurrentTransaction()) {
+			onAfterCommit(afterDurableCut);
+		} else if (db !== this.db) {
+			// An externally managed raw transaction has no framework after-commit
+			// queue. Start reconciliation without awaiting its conflicting read:
+			// the durable generation still blocks the next protected write, and
+			// this operation resumes as soon as the external caller commits.
+			void afterDurableCut().catch((error) => {
+				this.logger?.warn(
+					"[Realtime] Channel authority reconciliation failed",
+					error,
+				);
+			});
+		} else {
+			await afterDurableCut();
+		}
+		return { generation: receipt.generation, scope: scope! };
 	}
 
 	/** Read one bounded replay page for an already-authorized channel identity. */
@@ -459,6 +794,7 @@ export class ChannelEventLedger {
 
 	async drain(channelHash?: string): Promise<void> {
 		try {
+			await this.reconcileLocalAuthorities(channelHash);
 			if (this.clientTransport?.channelDeliveryScope === "shared-provider") {
 				await this.drainShared(channelHash);
 				return;
@@ -477,6 +813,17 @@ export class ChannelEventLedger {
 			if (hasPostgresErrorCode(error, "42P01")) return;
 			throw error;
 		}
+	}
+
+	private async reconcileLocalAuthorities(channelHash?: string): Promise<void> {
+		const subscriptions = channelHash
+			? [...(this.subscriptionsByChannel.get(channelHash) ?? [])]
+			: [...this.localSubscriptions.values()];
+		await Promise.all(
+			subscriptions.map((subscription) =>
+				this.reconcileLocalAuthority(subscription),
+			),
+		);
 	}
 
 	async cleanup(): Promise<void> {
@@ -525,10 +872,12 @@ export class ChannelEventLedger {
 		}
 	}
 
-	destroy(): void {
-		for (const subscription of this.localSubscriptions.values()) {
-			this.removeLocalSubscription(subscription);
-		}
+	async destroy(): Promise<void> {
+		await Promise.all(
+			[...this.localSubscriptions.values()].map((subscription) =>
+				this.releaseLocalSubscription(subscription),
+			),
+		);
 	}
 
 	private async writeGap(
@@ -567,7 +916,7 @@ export class ChannelEventLedger {
 	private async drainLocalSubscription(
 		subscription: LocalSubscription,
 	): Promise<void> {
-		if (subscription.closed) return;
+		if (subscription.closed || !subscription.active) return;
 		if (subscription.drainPromise) {
 			subscription.drainPending = true;
 			return subscription.drainPromise;
@@ -660,10 +1009,11 @@ export class ChannelEventLedger {
 				this.toLocalFrame(row),
 				subscription.encodeFrame,
 			);
-			const result = await subscription.sink.write(
+			const result = await this.writeAuthorizedLocalFrame(
+				subscription,
 				encodedFrame,
-				"ordered-channel-event",
 			);
+			if (!result) return false;
 			if (result.status === "busy") {
 				if (
 					result.bufferedBytes + subscription.pendingBytes >
@@ -721,6 +1071,8 @@ export class ChannelEventLedger {
 		if (subscription.closed) return;
 		subscription.closed = true;
 		if (subscription.retryTimer) clearTimeout(subscription.retryTimer);
+		subscription.pending = [];
+		subscription.pendingBytes = 0;
 		this.localSubscriptions.delete(subscription.id);
 		const channelSubscriptions = this.subscriptionsByChannel.get(
 			subscription.channelHash,
@@ -731,13 +1083,123 @@ export class ChannelEventLedger {
 		}
 	}
 
-	private async closeLocalSubscription(
+	private async releaseLocalSubscription(
 		subscription: LocalSubscription,
-		reason: "slow_consumer" | "write_failed",
 	): Promise<void> {
 		if (subscription.closed) return;
 		this.removeLocalSubscription(subscription);
+		const lifecycle = subscription.lifecycle;
+		subscription.lifecycle = undefined;
+		try {
+			await lifecycle?.deactivate();
+		} finally {
+			await subscription.onRelease?.();
+		}
+	}
+
+	private async closeLocalSubscription(
+		subscription: LocalSubscription,
+		reason: "slow_consumer" | "write_failed" | "access_revoked",
+	): Promise<void> {
+		if (subscription.closed) return;
+		await this.releaseLocalSubscription(subscription);
+		if (reason === "access_revoked" && subscription.close) {
+			await subscription.close(reason);
+			return;
+		}
 		await subscription.sink.close(reason);
+	}
+
+	private async writeAuthorizedLocalFrame(
+		subscription: LocalSubscription,
+		frame: Uint8Array,
+	): Promise<SinkWriteResult | null> {
+		if (
+			!subscription.subject ||
+			subscription.authorityGeneration === undefined ||
+			!subscription.reauthorize
+		) {
+			return subscription.sink.write(frame, "ordered-channel-event");
+		}
+		while (!subscription.closed && subscription.active) {
+			const generation = await this.authorityFences.read({
+				channelHash: subscription.channelHash,
+				subject: subscription.subject,
+			});
+			if (generation !== subscription.authorityGeneration) {
+				let authorization: LocalChannelAuthorization = false;
+				try {
+					authorization = await subscription.reauthorize();
+				} catch {
+					authorization = false;
+				}
+				if (!isAuthorized(authorization)) {
+					await this.closeLocalSubscription(subscription, "access_revoked");
+					return null;
+				}
+			}
+			const admission = await this.authorityFences.admitExpected(
+				{
+					channelHash: subscription.channelHash,
+					subject: subscription.subject,
+					expectedGeneration: generation,
+				},
+				{
+					publish: () => {
+						subscription.authorityGeneration = generation;
+					},
+				},
+			);
+			if (!admission.admitted) continue;
+			if (subscription.closed || !subscription.active) return null;
+			// The frame was logically admitted at this generation. The sink is
+			// deliberately outside the fence so revocation never waits on I/O.
+			return subscription.sink.write(frame, "ordered-channel-event");
+		}
+		return null;
+	}
+
+	private async reconcileLocalAuthority(
+		subscription: LocalSubscription,
+	): Promise<void> {
+		if (
+			subscription.closed ||
+			!subscription.subject ||
+			subscription.authorityGeneration === undefined ||
+			!subscription.reauthorize
+		) {
+			return;
+		}
+		while (!subscription.closed) {
+			const generation = await this.authorityFences.read({
+				channelHash: subscription.channelHash,
+				subject: subscription.subject,
+			});
+			if (generation === subscription.authorityGeneration) return;
+			let authorization: LocalChannelAuthorization = false;
+			try {
+				authorization = await subscription.reauthorize();
+			} catch {
+				// Refresh failures fail closed without exposing access details.
+			}
+			if (!isAuthorized(authorization)) {
+				await this.closeLocalSubscription(subscription, "access_revoked");
+				return;
+			}
+			const admission = await this.authorityFences.admitExpected(
+				{
+					channelHash: subscription.channelHash,
+					subject: subscription.subject,
+					expectedGeneration: generation,
+				},
+				{
+					publish: () => {
+						subscription.authorityGeneration = generation;
+					},
+				},
+			);
+			if (admission.admitted) return;
+		}
 	}
 
 	private async drainShared(channelHash?: string): Promise<void> {
@@ -788,6 +1250,7 @@ export class ChannelEventLedger {
 		) {
 			return;
 		}
+		const clientTransport = this.clientTransport;
 		const now = new Date();
 		const leaseExpiresAt = new Date(
 			now.getTime() + this.config.coordinatorLeaseMs,
@@ -825,7 +1288,10 @@ export class ChannelEventLedger {
 						eventId: row.eventId,
 						frame: this.encoder.encode(row.wireJson),
 					};
-					const result = await this.clientTransport.publishChannel(delivery);
+					if (!(await this.authorityFences.admitSharedDispatch(channelHash))) {
+						return;
+					}
+					const result = await clientTransport.publishChannel(delivery);
 					if (result.status === "busy") return;
 					cursor = Number(row.seq);
 					const [advanced] = await this.db

--- a/packages/questpie/src/server/modules/core/integrated/realtime/collection.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/collection.ts
@@ -2,6 +2,7 @@ import { sql } from "drizzle-orm";
 import {
 	bigint,
 	bigserial,
+	boolean,
 	customType,
 	index,
 	integer,
@@ -118,6 +119,49 @@ export const questpieChannelDispatchTable = pgTable(
 		}),
 		updatedAt: systemTimestamp("updated_at").defaultNow().notNull(),
 	},
+);
+
+/**
+ * Durable authority cut for one opaque subject on one resolved channel.
+ *
+ * This generation is deliberately separate from the public channel event
+ * sequence. Notice brokers may wake reconciliation, but delivery checks this
+ * row while holding a database lock before writing a protected frame.
+ */
+export const questpieChannelAuthorityFenceTable = pgTable(
+	"questpie_channel_authority_fence",
+	{
+		channelHash: text("channel_hash").notNull(),
+		subject: text("subject").notNull(),
+		generation: bigint("generation", { mode: "number" }).default(0).notNull(),
+		appliedGeneration: bigint("applied_generation", { mode: "number" })
+			.default(0)
+			.notNull(),
+		updatedAt: systemTimestamp("updated_at").defaultNow().notNull(),
+	},
+	(table) => [
+		primaryKey({ columns: [table.channelHash, table.subject] }),
+		index("idx_channel_authority_fence_updated").on(table.updatedAt),
+	],
+);
+
+/** Durable command identity that makes retried revocations idempotent. */
+export const questpieChannelAuthorityRevocationTable = pgTable(
+	"questpie_channel_authority_revocation",
+	{
+		idempotencyHash: text("idempotency_hash").primaryKey(),
+		channelHash: text("channel_hash").notNull(),
+		subject: text("subject").notNull(),
+		generation: bigint("generation", { mode: "number" }).default(0).notNull(),
+		applied: boolean("applied").default(false).notNull(),
+		createdAt: systemTimestamp("created_at").defaultNow().notNull(),
+	},
+	(table) => [
+		index("idx_channel_authority_revocation_target").on(
+			table.channelHash,
+			table.subject,
+		),
+	],
 );
 
 /** Connection leases for zero-infrastructure, cross-instance channel presence. */

--- a/packages/questpie/src/server/modules/core/integrated/realtime/pusher-transport.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/pusher-transport.ts
@@ -8,6 +8,7 @@ import {
 	type ChangeBroker,
 	type ChangeBrokerState,
 	type ChangeWake,
+	type ClientAuthorityRevocationInput,
 	type ClientConfigInput,
 	type ClientSink,
 	type ClientTransportConfig,
@@ -116,8 +117,13 @@ function principalIdentity(principal: Principal | null): string {
 
 function stableUserIdentity(principal: Principal): string {
 	if (principal.kind === "system") return "system";
-	if (principal.kind === "oauth") return `oauth:${principal.user.id}`;
 	return `user:${principal.user.id}`;
+}
+
+function authoritySubjectIdentity(
+	subject: ClientAuthorityRevocationInput["subject"],
+): string {
+	return `${subject.kind}:${subject.id}`;
 }
 
 function byteLength(value: unknown): number {
@@ -127,6 +133,9 @@ function byteLength(value: unknown): number {
 function wakeKey(wake: ChangeWake): string {
 	if (wake.kind === "outbox-maybe-advanced") return wake.kind;
 	if (wake.kind === "channel-events-maybe-advanced") {
+		return `${wake.kind}:${wake.channelHash ?? "*"}`;
+	}
+	if (wake.kind === "channel-authority-maybe-advanced") {
 		return `${wake.kind}:${wake.channelHash ?? "*"}`;
 	}
 	if (wake.kind === "crdt") {
@@ -357,6 +366,8 @@ class PusherSessionSink implements ClientSink {
 /** Managed-Pusher edge transport. Live-query writes become private refetch wakes. */
 export class PusherClientTransport implements SharedProviderClientTransport {
 	readonly channelDeliveryScope = "shared-provider" as const;
+	readonly channelGrantMode = "stateless-signed-grant" as const;
+	readonly authorityRevocationScope = "principal-connections" as const;
 
 	private onError: (error: unknown) => void = () => {};
 	private readonly sessions = new Map<string, PusherSession>();
@@ -508,9 +519,12 @@ export class PusherClientTransport implements SharedProviderClientTransport {
 
 	async generateUserAuth(input: {
 		socketId: string;
-		principal: Principal;
+		principal: Principal | null;
 	}): Promise<PusherUserAuthResponse> {
 		assertSocketId(input.socketId);
+		if (!input.principal || input.principal.kind === "system") {
+			throw new Error("Realtime user authentication requires a principal");
+		}
 		const id = this.opaquePrincipalId(input.principal);
 		if (this.revokedPrincipalIds.has(id)) {
 			throw new Error("Realtime principal is revoked");
@@ -571,8 +585,33 @@ export class PusherClientTransport implements SharedProviderClientTransport {
 	}
 
 	async revokePrincipal(principal: Principal): Promise<void> {
-		const id = this.opaquePrincipalId(principal);
+		await this.revokeOpaquePrincipal(this.opaquePrincipalId(principal));
+	}
+
+	async revokeAuthority(input: ClientAuthorityRevocationInput): Promise<void> {
+		this.validateAuthorityRevocation(input.subject);
+		const id = createHmac("sha256", this.options.identityKey)
+			.update(authoritySubjectIdentity(input.subject))
+			.digest("hex");
+		await this.terminateOpaquePrincipal(id);
+	}
+
+	validateAuthorityRevocation(
+		subject: ClientAuthorityRevocationInput["subject"],
+	): void {
+		if (subject.kind !== "user") {
+			throw new Error(
+				"Pusher channel authority revocation requires a user subject",
+			);
+		}
+	}
+
+	private async revokeOpaquePrincipal(id: string): Promise<void> {
 		this.revokedPrincipalIds.add(id);
+		await this.terminateOpaquePrincipal(id);
+	}
+
+	private async terminateOpaquePrincipal(id: string): Promise<void> {
 		const sessions = [...this.sessions.entries()]
 			.filter(([, session]) => session.opaquePrincipalId === id)
 			.map(([, session]) => this.sinks.get(session.sessionId))

--- a/packages/questpie/src/server/modules/core/integrated/realtime/service.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/service.ts
@@ -1,6 +1,14 @@
 import { asc, desc, eq, gt, lt, sql } from "drizzle-orm";
 
 import {
+	opaqueChannelAuthoritySubject,
+	resolveChannelAuthoritySubject,
+} from "#questpie/server/channels/authority.js";
+import type {
+	ChannelAuthorityRevocation,
+	ChannelAuthorityRevocationReceipt,
+} from "#questpie/server/channels/service.js";
+import {
 	getCurrentTransaction,
 	withTransaction,
 } from "#questpie/server/collection/crud/shared/transaction.js";
@@ -9,12 +17,14 @@ import type { LoggerAdapter } from "#questpie/server/modules/core/integrated/log
 
 import { CoreNoticeRouter } from "../collaboration/notice-router.js";
 import { PgNotifyChangeBroker } from "./adapters/pg-notify.js";
+import { ChannelAuthorityFenceStore } from "./channel-authority-fence.js";
 import {
 	type AppendChannelEventInput,
 	type AppendChannelEventOptions,
 	ChannelEventLedger,
 	type ChannelEventReceipt,
 	type ChannelReplayPage,
+	hashResolvedChannel,
 	type LocalChannelSubscriptionInput,
 } from "./channel-event-ledger.js";
 import {
@@ -50,6 +60,8 @@ import type {
 	ClientSink,
 	ClientTransport,
 	ClientTransportConfig,
+	ClientUserAuthInput,
+	ClientUserAuthResponse,
 	EdgeSessionInput,
 	OrderedChannelDelivery,
 	SinkWriteResult,
@@ -120,9 +132,13 @@ export class RealtimeService {
 	private nextRetentionCleanupAt = 0;
 	private retentionCleanupInProgress = false;
 	private readonly channelEventLedger: ChannelEventLedger;
+	private readonly authorityFences: ChannelAuthorityFenceStore;
 	private readonly channelPresenceRegistry: SseChannelPresenceRegistry;
 	private readonly topologyCoordinator: RealtimeTopologyCoordinator;
 	private channelPollTimer: ReturnType<typeof setInterval> | null = null;
+	private localChannelSubscriptionCount = 0;
+	private unsubscribeChannelNotices?: () => Promise<void>;
+	private channelNoticeStartPromise: Promise<void> | null = null;
 	private nextChannelCleanupAt = 0;
 	private readonly observability: RealtimeObservability;
 
@@ -179,9 +195,10 @@ export class RealtimeService {
 			this.clientTransport,
 			config.channelEvents,
 			this.logger,
-			() => this.initialize(),
+			() => (this.clientTransport ? this.initialize() : Promise.resolve()),
 			this.observability,
 		);
+		this.authorityFences = new ChannelAuthorityFenceStore(this.db);
 		this.channelPresenceRegistry = new SseChannelPresenceRegistry(
 			this.db,
 			config.channelPresence,
@@ -423,6 +440,17 @@ export class RealtimeService {
 							);
 						return;
 					}
+					if (wake.kind === "channel-authority-maybe-advanced") {
+						void this.channelEventLedger
+							.drain(wake.channelHash)
+							.catch((error) =>
+								this.reportTransportFailure(
+									"[Realtime] Channel authority reconciliation failed",
+									error,
+								),
+							);
+						return;
+					}
 					this.drainOrDeferUntilStarted(
 						wake.reason === "reconnect" ? "reconnect" : "broker",
 					);
@@ -529,8 +557,8 @@ export class RealtimeService {
 	async getClientTransportConfig(
 		input: ClientConfigInput,
 	): Promise<ClientTransportConfig> {
-		await this.initialize();
 		if (!this.clientTransport) return { transport: "sse" };
+		await this.initialize();
 		return this.clientTransport.getClientConfig(input);
 	}
 
@@ -609,6 +637,115 @@ export class RealtimeService {
 		}
 	}
 
+	/**
+	 * Optimistically evaluate policy and encode one side-effect-free provider
+	 * grant, then publish it only when the expected subject generation still
+	 * matches. Provider I/O is never serialized under a database lock.
+	 */
+	async generateAuthorizedClientAuth(
+		input: Omit<ClientAuthInput, "presence"> & { scope: "channel" },
+		authorize: () => Promise<{
+			presence?: ClientAuthInput["presence"];
+		}>,
+	): Promise<ClientAuthResponse> {
+		await this.initialize();
+		if (
+			!this.clientTransport ||
+			this.clientTransport.channelDeliveryScope !== "shared-provider"
+		) {
+			throw new Error("Realtime provider auth is not configured");
+		}
+		const clientTransport = this.clientTransport;
+		if (clientTransport.channelGrantMode !== "stateless-signed-grant") {
+			throw new Error(
+				"Shared provider does not support stateless signed channel grants",
+			);
+		}
+		const grant = async () => {
+			const authorization = await authorize();
+			return clientTransport.generateAuth({
+				...input,
+				...(authorization.presence ? { presence: authorization.presence } : {}),
+			});
+		};
+		try {
+			const authoritySubject = resolveChannelAuthoritySubject({
+				principal: input.principal,
+			});
+			if (!authoritySubject) {
+				const auth = await grant();
+				this.observe({
+					type: "channel.security",
+					verb: "grant",
+					outcome: "allowed",
+					reason: "allowed",
+				});
+				return auth;
+			}
+			const subject = opaqueChannelAuthoritySubject(authoritySubject);
+			const channelHash = hashResolvedChannel(input.channel);
+			await this.authorityFences.ensure({ channelHash, subject });
+			const generation = await this.authorityFences.read({
+				channelHash,
+				subject,
+			});
+			const auth = await grant();
+			const admission = await this.authorityFences.admitExpected(
+				{ channelHash, subject, expectedGeneration: generation },
+				{ publish: () => undefined },
+			);
+			if (!admission.admitted) {
+				throw new Error("Channel authority changed during provider grant");
+			}
+			this.observe({
+				type: "channel.security",
+				verb: "grant",
+				outcome: "allowed",
+				reason: "allowed",
+			});
+			return auth;
+		} catch (error) {
+			this.observe({
+				type: "channel.security",
+				verb: "grant",
+				outcome: "denied",
+				reason: "access_denied",
+			});
+			throw error;
+		}
+	}
+
+	async generateClientUserAuth(
+		input: ClientUserAuthInput,
+	): Promise<ClientUserAuthResponse> {
+		await this.initialize();
+		if (
+			!this.clientTransport ||
+			this.clientTransport.channelDeliveryScope !== "shared-provider" ||
+			!this.clientTransport.generateUserAuth
+		) {
+			throw new Error("Realtime provider user auth is not configured");
+		}
+		try {
+			const auth = await this.clientTransport.generateUserAuth(input);
+			this.observe({
+				type: "channel.security",
+				verb: "grant",
+				outcome: "allowed",
+				reason: "allowed",
+			});
+			return auth;
+		} catch (error) {
+			this.observe({
+				type: "channel.security",
+				verb: "grant",
+				outcome: "denied",
+				reason: "access_denied",
+			});
+			throw error;
+		}
+	}
+
 	async publishChannel(
 		input: OrderedChannelDelivery,
 	): Promise<SinkWriteResult> {
@@ -631,11 +768,68 @@ export class RealtimeService {
 		return receipt;
 	}
 
+	async revokeChannelAuthority(
+		input: ChannelAuthorityRevocation,
+		options: AppendChannelEventOptions = {},
+	): Promise<ChannelAuthorityRevocationReceipt> {
+		if (this.clientTransport) await this.initialize();
+		const subject = opaqueChannelAuthoritySubject(input.subject);
+		return this.channelEventLedger.revokeAuthority(
+			{
+				channel: input.channel,
+				subject,
+				transportSubject: input.subject,
+				idempotencyKey: input.idempotencyKey,
+			},
+			options,
+		);
+	}
+
 	async subscribeChannel(
-		input: LocalChannelSubscriptionInput,
-	): Promise<() => void> {
-		await this.initialize();
-		return this.channelEventLedger.subscribeLocal(input);
+		input: Omit<LocalChannelSubscriptionInput, "stage"> & {
+			presence?: RegisterChannelPresenceInput;
+		},
+	): Promise<() => Promise<void>> {
+		if (this.clientTransport) await this.initialize();
+		const { presence, ...subscription } = input;
+		let counted = false;
+		let finalized = false;
+		const finalizeLocalSubscription = async () => {
+			if (finalized) return;
+			finalized = true;
+			if (counted) {
+				this.localChannelSubscriptionCount = Math.max(
+					0,
+					this.localChannelSubscriptionCount - 1,
+				);
+			}
+			await this.stopIdleLocalChannelReconciliation();
+		};
+		const release = await this.channelEventLedger.subscribeLocal({
+			...subscription,
+			onRelease: finalizeLocalSubscription,
+			...(presence
+				? { stage: this.channelPresenceRegistry.stage(presence) }
+				: {}),
+		});
+		if (this.clientTransport) return release;
+		if (
+			!this.channelEventLedger.hasLocalSubscription(subscription.subscriptionId)
+		) {
+			return release;
+		}
+		counted = true;
+		this.localChannelSubscriptionCount += 1;
+		try {
+			await this.ensureLocalChannelReconciliation();
+		} catch (error) {
+			await release();
+			throw error;
+		}
+		return async () => {
+			await release();
+			await finalizeLocalSubscription();
+		};
 	}
 
 	/** Read a bounded page after route-level channel authorization. */
@@ -649,7 +843,7 @@ export class RealtimeService {
 	async registerChannelPresence(
 		input: RegisterChannelPresenceInput,
 	): Promise<() => Promise<void>> {
-		await this.initialize();
+		if (this.clientTransport) await this.initialize();
 		return this.channelPresenceRegistry.register(input);
 	}
 
@@ -679,9 +873,9 @@ export class RealtimeService {
 
 	private startChannelPollTimer(): void {
 		if (
-			!this.clientTransport ||
 			this.pollIntervalMs <= 0 ||
-			this.channelPollTimer
+			this.channelPollTimer ||
+			(!this.clientTransport && this.localChannelSubscriptionCount === 0)
 		) {
 			return;
 		}
@@ -694,6 +888,78 @@ export class RealtimeService {
 			});
 			this.cleanupChannelEventsSafely();
 		}, this.pollIntervalMs);
+	}
+
+	private async ensureLocalChannelReconciliation(): Promise<void> {
+		if (this.clientTransport) return;
+		if (this.unsubscribeChannelNotices) {
+			this.startChannelPollTimer();
+			return;
+		}
+		if (!this.channelNoticeStartPromise) {
+			this.channelNoticeStartPromise = (async () => {
+				this.unsubscribeChannelNotices = await this.noticeRouter.subscribe({
+					kind: "realtime",
+					onNotice: ({ wake }) => {
+						if (
+							wake.kind !== "channel-events-maybe-advanced" &&
+							wake.kind !== "channel-authority-maybe-advanced"
+						) {
+							return;
+						}
+						void this.channelEventLedger
+							.drain(wake.channelHash)
+							.catch((error) =>
+								this.reportTransportFailure(
+									"[Realtime] Local channel reconciliation failed",
+									error,
+								),
+							);
+					},
+					onError: (error) =>
+						this.reportTransportFailure(
+							"[Realtime] Local channel notice failed",
+							error,
+						),
+					onStateChange: (state) => {
+						if (state !== "connected") return;
+						void this.channelEventLedger
+							.drain()
+							.catch((error) =>
+								this.reportTransportFailure(
+									"[Realtime] Local channel reconnect failed",
+									error,
+								),
+							);
+					},
+					onOverflow: () => {
+						void this.channelEventLedger
+							.drain()
+							.catch((error) =>
+								this.reportTransportFailure(
+									"[Realtime] Local channel overflow failed",
+									error,
+								),
+							);
+					},
+				});
+			})().finally(() => {
+				this.channelNoticeStartPromise = null;
+			});
+		}
+		await this.channelNoticeStartPromise;
+		this.startChannelPollTimer();
+	}
+
+	private async stopIdleLocalChannelReconciliation(): Promise<void> {
+		if (this.clientTransport || this.localChannelSubscriptionCount > 0) return;
+		if (this.channelPollTimer) {
+			clearInterval(this.channelPollTimer);
+			this.channelPollTimer = null;
+		}
+		if (this.channelNoticeStartPromise) await this.channelNoticeStartPromise;
+		await this.unsubscribeChannelNotices?.();
+		this.unsubscribeChannelNotices = undefined;
 	}
 
 	private cleanupChannelEventsSafely(force = false): void {
@@ -924,17 +1190,19 @@ export class RealtimeService {
 			.orderBy(asc(questpieRealtimeLogTable.seq))
 			.limit(this.batchSize);
 
-		return rows.map((row: any) => ({
-			seq: Number(row.seq),
-			...(row.txid == null ? {} : { txid: String(row.txid) }),
-			resourceType: row.resourceType as RealtimeResourceType,
-			resource: row.resource,
-			operation: row.operation as RealtimeOperation,
-			recordId: row.recordId ?? null,
-			locale: row.locale ?? null,
-			payload: (row.payload ?? {}) as RealtimeChangePayload,
-			createdAt: row.createdAt,
-		}));
+		return rows
+			.map((row: any) => ({
+				seq: Number(row.seq),
+				...(row.txid == null ? {} : { txid: String(row.txid) }),
+				resourceType: row.resourceType as RealtimeResourceType,
+				resource: row.resource,
+				operation: row.operation as RealtimeOperation,
+				recordId: row.recordId ?? null,
+				locale: row.locale ?? null,
+				payload: (row.payload ?? {}) as RealtimeChangePayload,
+				createdAt: row.createdAt,
+			}))
+			.filter((event) => event.seq > seq);
 	}
 
 	private async ensureStarted(): Promise<void> {
@@ -986,7 +1254,11 @@ export class RealtimeService {
 			!this.startPromise &&
 			!this.publisherStarted &&
 			!this.publisherStartPromise &&
-			!this.unsubscribeNotices
+			!this.unsubscribeNotices &&
+			!this.unsubscribeChannelNotices &&
+			!this.channelNoticeStartPromise &&
+			!this.channelPollTimer &&
+			this.localChannelSubscriptionCount === 0
 		) {
 			return;
 		}
@@ -1009,6 +1281,13 @@ export class RealtimeService {
 				);
 			}
 		}
+		if (this.channelNoticeStartPromise) {
+			try {
+				await this.channelNoticeStartPromise;
+			} catch {
+				// channel-only notice startup already failed, continue cleanup
+			}
+		}
 
 		this.started = false;
 
@@ -1021,7 +1300,10 @@ export class RealtimeService {
 			this.channelPollTimer = null;
 		}
 
-		this.channelEventLedger.destroy();
+		await this.channelEventLedger.destroy();
+		await this.unsubscribeChannelNotices?.();
+		this.unsubscribeChannelNotices = undefined;
+		this.localChannelSubscriptionCount = 0;
 		await this.unsubscribeNotices?.();
 		this.unsubscribeNotices = undefined;
 		await this.clientTransport?.stop();

--- a/packages/questpie/src/server/modules/core/integrated/realtime/sse-channel-presence.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/sse-channel-presence.ts
@@ -3,7 +3,11 @@ import { and, asc, desc, eq, gt, lte } from "drizzle-orm";
 import type { AnyDrizzleClient } from "#questpie/server/config/types.js";
 import type { LoggerAdapter } from "#questpie/server/modules/core/integrated/logger/types.js";
 
-import { hashResolvedChannel } from "./channel-event-ledger.js";
+import {
+	hashResolvedChannel,
+	type LocalChannelAuthorization,
+	type LocalChannelBindingStage,
+} from "./channel-event-ledger.js";
 import {
 	questpieChannelHeadTable,
 	questpieChannelPresenceTable,
@@ -41,6 +45,9 @@ type LocalPresenceMember = {
 	sink: ClientSink;
 	data: Record<string, unknown>;
 	lastSnapshot?: string;
+	renew?: (
+		operation: (tx: AnyDrizzleClient<any>) => Promise<void>,
+	) => Promise<boolean>;
 };
 
 type PresenceRow = typeof questpieChannelPresenceTable.$inferSelect;
@@ -103,6 +110,23 @@ export class SseChannelPresenceRegistry {
 	async register(
 		input: RegisterChannelPresenceInput,
 	): Promise<() => Promise<void>> {
+		const stage = this.stage(input);
+		let lifecycle:
+			| Awaited<ReturnType<LocalChannelBindingStage["publish"]>>
+			| undefined;
+		await this.db.transaction(async (tx) => {
+			await stage.beforeFence?.(tx);
+			lifecycle = await stage.publish(tx);
+		});
+		await lifecycle!.activate();
+		return () => lifecycle!.deactivate();
+	}
+
+	/**
+	 * Stage one presence row for an authority-linearized channel binding.
+	 * Timers and snapshots remain inactive until the enclosing tx commits.
+	 */
+	stage(input: RegisterChannelPresenceInput): LocalChannelBindingStage {
 		if (this.destroyed)
 			throw new Error("Channel presence registry is destroyed");
 		if (!input.principalId) {
@@ -119,79 +143,126 @@ export class SseChannelPresenceRegistry {
 		}
 
 		const channelHash = hashResolvedChannel(input.channel);
-		const now = new Date();
 		const member: LocalPresenceMember = { ...input, channelHash };
-		await this.db.transaction(async (tx) => {
-			await tx
-				.insert(questpieChannelHeadTable)
-				.values({ channelHash, channel: input.channel })
-				.onConflictDoNothing();
-			await tx
-				.update(questpieChannelHeadTable)
-				.set({ updatedAt: now })
-				.where(eq(questpieChannelHeadTable.channelHash, channelHash));
-
-			const activeRows = await tx
-				.select({ principalId: questpieChannelPresenceTable.principalId })
-				.from(questpieChannelPresenceTable)
+		let published = false;
+		let activated = false;
+		let stopped = false;
+		const deleteRow = async () => {
+			await this.db
+				.delete(questpieChannelPresenceTable)
 				.where(
 					and(
 						eq(questpieChannelPresenceTable.channelHash, channelHash),
-						gt(questpieChannelPresenceTable.expiresAt, now),
+						eq(questpieChannelPresenceTable.connectionId, input.connectionId),
 					),
 				);
-			const principals = new Set(activeRows.map((row) => row.principalId));
-			if (
-				!principals.has(input.principalId) &&
-				principals.size >= this.config.maxMembers
-			) {
-				throw new Error("Presence channel member limit exceeded");
-			}
+		};
+		const lifecycle = {
+			activate: async () => {
+				if (stopped) {
+					await deleteRow();
+					return;
+				}
+				if (this.destroyed) {
+					await deleteRow();
+					throw new Error("Channel presence registry is destroyed");
+				}
+				this.localConnections.set(input.connectionId, member);
+				const channelMembers =
+					this.connectionsByChannel.get(channelHash) ?? new Set();
+				channelMembers.add(member);
+				this.connectionsByChannel.set(channelHash, channelMembers);
+				activated = true;
+				this.ensureTimers();
+				try {
+					await this.reconcile(channelHash);
+				} catch (error) {
+					await this.unregister(member, false);
+					throw error;
+				}
+			},
+			deactivate: async () => {
+				if (stopped) return;
+				stopped = true;
+				if (activated) {
+					await this.unregister(member);
+					return;
+				}
+				if (published) await deleteRow();
+			},
+			setRenewalGuard: (
+				guard: (
+					operation: (tx: AnyDrizzleClient<any>) => Promise<void>,
+				) => Promise<boolean>,
+			) => {
+				member.renew = guard;
+			},
+		};
+		return {
+			beforeFence: async (tx) => {
+				const now = new Date();
+				await tx
+					.insert(questpieChannelHeadTable)
+					.values({ channelHash, channel: input.channel })
+					.onConflictDoNothing();
+				await tx
+					.update(questpieChannelHeadTable)
+					.set({ updatedAt: now })
+					.where(eq(questpieChannelHeadTable.channelHash, channelHash));
+			},
+			publish: async (tx, authorization?: LocalChannelAuthorization) => {
+				const now = new Date();
+				const freshPresence =
+					authorization &&
+					typeof authorization === "object" &&
+					authorization.presence
+						? authorization.presence
+						: input.data;
+				member.data = freshPresence;
+				const activeRows = await tx
+					.select({ principalId: questpieChannelPresenceTable.principalId })
+					.from(questpieChannelPresenceTable)
+					.where(
+						and(
+							eq(questpieChannelPresenceTable.channelHash, channelHash),
+							gt(questpieChannelPresenceTable.expiresAt, now),
+						),
+					);
+				const principals = new Set(activeRows.map((row) => row.principalId));
+				if (
+					!principals.has(input.principalId) &&
+					principals.size >= this.config.maxMembers
+				) {
+					throw new Error("Presence channel member limit exceeded");
+				}
 
-			await tx
-				.insert(questpieChannelPresenceTable)
-				.values({
-					channelHash,
-					connectionId: input.connectionId,
-					principalId: input.principalId,
-					channel: input.channel,
-					data: input.data,
-					expiresAt: new Date(now.getTime() + this.config.leaseMs),
-					updatedAt: now,
-				})
-				.onConflictDoUpdate({
-					target: [
-						questpieChannelPresenceTable.channelHash,
-						questpieChannelPresenceTable.connectionId,
-					],
-					set: {
+				await tx
+					.insert(questpieChannelPresenceTable)
+					.values({
+						channelHash,
+						connectionId: input.connectionId,
 						principalId: input.principalId,
 						channel: input.channel,
-						data: input.data,
+						data: freshPresence,
 						expiresAt: new Date(now.getTime() + this.config.leaseMs),
 						updatedAt: now,
-					},
-				});
-		});
-
-		this.localConnections.set(input.connectionId, member);
-		const channelMembers =
-			this.connectionsByChannel.get(channelHash) ?? new Set();
-		channelMembers.add(member);
-		this.connectionsByChannel.set(channelHash, channelMembers);
-		this.ensureTimers();
-		try {
-			await this.reconcile(channelHash);
-		} catch (error) {
-			await this.unregister(member, false);
-			throw error;
-		}
-
-		let stopped = false;
-		return async () => {
-			if (stopped) return;
-			stopped = true;
-			await this.unregister(member);
+					})
+					.onConflictDoUpdate({
+						target: [
+							questpieChannelPresenceTable.channelHash,
+							questpieChannelPresenceTable.connectionId,
+						],
+						set: {
+							principalId: input.principalId,
+							channel: input.channel,
+							data: freshPresence,
+							expiresAt: new Date(now.getTime() + this.config.leaseMs),
+							updatedAt: now,
+						},
+					});
+				published = true;
+				return lifecycle;
+			},
 		};
 	}
 
@@ -264,20 +335,29 @@ export class SseChannelPresenceRegistry {
 		const now = new Date();
 		const expiresAt = new Date(now.getTime() + this.config.leaseMs);
 		await Promise.all(
-			[...this.localConnections.values()].map((member) =>
-				this.db
-					.update(questpieChannelPresenceTable)
-					.set({ expiresAt })
-					.where(
-						and(
-							eq(questpieChannelPresenceTable.channelHash, member.channelHash),
-							eq(
-								questpieChannelPresenceTable.connectionId,
-								member.connectionId,
+			[...this.localConnections.values()].map(async (member) => {
+				const renew = (db: AnyDrizzleClient<any>) =>
+					db
+						.update(questpieChannelPresenceTable)
+						.set({ expiresAt })
+						.where(
+							and(
+								eq(
+									questpieChannelPresenceTable.channelHash,
+									member.channelHash,
+								),
+								eq(
+									questpieChannelPresenceTable.connectionId,
+									member.connectionId,
+								),
 							),
-						),
-					),
-			),
+						);
+				if (member.renew) {
+					await member.renew(renew);
+					return;
+				}
+				await renew(this.db);
+			}),
 		);
 	}
 

--- a/packages/questpie/src/server/modules/core/integrated/realtime/transport.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/transport.ts
@@ -14,6 +14,11 @@ export type ChangeWake =
 			reason: "publish" | "reconnect" | "reconcile";
 	  }
 	| {
+			kind: "channel-authority-maybe-advanced";
+			channelHash?: string;
+			reason: "revoke" | "reconnect" | "reconcile";
+	  }
+	| {
 			kind: "topology-maybe-advanced";
 			sessionKey: string;
 			ownerId: string;
@@ -88,6 +93,29 @@ export function normalizeChangeWake(value: unknown): ChangeWake | null {
 			...(wake.highWaterEventId === undefined
 				? {}
 				: { highWaterEventId: wake.highWaterEventId }),
+		};
+	}
+
+	if (wake.kind === "channel-authority-maybe-advanced") {
+		if (
+			wake.reason !== "revoke" &&
+			wake.reason !== "reconnect" &&
+			wake.reason !== "reconcile"
+		) {
+			return null;
+		}
+		if (
+			wake.channelHash !== undefined &&
+			typeof wake.channelHash !== "string"
+		) {
+			return null;
+		}
+		return {
+			kind: wake.kind,
+			reason: wake.reason,
+			...(wake.channelHash === undefined
+				? {}
+				: { channelHash: wake.channelHash }),
 		};
 	}
 
@@ -180,7 +208,8 @@ export type ClientCloseReason =
 	| "no_topics"
 	| "transport_error"
 	| "write_failed"
-	| "slow_consumer";
+	| "slow_consumer"
+	| "access_revoked";
 
 export interface ClientSink {
 	readonly sessionId: string;
@@ -218,6 +247,16 @@ export type ClientAuthResponse = {
 	shared_secret?: string;
 };
 
+export type ClientUserAuthInput = {
+	socketId: string;
+	principal: Principal | null;
+};
+
+export type ClientUserAuthResponse = {
+	auth: string;
+	user_data: string;
+};
+
 export type ClientTransportConfig =
 	| { transport: "sse" }
 	| {
@@ -230,6 +269,22 @@ export type OrderedChannelDelivery = {
 	frame: Uint8Array;
 	eventId: string;
 };
+
+export type ClientAuthoritySubject = Readonly<{
+	kind: "user" | "oauth" | "session";
+	id: string;
+}>;
+
+export type ClientAuthorityRevocationInput = Readonly<{
+	channel: string;
+	subject: ClientAuthoritySubject;
+}>;
+
+export type AuthorityRevocationScope =
+	| "exact-subscription"
+	| "principal-connections";
+
+export type ChannelGrantMode = "stateless-signed-grant";
 
 export type OrderedChannelEventFrame = {
 	type: "channel_event";
@@ -250,6 +305,10 @@ interface ClientTransportBase {
 	start(input: { onError: (error: unknown) => void }): Promise<void>;
 	openSession(input: EdgeSessionInput): Promise<ClientSink>;
 	getClientConfig(input: ClientConfigInput): Promise<ClientTransportConfig>;
+	readonly authorityRevocationScope?: AuthorityRevocationScope;
+	/** Synchronous, side-effect-free validation before a durable generation cut. */
+	validateAuthorityRevocation?(subject: ClientAuthoritySubject): void;
+	revokeAuthority?(input: ClientAuthorityRevocationInput): Promise<void>;
 	stop(): Promise<void>;
 }
 
@@ -262,7 +321,16 @@ export interface LocalSessionClientTransport extends ClientTransportBase {
 
 export interface SharedProviderClientTransport extends ClientTransportBase {
 	readonly channelDeliveryScope: "shared-provider";
+	/**
+	 * Qualifies `generateAuth` as local, side-effect-free grant encoding.
+	 * The returned blob is safe to discard when the optimistic generation CAS
+	 * loses; no provider-side grant may have been mutated.
+	 */
+	readonly channelGrantMode?: ChannelGrantMode;
 	generateAuth(input: ClientAuthInput): Promise<ClientAuthResponse>;
+	generateUserAuth?(
+		input: ClientUserAuthInput,
+	): Promise<ClientUserAuthResponse>;
 	publishChannel(input: OrderedChannelDelivery): Promise<SinkWriteResult>;
 }
 

--- a/packages/questpie/src/server/modules/core/routes/channels/auth.post.ts
+++ b/packages/questpie/src/server/modules/core/routes/channels/auth.post.ts
@@ -28,29 +28,6 @@ export default route()
 				throw new Error("Channel name does not match generated identity");
 			}
 			const definition = channels.getDefinition(input.channel);
-			let presence: { user_info?: Record<string, unknown> } | undefined;
-			if (definition.visibility === "presence") {
-				const resolved = await channels.resolvePresence(
-					input.channel,
-					input.params,
-				);
-				if (resolved && typeof resolved === "object") {
-					presence = { user_info: resolved as Record<string, unknown> };
-				}
-			} else if (
-				!(await channels.authorize(input.channel, input.params, "subscribe"))
-			) {
-				observeChannelSecurity(ctx, {
-					verb: "subscribe",
-					outcome: "denied",
-					reason: "access_denied",
-				});
-				return channelRouteResponse(
-					{ error: "channel_subscribe_denied" },
-					403,
-					origin,
-				);
-			}
 			const realtime = routeApp(ctx).realtime;
 			if (!realtime) {
 				observeChannelSecurity(ctx, {
@@ -64,13 +41,44 @@ export default route()
 					origin,
 				);
 			}
-			const auth = await realtime.generateClientAuth({
-				socketId: input.socketId,
-				channel: resolvedName,
-				principal: principalOf(ctx),
-				scope: "channel",
-				presence,
-			});
+			const auth = await realtime.generateAuthorizedClientAuth(
+				{
+					socketId: input.socketId,
+					channel: resolvedName,
+					principal: principalOf(ctx),
+					scope: "channel",
+				},
+				async () => {
+					if (definition.visibility === "presence") {
+						const resolved = await channels.resolvePresence(
+							input.channel,
+							input.params,
+						);
+						return resolved && typeof resolved === "object"
+							? {
+									presence: {
+										user_info: resolved as Record<string, unknown>,
+									},
+								}
+							: {};
+					}
+					if (
+						!(await channels.authorize(
+							input.channel,
+							input.params,
+							"subscribe",
+						))
+					) {
+						observeChannelSecurity(ctx, {
+							verb: "subscribe",
+							outcome: "denied",
+							reason: "access_denied",
+						});
+						throw new Error("Channel subscription is not authorized");
+					}
+					return {};
+				},
+			);
 			observeChannelSecurity(ctx, {
 				verb: definition.visibility === "presence" ? "presence" : "subscribe",
 				outcome: "allowed",

--- a/packages/questpie/src/server/modules/core/routes/realtime/auth.post.ts
+++ b/packages/questpie/src/server/modules/core/routes/realtime/auth.post.ts
@@ -4,7 +4,7 @@ import { routeApp } from "#questpie/server/routes/route-app.js";
 
 async function authParameters(request: Request): Promise<{
 	socketId: string;
-	channel: string;
+	channel?: string;
 }> {
 	const contentType = request.headers.get("content-type") ?? "";
 	let socketId: unknown;
@@ -18,10 +18,16 @@ async function authParameters(request: Request): Promise<{
 		socketId = body.get("socket_id");
 		channel = body.get("channel_name");
 	}
-	if (typeof socketId !== "string" || typeof channel !== "string") {
-		throw new Error("socket_id and channel_name are required");
+	if (
+		typeof socketId !== "string" ||
+		(channel !== null && channel !== undefined && typeof channel !== "string")
+	) {
+		throw new Error("socket_id is required");
 	}
-	return { socketId, channel };
+	return {
+		socketId,
+		...(typeof channel === "string" ? { channel } : {}),
+	};
 }
 
 /** Socket/channel-bound Pusher authorization for active realtime sessions. */
@@ -39,10 +45,17 @@ export default route()
 				);
 			}
 			const input = await authParameters(ctx.request);
-			const auth = await realtime.generateClientAuth({
-				...input,
-				principal: (ctx as { principal?: Principal }).principal ?? null,
-			});
+			const principal = (ctx as { principal?: Principal }).principal ?? null;
+			const auth = input.channel
+				? await realtime.generateClientAuth({
+						socketId: input.socketId,
+						channel: input.channel,
+						principal,
+					})
+				: await realtime.generateClientUserAuth({
+						socketId: input.socketId,
+						principal,
+					});
 			return Response.json(auth, {
 				headers: { "Cache-Control": "no-store" },
 			});

--- a/packages/questpie/test/client/pusher-connection-manager.test.ts
+++ b/packages/questpie/test/client/pusher-connection-manager.test.ts
@@ -10,6 +10,11 @@ type Authorizer = (
 	callback: (error: Error | null, auth: unknown) => void,
 ) => void;
 
+type UserAuthenticator = (
+	input: { socketId: string },
+	callback: (error: Error | null, auth: unknown) => void,
+) => void;
+
 class FakeChannel {
 	unbound = false;
 
@@ -26,12 +31,25 @@ class FakeChannel {
 class FakePusher {
 	readonly channels = new Map<string, FakeChannel>();
 	readonly unsubscribed: string[] = [];
+	readonly user: {
+		signinDonePromise: Promise<unknown>;
+		user_data: { id: string } | null;
+	} = {
+		signinDonePromise: Promise.resolve(),
+		user_data: { id: "opaque-user" },
+	};
+	readonly connection = {
+		state: "connected",
+		socket_id: "1.2",
+	};
 	disconnected = false;
+	signinCalls = 0;
 
 	constructor(
 		readonly key: string,
 		readonly options: {
 			channelAuthorization: { customHandler: Authorizer };
+			userAuthentication?: { customHandler: UserAuthenticator };
 		},
 	) {}
 
@@ -47,6 +65,10 @@ class FakePusher {
 
 	disconnect(): void {
 		this.disconnected = true;
+	}
+
+	signin(): void {
+		this.signinCalls += 1;
 	}
 }
 
@@ -83,7 +105,72 @@ function authorize(
 	});
 }
 
+function authenticateUser(
+	pusher: FakePusher,
+	socketId: string,
+): Promise<{ error: Error | null; auth: unknown }> {
+	return new Promise((resolve) => {
+		pusher.options.userAuthentication!.customHandler(
+			{ socketId },
+			(error, auth) => resolve({ error, auth }),
+		);
+	});
+}
+
 describe("PusherConnectionManager", () => {
+	test("signs in once and resolves user auth through a currently live shared owner", async () => {
+		const fixture = managerFixture();
+		const first = await fixture.manager.subscribe({
+			config: {
+				provider: "pusher",
+				key: "key",
+				userAuthentication: true,
+			},
+			channelName: "private-questpie-rt-session",
+			lane: "edge",
+			authorize: async () => ({ auth: "edge" }),
+			authenticateUser: async (socketId) => ({
+				auth: `first:${socketId}`,
+				user_data: '{"id":"opaque-first"}',
+			}),
+		});
+		const second = await fixture.manager.subscribe({
+			config: {
+				provider: "pusher",
+				key: "key",
+				userAuthentication: true,
+			},
+			channelName: "private-room-one",
+			lane: "channel",
+			authorize: async () => ({ auth: "application" }),
+			authenticateUser: async (socketId) => ({
+				auth: `second:${socketId}`,
+				user_data: '{"id":"opaque-second"}',
+			}),
+		});
+		const pusher = fixture.getPusher()!;
+
+		expect(pusher.signinCalls).toBe(1);
+		expect(await authenticateUser(pusher, "1.2")).toEqual({
+			error: null,
+			auth: {
+				auth: "first:1.2",
+				user_data: '{"id":"opaque-first"}',
+			},
+		});
+
+		first.release();
+		expect(await authenticateUser(pusher, "3.4")).toEqual({
+			error: null,
+			auth: {
+				auth: "second:3.4",
+				user_data: '{"id":"opaque-second"}',
+			},
+		});
+		expect(pusher.signinCalls).toBe(1);
+		second.release();
+	});
+
 	test("dispatches authorization by exact channel name and rejects unknown names", async () => {
 		const fixture = managerFixture();
 		const edge = await fixture.manager.subscribe({
@@ -118,6 +205,154 @@ describe("PusherConnectionManager", () => {
 		expect(pusher.disconnected).toBe(false);
 		application.release();
 		expect(pusher.disconnected).toBe(true);
+	});
+
+	test("waits for physical-connection user sign-in before authorizing a channel", async () => {
+		const fixture = managerFixture();
+		let authorizationCalls = 0;
+		const application = await fixture.manager.subscribe({
+			config: {
+				provider: "pusher",
+				key: "key",
+				userAuthentication: true,
+			},
+			channelName: "private-room-one",
+			lane: "channel",
+			authorize: async () => {
+				authorizationCalls += 1;
+				return { auth: "application" };
+			},
+			authenticateUser: async () => ({
+				auth: "user",
+				user_data: '{"id":"opaque-user"}',
+			}),
+		});
+		const presence = await fixture.manager.subscribe({
+			config: {
+				provider: "pusher",
+				key: "key",
+				userAuthentication: true,
+			},
+			channelName: "presence-room-two",
+			lane: "channel",
+			authorize: async () => {
+				authorizationCalls += 1;
+				return { auth: "presence" };
+			},
+			authenticateUser: async () => ({
+				auth: "user",
+				user_data: '{"id":"opaque-user"}',
+			}),
+		});
+		const pusher = fixture.getPusher()!;
+		let finishSignin!: () => void;
+		pusher.user.user_data = null;
+		pusher.user.signinDonePromise = new Promise<void>((resolve) => {
+			finishSignin = resolve;
+		});
+
+		const pendingAuthorization = authorize(pusher, "private-room-one");
+		const pendingPresenceAuthorization = authorize(pusher, "presence-room-two");
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		expect(authorizationCalls).toBe(0);
+
+		pusher.user.user_data = { id: "opaque-user" };
+		finishSignin();
+		expect(await pendingAuthorization).toEqual({
+			error: null,
+			auth: { auth: "application" },
+		});
+		expect(await pendingPresenceAuthorization).toEqual({
+			error: null,
+			auth: { auth: "presence" },
+		});
+		expect(authorizationCalls).toBe(2);
+		application.release();
+		presence.release();
+	});
+
+	test("fails closed when sign-in fails or the authorizing socket is stale", async () => {
+		const failedSignin = managerFixture();
+		const failedSubscription = await failedSignin.manager.subscribe({
+			config: {
+				provider: "pusher",
+				key: "key",
+				userAuthentication: true,
+			},
+			channelName: "private-room-one",
+			lane: "channel",
+			authorize: async () => ({ auth: "must-not-run" }),
+			authenticateUser: async () => ({
+				auth: "user",
+				user_data: '{"id":"opaque-user"}',
+			}),
+		});
+		const failedPusher = failedSignin.getPusher()!;
+		failedPusher.user.user_data = null;
+		failedPusher.user.signinDonePromise = Promise.resolve();
+		expect(
+			(await authorize(failedPusher, "private-room-one")).error?.message,
+		).toBe("Realtime user authentication did not complete");
+		failedSubscription.release();
+
+		const staleSocket = managerFixture();
+		const staleSubscription = await staleSocket.manager.subscribe({
+			config: {
+				provider: "pusher",
+				key: "key",
+				userAuthentication: true,
+			},
+			channelName: "private-room-one",
+			lane: "channel",
+			authorize: async () => ({ auth: "must-not-run" }),
+			authenticateUser: async () => ({
+				auth: "user",
+				user_data: '{"id":"opaque-user"}',
+			}),
+		});
+		const stalePusher = staleSocket.getPusher()!;
+		stalePusher.connection.socket_id = "3.4";
+		expect(
+			(await authorize(stalePusher, "private-room-one")).error?.message,
+		).toBe("Realtime channel authorization socket is stale");
+		staleSubscription.release();
+	});
+
+	test("fails a channel auth waiter whose owner is released during sign-in", async () => {
+		const fixture = managerFixture();
+		let authorizationCalls = 0;
+		const application = await fixture.manager.subscribe({
+			config: {
+				provider: "pusher",
+				key: "key",
+				userAuthentication: true,
+			},
+			channelName: "private-room-one",
+			lane: "channel",
+			authorize: async () => {
+				authorizationCalls += 1;
+				return { auth: "must-not-run" };
+			},
+			authenticateUser: async () => ({
+				auth: "user",
+				user_data: '{"id":"opaque-user"}',
+			}),
+		});
+		const pusher = fixture.getPusher()!;
+		let finishSignin!: () => void;
+		pusher.user.user_data = null;
+		pusher.user.signinDonePromise = new Promise<void>((resolve) => {
+			finishSignin = resolve;
+		});
+		const pendingAuthorization = authorize(pusher, "private-room-one");
+
+		application.release();
+		pusher.user.user_data = { id: "opaque-user" };
+		finishSignin();
+		expect((await pendingAuthorization).error?.message).toBe(
+			"Realtime channel authorization owner was released",
+		);
+		expect(authorizationCalls).toBe(0);
 	});
 
 	test("fails closed on reserved application names and incompatible providers", async () => {

--- a/packages/questpie/test/integration/channel-routes.test.ts
+++ b/packages/questpie/test/integration/channel-routes.test.ts
@@ -5,9 +5,14 @@ import { z } from "zod";
 import { createFetchHandler } from "../../src/server/adapters/http.js";
 import { channel } from "../../src/server/channels/channel-builder.js";
 import { ChannelTokenBucketLimiter } from "../../src/server/channels/security.js";
+import { questpieChannelAuthorityRevocationTable } from "../../src/server/modules/core/integrated/realtime/collection.js";
 import type { RealtimeObservation } from "../../src/server/modules/core/integrated/realtime/observer.js";
 import type { PusherProvider } from "../../src/server/modules/core/integrated/realtime/pusher-transport.js";
 import { PusherClientTransport } from "../../src/server/modules/core/integrated/realtime/pusher-transport.js";
+import type {
+	ClientSink,
+	SharedProviderClientTransport,
+} from "../../src/server/modules/core/integrated/realtime/transport.js";
 import { setChannelPublishLimiterForTests } from "../../src/server/modules/core/routes/channels/_shared.js";
 import {
 	parseCompatibleTypedEventWire,
@@ -157,6 +162,107 @@ describe("channel module routes", () => {
 			event: "message",
 			eventId: expect.any(String),
 			data: { text: "hello" },
+		});
+		await reader.cancel();
+	});
+
+	test("a held-open SSE stream reruns presence policy and revokes only the exact channel binding", async () => {
+		const allowedSpaces = new Set(["a", "b"]);
+		let sessionResolutions = 0;
+		const setup = await buildMockApp(
+			{
+				channels: {
+					space: channel("space-[spaceId]")
+						.events({ message: z.object({ id: z.string() }) })
+						.authorize(({ session }: any) => session?.user.id === "user-1")
+						.presence(({ params, allowedSpaces }: any) => {
+							if (!allowedSpaces.has(params.spaceId)) {
+								throw new Error("Space membership is unavailable");
+							}
+							return { id: `member-${params.spaceId}` };
+						}),
+				},
+			},
+			{
+				app: { url: "https://app.example.com" },
+				realtime: { retentionDays: 0, rowLiveQueries: false },
+			},
+		);
+		cleanup = setup.cleanup;
+		await runTestDbMigrations(setup.app);
+		const handler = createFetchHandler(setup.app, {
+			getSession: async () => {
+				sessionResolutions += 1;
+				return {
+					user: { id: "user-1" },
+					session: { id: "session-1" },
+				};
+			},
+			extendContext: async () => ({
+				allowedSpaces: new Set(allowedSpaces),
+			}),
+		});
+		const response = await handler(
+			channelRequest("realtime", {
+				channels: [
+					{
+						id: "space-a",
+						channel: "space",
+						params: { spaceId: "a" },
+					},
+					{
+						id: "space-b",
+						channel: "space",
+						params: { spaceId: "b" },
+					},
+				],
+			}),
+		);
+		const reader = response.body!.getReader();
+		const state = { buffer: "" };
+		await readSseEvent(reader, state, "session");
+		for (let attempt = 0; sessionResolutions < 3 && attempt < 100; attempt++) {
+			await new Promise((resolve) => setTimeout(resolve, 5));
+		}
+		expect(sessionResolutions).toBeGreaterThanOrEqual(3);
+		await new Promise((resolve) => setTimeout(resolve, 25));
+		await setup.app.realtime!.appendChannelEvent({
+			channel: "presence-space-b",
+			event: "message",
+			schemaIdentity: "space:message",
+			data: { id: "binding-ready" },
+		});
+		expect(await readSseEvent(reader, state, "channel_event")).toMatchObject({
+			channel: "presence-space-b",
+			data: { id: "binding-ready" },
+		});
+
+		allowedSpaces.delete("a");
+		await expect(
+			setup.app.realtime!.revokeChannelAuthority({
+				channel: "presence-space-a",
+				subject: { kind: "user", id: "user-1" },
+				idempotencyKey: "space-a:user-1:membership-v2",
+			}),
+		).resolves.toEqual({ generation: 1, scope: "exact-subscription" });
+		expect(sessionResolutions).toBeGreaterThanOrEqual(2);
+
+		await setup.app.realtime!.appendChannelEvent({
+			channel: "presence-space-a",
+			event: "message",
+			schemaIdentity: "space:message",
+			data: { id: "must-not-arrive" },
+		});
+		await setup.app.realtime!.appendChannelEvent({
+			channel: "presence-space-b",
+			event: "message",
+			schemaIdentity: "space:message",
+			data: { id: "still-authorized-binding" },
+		});
+
+		expect(await readSseEvent(reader, state, "channel_event")).toMatchObject({
+			channel: "presence-space-b",
+			data: { id: "still-authorized-binding" },
 		});
 		await reader.cancel();
 	});
@@ -313,6 +419,282 @@ describe("channel module routes", () => {
 		expect(configResponse.status).toBe(200);
 		expect(configText).toContain("public-key");
 		expect(configText).not.toContain("provider-secret");
+	});
+
+	test("rejects an unqualified shared-provider grant before policy or provider signing", async () => {
+		let policyCalls = 0;
+		let grantCalls = 0;
+		const transport: SharedProviderClientTransport = {
+			channelDeliveryScope: "shared-provider",
+			authorityRevocationScope: "principal-connections",
+			async start() {},
+			async openSession(): Promise<ClientSink> {
+				throw new Error("not used");
+			},
+			async getClientConfig() {
+				return { transport: "shared-provider", config: {} };
+			},
+			async generateAuth() {
+				grantCalls += 1;
+				return { auth: "must-not-be-issued" };
+			},
+			async publishChannel() {
+				return { status: "accepted", bufferedBytes: null };
+			},
+			async revokeAuthority() {},
+			async stop() {},
+		};
+		const setup = await buildMockApp(
+			{
+				channels: {
+					room: channel("room-[id]").authorize(() => {
+						policyCalls += 1;
+						return true;
+					}),
+				},
+			},
+			{
+				app: { url: "https://app.example.com" },
+				realtime: { clientTransport: transport, retentionDays: 0 },
+			},
+		);
+		cleanup = setup.cleanup;
+		await runTestDbMigrations(setup.app);
+		const handler = createFetchHandler(setup.app);
+
+		const response = await handler(
+			channelRequest(
+				"channels/auth",
+				{
+					socket_id: "123.456",
+					channel_name: "private-room-one",
+					channel: "room",
+					params: { id: "one" },
+				},
+				{ origin: "https://app.example.com", cookie: true },
+			),
+		);
+
+		expect(response.status).toBe(403);
+		expect(policyCalls).toBe(0);
+		expect(grantCalls).toBe(0);
+	});
+
+	test("rejects unsupported Pusher authority subjects before advancing a durable generation", async () => {
+		const provider: PusherProvider = {
+			trigger: async () => {},
+			authorizeChannel: () => ({ auth: "channel" }),
+			authenticateUser: () => ({ auth: "user", user_data: "{}" }),
+			terminateUserConnections: async () => {},
+			getPresenceMemberCount: async () => 0,
+		};
+		const setup = await buildMockApp(
+			{},
+			{
+				realtime: {
+					clientTransport: new PusherClientTransport({
+						provider,
+						key: "public-key",
+						identityKey: "provider-secret",
+					}),
+					retentionDays: 0,
+				},
+			},
+		);
+		cleanup = setup.cleanup;
+		await runTestDbMigrations(setup.app);
+
+		await expect(
+			setup.app.realtime!.revokeChannelAuthority({
+				channel: "private-room-one",
+				subject: { kind: "oauth", id: "token-1" },
+				idempotencyKey: "room-one:token-1:unsupported",
+			}),
+		).rejects.toThrow("requires a user subject");
+		expect(
+			await setup.app.db.select().from(questpieChannelAuthorityRevocationTable),
+		).toEqual([]);
+	});
+
+	test("Pusher authority revocation reconnects with fresh channel policy", async () => {
+		const terminated: string[] = [];
+		const provider: PusherProvider = {
+			trigger: async () => {},
+			authorizeChannel: (_socket, channelName) => ({
+				auth: `signed:${channelName}`,
+			}),
+			authenticateUser: (socketId, user) => ({
+				auth: `${socketId}:${user.id}`,
+				user_data: JSON.stringify(user),
+			}),
+			terminateUserConnections: async (userId) => {
+				terminated.push(userId);
+			},
+			getPresenceMemberCount: async () => 0,
+		};
+		const transport = new PusherClientTransport({
+			provider,
+			key: "public-key",
+			identityKey: "provider-secret",
+		});
+		const allowedSpaces = new Set(["a", "b"]);
+		const setup = await buildMockApp(
+			{
+				channels: {
+					space: channel("space-[spaceId]").authorize(
+						({ params, allowedSpaces: current }: any) =>
+							current.has(params.spaceId),
+					),
+				},
+			},
+			{
+				app: { url: "https://app.example.com" },
+				realtime: {
+					clientTransport: transport,
+					retentionDays: 0,
+				},
+			},
+		);
+		cleanup = setup.cleanup;
+		await runTestDbMigrations(setup.app);
+		const handler = createFetchHandler(setup.app, {
+			getSession: async () => ({
+				user: { id: "user-1" },
+				session: { id: "session-1" },
+			}),
+			extendContext: async () => ({
+				allowedSpaces: new Set(allowedSpaces),
+			}),
+		});
+
+		allowedSpaces.delete("a");
+		await setup.app.realtime!.revokeChannelAuthority({
+			channel: "private-space-a",
+			subject: { kind: "user", id: "user-1" },
+			idempotencyKey: "space-a:user-1:membership-v3",
+		});
+		expect(terminated).toHaveLength(1);
+
+		const userAuth = await handler(
+			new Request("https://app.example.com/realtime/auth", {
+				method: "POST",
+				headers: { "Content-Type": "application/x-www-form-urlencoded" },
+				body: new URLSearchParams({ socket_id: "123.456" }),
+			}),
+		);
+		expect(userAuth.status).toBe(200);
+
+		const authorize = (spaceId: string) =>
+			handler(
+				channelRequest(
+					"channels/auth",
+					{
+						socket_id: "123.456",
+						channel_name: `private-space-${spaceId}`,
+						channel: "space",
+						params: { spaceId },
+					},
+					{ origin: "https://app.example.com", cookie: true },
+				),
+			);
+		expect((await authorize("a")).status).toBe(403);
+		expect((await authorize("b")).status).toBe(200);
+		expect(terminated).toHaveLength(1);
+	});
+
+	test("Pusher channel grants fail closed when a concurrent authority cut wins", async () => {
+		let grantStarted!: () => void;
+		let releaseGrant!: () => void;
+		const grantEntered = new Promise<void>((resolve) => {
+			grantStarted = resolve;
+		});
+		const grantRelease = new Promise<void>((resolve) => {
+			releaseGrant = resolve;
+		});
+		const terminated: string[] = [];
+		const provider: PusherProvider = {
+			trigger: async () => {},
+			authorizeChannel: (_socket, channelName) => {
+				grantStarted();
+				return grantRelease.then(() => ({
+					auth: `signed:${channelName}`,
+				})) as unknown as ReturnType<PusherProvider["authorizeChannel"]>;
+			},
+			authenticateUser: (socketId, user) => ({
+				auth: `${socketId}:${user.id}`,
+				user_data: JSON.stringify(user),
+			}),
+			terminateUserConnections: async (userId) => {
+				terminated.push(userId);
+			},
+			getPresenceMemberCount: async () => 0,
+		};
+		const allowedSpaces = new Set(["a"]);
+		const setup = await buildMockApp(
+			{
+				channels: {
+					space: channel("space-[spaceId]").authorize(
+						({ params, allowedSpaces: current }: any) =>
+							current.has(params.spaceId),
+					),
+				},
+			},
+			{
+				app: { url: "https://app.example.com" },
+				realtime: {
+					clientTransport: new PusherClientTransport({
+						provider,
+						key: "public-key",
+						identityKey: "provider-secret",
+					}),
+					retentionDays: 0,
+				},
+			},
+		);
+		cleanup = setup.cleanup;
+		await runTestDbMigrations(setup.app);
+		const handler = createFetchHandler(setup.app, {
+			getSession: async () => ({
+				user: { id: "user-1" },
+				session: { id: "session-1" },
+			}),
+			extendContext: async () => ({
+				allowedSpaces: new Set(allowedSpaces),
+			}),
+		});
+
+		const grant = handler(
+			channelRequest(
+				"channels/auth",
+				{
+					socket_id: "123.456",
+					channel_name: "private-space-a",
+					channel: "space",
+					params: { spaceId: "a" },
+				},
+				{ origin: "https://app.example.com", cookie: true },
+			),
+		);
+		await grantEntered;
+
+		allowedSpaces.delete("a");
+		let revocationFinished = false;
+		const revocation = setup.app
+			.realtime!.revokeChannelAuthority({
+				channel: "private-space-a",
+				subject: { kind: "user", id: "user-1" },
+				idempotencyKey: "space-a:user-1:grant-race",
+			})
+			.then(() => {
+				revocationFinished = true;
+			});
+		await new Promise((resolve) => setTimeout(resolve, 10));
+		expect(revocationFinished).toBe(true);
+
+		releaseGrant();
+		expect((await grant).status).toBe(403);
+		await revocation;
+		expect(terminated).toHaveLength(1);
 	});
 
 	test("replays a bounded channel page only after fresh subscribe authorization", async () => {

--- a/packages/questpie/test/integration/channel-routes.test.ts
+++ b/packages/questpie/test/integration/channel-routes.test.ts
@@ -221,7 +221,8 @@ describe("channel module routes", () => {
 		const reader = response.body!.getReader();
 		const state = { buffer: "" };
 		await readSseEvent(reader, state, "session");
-		for (let attempt = 0; sessionResolutions < 3 && attempt < 100; attempt++) {
+		for (let attempt = 0; attempt < 100; attempt++) {
+			if (sessionResolutions >= 3) break;
 			await new Promise((resolve) => setTimeout(resolve, 5));
 		}
 		expect(sessionResolutions).toBeGreaterThanOrEqual(3);

--- a/packages/questpie/test/integration/ordered-channel-ledger.test.ts
+++ b/packages/questpie/test/integration/ordered-channel-ledger.test.ts
@@ -7,18 +7,24 @@ import {
 	test,
 } from "bun:test";
 
-import { asc } from "drizzle-orm";
+import { and, asc, eq } from "drizzle-orm";
 
+import { channel } from "../../src/server/channels/channel-builder.js";
+import { ChannelsService } from "../../src/server/channels/service.js";
 import { withTransaction } from "../../src/server/collection/crud/shared/transaction.js";
 import {
 	ChannelEventLedger,
 	hashResolvedChannel,
 } from "../../src/server/modules/core/integrated/realtime/channel-event-ledger.js";
 import {
+	questpieChannelAuthorityFenceTable,
+	questpieChannelAuthorityRevocationTable,
 	questpieChannelDispatchTable,
 	questpieChannelEventTable,
 	questpieChannelHeadTable,
+	questpieChannelPresenceTable,
 } from "../../src/server/modules/core/integrated/realtime/collection.js";
+import { SseChannelPresenceRegistry } from "../../src/server/modules/core/integrated/realtime/sse-channel-presence.js";
 import type {
 	ClientCloseReason,
 	ClientSink,
@@ -57,11 +63,46 @@ function createSink(sessionId: string, busy = false): TestSink {
 
 class SharedTestTransport implements SharedProviderClientTransport {
 	readonly channelDeliveryScope = "shared-provider" as const;
+	readonly authorityRevocationScope = "principal-connections" as const;
 	readonly deliveries: OrderedChannelDelivery[] = [];
+	readonly revocations: unknown[] = [];
+	rejectRevocation = false;
 
 	async start(): Promise<void> {}
 	async openSession(_input: EdgeSessionInput): Promise<ClientSink> {
 		return createSink("shared");
+	}
+	async getClientConfig() {
+		return { transport: "shared-provider" as const, config: {} };
+	}
+	async generateAuth() {
+		return { auth: "test" };
+	}
+	async generateUserAuth() {
+		return { auth: "test", user_data: '{"id":"opaque"}' };
+	}
+	async revokeAuthority(input: unknown): Promise<void> {
+		this.revocations.push(input);
+		if (this.rejectRevocation) {
+			throw new Error("provider termination unavailable");
+		}
+	}
+	async publishChannel(
+		delivery: OrderedChannelDelivery,
+	): Promise<SinkWriteResult> {
+		this.deliveries.push(delivery);
+		return { status: "accepted", bufferedBytes: null };
+	}
+	async stop(): Promise<void> {}
+}
+
+class CapabilitylessSharedTransport implements SharedProviderClientTransport {
+	readonly channelDeliveryScope = "shared-provider" as const;
+	readonly deliveries: OrderedChannelDelivery[] = [];
+
+	async start(): Promise<void> {}
+	async openSession(_input: EdgeSessionInput): Promise<ClientSink> {
+		return createSink("capabilityless-shared");
 	}
 	async getClientConfig() {
 		return { transport: "shared-provider" as const, config: {} };
@@ -76,6 +117,25 @@ class SharedTestTransport implements SharedProviderClientTransport {
 		return { status: "accepted", bufferedBytes: null };
 	}
 	async stop(): Promise<void> {}
+}
+
+class ControlledAckSharedTransport extends SharedTestTransport {
+	readonly acknowledgements: Array<() => void> = [];
+
+	override async revokeAuthority(input: unknown): Promise<void> {
+		this.revocations.push(input);
+		await new Promise<void>((resolve) => {
+			this.acknowledgements.push(resolve);
+		});
+	}
+}
+
+async function waitFor(assertion: () => boolean): Promise<void> {
+	for (let attempt = 0; attempt < 100; attempt++) {
+		if (assertion()) return;
+		await new Promise((resolve) => setTimeout(resolve, 5));
+	}
+	throw new Error("Timed out waiting for ordered channel test condition");
 }
 
 describe("ordered channel event ledger", () => {
@@ -94,6 +154,8 @@ describe("ordered channel event ledger", () => {
 		ledgers.clear();
 		await setup.app.db.delete(questpieChannelEventTable);
 		await setup.app.db.delete(questpieChannelDispatchTable);
+		await setup.app.db.delete(questpieChannelAuthorityRevocationTable);
+		await setup.app.db.delete(questpieChannelAuthorityFenceTable);
 		await setup.app.db.delete(questpieChannelHeadTable);
 	});
 
@@ -330,6 +392,205 @@ describe("ordered channel event ledger", () => {
 		).toEqual([1, 2]);
 	});
 
+	test("provider revocation failure leaves the authority fence pending and blocks publish cursor advancement", async () => {
+		const transport = new SharedTestTransport();
+		const events = ledger(transport);
+		transport.rejectRevocation = true;
+		await expect(
+			events.revokeAuthority({
+				channel: "private-room-1",
+				subject: "opaque-user-1",
+				transportSubject: { kind: "user", id: "user-1" },
+				idempotencyKey: "room-1:user-1:membership-v2",
+			}),
+		).rejects.toThrow("provider termination unavailable");
+
+		await events.append({
+			channel: "private-room-1",
+			event: "message",
+			schemaIdentity: "room:message",
+			data: { id: "must-not-dispatch" },
+		});
+		await events.drain();
+		const [dispatch] = await setup.app.db
+			.select()
+			.from(questpieChannelDispatchTable);
+		expect(transport.deliveries).toEqual([]);
+		expect(Number(dispatch.publishedSeq)).toBe(0);
+
+		transport.rejectRevocation = false;
+		const retried = await events.revokeAuthority({
+			channel: "private-room-1",
+			subject: "opaque-user-1",
+			transportSubject: { kind: "user", id: "user-1" },
+			idempotencyKey: "room-1:user-1:membership-v2",
+		});
+		await events.drain();
+		expect(retried).toEqual({
+			generation: 1,
+			scope: "principal-connections",
+		});
+		expect(transport.revocations).toHaveLength(2);
+		expect(transport.deliveries).toHaveLength(1);
+	});
+
+	test("a shared provider without an explicit revocation capability fails closed", async () => {
+		const transport = new CapabilitylessSharedTransport();
+		const events = ledger(transport);
+
+		await expect(
+			events.revokeAuthority({
+				channel: "private-room-1",
+				subject: "opaque-user-1",
+				transportSubject: { kind: "user", id: "user-1" },
+				idempotencyKey: "room-1:user-1:unsupported-provider",
+			}),
+		).rejects.toThrow("revocation capability");
+
+		await events.append({
+			channel: "private-room-1",
+			event: "message",
+			schemaIdentity: "room:message",
+			data: { id: "must-remain-fenced" },
+		});
+		await events.drain();
+		expect(transport.deliveries).toEqual([]);
+	});
+
+	test("out-of-order provider acknowledgements never regress the applied generation", async () => {
+		const transport = new ControlledAckSharedTransport();
+		const events = ledger(transport);
+		const first = events.revokeAuthority({
+			channel: "private-room-1",
+			subject: "opaque-user-1",
+			transportSubject: { kind: "user", id: "user-1" },
+			idempotencyKey: "room-1:user-1:authority-v1",
+		});
+		await waitFor(() => transport.acknowledgements.length === 1);
+		const second = events.revokeAuthority({
+			channel: "private-room-1",
+			subject: "opaque-user-1",
+			transportSubject: { kind: "user", id: "user-1" },
+			idempotencyKey: "room-1:user-1:authority-v2",
+		});
+		await waitFor(() => transport.acknowledgements.length === 2);
+
+		await events.append({
+			channel: "private-room-1",
+			event: "message",
+			schemaIdentity: "room:message",
+			data: { id: "behind-both-cuts" },
+		});
+		await events.drain();
+		expect(transport.deliveries).toEqual([]);
+
+		transport.acknowledgements[1]!();
+		await expect(second).resolves.toMatchObject({ generation: 2 });
+		await events.drain();
+		expect(transport.deliveries).toHaveLength(1);
+
+		transport.acknowledgements[0]!();
+		await expect(first).resolves.toMatchObject({ generation: 1 });
+		await events.append({
+			channel: "private-room-1",
+			event: "message",
+			schemaIdentity: "room:message",
+			data: { id: "after-late-older-ack" },
+		});
+		await events.drain();
+		const [fence] = await setup.app.db
+			.select()
+			.from(questpieChannelAuthorityFenceTable)
+			.where(
+				and(
+					eq(
+						questpieChannelAuthorityFenceTable.channelHash,
+						hashResolvedChannel("private-room-1"),
+					),
+					eq(questpieChannelAuthorityFenceTable.subject, "opaque-user-1"),
+				),
+			);
+		expect(Number(fence.appliedGeneration)).toBe(2);
+		expect(transport.deliveries).toHaveLength(2);
+	});
+
+	test("ChannelsService reports managed provider effects truthfully inside the caller transaction", async () => {
+		const transport = new SharedTestTransport();
+		const definitions = {
+			room: channel("room-[roomId]").authorize(true),
+		};
+		const providerSetup = await buildMockApp(
+			{ channels: definitions },
+			{
+				db: { pglite: testDb },
+				realtime: { clientTransport: transport, retentionDays: 0 },
+			},
+		);
+		const revokeIn = (db: any, idempotencyKey: string) =>
+			new ChannelsService(definitions, providerSetup.app.realtime!, {
+				accessMode: "system",
+				db,
+			} as any).revokeAuthority("room", {
+				params: { roomId: "one" },
+				subject: { kind: "user", id: "user-1" },
+				idempotencyKey,
+			});
+
+		try {
+			transport.rejectRevocation = true;
+			await expect(
+				withTransaction(setup.app.db, async (tx) =>
+					revokeIn(tx, "room-one:user-1:membership-v4-failure"),
+				),
+			).rejects.toThrow("provider termination unavailable");
+			expect(
+				await setup.app.db
+					.select()
+					.from(questpieChannelAuthorityRevocationTable),
+			).toEqual([]);
+
+			transport.rejectRevocation = false;
+			const retried = await revokeIn(
+				setup.app.db,
+				"room-one:user-1:membership-v4-failure",
+			);
+			expect(retried).toEqual({
+				generation: 1,
+				scope: "principal-connections",
+			});
+			await expect(
+				withTransaction(setup.app.db, async (tx) => {
+					await revokeIn(tx, "room-one:user-1:membership-v4-rollback");
+					throw new Error("related domain write rolled back");
+				}),
+			).rejects.toThrow("related domain write rolled back");
+			expect(
+				await setup.app.db
+					.select()
+					.from(questpieChannelAuthorityRevocationTable),
+			).toHaveLength(1);
+
+			await expect(
+				withTransaction(setup.app.db, async (tx) =>
+					revokeIn(tx, "room-one:user-1:membership-v4-success"),
+				),
+			).resolves.toEqual({
+				generation: 2,
+				scope: "principal-connections",
+			});
+			const committed = await setup.app.db
+				.select()
+				.from(questpieChannelAuthorityRevocationTable);
+			expect(committed.every((row) => row.applied)).toBe(true);
+			expect(committed.map((row) => Number(row.generation)).sort()).toEqual([
+				1, 2,
+			]);
+			expect(transport.revocations).toHaveLength(4);
+		} finally {
+			await providerSetup.cleanup();
+		}
+	});
+
 	test("duplicate drains dedupe and reconciliation heals a missed wake", async () => {
 		const publisher = ledger();
 		const reconciler = ledger();
@@ -442,6 +703,363 @@ describe("ordered channel event ledger", () => {
 
 		expect(sink.frames).toHaveLength(0);
 		expect(sink.closeReasons).toEqual(["slow_consumer"]);
+	});
+
+	test("revocation discards a paused frame and closes only the exact authority binding once", async () => {
+		const events = ledger(undefined, { busyRetryMs: 60_000 });
+		const revokedSink = createSink("revoked", true);
+		const retainedSink = createSink("retained");
+		let revokedAuthorized = true;
+
+		await events.subscribeLocal({
+			subscriptionId: "space-a:user-1",
+			channel: "private-space-a",
+			subject: "opaque-user-1",
+			reauthorize: async () => revokedAuthorized,
+			sink: revokedSink,
+		});
+		await events.subscribeLocal({
+			subscriptionId: "space-b:user-1",
+			channel: "private-space-b",
+			subject: "opaque-user-1",
+			reauthorize: async () => true,
+			sink: retainedSink,
+		});
+
+		await events.append({
+			channel: "private-space-a",
+			event: "message",
+			schemaIdentity: "space:message",
+			data: { id: "paused-before-write" },
+		});
+		await events.drain();
+		expect(revokedSink.frames).toHaveLength(0);
+
+		revokedAuthorized = false;
+		const firstRevocation = await events.revokeAuthority({
+			channel: "private-space-a",
+			subject: "opaque-user-1",
+			idempotencyKey: "space-a:user-1:membership-v2",
+		});
+		const duplicateRevocation = await events.revokeAuthority({
+			channel: "private-space-a",
+			subject: "opaque-user-1",
+			idempotencyKey: "space-a:user-1:membership-v2",
+		});
+
+		revokedSink.busy = false;
+		await events.append({
+			channel: "private-space-a",
+			event: "message",
+			schemaIdentity: "space:message",
+			data: { id: "after-revocation" },
+		});
+		await events.append({
+			channel: "private-space-b",
+			event: "message",
+			schemaIdentity: "space:message",
+			data: { id: "still-authorized" },
+		});
+		await events.drain();
+
+		expect(revokedSink.frames).toEqual([]);
+		expect(revokedSink.closeReasons).toEqual(["access_revoked"]);
+		expect(duplicateRevocation).toEqual(firstRevocation);
+		expect(firstRevocation).toEqual({
+			generation: 1,
+			scope: "exact-subscription",
+		});
+		expect(retainedSink.closeReasons).toEqual([]);
+		expect(retainedSink.frames.map((frame) => frame.data.id)).toEqual([
+			"still-authorized",
+		]);
+	});
+
+	test("a blocked sink write never delays an authority cut", async () => {
+		const events = ledger();
+		const sink = createSink("blocked-write");
+		let writeStarted!: () => void;
+		let releaseWrite!: () => void;
+		const writeEntered = new Promise<void>((resolve) => {
+			writeStarted = resolve;
+		});
+		const writeRelease = new Promise<void>((resolve) => {
+			releaseWrite = resolve;
+		});
+		sink.write = async (frame) => {
+			writeStarted();
+			await writeRelease;
+			sink.frames.push(JSON.parse(new TextDecoder().decode(frame)));
+			return { status: "accepted", bufferedBytes: 0 };
+		};
+		let authorized = true;
+		await events.subscribeLocal({
+			subscriptionId: "space-a:user-1:blocked-write",
+			channel: "private-space-a",
+			subject: "opaque-user-1",
+			reauthorize: async () => authorized,
+			sink,
+		});
+		await events.append({
+			channel: "private-space-a",
+			event: "message",
+			schemaIdentity: "space:message",
+			data: { id: "admitted-before-cut" },
+		});
+		await writeEntered;
+
+		authorized = false;
+		await Promise.race([
+			events.revokeAuthority({
+				channel: "private-space-a",
+				subject: "opaque-user-1",
+				idempotencyKey: "space-a:user-1:blocked-write",
+			}),
+			new Promise<never>((_, reject) =>
+				setTimeout(
+					() => reject(new Error("Revocation waited for the blocked sink")),
+					250,
+				),
+			),
+		]);
+		expect(sink.closeReasons).toEqual(["access_revoked"]);
+
+		releaseWrite();
+		await events.drain();
+		expect(sink.frames.map((frame) => frame.data.id)).toEqual([
+			"admitted-before-cut",
+		]);
+	});
+
+	test("a blocked fresh authorization cannot delay a cut or publish its stale result", async () => {
+		const events = ledger();
+		const sink = createSink("registration-race");
+		let authorized = true;
+		let authorizationCalls = 0;
+		let authorizationStarted!: () => void;
+		let releaseAuthorization!: () => void;
+		const authorizationEntered = new Promise<void>((resolve) => {
+			authorizationStarted = resolve;
+		});
+		const authorizationRelease = new Promise<void>((resolve) => {
+			releaseAuthorization = resolve;
+		});
+		const subscription = events.subscribeLocal({
+			subscriptionId: "space-a:user-1:registration-race",
+			channel: "private-space-a",
+			subject: "opaque-user-1",
+			reauthorize: async () => {
+				authorizationCalls += 1;
+				const result = authorized;
+				if (authorizationCalls === 1) {
+					authorizationStarted();
+					await authorizationRelease;
+				}
+				return result;
+			},
+			sink,
+		});
+		await authorizationEntered;
+
+		authorized = false;
+		await events.revokeAuthority({
+			channel: "private-space-a",
+			subject: "opaque-user-1",
+			idempotencyKey: "space-a:user-1:registration-race",
+		});
+
+		releaseAuthorization();
+		await subscription;
+
+		expect(authorizationCalls).toBe(2);
+		expect(sink.closeReasons).toEqual(["access_revoked"]);
+	});
+
+	test("a stale presence admission publishes no row, timer snapshot, or binding after a cut", async () => {
+		const events = ledger();
+		const presence = new SseChannelPresenceRegistry(setup.app.db, {
+			heartbeatMs: 5,
+			reconciliationMs: 5,
+		});
+		const sink = createSink("presence-race");
+		let authorized = true;
+		let authorizationCalls = 0;
+		let authorizationStarted!: () => void;
+		let releaseAuthorization!: () => void;
+		const authorizationEntered = new Promise<void>((resolve) => {
+			authorizationStarted = resolve;
+		});
+		const authorizationRelease = new Promise<void>((resolve) => {
+			releaseAuthorization = resolve;
+		});
+		const subscription = events.subscribeLocal({
+			subscriptionId: "presence-space-a:user-1:registration-race",
+			channel: "presence-space-a",
+			subject: "opaque-user-1",
+			reauthorize: async () => {
+				authorizationCalls += 1;
+				const result = authorized;
+				if (authorizationCalls === 1) {
+					authorizationStarted();
+					await authorizationRelease;
+				}
+				return result;
+			},
+			sink,
+			stage: presence.stage({
+				channel: "presence-space-a",
+				connectionId: "presence-space-a:user-1:registration-race",
+				principalId: "opaque-user-1",
+				sink,
+				data: { id: "member-1" },
+			}),
+		});
+		await authorizationEntered;
+
+		authorized = false;
+		await events.revokeAuthority({
+			channel: "presence-space-a",
+			subject: "opaque-user-1",
+			idempotencyKey: "presence-space-a:user-1:heartbeat-race",
+		});
+		releaseAuthorization();
+		await subscription;
+		await new Promise((resolve) => setTimeout(resolve, 20));
+
+		expect(authorizationCalls).toBe(2);
+		expect(sink.closeReasons).toEqual(["access_revoked"]);
+		expect(sink.frames).toEqual([]);
+		expect(
+			await setup.app.db.select().from(questpieChannelPresenceTable),
+		).toEqual([]);
+		await presence.destroy();
+	});
+
+	test("a retried presence admission publishes only the latest fresh member data", async () => {
+		const events = ledger();
+		const presence = new SseChannelPresenceRegistry(setup.app.db, {
+			heartbeatMs: 60_000,
+			reconciliationMs: 60_000,
+		});
+		const sink = createSink("presence-fresh-data");
+		sink.write = async () => ({
+			status: "accepted",
+			bufferedBytes: 0,
+		});
+		let authorizationCalls = 0;
+		let authorizationStarted!: () => void;
+		let releaseAuthorization!: () => void;
+		const authorizationEntered = new Promise<void>((resolve) => {
+			authorizationStarted = resolve;
+		});
+		const authorizationRelease = new Promise<void>((resolve) => {
+			releaseAuthorization = resolve;
+		});
+		const subscription = events.subscribeLocal({
+			subscriptionId: "presence-space-a:user-1:fresh-data",
+			channel: "presence-space-a",
+			subject: "opaque-user-1",
+			reauthorize: async () => {
+				authorizationCalls += 1;
+				if (authorizationCalls === 1) {
+					authorizationStarted();
+					await authorizationRelease;
+					return {
+						authorized: true,
+						presence: { id: "member-1", role: "old" },
+					};
+				}
+				return {
+					authorized: true,
+					presence: { id: "member-1", role: "new" },
+				};
+			},
+			sink,
+			stage: presence.stage({
+				channel: "presence-space-a",
+				connectionId: "presence-space-a:user-1:fresh-data",
+				principalId: "opaque-user-1",
+				sink,
+				data: { id: "member-1", role: "initial" },
+			}),
+		});
+		await authorizationEntered;
+
+		await events.revokeAuthority({
+			channel: "presence-space-a",
+			subject: "opaque-user-1",
+			idempotencyKey: "presence-space-a:user-1:fresh-data",
+		});
+		releaseAuthorization();
+		const release = await subscription;
+
+		expect(authorizationCalls).toBe(2);
+		const rows = await setup.app.db.select().from(questpieChannelPresenceTable);
+		expect(rows).toHaveLength(1);
+		expect(rows[0]?.data).toEqual({ id: "member-1", role: "new" });
+		expect(JSON.stringify(rows)).not.toContain('"old"');
+		expect(JSON.stringify(rows)).not.toContain('"initial"');
+		await release();
+		await presence.destroy();
+	});
+
+	test("a dropped authority wake reconciles from the durable fence on another instance", async () => {
+		const revoker = ledger();
+		const subscriber = ledger();
+		const sink = createSink("cross-instance");
+		let authorized = true;
+		await subscriber.subscribeLocal({
+			subscriptionId: "space-a:user-1:cross-instance",
+			channel: "private-space-a",
+			subject: "opaque-user-1",
+			reauthorize: async () => authorized,
+			sink,
+		});
+
+		authorized = false;
+		await revoker.revokeAuthority({
+			channel: "private-space-a",
+			subject: "opaque-user-1",
+			idempotencyKey: "space-a:user-1:membership-v3",
+		});
+		expect(sink.closeReasons).toEqual([]);
+
+		await subscriber.drain();
+		expect(sink.frames).toEqual([]);
+		expect(sink.closeReasons).toEqual(["access_revoked"]);
+	});
+
+	test("an externally managed transaction commits before exact local reconciliation", async () => {
+		const events = ledger();
+		const sink = createSink("raw-transaction");
+		let authorized = true;
+		await events.subscribeLocal({
+			subscriptionId: "space-a:user-1:raw-transaction",
+			channel: "private-space-a",
+			subject: "opaque-user-1",
+			reauthorize: async () => authorized,
+			sink,
+		});
+
+		authorized = false;
+		await setup.app.db.transaction(async (tx) => {
+			await events.revokeAuthority(
+				{
+					channel: "private-space-a",
+					subject: "opaque-user-1",
+					idempotencyKey: "space-a:user-1:membership-raw-tx",
+				},
+				{ db: tx },
+			);
+		});
+		for (
+			let attempt = 0;
+			sink.closeReasons.length === 0 && attempt < 100;
+			attempt++
+		) {
+			await new Promise((resolve) => setTimeout(resolve, 5));
+		}
+		expect(sink.closeReasons).toEqual(["access_revoked"]);
 	});
 
 	test("retention cleanup runs with zero subscribers across instances", async () => {

--- a/packages/questpie/test/integration/realtime-channel-reconciliation.test.ts
+++ b/packages/questpie/test/integration/realtime-channel-reconciliation.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from "bun:test";
+
+import { opaqueChannelAuthoritySubject } from "../../src/server/channels/authority.js";
+import type {
+	ClientCloseReason,
+	ClientSink,
+	DeliveryClass,
+} from "../../src/server/modules/core/integrated/realtime/transport.js";
+import { buildMockApp } from "../utils/mocks/mock-app-builder.js";
+import { createTestDb, runTestDbMigrations } from "../utils/test-db.js";
+
+async function waitFor(assertion: () => boolean): Promise<void> {
+	for (let attempt = 0; attempt < 200; attempt++) {
+		if (assertion()) return;
+		await new Promise((resolve) => setTimeout(resolve, 5));
+	}
+	throw new Error("Timed out waiting for channel reconciliation");
+}
+
+describe("default SSE channel reconciliation", () => {
+	test("a demand-driven ledger poll heals a dropped authority wake and stops with the last binding", async () => {
+		const database = await createTestDb();
+		const revoker = await buildMockApp(
+			{},
+			{
+				db: { pglite: database },
+				realtime: {
+					pollIntervalMs: 20,
+					retentionDays: 0,
+					rowLiveQueries: false,
+				},
+			},
+		);
+		const subscriber = await buildMockApp(
+			{},
+			{
+				db: { pglite: database },
+				realtime: {
+					pollIntervalMs: 20,
+					retentionDays: 0,
+					rowLiveQueries: false,
+				},
+			},
+		);
+		try {
+			await runTestDbMigrations(subscriber.app);
+			const realtime = subscriber.app.realtime as any;
+			let topologyStarts = 0;
+			realtime.topologyCoordinator.start = async () => {
+				topologyStarts += 1;
+			};
+			expect(
+				await subscriber.app.realtime.getClientTransportConfig({}),
+			).toEqual({ transport: "sse" });
+			expect(topologyStarts).toBe(0);
+			let ledgerDrains = 0;
+			const originalDrain = realtime.channelEventLedger.drain.bind(
+				realtime.channelEventLedger,
+			);
+			realtime.channelEventLedger.drain = async (...args: unknown[]) => {
+				ledgerDrains += 1;
+				return originalDrain(...args);
+			};
+			const deniedSink: ClientSink = {
+				sessionId: "default-sse-denied-channel",
+				async write() {
+					return { status: "accepted", bufferedBytes: 0 };
+				},
+				async close() {},
+			};
+			const releaseDenied = await subscriber.app.realtime.subscribeChannel({
+				subscriptionId: "space-a:user-1:denied",
+				channel: "private-space-a",
+				subject: opaqueChannelAuthoritySubject({
+					kind: "user",
+					id: "user-1",
+				}),
+				reauthorize: async () => false,
+				sink: deniedSink,
+			});
+			const drainsBeforeDeniedWait = ledgerDrains;
+			await new Promise((resolve) => setTimeout(resolve, 60));
+			expect(ledgerDrains).toBe(drainsBeforeDeniedWait);
+			await releaseDenied();
+
+			const closeReasons: ClientCloseReason[] = [];
+			const sink: ClientSink = {
+				sessionId: "default-sse-channel-reconciliation",
+				async write(_frame: Uint8Array, _delivery: DeliveryClass) {
+					return { status: "accepted", bufferedBytes: 0 };
+				},
+				async close(reason) {
+					closeReasons.push(reason);
+				},
+			};
+			let authorized = true;
+			const release = await subscriber.app.realtime.subscribeChannel({
+				subscriptionId: "space-a:user-1:dropped-wake",
+				channel: "private-space-a",
+				subject: opaqueChannelAuthoritySubject({
+					kind: "user",
+					id: "user-1",
+				}),
+				reauthorize: async () => authorized,
+				sink,
+			});
+			expect(topologyStarts).toBe(0);
+
+			authorized = false;
+			await revoker.app.realtime.revokeChannelAuthority({
+				channel: "private-space-a",
+				subject: { kind: "user", id: "user-1" },
+				idempotencyKey: "space-a:user-1:dropped-wake",
+			});
+			expect(closeReasons).toEqual([]);
+			await waitFor(() => closeReasons.length === 1);
+			expect(closeReasons).toEqual(["access_revoked"]);
+			expect(topologyStarts).toBe(0);
+
+			const drainsAfterInternalClose = ledgerDrains;
+			await new Promise((resolve) => setTimeout(resolve, 60));
+			expect(ledgerDrains).toBe(drainsAfterInternalClose);
+			await release();
+		} finally {
+			await Promise.all([revoker.cleanup(), subscriber.cleanup()]);
+			await database.close();
+		}
+	});
+});

--- a/packages/questpie/test/integration/realtime-pusher-routes.test.ts
+++ b/packages/questpie/test/integration/realtime-pusher-routes.test.ts
@@ -138,6 +138,54 @@ describe("pusher channel matrix module routes", () => {
 		expect(response.headers.get("cache-control")).toBe("no-store");
 	});
 
+	test("authenticates a signed-in Pusher user with only an opaque identity", async () => {
+		const transport = new PusherClientTransport({
+			provider,
+			key: "public-key",
+			identityKey: "test-secret",
+		});
+		setup = await buildMockApp(
+			{},
+			{ realtime: { clientTransport: transport, retentionDays: 0 } },
+		);
+		const authenticated = createFetchHandler(setup.app, {
+			getSession: async () => ({
+				user: { id: "raw-user-id" },
+				session: { id: "raw-session-id" },
+			}),
+		});
+		const input = new URLSearchParams({ socket_id: "123.456" });
+		const response = await authenticated(
+			new Request("http://localhost/realtime/auth", {
+				method: "POST",
+				headers: { "Content-Type": "application/x-www-form-urlencoded" },
+				body: input,
+			}),
+		);
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get("cache-control")).toBe("no-store");
+		const auth = (await response.json()) as {
+			auth: string;
+			user_data: string;
+		};
+		expect(auth.auth).toContain("123.456:");
+		const user = JSON.parse(auth.user_data) as { id: string };
+		expect(user.id).toHaveLength(64);
+		expect(JSON.stringify(auth)).not.toContain("raw-user-id");
+		expect(JSON.stringify(auth)).not.toContain("raw-session-id");
+
+		const anonymous = await createFetchHandler(setup.app)(
+			new Request("http://localhost/realtime/auth", {
+				method: "POST",
+				headers: { "Content-Type": "application/x-www-form-urlencoded" },
+				body: new URLSearchParams({ socket_id: "123.456" }),
+			}),
+		);
+		expect(anonymous.status).toBe(403);
+		expect(anonymous.headers.get("cache-control")).toBe("no-store");
+	});
+
 	test("releases principal admission when provider config loading fails", async () => {
 		setup = await buildMockApp(
 			{},

--- a/packages/questpie/test/integration/realtime-reconciliation.test.ts
+++ b/packages/questpie/test/integration/realtime-reconciliation.test.ts
@@ -303,6 +303,9 @@ describe("realtime matrix reconciliation", () => {
 		await flushMicrotasks();
 
 		expect(delivered).toEqual([change]);
+		await publisher.notify(change);
+		await flushMicrotasks();
+		expect(delivered).toEqual([change]);
 		expect(publisherAdapter.startCalls).toBe(1);
 	});
 

--- a/packages/questpie/test/types/realtime-transport.test-d.ts
+++ b/packages/questpie/test/types/realtime-transport.test-d.ts
@@ -26,6 +26,15 @@ type _sharedTransportCanPublishSharedChannels = Expect<
 	>
 >;
 
+type _sharedUserAuthenticationRemainsAnOptionalCapability = Expect<
+	Equal<
+		{} extends Pick<SharedProviderClientTransport, "generateUserAuth">
+			? true
+			: false,
+		true
+	>
+>;
+
 declare const sink: ClientSink;
 declare const wake: ChangeWake;
 

--- a/packages/questpie/test/units/channel-builder.test.ts
+++ b/packages/questpie/test/units/channel-builder.test.ts
@@ -194,6 +194,59 @@ describe("channel ChannelsService", () => {
 		).toEqual({ id: "user-1", roomId: "allowed" });
 	});
 
+	test("revokes resolved channel authority through the generic publisher and awaits acknowledgement", async () => {
+		const definitions = {
+			room: channel("room-[roomId]").authorize(() => true),
+		};
+		const revocations: unknown[] = [];
+		let acknowledge: (() => void) | undefined;
+		const acknowledged = new Promise<void>((resolve) => {
+			acknowledge = resolve;
+		});
+		const service = new ChannelsService(
+			definitions,
+			{
+				appendChannelEvent: async () => ({ eventId: "event-1" }),
+				revokeChannelAuthority: async (input) => {
+					revocations.push(input);
+					await acknowledged;
+					return {
+						scope: "principal-connections" as const,
+						generation: 1,
+					};
+				},
+			},
+			userContext,
+		);
+		let settled = false;
+
+		const revocation = service
+			.revokeAuthority("room", {
+				params: { roomId: "one" },
+				subject: { kind: "user", id: "user-2" },
+				idempotencyKey: "room-one:user-2:membership-v2",
+			})
+			.then((receipt) => {
+				settled = true;
+				return receipt;
+			});
+		await Promise.resolve();
+
+		expect(revocations).toEqual([
+			{
+				channel: "private-room-one",
+				subject: { kind: "user", id: "user-2" },
+				idempotencyKey: "room-one:user-2:membership-v2",
+			},
+		]);
+		expect(settled).toBe(false);
+		acknowledge?.();
+		await expect(revocation).resolves.toEqual({
+			scope: "principal-connections",
+			generation: 1,
+		});
+	});
+
 	test("publishes a batch in input order", async () => {
 		const definitions = {
 			news: channel("news").events({ updated: z.object({ id: z.string() }) }),

--- a/packages/questpie/test/units/realtime-pusher-transport.test.ts
+++ b/packages/questpie/test/units/realtime-pusher-transport.test.ts
@@ -590,23 +590,28 @@ describe("pusher channel matrix client delivery", () => {
 		expect(member.startsAt.getTime()).toBe(instant.getTime());
 		expect(member.isoLookingString).not.toBeInstanceOf(Date);
 
-		await transport.revokePrincipal(principal);
+		expect(transport.authorityRevocationScope).toBe("principal-connections");
+		await transport.revokeAuthority({
+			channel: "private-chat-room-1",
+			subject: { kind: "user", id: "user-1" },
+		});
 		expect(terminated).toEqual([channelData.user_id]);
 		expect(closedSessions).toBe(1);
 		await expect(
 			transport.generateUserAuth({ socketId: "123.456", principal }),
-		).rejects.toThrow("revoked");
+		).resolves.toMatchObject({ auth: expect.any(String) });
 		await expect(
 			transport.generatePresenceAuth({
 				socketId: "123.456",
 				channel: "presence-chat-room-1",
 				principal,
 			}),
-		).rejects.toThrow("revoked");
+		).resolves.toMatchObject({ auth: expect.any(String) });
 
-		transport.restorePrincipal(principal);
+		await transport.revokePrincipal(principal);
+		expect(terminated).toEqual([channelData.user_id, channelData.user_id]);
 		await expect(
 			transport.generateUserAuth({ socketId: "123.456", principal }),
-		).resolves.toMatchObject({ auth: expect.any(String) });
+		).rejects.toThrow("revoked");
 	});
 });

--- a/scripts/bundle-budget.json
+++ b/scripts/bundle-budget.json
@@ -2,12 +2,12 @@
 	"$comment": "Consumer bundle budget — the ENTRY chunk a browser downloads, measured with esbuild --splitting (what real bundlers do). Distinct from scripts/size-budget.json, which measures what npm publishes; a dependency moved behind a dynamic import shrinks this and not that. Regenerate with `bun run scripts/bundle-budget.ts --update` after a build. Gate: entry chunk >3% over budget fails CI.",
 	"entries": {
 		"questpie/client": {
-			"entryBytes": 179209,
-			"totalBytes": 352995
+			"entryBytes": 184788,
+			"totalBytes": 359236
 		},
 		"questpie/client+crdt": {
-			"entryBytes": 370165,
-			"totalBytes": 543951
+			"entryBytes": 375750,
+			"totalBytes": 550198
 		}
 	}
 }

--- a/skills/questpie/AGENTS.md
+++ b/skills/questpie/AGENTS.md
@@ -6022,6 +6022,24 @@ malformed targeting collapses to one generic reconcile. Channel application
 events use the exact 10,000-byte QUESTPIE cap while remaining below the
 provider's <10 kB ceiling.
 
+Managed Pusher clients use the SDK's signed-user protocol with an opaque,
+HMAC-derived user id. User authentication posts only `socket_id` to the
+authenticated, `no-store` realtime auth route; channel authentication remains
+bound to both `socket_id` and the final channel name. The SDK requests fresh
+user authentication after reconnect; channel authorization waits for that
+sign-in and rechecks the current socket and owner before succeeding. On an
+application login/logout transition that keeps the same browser socket, destroy
+both `client.realtime` and
+`client.channels` (or recreate the client) so the shared physical connection is
+also recreated under the new identity.
+
+Channel-scoped authority cuts use the generic `channels.revokeAuthority()` seam.
+SSE closes only the denied logical binding. Pusher's honest capability is
+`principal-connections`: it terminates all current connections for that user,
+then fresh user/channel authentication allows still-authorized bindings to
+return. See `references/channels.md` for the transaction and in-flight-frame
+contract.
+
 ## Admission and lifecycle
 
 Default SSE limits are 20 topics per connection, 5 connections per authenticated principal, `find` limit 100, nested `with` depth 3, 4 concurrent initial snapshots, and 1 MiB buffered snapshot bytes per edge session. Slow consumers are bounded and disconnected rather than allowed unbounded memory growth.
@@ -6178,6 +6196,51 @@ Framework handlers and hooks receive a generated `channels` service:
 ```
 
 In collection/global/hook files, use the injected `{ channels }`. Never import the generated `app` or defer lookup through ambient `getContext()`; the injected service is generated-type-safe and mutation-context aware.
+
+## Revoke current delivery authority
+
+When a membership or authorization mutation removes access, cut the affected
+resolved channel in the same transaction:
+
+```ts
+await channels.revokeAuthority("chatRoom", {
+	params: { roomId },
+	subject: { kind: "user", id: removedUserId },
+	idempotencyKey: `chat-room:${roomId}:${removedUserId}:membership-v2`,
+});
+```
+
+The idempotency key identifies the domain authorization transition. QUESTPIE
+advances a durable per-channel/subject generation and returns
+`{ generation, scope }`. `scope: "exact-subscription"` means the local SSE
+binding is cut without closing unrelated channel bindings.
+`scope: "principal-connections"` means the provider can only conservatively
+terminate every current connection for the signed-in user. Pusher supports the
+`user` subject for that capability.
+
+Fresh request context, subscribe authorization, and the presence resolver (for
+presence channels) run outside database locks. A short expected-generation
+publication installs the binding, latest fresh member payload, and optional
+presence lease together; a stale result and stale payload publish nothing and
+retry fresh. Internal revocation of the last SSE binding also stops its
+demand-driven authority reconciliation. A Pusher client signs in with an opaque
+provider user id before channel authorization, reconnects after termination,
+then obtains fresh user and per-channel authorization. Its channel grant is
+side-effect-free local signing guarded by an optimistic generation check, so a
+post-cut blob is discarded before reaching the client. Thus removing Space A
+may disconnect Space B briefly, but Space B can reconnect while Space A remains
+denied.
+
+In a managed caller transaction, Pusher termination and authority
+acknowledgement run inline under a bounded call. Provider failure throws and
+rolls back the database transaction; a conservative disconnect may survive a
+later caller rollback. Standalone provider failure leaves the durable cut
+pending for an idempotent retry.
+
+Pusher does not provide zero-frame atomicity: a frame already accepted by the
+physical provider connection may arrive while termination is in flight. The
+durable fence prevents new ordered provider dispatch from crossing a pending
+cut; reconnect and replay reauthorize against current application state.
 
 ## Client, presence, and TanStack Query
 

--- a/skills/questpie/coverage.json
+++ b/skills/questpie/coverage.json
@@ -149,6 +149,8 @@
 		"questpieRealtimeHeadTable": "durable realtime commit-order cursor infrastructure table",
 		"questpieRealtimeTopologyTable": "durable realtime infrastructure table managed by realtime migrations",
 		"questpieChannelDispatchTable": "ordered channel infrastructure table managed by realtime migrations",
+		"questpieChannelAuthorityFenceTable": "channel authority infrastructure table managed by realtime migrations",
+		"questpieChannelAuthorityRevocationTable": "channel authority idempotency infrastructure table managed by realtime migrations",
 		"questpieChannelEventTable": "ordered channel infrastructure table managed by realtime migrations",
 		"questpieChannelHeadTable": "ordered channel infrastructure table managed by realtime migrations",
 		"questpieChannelPresenceTable": "channel presence infrastructure table managed by realtime migrations",

--- a/skills/questpie/references/channels.md
+++ b/skills/questpie/references/channels.md
@@ -72,6 +72,51 @@ Framework handlers and hooks receive a generated `channels` service:
 
 In collection/global/hook files, use the injected `{ channels }`. Never import the generated `app` or defer lookup through ambient `getContext()`; the injected service is generated-type-safe and mutation-context aware.
 
+## Revoke current delivery authority
+
+When a membership or authorization mutation removes access, cut the affected
+resolved channel in the same transaction:
+
+```ts
+await channels.revokeAuthority("chatRoom", {
+	params: { roomId },
+	subject: { kind: "user", id: removedUserId },
+	idempotencyKey: `chat-room:${roomId}:${removedUserId}:membership-v2`,
+});
+```
+
+The idempotency key identifies the domain authorization transition. QUESTPIE
+advances a durable per-channel/subject generation and returns
+`{ generation, scope }`. `scope: "exact-subscription"` means the local SSE
+binding is cut without closing unrelated channel bindings.
+`scope: "principal-connections"` means the provider can only conservatively
+terminate every current connection for the signed-in user. Pusher supports the
+`user` subject for that capability.
+
+Fresh request context, subscribe authorization, and the presence resolver (for
+presence channels) run outside database locks. A short expected-generation
+publication installs the binding, latest fresh member payload, and optional
+presence lease together; a stale result and stale payload publish nothing and
+retry fresh. Internal revocation of the last SSE binding also stops its
+demand-driven authority reconciliation. A Pusher client signs in with an opaque
+provider user id before channel authorization, reconnects after termination,
+then obtains fresh user and per-channel authorization. Its channel grant is
+side-effect-free local signing guarded by an optimistic generation check, so a
+post-cut blob is discarded before reaching the client. Thus removing Space A
+may disconnect Space B briefly, but Space B can reconnect while Space A remains
+denied.
+
+In a managed caller transaction, Pusher termination and authority
+acknowledgement run inline under a bounded call. Provider failure throws and
+rolls back the database transaction; a conservative disconnect may survive a
+later caller rollback. Standalone provider failure leaves the durable cut
+pending for an idempotent retry.
+
+Pusher does not provide zero-frame atomicity: a frame already accepted by the
+physical provider connection may arrive while termination is in flight. The
+durable fence prevents new ordered provider dispatch from crossing a pending
+cut; reconnect and replay reauthorize against current application state.
+
 ## Client, presence, and TanStack Query
 
 ```ts

--- a/skills/questpie/references/realtime.md
+++ b/skills/questpie/references/realtime.md
@@ -103,6 +103,24 @@ malformed targeting collapses to one generic reconcile. Channel application
 events use the exact 10,000-byte QUESTPIE cap while remaining below the
 provider's <10 kB ceiling.
 
+Managed Pusher clients use the SDK's signed-user protocol with an opaque,
+HMAC-derived user id. User authentication posts only `socket_id` to the
+authenticated, `no-store` realtime auth route; channel authentication remains
+bound to both `socket_id` and the final channel name. The SDK requests fresh
+user authentication after reconnect; channel authorization waits for that
+sign-in and rechecks the current socket and owner before succeeding. On an
+application login/logout transition that keeps the same browser socket, destroy
+both `client.realtime` and
+`client.channels` (or recreate the client) so the shared physical connection is
+also recreated under the new identity.
+
+Channel-scoped authority cuts use the generic `channels.revokeAuthority()` seam.
+SSE closes only the denied logical binding. Pusher's honest capability is
+`principal-connections`: it terminates all current connections for that user,
+then fresh user/channel authentication allows still-authorized bindings to
+return. See `references/channels.md` for the transaction and in-flight-frame
+contract.
+
 ## Admission and lifecycle
 
 Default SSE limits are 20 topics per connection, 5 connections per authenticated principal, `find` limit 100, nested `with` depth 3, 4 concurrent initial snapshots, and 1 MiB buffered snapshot bytes per edge session. Slow consumers are bounded and disconnected rather than allowed unbounded memory growth.


### PR DESCRIPTION
## Summary

- add durable per-channel authority generations and idempotent revocation receipts
- enforce exact held-open SSE revocation with fresh reauthorization, presence fencing, dropped-wake reconciliation, and monotonic delivery cursors
- add explicit shared-provider revocation capabilities plus Pusher signed-user reconnect reauthorization
- document the provider-neutral contract and ship generated example migrations

## Verification

- targeted realtime/revocation scenarios: 70 passed, 0 failed
- package typecheck: passed
- root typecheck: 25/25 tasks passed
- lint, format check, and git diff check: passed
- docs validation: 183 files, 0 errors, 0 warnings
- realtime migration verification: city-portal and tanstack-barbershop clean/idempotent
- independent adversarial review: no remaining P0/P1 under the accepted bounded managed-provider transaction semantics

The full root suite ran 3,932 tests: 3,901 passed, 29 skipped, and two failed before the final monotonic-cursor repair. The realtime failure was reproduced, repaired, and its combined focused suite is now green. The remaining observability root-selection failure is suite-order dependent; its file passes 6/6 in isolation and is unrelated to this diff.

## Follow-ups

- bound authority-fence retention and pending-dispatch lookup cost
- qualify real pusher-js reconnect/in-flight authorization lifecycle
- add explicit managed-provider timeout/lock-contention coverage
