### PR TITLE
feat(queue): secure transactional secret dispatches

### DIFF
--- a/.changeset/secure-queue-payloads.md
+++ b/.changeset/secure-queue-payloads.md
@@ -1,0 +1,18 @@
+---
+"questpie": minor
+---
+
+Add transactional Queue dispatches for short-lived secret payloads. Payloads are
+envelope-encrypted before durable storage or broker publication, their wrapped
+data keys are erased after durable completion or an unclaimed broker-terminal
+outcome, and applications can read a payload-free queued/completed/failed
+receipt by stable dispatch id. This release qualifies pg-boss through durable
+broker-state reconciliation and fails secret publication closed on BullMQ,
+Cloudflare Queues, and unqualified custom adapters. Deploy the additive Queue
+ledger migration before enabling secret dispatches; populated legacy rows remain
+ordinary non-secret dispatches. Separate-database pg-boss relays recover the
+stable physical Job identity after an uncertain publication receipt only after
+proving that exact broker row exists; other queue-policy conflicts fail closed.
+Transactional publication performs the same proof through the caller's
+transaction connection. Accepted secret work is reconciled through finite
+snapshot pages so older active Jobs cannot starve later terminal key erasure.

--- a/apps/docs/content/docs/adapters/queue.mdx
+++ b/apps/docs/content/docs/adapters/queue.mdx
@@ -57,6 +57,7 @@ Each adapter advertises what it can do through capability flags. These gate whic
 | `pushConsumer` (`queue.createPushConsumer()`)         | no      | no     | yes               |
 | `scheduling` (`options.cron`, `queue.<n>.schedule()`) | yes     | yes    | no                |
 | `singleton` (`singletonKey` dedup)                    | yes     | yes    | no                |
+| `executionTerminalState` (`secretPayload`)            | yes     | no     | no                |
 
 <Callout
 	type="info"
@@ -64,12 +65,14 @@ Each adapter advertises what it can do through capability flags. These gate whic
 >
 	The resolved flags are exposed on `app.queue.capabilities`,
 	`longRunningConsumer`, `runOnceConsumer`, `pushConsumer`, `scheduling`,
-	`singleton`. If one codebase targets multiple runtimes, check the relevant
-	flag before calling `listen` / `runOnce` / `schedule` rather than catching the
-	throw. When an adapter omits `capabilities`, the runtime infers them:
+	`singleton`, and `executionTerminalState`. If one codebase targets multiple
+	runtimes, check the relevant flag before calling `listen` / `runOnce` /
+	`schedule` or publishing a secret payload rather than catching the throw. When
+	an adapter omits `capabilities`, the runtime infers them:
 	`longRunningConsumer`/`runOnceConsumer`/`pushConsumer` default to *"is the
 	matching method implemented?"*, `scheduling` to *"are both `schedule` and
-	`unschedule` functions?"*, and `singleton` to `false`.
+	`unschedule` functions?"*, and `singleton`/`executionTerminalState` to
+	`false`.
 </Callout>
 
 ## The consumer models
@@ -98,10 +101,42 @@ The adapter's capabilities decide _how_ a worker drains the queue. The mechanics
 - A crash after broker acceptance but before the receipt is recorded can cause another physical delivery. Every attempt keeps the same `dispatchId`; handlers must be idempotent.
 - Outside a transaction, a publish without `idempotencyKey` continues to await adapter acceptance directly. Supplying `idempotencyKey` uses the durable ledger so repeated calls resolve to one logical dispatch.
 - `idempotencyKey` and `singletonKey` cannot be combined. Native singleton suppression cannot produce a trustworthy receipt for a newly accepted logical dispatch.
+- `secretPayload: true` encrypts the validated payload before either the dispatch ledger or broker sees it. It requires a non-secret `idempotencyKey`, a stable `runtimeConfig.secret` of at least 32 bytes, and an adapter that can inspect durable broker execution state after process recovery. Only pg-boss is qualified in this release; BullMQ, Cloudflare Queues, and custom adapters without that proof fail closed before publication.
 
-The ledger is Queue-owned and is intentionally separate from the realtime outbox. It is always part of `app.getSchema()` so adapter changes do not accidentally drop recovery state; deploy the generated migration before running the new framework version. Accepted idempotent rows retain only identity and adapter-receipt metadata with no automatic expiry, while non-idempotent accepted rows are removed. Keep idempotency keys non-secret.
+The ledger is Queue-owned and is intentionally separate from the realtime outbox. It is always part of `app.getSchema()` so adapter changes do not accidentally drop recovery state. Before running this framework version, generate and deploy the additive migration for `wrapped_secret_key`, `completed_at`, `failed_at`, `secret_payload`, `execution_claim_token`, and `execution_claimed_until`. Existing populated rows remain ordinary, non-secret dispatches (`secret_payload = false`). Accepted idempotent rows retain only identity and safe receipt metadata with no automatic expiry, while non-idempotent accepted rows are removed. Keep idempotency keys non-secret.
 
-Adapter-publication recovery is bounded: 25 attempts, exponential backoff capped at one hour. A terminal row remains `failed`; `queue.drain()` reports it in `{ terminal }` and emits a payload-free structured error. Fix the adapter and publish a new logical attempt with a new `idempotencyKey`; the original key remains bound to its terminal receipt. Failed rows retain their payload for diagnosis, so use opaque identifiers rather than bearer secrets until the separate generic Queue payload-encryption capability exists.
+Adapter-publication recovery is bounded: 25 attempts, exponential backoff capped at one hour. A terminal row remains `failed`; `queue.drain()` reports it in `{ terminal }` and emits a payload-free structured error. Fix the adapter and publish a new logical attempt with a new `idempotencyKey`; the original key remains bound to its terminal receipt. Ordinary failed rows retain their payload for diagnosis. Secret-bearing rows erase their wrapped per-dispatch data key on relay failure, handler success, or a durable unclaimed broker-terminal outcome, so retained broker ciphertext is no longer decryptable.
+
+<Callout type="warn" title="Secret dispatch is at-least-once, not exactly-once">
+	The stable `dispatchId` and `idempotencyKey` identify retries; they do not
+	make an external side effect exactly-once. A crash after a provider accepted
+	an effect but before QUESTPIE stored handler completion can run the handler
+	again. Pass `dispatchId` to the provider's idempotency facility or keep a
+	consumer-owned processed-dispatch record. Put the domain payload version in
+	the idempotency key; replaying the same key always keeps the first encrypted
+	payload.
+</Callout>
+
+<Callout type="warn" title="Crypto-erasure cannot retract an accepted effect">
+	A secret execution holds a leased database claim while the handler runs.
+	Broker reconciliation waits for that live claim, completion wins over a
+	concurrent failure transition, and terminal state erases the wrapped data key.
+	If a process loses its lease after the provider accepted an effect but before
+	the completion row commits, another attempt can still run. Use the stable
+	`dispatchId` as the provider idempotency key. A `failed` receipt means
+	QUESTPIE cannot prove durable handler completion; it does not prove the
+	provider did nothing.
+</Callout>
+
+<Callout
+	type="warn"
+	title="Keep the Queue root secret stable while work is pending"
+>
+	Each dispatch uses a random data key wrapped by `runtimeConfig.secret`.
+	QUESTPIE does not keep a historical root-key ring. Drain or terminally fail
+	all secret-bearing work before rotating that runtime secret; otherwise old
+	payloads fail closed and cannot be recovered.
+</Callout>
 
 <Callout type="warn" title="Recovery requires an execution opportunity">
 	Node/Bun `listen()` runs a five-second recovery tick. Serverless and push-only
@@ -140,8 +175,9 @@ Behavior worth knowing:
 - **Queues are created on demand.** The adapter calls `createQueue(jobName)` the first time it touches a job and caches it, you never declare queues yourself.
 - **Ambient transactions stay atomic.** pg-boss receives `db: fromDrizzle(tx, sql)`, so the Job insert commits or rolls back with the current QUESTPIE transaction.
 - **The application and pg-boss must share PostgreSQL.** Same-transaction insertion is enabled by default. If pg-boss points at a separate database, set `useApplicationTransaction: false`; QUESTPIE then commits an application-database dispatch intent and relays it to pg-boss after commit.
-- **Logical identity is portable.** The stable `dispatchId` becomes pg-boss's Job `id`; the framework identity receipt survives pg-boss Job retention and adapter changes. `idempotencyKey` is not forwarded as a scheduling option.
+- **Logical identity is portable and recoverable.** The stable `dispatchId` becomes pg-boss's Job `id`; the framework identity receipt survives pg-boss Job retention and adapter changes. If a separate-database relay loses the publication receipt, QUESTPIE replays the stable ID and records acceptance only after querying the broker for that exact physical UUID. pg-boss also returns `null` when a different Job wins a queue-policy conflict; if the exact UUID is absent, QUESTPIE treats publication as failed and retries the relay (or rolls back a same-database transaction). `idempotencyKey` is not forwarded as a scheduling option.
 - **Other `PublishOptions` map ~1:1** to pg-boss send options (`priority`, `startAfter`, `singletonKey`, `retryLimit`, `retryDelay`, `expireInSeconds`).
+- **Non-standard policies also constrain missing keys.** pg-boss indexes `COALESCE(singleton_key, '')`, so `short`, `stately`, and `exclusive` queues can suppress otherwise unkeyed Jobs. Use a non-standard `queuePolicy` on an unkeyed queue only when that shared empty-key serialization is intentional.
 - **Batches are processed serially.** pg-boss always hands an array to its `work()` callback; the adapter iterates items one at a time and reports per-item failures via `boss.fail(...)` so a sibling failure doesn't sink the rest of the batch.
 - **`runOnce` explicitly settles fetched work.** Successful jobs call `boss.complete(...)`; handler failures call `boss.fail(...)` before the first batch error is surfaced. It throws _"PgBossAdapter.runOnce requires pg-boss fetch() support."_ if the installed pg-boss version doesn't expose it.
 
@@ -189,6 +225,12 @@ Behavior worth knowing:
 </Callout>
 
 Supports long-running workers, `runOnce`, cron scheduling, and `singletonKey` through BullMQ deduplication.
+
+`secretPayload: true` is intentionally rejected by BullMQ in this release.
+BullMQ can terminalize work through stalled-job limits and custom backoff paths
+outside the QUESTPIE handler. Preserving `finalAttempt` on handler deliveries is
+therefore insufficient to prove crash-safe key erasure. Ordinary BullMQ jobs are
+unchanged.
 
 ## Cloudflare Queues (push)
 
@@ -266,11 +308,18 @@ interface QueueAdapter {
 		dispatchId: string,
 	): Promise<string | null>;
 	transactionalPublishing?: boolean;
+	inspectExecutionState?(
+		jobName: string,
+		adapterJobId: string,
+	): Promise<"pending" | "active" | "completed" | "failed" | "missing">;
 	schedule(
 		jobName: string,
 		cron: string,
 		payload: any,
-		options?: Omit<PublishOptions, "idempotencyKey" | "startAfter">,
+		options?: Omit<
+			PublishOptions,
+			"idempotencyKey" | "startAfter" | "secretPayload"
+		>,
 	): Promise<void>;
 	unschedule(jobName: string): Promise<void>;
 	on(event: "error", handler: (error: Error) => void): void;
@@ -295,8 +344,11 @@ interface QueueAdapter {
 Three contract details adapter authors rely on:
 
 - **`dispatchId` is stable logical identity.** QUESTPIE passes it as the fourth `publish` argument; use it for the broker's physical dedupe id and carry it back to handlers. Implement `publishInTransaction` only when the adapter can insert through the supplied application Drizzle transaction. Set `transactionalPublishing: false` when a conditionally transactional adapter uses separate storage; the runtime then uses the framework dispatch ledger.
-- **Handlers are keyed by the durable job name.** The framework builds a `QueueHandlerMap` (`Record<jobName, handler>`) and passes it to `listen` / `runOnce` / `createPushConsumer`. Each handler receives a `QueueJobRecord`, `{ id, data, dispatchId?, idempotencyKey? }`.
+- **Handlers are keyed by the durable job name.** The framework builds a `QueueHandlerMap` (`Record<jobName, handler>`) and passes it to `listen` / `runOnce` / `createPushConsumer`. Each handler receives a `QueueJobRecord`, `{ id, data, dispatchId?, idempotencyKey?, secretPayload?, finalAttempt? }`.
 - **`data` is raw, the framework re-validates it.** Adapters store and replay the raw payload; QUESTPIE re-parses `data` against the job's Zod schema before invoking the user handler. Your adapter never needs to validate. (See [Jobs](/docs/concepts/jobs#the-handler) for the dispatch- and handler-time validation passes.)
+- **Secret payload support is explicit.** Set `executionTerminalState: true` only when the adapter preserves `options.secretPayload` on every physical attempt and implements `inspectExecutionState()` from durable broker truth, including timeout, heartbeat, stall, cancellation, and retry-exhaustion paths that happen outside the handler. QUESTPIE uses the outer framework marker, not a user-payload shape, to decide whether to decrypt. A database claim fences concurrent decryptions; its heartbeat protects active work from reconciliation. Handler completion is monotonic and erases the wrapped key. A broker terminal or missing state erases it only after the claim is absent or expired. `finalAttempt` remains useful delivery metadata but is not the security capability.
+- **Secret reconciliation exhausts a finite snapshot.** Each `queue.drain()` captures the current high-water accepted secret dispatch and inspects that snapshot in `batchSize` keyset pages until it reaches the high-water row. The page size bounds each database and broker-inspection batch; older active work cannot indefinitely hide a later terminal dispatch.
+- **The outer envelope namespace is reserved.** A payload whose top-level `__questpieQueue` metadata exactly matches the framework protocol and physical Job identity is decoded as a QUESTPIE envelope. The inner `__questpieQueueSecret` shape alone is not reserved user behavior and never triggers decryption; only the framework-authored outer `secretPayload` marker does.
 
 ## Extending: a custom adapter
 
@@ -312,6 +364,7 @@ class MyAdapter implements QueueAdapter {
 		pushConsumer: false,
 		scheduling: false,
 		singleton: false,
+		executionTerminalState: false,
 	};
 
 	async start() {

--- a/apps/docs/content/docs/concepts/jobs.mdx
+++ b/apps/docs/content/docs/concepts/jobs.mdx
@@ -94,7 +94,7 @@ That's the whole loop: define → wire an adapter → publish. A worker drains t
 </Callout>
 
 <Callout type="info" title="`publish()` joins the ambient transaction">
-  Call and `await` `queue.x.publish(...)` directly from transactional hooks. With pg-boss, QUESTPIE inserts the job through the current Drizzle transaction. With BullMQ, Cloudflare Queues, and custom external adapters, it writes an internal dispatch intent in that transaction and relays it after commit. A rollback therefore creates neither a job nor a dispatch intent. Existing `onAfterCommit(() => queue.x.publish(...))` call sites still work, but moving the call outside the transaction gives up the atomic handoff.
+  Call and `await` `queue.x.publish(...)` directly from transactional hooks. With pg-boss pointed at the same PostgreSQL database and `useApplicationTransaction: true`, QUESTPIE inserts the job and ledger row through the current Drizzle transaction. With pg-boss configured for separate storage (`useApplicationTransaction: false`), BullMQ, Cloudflare Queues, and custom external adapters, it writes an internal dispatch intent in that transaction and relays it after commit. A rollback therefore creates neither a job nor a dispatch intent. Existing `onAfterCommit(() => queue.x.publish(...))` call sites still work, but moving the call outside the transaction gives up the atomic handoff.
 </Callout>
 
 ## Example → what you get
@@ -191,9 +191,9 @@ const dispatchId = await queue.sendWelcomeEmail.publish(
 );
 ```
 
-The optional second argument is [`PublishOptions`](#publishoptions), spread-merged **over** the job's own `options` (`{ ...jobDef.options, ...publishOptions }`, so call-time wins). It throws if the payload fails the schema, `idempotencyKey` is empty or longer than 512 characters, or `idempotencyKey` and `singletonKey` are combined. Native singleton suppression cannot safely prove that a new logical dispatch was accepted, so that ambiguous combination fails closed.
+The optional second argument is [`PublishOptions`](#publishoptions), spread-merged **over** the job's own `options` (`{ ...jobDef.options, ...publishOptions }`, so call-time wins). It throws if the payload fails the schema, `idempotencyKey` is empty or longer than 512 characters, or `idempotencyKey` and `singletonKey` are combined. Native singleton suppression cannot safely prove that a new logical dispatch was accepted, so that ambiguous combination fails closed. A secret-bearing publish also fails closed unless it has a non-secret idempotency key, a stable `runtimeConfig.secret` of at least 32 bytes, and an adapter with `executionTerminalState`.
 
-Inside a QUESTPIE transaction, `publish()` is atomic with the business write. pg-boss inserts through the same Drizzle transaction. External adapters persist an internal `questpie_queue_dispatch` row in that transaction and relay it after commit with leased, retryable recovery. Outside a transaction, a call without `idempotencyKey` keeps the low-latency behavior and waits for adapter acceptance; a call with `idempotencyKey` uses the durable dispatch ledger so retries can resolve to one logical dispatch.
+Inside a QUESTPIE transaction, `publish()` is atomic with the business write. pg-boss inserts through the same Drizzle transaction only when it points at that PostgreSQL database and `useApplicationTransaction` is enabled. External adapters and a separate pg-boss database persist an internal `questpie_queue_dispatch` row in the transaction and relay it after commit with leased, retryable recovery. Outside a transaction, a call without `idempotencyKey` keeps the low-latency behavior and waits for adapter acceptance; a call with `idempotencyKey` uses the durable dispatch ledger so retries can resolve to one logical dispatch.
 
 ### `schedule(payload, cron, options?)`
 
@@ -206,7 +206,7 @@ await queue.generateReport.schedule(
 );
 ```
 
-`options` here is `Omit<PublishOptions, "idempotencyKey" | "startAfter">`. `startAfter` is meaningless for a recurring schedule, and one idempotency identity cannot describe recurring occurrences. This is the **imperative** scheduling path; the declarative one is [`options.cron`](#recurring-jobs) on the job itself. Throws on adapters without scheduling support (Cloudflare Queues).
+`options` here is `Omit<PublishOptions, "idempotencyKey" | "startAfter" | "secretPayload">`. `startAfter` is meaningless for a recurring schedule, one idempotency identity cannot describe recurring occurrences, and secret-bearing work requires a durable one-off dispatch ledger. This is the **imperative** scheduling path; the declarative one is [`options.cron`](#recurring-jobs) on the job itself. Throws on adapters without scheduling support (Cloudflare Queues).
 
 ### `unschedule()`
 
@@ -274,6 +274,7 @@ The per-call override surface for `publish()`. It's a superset of `options` minu
 
 ```ts
 interface PublishOptions {
+	secretPayload?: boolean; // per-dispatch envelope encryption + crypto-erasure
 	idempotencyKey?: string; // 1..512 chars; one logical dispatch per job name + key
 	priority?: number;
 	startAfter?: number | string | Date;
@@ -285,7 +286,39 @@ interface PublishOptions {
 }
 ```
 
-`idempotencyKey` is portable and scoped to the durable job name. Reusing it returns the same `dispatchId`; the first accepted payload/options win, even after pg-boss Job retention or an adapter switch. Accepted idempotent dispatches retain only their identity receipt, not their payload, with no automatic expiry: keep the key non-secret and remove a receipt only when your application can prove the key will never be retried. `singletonKey` is different: it controls adapter-native scheduling/concurrency deduplication while work is queued or active. It is supported by pg-boss queue policies and BullMQ deduplication and ignored by Cloudflare Queues. Combining both keys is rejected because a singleton-suppressed publish has no new logical Job identity. `schedule()` accepts `Omit<PublishOptions, "idempotencyKey" | "startAfter">`.
+`idempotencyKey` is portable and scoped to the durable job name. Reusing it returns the same `dispatchId`; the first accepted payload/options win, even after pg-boss Job retention or an adapter switch. Put the application payload version in this key when a later version must create new work. Accepted idempotent dispatches retain only their identity receipt, not their payload, with no automatic expiry: keep the key non-secret and remove a receipt only when your application can prove the key will never be retried. `singletonKey` is different: it controls adapter-native scheduling/concurrency deduplication while work is queued or active. It is supported by pg-boss queue policies and BullMQ deduplication and ignored by Cloudflare Queues. Combining both keys is rejected because a singleton-suppressed publish has no new logical Job identity. `schedule()` accepts `Omit<PublishOptions, "idempotencyKey" | "startAfter" | "secretPayload">`.
+
+### Secret-bearing payloads and safe receipts
+
+Use `secretPayload: true` only when the job must carry a short-lived bearer secret that cannot be resolved from durable application state:
+
+```ts
+const dispatchId = await queue.deliverOneTimeLink.publish(
+	{ recipientId, rawLink },
+	{
+		idempotencyKey: `one-time-link:${recipientId}:v1`,
+		secretPayload: true,
+	},
+);
+
+const receipt = await queue.getReceipt(dispatchId!);
+```
+
+QUESTPIE validates the plaintext first, creates a random AES-256-GCM data key, sends only ciphertext to Queue persistence and the broker, and keeps only the root-key-wrapped data key in `questpie_queue_dispatch`. The worker resolves that key by stable `dispatchId` only after acquiring a leased execution claim. The claim fences concurrent physical deliveries and is heartbeated while the handler runs. Handler completion is monotonic and erases the key. A durable broker failure, cancellation, timeout, heartbeat expiry, or missing job erases it only when no live execution claim remains. A duplicate delivery after erasure is acknowledged without running user code again.
+
+`getReceipt()` returns only `{ dispatchId, jobName, idempotencyKey?, status, createdAt, queuedAt, handledAt }`:
+
+- `queued` includes a committed relay intent and broker-accepted work. `queuedAt` is non-null only after broker acceptance.
+- `completed` means the job handler returned successfully. For a handler whose final action is `email.sendTemplate()`, an application may project this as `sent`, meaning only that the configured mail adapter accepted the request, not inbox delivery.
+- `failed` means broker publication exhausted recovery or durable broker state no longer proves a successful handler completion. A provider may already have accepted an external effect in the crash gap; use `dispatchId` for provider idempotency.
+
+The receipt contains no payload, wrapped key, adapter job id, provider response, or provider error. `getReceipt()` returns `null` for ordinary, non-secret dispatch rows so it cannot become a broad ledger-read API. It is still a server-side infrastructure query and applies no product authorization; authorize any route that projects a secret receipt.
+
+Framework-owned validation errors, handler failures, broker receipts,
+observability spans, and Queue logger calls use generic payload-free messages for
+secret dispatches. This boundary cannot prevent trusted application schema
+refinements, handlers, provider SDKs, or custom logging from recording plaintext
+before they throw. Do not log the payload or embed it in application telemetry.
 
 <Callout type="warn" title="Delivery is at-least-once">
 	Crash recovery can republish after an adapter accepted a message but before
@@ -400,7 +433,7 @@ export default {
 
 `createPushConsumer()` throws on pg-boss / BullMQ (they're poll-based, not push).
 
-For crash recovery when no new push batch arrives, invoke `await app.queue.drain()` from a Cloudflare Cron Trigger. `drain({ batchSize, concurrency, maxBatches })` claims up to 1000 rows per batch and up to 100 consecutive batches, then returns `{ claimed, accepted, failed, terminal }`. Defaults are one 100-row batch at concurrency eight. It is a bounded operational recovery seam, not another application dispatch API.
+For crash recovery when no new push batch arrives, invoke `await app.queue.drain()` from a Cloudflare Cron Trigger. `drain({ batchSize, concurrency, maxBatches })` claims up to 1000 relay rows per batch and up to 100 consecutive relay batches, then returns `{ claimed, accepted, failed, terminal }`. Defaults are one 100-row relay batch at concurrency eight. For adapters qualified for secret dispatch, the same call captures the current accepted-secret high-water row and reconciles that finite snapshot in `batchSize` keyset pages to exhaustion. This prevents older active work from hiding later broker-terminal work; `batchSize` bounds each reconciliation page rather than the whole snapshot. `drain()` is an operational recovery seam, not another application dispatch API.
 
 The relay retries adapter publication at most 25 times with exponential backoff capped at one hour. The 25th failure remains in `questpie_queue_dispatch` with `status = "failed"`, increments `terminal`, and emits a structured error containing only `dispatchId`, job name, attempt count, and the generic `"Adapter publication failed"` category. QUESTPIE deliberately does not persist or automatically log the foreign adapter's `Error.message`, because it may contain a serialized payload or bearer secret. After fixing the adapter, remediate through the existing application API by publishing a new logical attempt with a new `idempotencyKey`; reusing the terminal key deliberately returns the same terminal receipt.
 
@@ -410,8 +443,9 @@ The relay retries adapter publication at most 25 times with exponential backoff 
 >
 	Each adapter advertises what it supports via `app.queue.capabilities`,
 	`longRunningConsumer`, `runOnceConsumer`, `pushConsumer`, `scheduling`,
-	`singleton`. If you target multiple runtimes from one codebase, check the
-	relevant flag before calling a method; that's cheaper than catching the throw.
+	`singleton`, and `executionTerminalState`. If you target multiple runtimes
+	from one codebase, check the relevant flag before calling a method; that's
+	cheaper than catching the throw.
 </Callout>
 
 ## Adapters
@@ -436,7 +470,7 @@ import { pgBossAdapter } from "questpie/adapters/pg-boss";
 });
 ```
 
-`PgBossAdapterOptions` extends pg-boss's `ConstructorOptions` with `useApplicationTransaction`; all other options pass straight through to `new PgBoss(...)` (`connectionString`, `db`, `schema`, `max`, …). Queues are created on demand. When pg-boss and the application share PostgreSQL, the default `useApplicationTransaction: true` uses `fromDrizzle(tx, sql)` so the business write, durable idempotency receipt, and Job commit together. If pg-boss points at a separate database, set `useApplicationTransaction: false`; QUESTPIE then uses the application-database dispatch relay. Supports long-running workers, `runOnce`, scheduling, and native `singletonKey`.
+`PgBossAdapterOptions` extends pg-boss's `ConstructorOptions` with `useApplicationTransaction`; all other options pass straight through to `new PgBoss(...)` (`connectionString`, `db`, `schema`, `max`, …). Queues are created on demand. When pg-boss and the application share PostgreSQL, the default `useApplicationTransaction: true` uses `fromDrizzle(tx, sql)` so the business write, durable idempotency receipt, and Job commit together. If pg-boss points at a separate database, set `useApplicationTransaction: false`; QUESTPIE then uses the application-database dispatch relay. A lost publication receipt is recovered by replaying the stable `dispatchId` and querying for that exact physical Job before acceptance. A `null` result caused by a different queue-policy conflict is a publication failure, not a duplicate receipt. Supports long-running workers, `runOnce`, scheduling, and native `singletonKey`.
 
 ### BullMQ (Redis)
 
@@ -495,13 +529,17 @@ await queue.sendWelcomeEmail.publish(
 
 This is the complete composition: typed `send-welcome-email` Job → `email.sendTemplate()` → configured mail adapter. QUESTPIE does not expose `email.enqueueTemplate()` or a mail-specific outbox.
 
-<Callout type="warn" title="Do not place long-lived secrets in Queue payloads">
-	External-adapter payloads can remain in `questpie_queue_dispatch` until
-	acceptance and remain there after terminal failure, and then enter the broker.
-	Generic encryption for secret-bearing Queue payloads is a separate security
-	capability; pass durable record identifiers and resolve sensitive values
-	inside the handler. Failed rows are deliberately retained for operator
-	inspection and have no automatic payload-retention deadline in this release.
+<Callout
+	type="warn"
+	title="Prefer durable identifiers; protect unavoidable bearer secrets"
+>
+	Pass durable record identifiers and resolve sensitive values inside the
+	handler whenever possible. If a short-lived bearer value must cross Queue, use
+	`secretPayload: true`. Only pg-boss is qualified in this release. BullMQ and
+	Cloudflare Queues fail closed because their current adapters do not expose all
+	durable broker-owned terminal paths for recovery. Keep `runtimeConfig.secret`
+	stable until all such work is terminal; this release does not provide a
+	historical root-key ring.
 </Callout>
 
 <Callout type="warn" title="An adapter is required once any job exists">
@@ -522,6 +560,7 @@ class MyAdapter implements QueueAdapter {
 		pushConsumer: false,
 		scheduling: false,
 		singleton: false,
+		executionTerminalState: false,
 	};
 
 	async start() {
@@ -556,7 +595,7 @@ class MyAdapter implements QueueAdapter {
 }
 ```
 
-`start` / `stop` / `publish` / `schedule` / `unschedule` / `on` are **required**; `listen` / `runOnce` / `createPushConsumer` are **optional** and drive their capability flags when `capabilities` leaves them unset. QUESTPIE passes the stable logical `dispatchId` as the fourth `publish` argument; custom adapters should use it as their physical dedupe identity. Each `QueueHandlerMap` entry is keyed by the durable job name and receives `{ id, data, dispatchId?, idempotencyKey? }`; QUESTPIE validates `data` against the job's Zod schema before the handler runs.
+`start` / `stop` / `publish` / `schedule` / `unschedule` / `on` are **required**; `listen` / `runOnce` / `createPushConsumer` are **optional** and drive their capability flags when `capabilities` leaves them unset. QUESTPIE passes the stable logical `dispatchId` as the fourth `publish` argument; custom adapters should use it as their physical dedupe identity. Each `QueueHandlerMap` entry is keyed by the durable job name and receives `{ id, data, dispatchId?, idempotencyKey?, secretPayload?, finalAttempt? }`; QUESTPIE validates `data` against the job's Zod schema before the handler runs. A custom adapter may set `executionTerminalState: true` only when it preserves the outer secret marker and implements durable `inspectExecutionState()` coverage for every handler and broker-owned terminal path; otherwise secret-bearing publish fails closed.
 
 ## Built-in job: `index-records`
 

--- a/examples/city-portal/src/questpie/server/.generated/context.gen.ts
+++ b/examples/city-portal/src/questpie/server/.generated/context.gen.ts
@@ -24,6 +24,7 @@ import _glob_site_settings from "../globals/site-settings";
 // ── Migrations ─────────────────────────────────────────────
 import _mig_20260725T184252_realtimeV3Umbrella from "../migrations/20260725T184252_realtime-v3-umbrella";
 import _mig_20260726T163039_queueTransactionalDispatch from "../migrations/20260726T163039_queue-transactional-dispatch";
+import _mig_20260731T084648_realtimeIdempotency1 from "../migrations/20260731T084648_realtime-idempotency-1";
 
 // ── Blocks ─────────────────────────────────────────────────
 import { accordionBlock as _bloc_accordion } from "../blocks/accordion";

--- a/examples/city-portal/src/questpie/server/.generated/entities.gen.ts
+++ b/examples/city-portal/src/questpie/server/.generated/entities.gen.ts
@@ -25,6 +25,7 @@ import _glob_site_settings from "../globals/site-settings";
 // ── Migrations ─────────────────────────────────────────────
 import _mig_20260725T184252_realtimeV3Umbrella from "../migrations/20260725T184252_realtime-v3-umbrella";
 import _mig_20260726T163039_queueTransactionalDispatch from "../migrations/20260726T163039_queue-transactional-dispatch";
+import _mig_20260731T084648_realtimeIdempotency1 from "../migrations/20260731T084648_realtime-idempotency-1";
 
 // ── Blocks ─────────────────────────────────────────────────
 import { accordionBlock as _bloc_accordion } from "../blocks/accordion";

--- a/examples/city-portal/src/questpie/server/.generated/index.ts
+++ b/examples/city-portal/src/questpie/server/.generated/index.ts
@@ -30,6 +30,7 @@ import _glob_site_settings from "../globals/site-settings";
 // ── Migrations ─────────────────────────────────────────────
 import _mig_20260725T184252_realtimeV3Umbrella from "../migrations/20260725T184252_realtime-v3-umbrella";
 import _mig_20260726T163039_queueTransactionalDispatch from "../migrations/20260726T163039_queue-transactional-dispatch";
+import _mig_20260731T084648_realtimeIdempotency1 from "../migrations/20260731T084648_realtime-idempotency-1";
 
 // ── Blocks ─────────────────────────────────────────────────
 import { accordionBlock as _bloc_accordion } from "../blocks/accordion";
@@ -136,7 +137,7 @@ var _appLease = acquireGeneratedApp("city-portal-example:src/questpie/server:src
 		globals: {
 			site_settings: _glob_site_settings,
 		},
-		migrations: [_mig_20260725T184252_realtimeV3Umbrella, _mig_20260726T163039_queueTransactionalDispatch],
+		migrations: [_mig_20260725T184252_realtimeV3Umbrella, _mig_20260726T163039_queueTransactionalDispatch, _mig_20260731T084648_realtimeIdempotency1],
 		blocks: {
 			[_bloc_accordion.state.name]: _bloc_accordion,
 			[_bloc_announcementBanner.state.name]: _bloc_announcementBanner,

--- a/examples/city-portal/src/questpie/server/migrations/20260731T084648_realtime-idempotency-1.ts
+++ b/examples/city-portal/src/questpie/server/migrations/20260731T084648_realtime-idempotency-1.ts
@@ -1,0 +1,27 @@
+import { migration } from "questpie/services"
+import type { OperationSnapshot } from "questpie/migration"
+import { sql } from "drizzle-orm"
+import snapshotJson from "./snapshots/20260731T084648_realtime-idempotency-1.json"
+
+const snapshot = snapshotJson as OperationSnapshot
+
+export default migration({
+	id: "realtimeIdempotency120260731T084648",
+	async up({ db }) {
+		await db.execute(sql`ALTER TABLE "questpie_queue_dispatch" ADD COLUMN "secret_payload" boolean DEFAULT false NOT NULL;`)
+		await db.execute(sql`ALTER TABLE "questpie_queue_dispatch" ADD COLUMN "wrapped_secret_key" jsonb;`)
+		await db.execute(sql`ALTER TABLE "questpie_queue_dispatch" ADD COLUMN "completed_at" timestamp with time zone;`)
+		await db.execute(sql`ALTER TABLE "questpie_queue_dispatch" ADD COLUMN "failed_at" timestamp with time zone;`)
+		await db.execute(sql`ALTER TABLE "questpie_queue_dispatch" ADD COLUMN "execution_claim_token" uuid;`)
+		await db.execute(sql`ALTER TABLE "questpie_queue_dispatch" ADD COLUMN "execution_claimed_until" timestamp with time zone;`)
+	},
+	async down({ db }) {
+		await db.execute(sql`ALTER TABLE "questpie_queue_dispatch" DROP COLUMN "secret_payload";`)
+		await db.execute(sql`ALTER TABLE "questpie_queue_dispatch" DROP COLUMN "wrapped_secret_key";`)
+		await db.execute(sql`ALTER TABLE "questpie_queue_dispatch" DROP COLUMN "completed_at";`)
+		await db.execute(sql`ALTER TABLE "questpie_queue_dispatch" DROP COLUMN "failed_at";`)
+		await db.execute(sql`ALTER TABLE "questpie_queue_dispatch" DROP COLUMN "execution_claim_token";`)
+		await db.execute(sql`ALTER TABLE "questpie_queue_dispatch" DROP COLUMN "execution_claimed_until";`)
+	},
+	snapshot,
+})

--- a/examples/city-portal/src/questpie/server/migrations/snapshots/20260731T084648_realtime-idempotency-1.json
+++ b/examples/city-portal/src/questpie/server/migrations/snapshots/20260731T084648_realtime-idempotency-1.json
@@ -1,0 +1,123 @@
+{
+  "operations": [
+    {
+      "type": "set",
+      "path": "ddl.column__COLON__public__DOT__questpie_queue_dispatch__DOT__secret_payload",
+      "value": {
+        "type": "boolean",
+        "typeSchema": null,
+        "notNull": true,
+        "dimensions": 0,
+        "default": "false",
+        "generated": null,
+        "identity": null,
+        "name": "secret_payload",
+        "entityType": "columns",
+        "schema": "public",
+        "table": "questpie_queue_dispatch"
+      },
+      "timestamp": "2026-07-31T08:46:48.969Z",
+      "migrationId": "realtimeIdempotency120260731T084648"
+    },
+    {
+      "type": "set",
+      "path": "ddl.column__COLON__public__DOT__questpie_queue_dispatch__DOT__wrapped_secret_key",
+      "value": {
+        "type": "jsonb",
+        "typeSchema": null,
+        "notNull": false,
+        "dimensions": 0,
+        "default": null,
+        "generated": null,
+        "identity": null,
+        "name": "wrapped_secret_key",
+        "entityType": "columns",
+        "schema": "public",
+        "table": "questpie_queue_dispatch"
+      },
+      "timestamp": "2026-07-31T08:46:48.969Z",
+      "migrationId": "realtimeIdempotency120260731T084648"
+    },
+    {
+      "type": "set",
+      "path": "ddl.column__COLON__public__DOT__questpie_queue_dispatch__DOT__completed_at",
+      "value": {
+        "type": "timestamp with time zone",
+        "typeSchema": null,
+        "notNull": false,
+        "dimensions": 0,
+        "default": null,
+        "generated": null,
+        "identity": null,
+        "name": "completed_at",
+        "entityType": "columns",
+        "schema": "public",
+        "table": "questpie_queue_dispatch"
+      },
+      "timestamp": "2026-07-31T08:46:48.969Z",
+      "migrationId": "realtimeIdempotency120260731T084648"
+    },
+    {
+      "type": "set",
+      "path": "ddl.column__COLON__public__DOT__questpie_queue_dispatch__DOT__failed_at",
+      "value": {
+        "type": "timestamp with time zone",
+        "typeSchema": null,
+        "notNull": false,
+        "dimensions": 0,
+        "default": null,
+        "generated": null,
+        "identity": null,
+        "name": "failed_at",
+        "entityType": "columns",
+        "schema": "public",
+        "table": "questpie_queue_dispatch"
+      },
+      "timestamp": "2026-07-31T08:46:48.969Z",
+      "migrationId": "realtimeIdempotency120260731T084648"
+    },
+    {
+      "type": "set",
+      "path": "ddl.column__COLON__public__DOT__questpie_queue_dispatch__DOT__execution_claim_token",
+      "value": {
+        "type": "uuid",
+        "typeSchema": null,
+        "notNull": false,
+        "dimensions": 0,
+        "default": null,
+        "generated": null,
+        "identity": null,
+        "name": "execution_claim_token",
+        "entityType": "columns",
+        "schema": "public",
+        "table": "questpie_queue_dispatch"
+      },
+      "timestamp": "2026-07-31T08:46:48.969Z",
+      "migrationId": "realtimeIdempotency120260731T084648"
+    },
+    {
+      "type": "set",
+      "path": "ddl.column__COLON__public__DOT__questpie_queue_dispatch__DOT__execution_claimed_until",
+      "value": {
+        "type": "timestamp with time zone",
+        "typeSchema": null,
+        "notNull": false,
+        "dimensions": 0,
+        "default": null,
+        "generated": null,
+        "identity": null,
+        "name": "execution_claimed_until",
+        "entityType": "columns",
+        "schema": "public",
+        "table": "questpie_queue_dispatch"
+      },
+      "timestamp": "2026-07-31T08:46:48.969Z",
+      "migrationId": "realtimeIdempotency120260731T084648"
+    }
+  ],
+  "metadata": {
+    "migrationId": "realtimeIdempotency120260731T084648",
+    "timestamp": "2026-07-31T08:46:49.162Z",
+    "prevId": "00000000-0000-0000-0000-000000000000"
+  }
+}

--- a/examples/tanstack-barbershop/src/questpie/server/.generated/context.gen.ts
+++ b/examples/tanstack-barbershop/src/questpie/server/.generated/context.gen.ts
@@ -59,6 +59,7 @@ import _mig_20260712T094709_bold_red_griffin from "../migrations/20260712T094709
 import _mig_20260712T195414_eager_red_tiger from "../migrations/20260712T195414_eager_red_tiger";
 import _mig_20260725T184252_realtimeV3Umbrella from "../migrations/20260725T184252_realtime-v3-umbrella";
 import _mig_20260726T163042_queueTransactionalDispatch from "../migrations/20260726T163042_queue-transactional-dispatch";
+import _mig_20260731T084650_realtimeIdempotency1 from "../migrations/20260731T084650_realtime-idempotency-1";
 
 // ── Seeds ──────────────────────────────────────────────────
 import _seed_blogPosts from "../seeds/blog-posts";

--- a/examples/tanstack-barbershop/src/questpie/server/.generated/entities.gen.ts
+++ b/examples/tanstack-barbershop/src/questpie/server/.generated/entities.gen.ts
@@ -60,6 +60,7 @@ import _mig_20260712T094709_bold_red_griffin from "../migrations/20260712T094709
 import _mig_20260712T195414_eager_red_tiger from "../migrations/20260712T195414_eager_red_tiger";
 import _mig_20260725T184252_realtimeV3Umbrella from "../migrations/20260725T184252_realtime-v3-umbrella";
 import _mig_20260726T163042_queueTransactionalDispatch from "../migrations/20260726T163042_queue-transactional-dispatch";
+import _mig_20260731T084650_realtimeIdempotency1 from "../migrations/20260731T084650_realtime-idempotency-1";
 
 // ── Seeds ──────────────────────────────────────────────────
 import _seed_blogPosts from "../seeds/blog-posts";

--- a/examples/tanstack-barbershop/src/questpie/server/.generated/index.ts
+++ b/examples/tanstack-barbershop/src/questpie/server/.generated/index.ts
@@ -65,6 +65,7 @@ import _mig_20260712T094709_bold_red_griffin from "../migrations/20260712T094709
 import _mig_20260712T195414_eager_red_tiger from "../migrations/20260712T195414_eager_red_tiger";
 import _mig_20260725T184252_realtimeV3Umbrella from "../migrations/20260725T184252_realtime-v3-umbrella";
 import _mig_20260726T163042_queueTransactionalDispatch from "../migrations/20260726T163042_queue-transactional-dispatch";
+import _mig_20260731T084650_realtimeIdempotency1 from "../migrations/20260731T084650_realtime-idempotency-1";
 
 // ── Seeds ──────────────────────────────────────────────────
 import _seed_blogPosts from "../seeds/blog-posts";
@@ -203,7 +204,7 @@ var _appLease = acquireGeneratedApp("tanstack-barbershop-example:src/questpie/se
 			appointmentConfirmation: _email_appointmentConfirmation,
 			newBlogPost: _email_newBlogPost,
 		},
-		migrations: [_mig_20260206T174642_gentle_azure_eagle, _mig_20260206T180920_fancy_green_tiger, _mig_20260211T100836_calm_blue_phoenix, _mig_20260218T195452_calm_blue_dragon, _mig_20260218T223923_fancy_blue_panda, _mig_20260218T235924_kind_crimson_falcon, _mig_20260307T122102_eager_red_eagle, _mig_20260307T135142_fancy_orange_tiger, _mig_20260424T221327_bold_yellow_phoenix, _mig_20260427T093217_eager_blue_phoenix, _mig_20260429T170546_kind_yellow_eagle, _mig_20260615T084209_swift_orange_eagle, _mig_20260712T094709_bold_red_griffin, _mig_20260712T195414_eager_red_tiger, _mig_20260725T184252_realtimeV3Umbrella, _mig_20260726T163042_queueTransactionalDispatch],
+		migrations: [_mig_20260206T174642_gentle_azure_eagle, _mig_20260206T180920_fancy_green_tiger, _mig_20260211T100836_calm_blue_phoenix, _mig_20260218T195452_calm_blue_dragon, _mig_20260218T223923_fancy_blue_panda, _mig_20260218T235924_kind_crimson_falcon, _mig_20260307T122102_eager_red_eagle, _mig_20260307T135142_fancy_orange_tiger, _mig_20260424T221327_bold_yellow_phoenix, _mig_20260427T093217_eager_blue_phoenix, _mig_20260429T170546_kind_yellow_eagle, _mig_20260615T084209_swift_orange_eagle, _mig_20260712T094709_bold_red_griffin, _mig_20260712T195414_eager_red_tiger, _mig_20260725T184252_realtimeV3Umbrella, _mig_20260726T163042_queueTransactionalDispatch, _mig_20260731T084650_realtimeIdempotency1],
 		seeds: [_seed_blogPosts, _seed_demoData, _seed_siteSettings],
 		fieldTypes: {
 			color: _ftype_color,

--- a/examples/tanstack-barbershop/src/questpie/server/migrations/20260731T084650_realtime-idempotency-1.ts
+++ b/examples/tanstack-barbershop/src/questpie/server/migrations/20260731T084650_realtime-idempotency-1.ts
@@ -1,0 +1,27 @@
+import { migration } from "questpie/services"
+import type { OperationSnapshot } from "questpie/migration"
+import { sql } from "drizzle-orm"
+import snapshotJson from "./snapshots/20260731T084650_realtime-idempotency-1.json"
+
+const snapshot = snapshotJson as OperationSnapshot
+
+export default migration({
+	id: "realtimeIdempotency120260731T084650",
+	async up({ db }) {
+		await db.execute(sql`ALTER TABLE "questpie_queue_dispatch" ADD COLUMN "secret_payload" boolean DEFAULT false NOT NULL;`)
+		await db.execute(sql`ALTER TABLE "questpie_queue_dispatch" ADD COLUMN "wrapped_secret_key" jsonb;`)
+		await db.execute(sql`ALTER TABLE "questpie_queue_dispatch" ADD COLUMN "completed_at" timestamp with time zone;`)
+		await db.execute(sql`ALTER TABLE "questpie_queue_dispatch" ADD COLUMN "failed_at" timestamp with time zone;`)
+		await db.execute(sql`ALTER TABLE "questpie_queue_dispatch" ADD COLUMN "execution_claim_token" uuid;`)
+		await db.execute(sql`ALTER TABLE "questpie_queue_dispatch" ADD COLUMN "execution_claimed_until" timestamp with time zone;`)
+	},
+	async down({ db }) {
+		await db.execute(sql`ALTER TABLE "questpie_queue_dispatch" DROP COLUMN "secret_payload";`)
+		await db.execute(sql`ALTER TABLE "questpie_queue_dispatch" DROP COLUMN "wrapped_secret_key";`)
+		await db.execute(sql`ALTER TABLE "questpie_queue_dispatch" DROP COLUMN "completed_at";`)
+		await db.execute(sql`ALTER TABLE "questpie_queue_dispatch" DROP COLUMN "failed_at";`)
+		await db.execute(sql`ALTER TABLE "questpie_queue_dispatch" DROP COLUMN "execution_claim_token";`)
+		await db.execute(sql`ALTER TABLE "questpie_queue_dispatch" DROP COLUMN "execution_claimed_until";`)
+	},
+	snapshot,
+})

--- a/examples/tanstack-barbershop/src/questpie/server/migrations/snapshots/20260731T084650_realtime-idempotency-1.json
+++ b/examples/tanstack-barbershop/src/questpie/server/migrations/snapshots/20260731T084650_realtime-idempotency-1.json
@@ -1,0 +1,123 @@
+{
+  "operations": [
+    {
+      "type": "set",
+      "path": "ddl.column__COLON__public__DOT__questpie_queue_dispatch__DOT__secret_payload",
+      "value": {
+        "type": "boolean",
+        "typeSchema": null,
+        "notNull": true,
+        "dimensions": 0,
+        "default": "false",
+        "generated": null,
+        "identity": null,
+        "name": "secret_payload",
+        "entityType": "columns",
+        "schema": "public",
+        "table": "questpie_queue_dispatch"
+      },
+      "timestamp": "2026-07-31T08:46:50.412Z",
+      "migrationId": "realtimeIdempotency120260731T084650"
+    },
+    {
+      "type": "set",
+      "path": "ddl.column__COLON__public__DOT__questpie_queue_dispatch__DOT__wrapped_secret_key",
+      "value": {
+        "type": "jsonb",
+        "typeSchema": null,
+        "notNull": false,
+        "dimensions": 0,
+        "default": null,
+        "generated": null,
+        "identity": null,
+        "name": "wrapped_secret_key",
+        "entityType": "columns",
+        "schema": "public",
+        "table": "questpie_queue_dispatch"
+      },
+      "timestamp": "2026-07-31T08:46:50.412Z",
+      "migrationId": "realtimeIdempotency120260731T084650"
+    },
+    {
+      "type": "set",
+      "path": "ddl.column__COLON__public__DOT__questpie_queue_dispatch__DOT__completed_at",
+      "value": {
+        "type": "timestamp with time zone",
+        "typeSchema": null,
+        "notNull": false,
+        "dimensions": 0,
+        "default": null,
+        "generated": null,
+        "identity": null,
+        "name": "completed_at",
+        "entityType": "columns",
+        "schema": "public",
+        "table": "questpie_queue_dispatch"
+      },
+      "timestamp": "2026-07-31T08:46:50.412Z",
+      "migrationId": "realtimeIdempotency120260731T084650"
+    },
+    {
+      "type": "set",
+      "path": "ddl.column__COLON__public__DOT__questpie_queue_dispatch__DOT__failed_at",
+      "value": {
+        "type": "timestamp with time zone",
+        "typeSchema": null,
+        "notNull": false,
+        "dimensions": 0,
+        "default": null,
+        "generated": null,
+        "identity": null,
+        "name": "failed_at",
+        "entityType": "columns",
+        "schema": "public",
+        "table": "questpie_queue_dispatch"
+      },
+      "timestamp": "2026-07-31T08:46:50.412Z",
+      "migrationId": "realtimeIdempotency120260731T084650"
+    },
+    {
+      "type": "set",
+      "path": "ddl.column__COLON__public__DOT__questpie_queue_dispatch__DOT__execution_claim_token",
+      "value": {
+        "type": "uuid",
+        "typeSchema": null,
+        "notNull": false,
+        "dimensions": 0,
+        "default": null,
+        "generated": null,
+        "identity": null,
+        "name": "execution_claim_token",
+        "entityType": "columns",
+        "schema": "public",
+        "table": "questpie_queue_dispatch"
+      },
+      "timestamp": "2026-07-31T08:46:50.412Z",
+      "migrationId": "realtimeIdempotency120260731T084650"
+    },
+    {
+      "type": "set",
+      "path": "ddl.column__COLON__public__DOT__questpie_queue_dispatch__DOT__execution_claimed_until",
+      "value": {
+        "type": "timestamp with time zone",
+        "typeSchema": null,
+        "notNull": false,
+        "dimensions": 0,
+        "default": null,
+        "generated": null,
+        "identity": null,
+        "name": "execution_claimed_until",
+        "entityType": "columns",
+        "schema": "public",
+        "table": "questpie_queue_dispatch"
+      },
+      "timestamp": "2026-07-31T08:46:50.412Z",
+      "migrationId": "realtimeIdempotency120260731T084650"
+    }
+  ],
+  "metadata": {
+    "migrationId": "realtimeIdempotency120260731T084650",
+    "timestamp": "2026-07-31T08:46:50.621Z",
+    "prevId": "00000000-0000-0000-0000-000000000000"
+  }
+}

--- a/packages/questpie/src/server/modules/core/integrated/queue/adapter.ts
+++ b/packages/questpie/src/server/modules/core/integrated/queue/adapter.ts
@@ -6,7 +6,19 @@ export interface QueueAdapterCapabilities {
 	pushConsumer: boolean;
 	scheduling: boolean;
 	singleton: boolean;
+	/**
+	 * Adapter can inspect durable broker execution state after process crashes,
+	 * worker timeouts, and broker-owned terminalization.
+	 */
+	executionTerminalState: boolean;
 }
+
+export type QueueExecutionState =
+	| "pending"
+	| "active"
+	| "completed"
+	| "failed"
+	| "missing";
 
 export interface QueueJobRecord {
 	id: string;
@@ -15,6 +27,10 @@ export interface QueueJobRecord {
 	dispatchId?: string;
 	/** Portable caller-supplied idempotency identity. */
 	idempotencyKey?: string;
+	/** True only when a handler failure cannot be retried by the adapter. */
+	finalAttempt?: boolean;
+	/** Framework-authored marker that the adapter payload is encrypted. */
+	secretPayload?: boolean;
 }
 
 export interface QueueListenOptions {
@@ -108,13 +124,27 @@ export interface QueueAdapter {
 	transactionalPublishing?: boolean;
 
 	/**
+	 * Inspect the durable broker state for crash-recovery reconciliation.
+	 *
+	 * Adapters must not advertise executionTerminalState without implementing
+	 * this method for every broker-owned terminal path.
+	 */
+	inspectExecutionState?(
+		jobName: string,
+		adapterJobId: string,
+	): Promise<QueueExecutionState>;
+
+	/**
 	 * Schedule a recurring job with cron
 	 */
 	schedule(
 		jobName: string,
 		cron: string,
 		payload: any,
-		options?: Omit<PublishOptions, "idempotencyKey" | "startAfter">,
+		options?: Omit<
+			PublishOptions,
+			"idempotencyKey" | "startAfter" | "secretPayload"
+		>,
 	): Promise<void>;
 
 	/**

--- a/packages/questpie/src/server/modules/core/integrated/queue/adapters/bullmq.ts
+++ b/packages/questpie/src/server/modules/core/integrated/queue/adapters/bullmq.ts
@@ -32,6 +32,10 @@ export class BullMQAdapter implements QueueAdapter {
 		pushConsumer: false,
 		scheduling: true,
 		singleton: true,
+		// BullMQ can terminalize outside the processor through stalls,
+		// maxStartedAttempts, and custom backoff failures. This release has no
+		// source-qualified reconciliation for all of those paths.
+		executionTerminalState: false,
 	} as const;
 
 	private readonly connection: ConnectionOptions;
@@ -141,6 +145,20 @@ export class BullMQAdapter implements QueueAdapter {
 		return opts;
 	}
 
+	private toQueueJobRecord(job: {
+		id?: string | number;
+		data: unknown;
+		attemptsMade: number;
+		opts: { attempts?: number };
+	}) {
+		const id = String(job.id);
+		return {
+			id,
+			...decodeQueueDispatchEnvelope(job.data, id),
+			finalAttempt: job.attemptsMade + 1 >= (job.opts.attempts ?? 1),
+		};
+	}
+
 	async publish(
 		jobName: string,
 		payload: any,
@@ -155,6 +173,7 @@ export class BullMQAdapter implements QueueAdapter {
 						payload,
 						dispatchId,
 						options?.idempotencyKey,
+						options?.secretPayload,
 					)
 				: payload,
 			this.mapPublishOptions(options, dispatchId),
@@ -166,7 +185,10 @@ export class BullMQAdapter implements QueueAdapter {
 		jobName: string,
 		cron: string,
 		payload: any,
-		options?: Omit<PublishOptions, "idempotencyKey" | "startAfter">,
+		options?: Omit<
+			PublishOptions,
+			"idempotencyKey" | "startAfter" | "secretPayload"
+		>,
 	): Promise<void> {
 		const queue = this.getQueue(jobName);
 		// Use a deterministic repeat key keyed by jobName so unschedule() can
@@ -202,10 +224,7 @@ export class BullMQAdapter implements QueueAdapter {
 			const worker = new Worker(
 				jobName,
 				async (job) => {
-					await handler({
-						id: String(job.id),
-						...decodeQueueDispatchEnvelope(job.data, String(job.id)),
-					});
+					await handler(this.toQueueJobRecord(job));
 				},
 				{
 					connection: this.connection,
@@ -243,10 +262,7 @@ export class BullMQAdapter implements QueueAdapter {
 			const worker = new Worker(
 				jobName,
 				async (job) => {
-					await handler({
-						id: String(job.id),
-						...decodeQueueDispatchEnvelope(job.data, String(job.id)),
-					});
+					await handler(this.toQueueJobRecord(job));
 				},
 				{
 					connection: this.connection,

--- a/packages/questpie/src/server/modules/core/integrated/queue/adapters/cloudflare-queues.ts
+++ b/packages/questpie/src/server/modules/core/integrated/queue/adapters/cloudflare-queues.ts
@@ -134,6 +134,7 @@ export class CloudflareQueuesAdapter implements QueueAdapter {
 		pushConsumer: true,
 		scheduling: false,
 		singleton: false,
+		executionTerminalState: false,
 	} as const;
 
 	private readonly enqueue: (

--- a/packages/questpie/src/server/modules/core/integrated/queue/adapters/pg-boss.ts
+++ b/packages/questpie/src/server/modules/core/integrated/queue/adapters/pg-boss.ts
@@ -8,6 +8,7 @@ import {
 
 import type {
 	QueueAdapter,
+	QueueExecutionState,
 	QueueHandlerMap,
 	QueueListenOptions,
 	QueueRunOnceOptions,
@@ -37,6 +38,7 @@ export class PgBossAdapter implements QueueAdapter {
 		pushConsumer: false,
 		scheduling: true,
 		singleton: true,
+		executionTerminalState: true,
 	} as const;
 
 	private boss: PgBoss;
@@ -74,8 +76,6 @@ export class PgBossAdapter implements QueueAdapter {
 			// A queue's policy is fixed at creation. A dedupe policy (short/
 			// singleton/stately) is what makes `singletonKey` actually enforce —
 			// on a `standard` queue pg-boss stores the key but never dedupes.
-			// Policies only constrain KEYED jobs, so non-keyed jobs keep full
-			// throughput regardless.
 			await this.boss.createQueue(jobName, policy ? { policy } : undefined);
 			this.createdQueues.add(jobName);
 		}
@@ -99,6 +99,24 @@ export class PgBossAdapter implements QueueAdapter {
 		}
 	}
 
+	private async requireAcceptedJobId(
+		jobName: string,
+		adapterJobId: string | null,
+		dispatchId?: string,
+		db?: ReturnType<typeof fromDrizzle>,
+	): Promise<string> {
+		if (adapterJobId) return adapterJobId;
+		if (dispatchId) {
+			const persisted = await this.boss.getJobById(
+				jobName,
+				dispatchId,
+				db ? { db } : undefined,
+			);
+			if (persisted?.id === dispatchId) return dispatchId;
+		}
+		throw new Error("QUESTPIE pg-boss publication was not accepted");
+	}
+
 	async publish(
 		jobName: string,
 		payload: any,
@@ -113,18 +131,28 @@ export class PgBossAdapter implements QueueAdapter {
 		const {
 			queuePolicy: _queuePolicy,
 			idempotencyKey,
+			secretPayload,
 			...sendOptions
 		} = options ?? {};
-		return this.boss.send(
+		const adapterJobId = await this.boss.send(
 			jobName,
 			dispatchId
-				? encodeQueueDispatchEnvelope(payload, dispatchId, idempotencyKey)
+				? encodeQueueDispatchEnvelope(
+						payload,
+						dispatchId,
+						idempotencyKey,
+						secretPayload,
+					)
 				: payload,
 			{
 				...sendOptions,
 				...(dispatchId ? { id: dispatchId } : {}),
 			} satisfies SendOptions,
 		);
+		// pg-boss returns null for every ON CONFLICT DO NOTHING path, including
+		// queue-policy suppression by a different physical job. Recover an
+		// uncertain stable-id replay only after proving that exact row exists.
+		return this.requireAcceptedJobId(jobName, adapterJobId, dispatchId);
 	}
 
 	async publishInTransaction(
@@ -140,24 +168,61 @@ export class PgBossAdapter implements QueueAdapter {
 		const {
 			queuePolicy: _queuePolicy,
 			idempotencyKey,
+			secretPayload,
 			...sendOptions
 		} = options ?? {};
-		return this.boss.send(
+		const transactionDb = fromQuestpieDrizzleTransaction(tx);
+		const adapterJobId = await this.boss.send(
 			jobName,
-			encodeQueueDispatchEnvelope(payload, dispatchId, idempotencyKey),
+			encodeQueueDispatchEnvelope(
+				payload,
+				dispatchId,
+				idempotencyKey,
+				secretPayload,
+			),
 			{
 				...sendOptions,
 				id: dispatchId,
-				db: fromDrizzle(tx as Parameters<typeof fromDrizzle>[0], sql),
+				db: transactionDb,
 			} satisfies SendOptions,
 		);
+		return this.requireAcceptedJobId(
+			jobName,
+			adapterJobId,
+			dispatchId,
+			transactionDb,
+		);
+	}
+
+	async inspectExecutionState(
+		jobName: string,
+		adapterJobId: string,
+	): Promise<QueueExecutionState> {
+		await this.start();
+		const job = await this.boss.getJobById(jobName, adapterJobId);
+		if (!job) return "missing";
+		switch (job.state) {
+			case "completed":
+				return "completed";
+			case "failed":
+			case "cancelled":
+				return "failed";
+			case "active":
+				return "active";
+			case "created":
+			case "retry":
+				return "pending";
+		}
 	}
 
 	async schedule(
 		jobName: string,
 		cron: string,
 		payload: any,
-		options?: Omit<PublishOptions, "idempotencyKey" | "startAfter">,
+		options?: Omit<
+			PublishOptions,
+			"idempotencyKey" | "startAfter" | "secretPayload"
+		>,
 	): Promise<void> {
 		await this.start();
 		await this.ensureQueue(jobName, { policy: options?.queuePolicy });
@@ -188,37 +253,44 @@ export class PgBossAdapter implements QueueAdapter {
 			// failures are reported to pg-boss via boss.fail(jobName, id, …) so
 			// they retry independently while siblings in the same batch still
 			// complete.
-			await this.boss.work(jobName, options as any, async (jobs: any) => {
-				const arr: any[] = Array.isArray(jobs) ? jobs : jobs ? [jobs] : [];
-				for (const j of arr) {
-					try {
-						await handler({
-							id: String(j.id),
-							...decodeQueueDispatchEnvelope(j.data, String(j.id)),
-						});
-					} catch (error) {
-						const err =
-							error instanceof Error
-								? error
-								: new Error(typeof error === "string" ? error : String(error));
+			await this.boss.work(
+				jobName,
+				{ ...options, includeMetadata: true } as any,
+				async (jobs: any) => {
+					const arr: any[] = Array.isArray(jobs) ? jobs : jobs ? [jobs] : [];
+					for (const j of arr) {
 						try {
-							await this.boss.fail(jobName, String(j.id), {
-								message: err.message,
-								stack: err.stack,
+							await handler({
+								id: String(j.id),
+								...decodeQueueDispatchEnvelope(j.data, String(j.id)),
+								...finalAttemptMetadata(j),
 							});
-						} catch (failError) {
-							// If reporting the failure itself fails, surface the
-							// original handler error so pg-boss's own timeout/retry
-							// path can take over.
-							console.error(
-								`[questpie:pg-boss] failed to mark job ${j.id} as failed`,
-								failError,
-							);
-							throw err;
+						} catch (error) {
+							const err =
+								error instanceof Error
+									? error
+									: new Error(
+											typeof error === "string" ? error : String(error),
+										);
+							try {
+								await this.boss.fail(jobName, String(j.id), {
+									message: err.message,
+									stack: err.stack,
+								});
+							} catch (failError) {
+								// If reporting the failure itself fails, surface the
+								// original handler error so pg-boss's own timeout/retry
+								// path can take over.
+								console.error(
+									`[questpie:pg-boss] failed to mark job ${j.id} as failed`,
+									failError,
+								);
+								throw err;
+							}
 						}
 					}
-				}
-			});
+				},
+			);
 		}
 	}
 
@@ -259,6 +331,7 @@ export class PgBossAdapter implements QueueAdapter {
 
 			const fetched = await fetchFn.call(this.boss, jobName, {
 				batchSize,
+				includeMetadata: true,
 			});
 
 			const jobs = Array.isArray(fetched) ? fetched : fetched ? [fetched] : [];
@@ -269,6 +342,7 @@ export class PgBossAdapter implements QueueAdapter {
 					await handler({
 						id,
 						...decodeQueueDispatchEnvelope(job.data, id),
+						...finalAttemptMetadata(job),
 					});
 					await this.boss.complete(jobName, id);
 					processed += 1;
@@ -298,6 +372,45 @@ export class PgBossAdapter implements QueueAdapter {
 		// that expose 'on' only as a static member in the class declaration
 		(this.boss as unknown as NodeJS.EventEmitter).addListener(event, handler);
 	}
+}
+
+function fromQuestpieDrizzleTransaction(
+	tx: unknown,
+): ReturnType<typeof fromDrizzle> {
+	const database = fromDrizzle(tx as Parameters<typeof fromDrizzle>[0], sql);
+	return {
+		executeSql: (text, values) =>
+			database.executeSql(
+				text,
+				values?.map((value, index) => {
+					if (
+						typeof value !== "string" ||
+						!new RegExp(`\\$${index + 1}\\s*::\\s*jsonb?\\b`).test(text)
+					) {
+						return value;
+					}
+					try {
+						// Bun SQL serializes a string supplied to a JSON-typed
+						// placeholder as a JSON string scalar. pg-boss supplies its
+						// batch as JSON text, so restore the structured value before
+						// the official Drizzle bridge binds it.
+						return JSON.parse(value);
+					} catch {
+						return value;
+					}
+				}),
+			),
+	};
+}
+
+function finalAttemptMetadata(
+	job: Record<string, unknown>,
+): { finalAttempt: boolean } | Record<string, never> {
+	return Number.isInteger(job.retryCount) && Number.isInteger(job.retryLimit)
+		? {
+				finalAttempt: (job.retryCount as number) >= (job.retryLimit as number),
+			}
+		: {};
 }
 
 /**

--- a/packages/questpie/src/server/modules/core/integrated/queue/dispatch-envelope.ts
+++ b/packages/questpie/src/server/modules/core/integrated/queue/dispatch-envelope.ts
@@ -5,6 +5,7 @@ interface QueueDispatchEnvelope {
 		version: typeof QUESTPIE_QUEUE_DISPATCH_ENVELOPE_VERSION;
 		dispatchId: string;
 		idempotencyKey?: string;
+		secretPayload?: true;
 	};
 	payload: unknown;
 }
@@ -13,12 +14,14 @@ export function encodeQueueDispatchEnvelope(
 	payload: unknown,
 	dispatchId: string,
 	idempotencyKey?: string,
+	secretPayload?: boolean,
 ): QueueDispatchEnvelope {
 	return {
 		__questpieQueue: {
 			version: QUESTPIE_QUEUE_DISPATCH_ENVELOPE_VERSION,
 			dispatchId,
 			...(idempotencyKey ? { idempotencyKey } : {}),
+			...(secretPayload ? { secretPayload: true as const } : {}),
 		},
 		payload,
 	};
@@ -31,6 +34,7 @@ export function decodeQueueDispatchEnvelope(
 	data: unknown;
 	dispatchId?: string;
 	idempotencyKey?: string;
+	secretPayload?: boolean;
 };
 export function decodeQueueDispatchEnvelope(
 	value: unknown,
@@ -39,6 +43,7 @@ export function decodeQueueDispatchEnvelope(
 	data: unknown;
 	dispatchId?: string;
 	idempotencyKey?: string;
+	secretPayload?: boolean;
 } {
 	if (!value || typeof value !== "object" || Array.isArray(value)) {
 		return { data: value };
@@ -61,6 +66,7 @@ export function decodeQueueDispatchEnvelope(
 		...(typeof metadata.idempotencyKey === "string"
 			? { idempotencyKey: metadata.idempotencyKey }
 			: {}),
+		...(metadata.secretPayload === true ? { secretPayload: true } : {}),
 	};
 }
 

--- a/packages/questpie/src/server/modules/core/integrated/queue/dispatch-store.ts
+++ b/packages/questpie/src/server/modules/core/integrated/queue/dispatch-store.ts
@@ -1,10 +1,28 @@
-import { and, asc, eq, inArray, isNull, lt, lte, or, sql } from "drizzle-orm";
+import {
+	and,
+	asc,
+	desc,
+	eq,
+	gt,
+	inArray,
+	isNotNull,
+	isNull,
+	lt,
+	lte,
+	or,
+	sql,
+} from "drizzle-orm";
 
 import type { AnyDrizzleClient } from "#questpie/server/config/types.js";
 
 import type { QueueAdapter } from "./adapter.js";
 import { questpieQueueDispatchTable } from "./dispatch-table.js";
-import type { PublishOptions, QueueDrainResult } from "./types.js";
+import type { QueueWrappedSecretKey } from "./secret-payload.js";
+import type {
+	PublishOptions,
+	QueueDispatchReceipt,
+	QueueDrainResult,
+} from "./types.js";
 
 const DEFAULT_BATCH_SIZE = 100;
 const DEFAULT_CONCURRENCY = 8;
@@ -13,6 +31,7 @@ const MAX_RELAY_ATTEMPTS = 25;
 const MAX_IDEMPOTENCY_KEY_LENGTH = 512;
 const MAX_RETRY_DELAY_SECONDS = 3_600;
 const SAFE_ADAPTER_PUBLICATION_ERROR = "Adapter publication failed";
+const DEFAULT_EXECUTION_LEASE_MS = 60_000;
 
 type QueueDatabase = AnyDrizzleClient;
 
@@ -65,6 +84,7 @@ export async function enqueueQueueDispatch(
 		jobName: string;
 		idempotencyKey?: string;
 		payload: unknown;
+		wrappedSecretKey?: QueueWrappedSecretKey;
 		options?: PublishOptions;
 	},
 ): Promise<string> {
@@ -78,6 +98,7 @@ export async function reserveQueueDispatch(
 		jobName: string;
 		idempotencyKey?: string;
 		payload: unknown;
+		wrappedSecretKey?: QueueWrappedSecretKey;
 		options?: PublishOptions;
 	},
 ): Promise<{ dispatchId: string; inserted: boolean }> {
@@ -88,6 +109,8 @@ export async function reserveQueueDispatch(
 			jobName: input.jobName,
 			idempotencyKey: input.idempotencyKey,
 			payload: input.payload,
+			secretPayload: input.options?.secretPayload === true,
+			wrappedSecretKey: input.wrappedSecretKey,
 			options: input.options ?? {},
 		})
 		.onConflictDoNothing()
@@ -112,6 +135,375 @@ export async function reserveQueueDispatch(
 		}
 	}
 	throw new Error("QUESTPIE Queue failed to persist dispatch intent");
+}
+
+export type QueueExecutionClaim =
+	| {
+			status: "claimed";
+			token: string;
+			wrappedKey: QueueWrappedSecretKey;
+	  }
+	| { status: "busy" | "terminal" | "unavailable" };
+
+export async function claimQueueDispatchExecution(
+	db: QueueDatabase,
+	dispatchId: string,
+	options: { leaseMs?: number; now?: Date } = {},
+): Promise<QueueExecutionClaim> {
+	const leaseMs = boundedInteger(
+		options.leaseMs,
+		DEFAULT_EXECUTION_LEASE_MS,
+		3_600_000,
+	);
+	const currentTime = options.now ?? sql`CURRENT_TIMESTAMP`;
+	const claimedUntil = options.now
+		? new Date(options.now.getTime() + leaseMs)
+		: sql`CURRENT_TIMESTAMP + (${leaseMs} * interval '1 millisecond')`;
+	const token = crypto.randomUUID();
+	const claimed = await db
+		.update(questpieQueueDispatchTable)
+		.set({
+			executionClaimToken: token,
+			executionClaimedUntil: claimedUntil,
+		})
+		.where(
+			and(
+				eq(questpieQueueDispatchTable.dispatchId, dispatchId),
+				eq(questpieQueueDispatchTable.secretPayload, true),
+				eq(questpieQueueDispatchTable.status, "accepted"),
+				isNotNull(questpieQueueDispatchTable.wrappedSecretKey),
+				or(
+					isNull(questpieQueueDispatchTable.executionClaimToken),
+					isNull(questpieQueueDispatchTable.executionClaimedUntil),
+					lt(questpieQueueDispatchTable.executionClaimedUntil, currentTime),
+				),
+			),
+		)
+		.returning({
+			wrappedSecretKey: questpieQueueDispatchTable.wrappedSecretKey,
+		});
+	if (claimed[0]?.wrappedSecretKey) {
+		return {
+			status: "claimed",
+			token,
+			wrappedKey: claimed[0].wrappedSecretKey as QueueWrappedSecretKey,
+		};
+	}
+
+	const [existing] = await db
+		.select({
+			status: questpieQueueDispatchTable.status,
+			secretPayload: questpieQueueDispatchTable.secretPayload,
+			executionClaimToken: questpieQueueDispatchTable.executionClaimToken,
+			executionClaimedUntil: questpieQueueDispatchTable.executionClaimedUntil,
+		})
+		.from(questpieQueueDispatchTable)
+		.where(eq(questpieQueueDispatchTable.dispatchId, dispatchId))
+		.limit(1);
+	if (!existing || !existing.secretPayload) return { status: "unavailable" };
+	if (existing.status === "completed" || existing.status === "failed") {
+		return { status: "terminal" };
+	}
+	if (
+		existing.status === "accepted" &&
+		existing.executionClaimToken &&
+		existing.executionClaimedUntil &&
+		existing.executionClaimedUntil.getTime() >
+			(options.now?.getTime() ?? Date.now())
+	) {
+		return { status: "busy" };
+	}
+	return { status: "unavailable" };
+}
+
+export async function renewQueueDispatchExecution(
+	db: QueueDatabase,
+	dispatchId: string,
+	token: string,
+	options: { leaseMs?: number } = {},
+): Promise<boolean> {
+	const leaseMs = boundedInteger(
+		options.leaseMs,
+		DEFAULT_EXECUTION_LEASE_MS,
+		3_600_000,
+	);
+	const updated = await db
+		.update(questpieQueueDispatchTable)
+		.set({
+			executionClaimedUntil: sql`CURRENT_TIMESTAMP + (${leaseMs} * interval '1 millisecond')`,
+		})
+		.where(
+			and(
+				eq(questpieQueueDispatchTable.dispatchId, dispatchId),
+				eq(questpieQueueDispatchTable.status, "accepted"),
+				eq(questpieQueueDispatchTable.executionClaimToken, token),
+			),
+		)
+		.returning({ dispatchId: questpieQueueDispatchTable.dispatchId });
+	return updated.length === 1;
+}
+
+export async function releaseQueueDispatchExecution(
+	db: QueueDatabase,
+	dispatchId: string,
+	token: string,
+): Promise<void> {
+	await db
+		.update(questpieQueueDispatchTable)
+		.set({
+			executionClaimToken: null,
+			executionClaimedUntil: null,
+		})
+		.where(
+			and(
+				eq(questpieQueueDispatchTable.dispatchId, dispatchId),
+				eq(questpieQueueDispatchTable.status, "accepted"),
+				eq(questpieQueueDispatchTable.executionClaimToken, token),
+			),
+		);
+}
+
+export async function getQueueDispatchReceipt(
+	db: QueueDatabase,
+	dispatchId: string,
+): Promise<QueueDispatchReceipt | null> {
+	const [record] = await db
+		.select({
+			dispatchId: questpieQueueDispatchTable.dispatchId,
+			jobName: questpieQueueDispatchTable.jobName,
+			idempotencyKey: questpieQueueDispatchTable.idempotencyKey,
+			status: questpieQueueDispatchTable.status,
+			createdAt: questpieQueueDispatchTable.createdAt,
+			acceptedAt: questpieQueueDispatchTable.acceptedAt,
+			completedAt: questpieQueueDispatchTable.completedAt,
+			failedAt: questpieQueueDispatchTable.failedAt,
+			secretPayload: questpieQueueDispatchTable.secretPayload,
+		})
+		.from(questpieQueueDispatchTable)
+		.where(eq(questpieQueueDispatchTable.dispatchId, dispatchId))
+		.limit(1);
+	if (!record) return null;
+	if (!record.secretPayload) return null;
+	return {
+		dispatchId: record.dispatchId,
+		jobName: record.jobName,
+		...(record.idempotencyKey ? { idempotencyKey: record.idempotencyKey } : {}),
+		status:
+			record.status === "completed"
+				? "completed"
+				: record.status === "failed"
+					? "failed"
+					: "queued",
+		createdAt: record.createdAt,
+		queuedAt: record.acceptedAt,
+		handledAt: record.completedAt ?? record.failedAt,
+	};
+}
+
+export async function completeQueueDispatch(
+	db: QueueDatabase,
+	dispatchId: string,
+): Promise<void> {
+	const updated = await db
+		.update(questpieQueueDispatchTable)
+		.set({
+			status: "completed",
+			payload: null,
+			options: null,
+			wrappedSecretKey: null,
+			executionClaimToken: null,
+			executionClaimedUntil: null,
+			completedAt: sql`CURRENT_TIMESTAMP`,
+			failedAt: null,
+			lastError: null,
+		})
+		.where(
+			and(
+				eq(questpieQueueDispatchTable.dispatchId, dispatchId),
+				eq(questpieQueueDispatchTable.secretPayload, true),
+				inArray(questpieQueueDispatchTable.status, ["accepted", "failed"]),
+			),
+		)
+		.returning({ dispatchId: questpieQueueDispatchTable.dispatchId });
+	if (updated.length === 1) return;
+	const [existing] = await db
+		.select({ status: questpieQueueDispatchTable.status })
+		.from(questpieQueueDispatchTable)
+		.where(eq(questpieQueueDispatchTable.dispatchId, dispatchId))
+		.limit(1);
+	if (existing?.status !== "completed") {
+		throw new Error("QUESTPIE Queue failed to persist handler completion");
+	}
+}
+
+export async function failQueueDispatch(
+	db: QueueDatabase,
+	dispatchId: string,
+	options: { now?: Date } = {},
+): Promise<boolean> {
+	const currentTime = options.now ?? sql`CURRENT_TIMESTAMP`;
+	const updated = await db
+		.update(questpieQueueDispatchTable)
+		.set({
+			status: "failed",
+			payload: null,
+			options: null,
+			wrappedSecretKey: null,
+			failedAt: sql`CURRENT_TIMESTAMP`,
+			lastError: "Job handling failed",
+		})
+		.where(
+			and(
+				eq(questpieQueueDispatchTable.dispatchId, dispatchId),
+				eq(questpieQueueDispatchTable.secretPayload, true),
+				eq(questpieQueueDispatchTable.status, "accepted"),
+				or(
+					isNull(questpieQueueDispatchTable.executionClaimToken),
+					isNull(questpieQueueDispatchTable.executionClaimedUntil),
+					lte(questpieQueueDispatchTable.executionClaimedUntil, currentTime),
+				),
+			),
+		)
+		.returning({ dispatchId: questpieQueueDispatchTable.dispatchId });
+	if (updated.length === 1) return true;
+	const [existing] = await db
+		.select({ status: questpieQueueDispatchTable.status })
+		.from(questpieQueueDispatchTable)
+		.where(eq(questpieQueueDispatchTable.dispatchId, dispatchId))
+		.limit(1);
+	if (!existing) {
+		throw new Error(
+			"QUESTPIE Queue failed to persist terminal handler failure",
+		);
+	}
+	return false;
+}
+
+export async function reconcileQueueDispatchExecutions(options: {
+	adapter: QueueAdapter;
+	db: QueueDatabase;
+	batchSize?: number;
+	logger?: QueueDispatchLogger;
+	now?: Date;
+}): Promise<{ inspected: number; terminal: number }> {
+	if (
+		options.adapter.capabilities?.executionTerminalState !== true ||
+		typeof options.adapter.inspectExecutionState !== "function"
+	) {
+		return { inspected: 0, terminal: 0 };
+	}
+	const batchSize = boundedInteger(
+		options.batchSize,
+		DEFAULT_BATCH_SIZE,
+		1_000,
+	);
+	const eligible = and(
+		eq(questpieQueueDispatchTable.secretPayload, true),
+		eq(questpieQueueDispatchTable.status, "accepted"),
+		isNotNull(questpieQueueDispatchTable.adapterJobId),
+	);
+	const [highWater] = await options.db
+		.select({
+			createdAt: questpieQueueDispatchTable.createdAt,
+			dispatchId: questpieQueueDispatchTable.dispatchId,
+		})
+		.from(questpieQueueDispatchTable)
+		.where(eligible)
+		.orderBy(
+			desc(questpieQueueDispatchTable.createdAt),
+			desc(questpieQueueDispatchTable.dispatchId),
+		)
+		.limit(1);
+	if (!highWater) return { inspected: 0, terminal: 0 };
+
+	let cursor:
+		| {
+				createdAt: Date;
+				dispatchId: string;
+		  }
+		| undefined;
+	let inspected = 0;
+	let terminal = 0;
+	while (true) {
+		const records = await options.db
+			.select({
+				dispatchId: questpieQueueDispatchTable.dispatchId,
+				jobName: questpieQueueDispatchTable.jobName,
+				adapterJobId: questpieQueueDispatchTable.adapterJobId,
+				createdAt: questpieQueueDispatchTable.createdAt,
+			})
+			.from(questpieQueueDispatchTable)
+			.where(
+				and(
+					eligible,
+					or(
+						lt(questpieQueueDispatchTable.createdAt, highWater.createdAt),
+						and(
+							eq(questpieQueueDispatchTable.createdAt, highWater.createdAt),
+							lte(questpieQueueDispatchTable.dispatchId, highWater.dispatchId),
+						),
+					),
+					cursor
+						? or(
+								gt(questpieQueueDispatchTable.createdAt, cursor.createdAt),
+								and(
+									eq(questpieQueueDispatchTable.createdAt, cursor.createdAt),
+									gt(questpieQueueDispatchTable.dispatchId, cursor.dispatchId),
+								),
+							)
+						: undefined,
+				),
+			)
+			.orderBy(
+				asc(questpieQueueDispatchTable.createdAt),
+				asc(questpieQueueDispatchTable.dispatchId),
+			)
+			.limit(batchSize);
+		if (records.length === 0) break;
+		inspected += records.length;
+		for (const record of records) {
+			if (!record.adapterJobId) continue;
+			let brokerState;
+			try {
+				brokerState = await options.adapter.inspectExecutionState(
+					record.jobName,
+					record.adapterJobId,
+				);
+			} catch {
+				options.logger?.warn?.(
+					"[QUESTPIE Queue] Broker execution reconciliation failed",
+					{
+						dispatchId: record.dispatchId,
+						jobName: record.jobName,
+					},
+				);
+				continue;
+			}
+			if (
+				brokerState !== "failed" &&
+				brokerState !== "missing" &&
+				brokerState !== "completed"
+			) {
+				continue;
+			}
+			if (
+				await failQueueDispatch(
+					options.db,
+					record.dispatchId,
+					options.now === undefined ? {} : { now: options.now },
+				)
+			) {
+				terminal += 1;
+			}
+		}
+		const last = records.at(-1)!;
+		cursor = {
+			createdAt: last.createdAt,
+			dispatchId: last.dispatchId,
+		};
+		if (records.length < batchSize) break;
+	}
+	return { inspected, terminal };
 }
 
 function boundedInteger(
@@ -269,6 +661,18 @@ async function retryQueueDispatch(
 			leaseToken: null,
 			leasedUntil: null,
 			lastError: SAFE_ADAPTER_PUBLICATION_ERROR,
+			...(terminal
+				? {
+						failedAt: now ?? sql`CURRENT_TIMESTAMP`,
+						...(task.wrappedSecretKey
+							? {
+									payload: null,
+									options: null,
+									wrappedSecretKey: null,
+								}
+							: {}),
+					}
+				: {}),
 		})
 		.where(
 			and(

--- a/packages/questpie/src/server/modules/core/integrated/queue/dispatch-table.ts
+++ b/packages/questpie/src/server/modules/core/integrated/queue/dispatch-table.ts
@@ -1,5 +1,6 @@
 import { sql } from "drizzle-orm";
 import {
+	boolean,
 	customType,
 	index,
 	integer,
@@ -41,6 +42,8 @@ export const questpieQueueDispatchTable = pgTable(
 		jobName: text("job_name").notNull(),
 		idempotencyKey: text("idempotency_key"),
 		payload: jsonbSafe("payload"),
+		secretPayload: boolean("secret_payload").default(false).notNull(),
+		wrappedSecretKey: jsonbSafe("wrapped_secret_key"),
 		options: jsonbSafe("options"),
 		status: text("status").default("pending").notNull(),
 		attempts: integer("attempts").default(0).notNull(),
@@ -58,6 +61,19 @@ export const questpieQueueDispatchTable = pgTable(
 		adapterJobId: text("adapter_job_id"),
 		lastError: text("last_error"),
 		acceptedAt: timestamp("accepted_at", {
+			withTimezone: true,
+			mode: "date",
+		}),
+		completedAt: timestamp("completed_at", {
+			withTimezone: true,
+			mode: "date",
+		}),
+		failedAt: timestamp("failed_at", {
+			withTimezone: true,
+			mode: "date",
+		}),
+		executionClaimToken: uuid("execution_claim_token"),
+		executionClaimedUntil: timestamp("execution_claimed_until", {
 			withTimezone: true,
 			mode: "date",
 		}),

--- a/packages/questpie/src/server/modules/core/integrated/queue/secret-payload.ts
+++ b/packages/questpie/src/server/modules/core/integrated/queue/secret-payload.ts
@@ -1,0 +1,218 @@
+const SECRET_PAYLOAD_VERSION = 1;
+const MINIMUM_ROOT_SECRET_BYTES = 32;
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+export interface QueueSecretPayloadEnvelope {
+	__questpieQueueSecret: {
+		version: typeof SECRET_PAYLOAD_VERSION;
+		iv: string;
+		ciphertext: string;
+	};
+}
+
+export interface QueueWrappedSecretKey {
+	version: typeof SECRET_PAYLOAD_VERSION;
+	iv: string;
+	ciphertext: string;
+}
+
+export function isQueueSecretPayloadEnvelope(
+	value: unknown,
+): value is QueueSecretPayloadEnvelope {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+	const secret = (value as Partial<QueueSecretPayloadEnvelope>)
+		.__questpieQueueSecret;
+	return (
+		secret?.version === SECRET_PAYLOAD_VERSION &&
+		typeof secret.iv === "string" &&
+		typeof secret.ciphertext === "string"
+	);
+}
+
+export async function encryptQueueSecretPayload(input: {
+	dispatchId: string;
+	jobName: string;
+	payload: unknown;
+	rootSecret: string;
+}): Promise<{
+	payload: QueueSecretPayloadEnvelope;
+	wrappedKey: QueueWrappedSecretKey;
+}> {
+	assertRootSecret(input.rootSecret);
+	const dataKey = await crypto.subtle.generateKey(
+		{ name: "AES-GCM", length: 256 },
+		true,
+		["encrypt", "decrypt"],
+	);
+	const payloadIv = crypto.getRandomValues(new Uint8Array(12));
+	const payloadCiphertext = await crypto.subtle.encrypt(
+		{
+			name: "AES-GCM",
+			iv: toArrayBuffer(payloadIv),
+			additionalData: associatedData(
+				input.jobName,
+				input.dispatchId,
+				"payload",
+			),
+		},
+		dataKey,
+		encoder.encode(JSON.stringify(input.payload)),
+	);
+	const rawDataKey = await crypto.subtle.exportKey("raw", dataKey);
+	const wrappingKey = await deriveWrappingKey(
+		input.rootSecret,
+		input.dispatchId,
+	);
+	const wrappingIv = crypto.getRandomValues(new Uint8Array(12));
+	const wrappedKey = await crypto.subtle.encrypt(
+		{
+			name: "AES-GCM",
+			iv: toArrayBuffer(wrappingIv),
+			additionalData: associatedData(
+				input.jobName,
+				input.dispatchId,
+				"data-key",
+			),
+		},
+		wrappingKey,
+		rawDataKey,
+	);
+
+	return {
+		payload: {
+			__questpieQueueSecret: {
+				version: SECRET_PAYLOAD_VERSION,
+				iv: encodeBase64(payloadIv),
+				ciphertext: encodeBase64(new Uint8Array(payloadCiphertext)),
+			},
+		},
+		wrappedKey: {
+			version: SECRET_PAYLOAD_VERSION,
+			iv: encodeBase64(wrappingIv),
+			ciphertext: encodeBase64(new Uint8Array(wrappedKey)),
+		},
+	};
+}
+
+export async function decryptQueueSecretPayload(input: {
+	dispatchId: string;
+	jobName: string;
+	payload: QueueSecretPayloadEnvelope;
+	rootSecret: string;
+	wrappedKey: QueueWrappedSecretKey;
+}): Promise<unknown> {
+	assertRootSecret(input.rootSecret);
+	if (input.wrappedKey.version !== SECRET_PAYLOAD_VERSION) {
+		throw new Error("QUESTPIE Queue secret payload key is unavailable");
+	}
+	try {
+		const wrappingKey = await deriveWrappingKey(
+			input.rootSecret,
+			input.dispatchId,
+		);
+		const rawDataKey = await crypto.subtle.decrypt(
+			{
+				name: "AES-GCM",
+				iv: decodeBase64(input.wrappedKey.iv),
+				additionalData: associatedData(
+					input.jobName,
+					input.dispatchId,
+					"data-key",
+				),
+			},
+			wrappingKey,
+			decodeBase64(input.wrappedKey.ciphertext),
+		);
+		const dataKey = await crypto.subtle.importKey(
+			"raw",
+			rawDataKey,
+			"AES-GCM",
+			false,
+			["decrypt"],
+		);
+		const plaintext = await crypto.subtle.decrypt(
+			{
+				name: "AES-GCM",
+				iv: decodeBase64(input.payload.__questpieQueueSecret.iv),
+				additionalData: associatedData(
+					input.jobName,
+					input.dispatchId,
+					"payload",
+				),
+			},
+			dataKey,
+			decodeBase64(input.payload.__questpieQueueSecret.ciphertext),
+		);
+		return JSON.parse(decoder.decode(plaintext));
+	} catch {
+		throw new Error("QUESTPIE Queue secret payload cannot be decrypted");
+	}
+}
+
+function assertRootSecret(rootSecret: string): void {
+	if (
+		typeof rootSecret !== "string" ||
+		encoder.encode(rootSecret).byteLength < MINIMUM_ROOT_SECRET_BYTES
+	) {
+		throw new Error(
+			`QUESTPIE Queue secret payloads require runtimeConfig.secret with at least ${MINIMUM_ROOT_SECRET_BYTES} bytes`,
+		);
+	}
+}
+
+async function deriveWrappingKey(
+	rootSecret: string,
+	dispatchId: string,
+): Promise<CryptoKey> {
+	const keyMaterial = await crypto.subtle.importKey(
+		"raw",
+		encoder.encode(rootSecret),
+		"HKDF",
+		false,
+		["deriveKey"],
+	);
+	return crypto.subtle.deriveKey(
+		{
+			name: "HKDF",
+			hash: "SHA-256",
+			salt: encoder.encode("questpie-queue-secret-payload-v1"),
+			info: encoder.encode(dispatchId),
+		},
+		keyMaterial,
+		{ name: "AES-GCM", length: 256 },
+		false,
+		["encrypt", "decrypt"],
+	);
+}
+
+function associatedData(
+	jobName: string,
+	dispatchId: string,
+	purpose: "payload" | "data-key",
+): ArrayBuffer {
+	return toArrayBuffer(
+		encoder.encode(
+			`questpie-queue-secret-v1\u0000${purpose}\u0000${jobName}\u0000${dispatchId}`,
+		),
+	);
+}
+
+function encodeBase64(value: Uint8Array): string {
+	let binary = "";
+	for (const byte of value) binary += String.fromCharCode(byte);
+	return btoa(binary);
+}
+
+function decodeBase64(value: string): ArrayBuffer {
+	const binary = atob(value);
+	return toArrayBuffer(
+		Uint8Array.from(binary, (character) => character.charCodeAt(0)),
+	);
+}
+
+function toArrayBuffer(value: Uint8Array): ArrayBuffer {
+	const copy = new Uint8Array(value.byteLength);
+	copy.set(value);
+	return copy.buffer;
+}

--- a/packages/questpie/src/server/modules/core/integrated/queue/service.ts
+++ b/packages/questpie/src/server/modules/core/integrated/queue/service.ts
@@ -17,11 +17,22 @@ import type {
 } from "./adapter.js";
 import {
 	acceptReservedQueueDispatch,
+	claimQueueDispatchExecution,
+	completeQueueDispatch,
 	drainQueueDispatches,
 	enqueueQueueDispatch,
+	getQueueDispatchReceipt,
+	reconcileQueueDispatchExecutions,
+	releaseQueueDispatchExecution,
+	renewQueueDispatchExecution,
 	reserveQueueDispatch,
 	stableQueueDispatchId,
 } from "./dispatch-store.js";
+import {
+	decryptQueueSecretPayload,
+	encryptQueueSecretPayload,
+	isQueueSecretPayloadEnvelope,
+} from "./secret-payload.js";
 import type {
 	JobDefinition,
 	PublishOptions,
@@ -49,6 +60,7 @@ export interface QueueClientRuntimeOptions {
 	getDatabase?: () => AnyDrizzleClient | undefined;
 	getApp?: () => unknown;
 	logger?: QueueLogger;
+	secret?: string;
 }
 
 const defaultLogger: QueueLogger = {
@@ -69,6 +81,9 @@ function resolveCapabilities(adapter: QueueAdapter): QueueAdapterCapabilities {
 			(typeof adapter.schedule === "function" &&
 				typeof adapter.unschedule === "function"),
 		singleton: adapter.capabilities?.singleton ?? false,
+		executionTerminalState:
+			adapter.capabilities?.executionTerminalState === true &&
+			typeof adapter.inspectExecutionState === "function",
 	};
 }
 
@@ -163,73 +178,148 @@ export function createQueueClient<
 		for (const jobDef of Object.values(sourceJobs)) {
 			handlers[jobDef.name] = async (job) => {
 				const context = await getContextOrThrow();
-				const validated = jobDef.schema.parse(job.data);
-				const appInstance = getAppOrThrow() as any;
-				const { extractAppServices } =
-					await import("#questpie/server/config/app-context.js");
-				const services = extractAppServices(appInstance, {
-					db: context.db,
-					session: context.session,
-					accessMode: "system",
-				});
-				// Establish the ambient AppContext (ALS) for the job so implicit
-				// consumers — mailer template handlers, logger trace, admin-audit
-				// actor, and ctx-less CRUD — work inside jobs exactly as they do in
-				// HTTP/CRUD scopes. Jobs are system scope (matches today's empty-ALS
-				// fallback). `runWithContext` only inherits `_hookDepth` from an
-				// existing parent; a top-level job has none, so no double-count.
-				const { runWithContext } =
-					await import("#questpie/server/config/context.js");
-				// A job runs OUTSIDE any request, so this span is a trace root
-				// rather than a child. kind=consumer marks it as work pulled off a
-				// queue, which is how backends separate it from inbound traffic.
-				const observability = appInstance.observability as
-					| ObservabilityService
-					| undefined;
-				const runHandler = () =>
-					runWithContext(
-						{
-							app: appInstance,
-							db: context.db,
-							session: context.session,
-							locale: context.locale,
-							accessMode: "system",
-						},
-						() =>
-							jobDef.handler({
-								...services,
-								payload: validated,
-								locale: context.locale,
-								dispatchId: job.dispatchId,
-								idempotencyKey: job.idempotencyKey,
-							} as any),
-					);
-
-				if (!observability?.enabled) {
-					await runHandler();
-					return;
-				}
-
-				await observability.span(
-					`job ${jobDef.name}`,
-					(span) => {
-						span.setAttributes({
-							"messaging.operation.name": "process",
-							"messaging.destination.name": jobDef.name,
-							// dispatchId is the stable logical id across retries and
-							// across adapters, so it is what correlates a failed
-							// attempt with the one that eventually succeeded.
-							...(job.dispatchId
-								? { "questpie.job.dispatch_id": job.dispatchId }
-								: {}),
-							...(job.idempotencyKey
-								? { "questpie.job.idempotency_key": job.idempotencyKey }
-								: {}),
+				const secretPayload = job.secretPayload === true;
+				let executionToken: string | undefined;
+				let executionHeartbeat: ReturnType<typeof setInterval> | undefined;
+				let completionPersisted = false;
+				try {
+					if (secretPayload) {
+						if (
+							!job.dispatchId ||
+							!context.db ||
+							!runtimeOptions.secret ||
+							!isQueueSecretPayloadEnvelope(job.data)
+						) {
+							throw new Error("Secret execution prerequisites unavailable");
+						}
+						const claim = await claimQueueDispatchExecution(
+							context.db,
+							job.dispatchId,
+						);
+						if (claim.status === "terminal") return;
+						if (claim.status !== "claimed") {
+							throw new Error("Secret execution claim unavailable");
+						}
+						executionToken = claim.token;
+						executionHeartbeat = setInterval(() => {
+							void renewQueueDispatchExecution(
+								context.db!,
+								job.dispatchId!,
+								claim.token,
+							).catch(() => {
+								logger.warn(
+									"[QUESTPIE Queue] Secret execution claim heartbeat failed",
+									{ dispatchId: job.dispatchId, jobName: jobDef.name },
+								);
+							});
+						}, 20_000);
+						executionHeartbeat.unref?.();
+						job.data = await decryptQueueSecretPayload({
+							dispatchId: job.dispatchId,
+							jobName: jobDef.name,
+							payload: job.data,
+							rootSecret: runtimeOptions.secret,
+							wrappedKey: claim.wrappedKey,
 						});
-						return runHandler();
-					},
-					{ kind: "consumer" },
-				);
+					}
+					const validated = jobDef.schema.parse(job.data);
+					const appInstance = getAppOrThrow() as any;
+					const { extractAppServices } =
+						await import("#questpie/server/config/app-context.js");
+					const services = extractAppServices(appInstance, {
+						db: context.db,
+						session: context.session,
+						accessMode: "system",
+					});
+					const { runWithContext } =
+						await import("#questpie/server/config/context.js");
+					const observability = appInstance.observability as
+						| ObservabilityService
+						| undefined;
+					const runHandler = () =>
+						runWithContext(
+							{
+								app: appInstance,
+								db: context.db,
+								session: context.session,
+								locale: context.locale,
+								accessMode: "system",
+							},
+							async () => {
+								try {
+									return await jobDef.handler({
+										...services,
+										payload: validated,
+										locale: context.locale,
+										dispatchId: job.dispatchId,
+										idempotencyKey: job.idempotencyKey,
+									} as any);
+								} catch (error) {
+									if (secretPayload) {
+										throw new Error(
+											"QUESTPIE Queue secret job handling failed",
+										);
+									}
+									throw error;
+								}
+							},
+						);
+					if (!observability?.enabled) {
+						await runHandler();
+					} else {
+						await observability.span(
+							`job ${jobDef.name}`,
+							(span) => {
+								span.setAttributes({
+									"messaging.operation.name": "process",
+									"messaging.destination.name": jobDef.name,
+									// dispatchId is the stable logical id across retries and
+									// across adapters, so it is what correlates a failed
+									// attempt with the one that eventually succeeded.
+									...(job.dispatchId
+										? { "questpie.job.dispatch_id": job.dispatchId }
+										: {}),
+									...(job.idempotencyKey
+										? {
+												"questpie.job.idempotency_key": job.idempotencyKey,
+											}
+										: {}),
+								});
+								return runHandler();
+							},
+							{ kind: "consumer" },
+						);
+					}
+					if (secretPayload && job.dispatchId && context.db) {
+						await completeQueueDispatch(context.db, job.dispatchId);
+						completionPersisted = true;
+					}
+				} catch (error) {
+					if (secretPayload) {
+						throw new Error("QUESTPIE Queue secret job handling failed");
+					}
+					throw error;
+				} finally {
+					if (executionHeartbeat) clearInterval(executionHeartbeat);
+					if (
+						secretPayload &&
+						executionToken &&
+						!completionPersisted &&
+						job.dispatchId &&
+						context.db
+					) {
+						await releaseQueueDispatchExecution(
+							context.db,
+							job.dispatchId,
+							executionToken,
+						).catch(() => {
+							logger.warn(
+								"[QUESTPIE Queue] Secret execution claim release failed",
+								{ dispatchId: job.dispatchId, jobName: jobDef.name },
+							);
+						});
+					}
+				}
 			};
 		}
 
@@ -326,6 +416,13 @@ export function createQueueClient<
 				total.terminal += result.terminal;
 				if (result.claimed < batchSize) break;
 			}
+			const reconciliation = await reconcileQueueDispatchExecutions({
+				adapter,
+				db,
+				logger,
+				batchSize,
+			});
+			total.terminal += reconciliation.terminal;
 			return total;
 		})().finally(() => {
 			activeDrain = undefined;
@@ -465,12 +562,25 @@ export function createQueueClient<
 				(job) => job.name,
 			);
 			await drain();
-			return adapter.runOnce(buildHandlers(selectedJobs), {
-				batchSize: options?.batchSize,
-				jobs: selectedJobNames,
-			});
+			try {
+				return await adapter.runOnce(buildHandlers(selectedJobs), {
+					batchSize: options?.batchSize,
+					jobs: selectedJobNames,
+				});
+			} finally {
+				await drain();
+			}
 		},
 		drain,
+		getReceipt: async (dispatchId: string) => {
+			const db = runtimeOptions.getDatabase?.();
+			if (!db) {
+				throw new Error(
+					"QUESTPIE Queue: database context is required for dispatch receipts.",
+				);
+			}
+			return getQueueDispatchReceipt(db, dispatchId);
+		},
 		registerSchedules,
 		stop: async () => {
 			await stopInternal();
@@ -512,14 +622,30 @@ export function createQueueClient<
 			publish: async (payload: any, publishOptions?: PublishOptions) => {
 				await ensureStarted();
 
-				// Validate payload with schema
-				const validated = jobDef.schema.parse(payload);
-
 				// Merge job options with publish options
 				const options = {
 					...jobDef.options,
 					...publishOptions,
 				};
+				let validated: unknown;
+				try {
+					validated = jobDef.schema.parse(payload);
+				} catch (error) {
+					if (options.secretPayload) {
+						throw new Error("QUESTPIE Queue secret payload validation failed");
+					}
+					throw error;
+				}
+				if (options.secretPayload && !options.idempotencyKey) {
+					throw new Error(
+						"QUESTPIE Queue secret payloads require idempotencyKey",
+					);
+				}
+				if (options.secretPayload && !capabilities.executionTerminalState) {
+					throw new Error(
+						"QUESTPIE Queue: selected adapter cannot reconcile durable broker terminal execution state required for secret payload erasure.",
+					);
+				}
 				if (
 					options.idempotencyKey !== undefined &&
 					options.singletonKey !== undefined
@@ -532,6 +658,16 @@ export function createQueueClient<
 					jobDef.name,
 					options.idempotencyKey,
 				);
+				const encrypted = options.secretPayload
+					? await encryptQueueSecretPayload({
+							dispatchId,
+							jobName: jobDef.name,
+							payload: validated,
+							rootSecret: runtimeOptions.secret ?? "",
+						})
+					: undefined;
+				const adapterPayload = encrypted?.payload ?? validated;
+				const adapterOptions = options;
 				const tx = getCurrentTransaction();
 
 				if (tx && canPublishInTransaction && options.idempotencyKey) {
@@ -539,15 +675,16 @@ export function createQueueClient<
 						dispatchId,
 						jobName: jobDef.name,
 						idempotencyKey: options.idempotencyKey,
-						payload: validated,
-						options,
+						payload: adapterPayload,
+						wrappedSecretKey: encrypted?.wrappedKey,
+						options: adapterOptions,
 					});
 					if (!reservation.inserted) return reservation.dispatchId;
 					const adapterJobId = await adapter.publishInTransaction!(
 						tx,
 						jobDef.name,
-						validated,
-						options,
+						adapterPayload,
+						adapterOptions,
 						dispatchId,
 					);
 					await acceptReservedQueueDispatch(
@@ -562,8 +699,8 @@ export function createQueueClient<
 					await adapter.publishInTransaction!(
 						tx,
 						jobDef.name,
-						validated,
-						options,
+						adapterPayload,
+						adapterOptions,
 						dispatchId,
 					);
 					return dispatchId;
@@ -574,8 +711,9 @@ export function createQueueClient<
 						dispatchId,
 						jobName: jobDef.name,
 						idempotencyKey: options.idempotencyKey,
-						payload: validated,
-						options,
+						payload: adapterPayload,
+						wrappedSecretKey: encrypted?.wrappedKey,
+						options: adapterOptions,
 					});
 					schedulePostCommitDrain();
 					return persistedId;
@@ -594,15 +732,16 @@ export function createQueueClient<
 								dispatchId,
 								jobName: jobDef.name,
 								idempotencyKey: options.idempotencyKey,
-								payload: validated,
-								options,
+								payload: adapterPayload,
+								wrappedSecretKey: encrypted?.wrappedKey,
+								options: adapterOptions,
 							});
 							if (!reservation.inserted) return reservation.dispatchId;
 							const adapterJobId = await adapter.publishInTransaction!(
 								transaction,
 								jobDef.name,
-								validated,
-								options,
+								adapterPayload,
+								adapterOptions,
 								reservation.dispatchId,
 							);
 							await acceptReservedQueueDispatch(
@@ -618,15 +757,21 @@ export function createQueueClient<
 							dispatchId,
 							jobName: jobDef.name,
 							idempotencyKey: options.idempotencyKey,
-							payload: validated,
-							options,
+							payload: adapterPayload,
+							wrappedSecretKey: encrypted?.wrappedKey,
+							options: adapterOptions,
 						}),
 					);
 					await drain();
 					return persistedId;
 				}
 
-				await adapter.publish(jobDef.name, validated, options, dispatchId);
+				await adapter.publish(
+					jobDef.name,
+					adapterPayload,
+					adapterOptions,
+					dispatchId,
+				);
 				return dispatchId;
 			},
 
@@ -636,7 +781,10 @@ export function createQueueClient<
 			schedule: async (
 				payload: any,
 				cron: string,
-				publishOptions?: Omit<PublishOptions, "idempotencyKey" | "startAfter">,
+				publishOptions?: Omit<
+					PublishOptions,
+					"idempotencyKey" | "startAfter" | "secretPayload"
+				>,
 			) => {
 				await ensureStarted();
 

--- a/packages/questpie/src/server/modules/core/integrated/queue/service.ts
+++ b/packages/questpie/src/server/modules/core/integrated/queue/service.ts
@@ -69,6 +69,17 @@ const defaultLogger: QueueLogger = {
 	error: (msg, ...args) => console.error(msg, ...args),
 };
 
+/**
+ * Create a deliberately cause-free error at the secret boundary.
+ *
+ * Validation, provider, and handler errors may contain the original payload.
+ * Keeping construction outside the catch blocks makes the intentional
+ * redaction explicit without attaching a secret-bearing `cause`.
+ */
+function redactedSecretQueueError(message: string): Error {
+	return new Error(message);
+}
+
 function resolveCapabilities(adapter: QueueAdapter): QueueAdapterCapabilities {
 	return {
 		longRunningConsumer:
@@ -256,7 +267,7 @@ export function createQueueClient<
 									} as any);
 								} catch (error) {
 									if (secretPayload) {
-										throw new Error(
+										throw redactedSecretQueueError(
 											"QUESTPIE Queue secret job handling failed",
 										);
 									}
@@ -296,7 +307,9 @@ export function createQueueClient<
 					}
 				} catch (error) {
 					if (secretPayload) {
-						throw new Error("QUESTPIE Queue secret job handling failed");
+						throw redactedSecretQueueError(
+							"QUESTPIE Queue secret job handling failed",
+						);
 					}
 					throw error;
 				} finally {
@@ -632,7 +645,9 @@ export function createQueueClient<
 					validated = jobDef.schema.parse(payload);
 				} catch (error) {
 					if (options.secretPayload) {
-						throw new Error("QUESTPIE Queue secret payload validation failed");
+						throw redactedSecretQueueError(
+							"QUESTPIE Queue secret payload validation failed",
+						);
 					}
 					throw error;
 				}

--- a/packages/questpie/src/server/modules/core/integrated/queue/types.ts
+++ b/packages/questpie/src/server/modules/core/integrated/queue/types.ts
@@ -168,6 +168,13 @@ export type InferJobResult<T> =
  */
 export interface PublishOptions {
 	/**
+	 * Encrypt the job payload with a per-dispatch data key before it reaches
+	 * Queue persistence or an adapter. Requires a non-secret idempotency key and
+	 * runtimeConfig.secret with at least 32 bytes.
+	 */
+	secretPayload?: boolean;
+
+	/**
 	 * Portable logical idempotency identity.
 	 *
 	 * Reusing the same key for one job name resolves to the same dispatch.
@@ -201,8 +208,9 @@ export interface PublishOptions {
 	 * - `singleton` — 1 active job per key (unlimited queued)
 	 * - `stately` — 1 job per key across queued AND active (typical "singleton")
 	 *
-	 * Only affects keyed jobs. Adapters that don't support policies ignore it.
-	 * (Standard queues stay full-throughput for non-keyed jobs.)
+	 * pg-boss coalesces an omitted singleton key to the empty key for policy
+	 * indexes, so a non-standard policy can also suppress otherwise unkeyed
+	 * jobs. Adapters that don't support policies ignore it.
 	 */
 	queuePolicy?: "standard" | "short" | "singleton" | "stately" | "exclusive";
 
@@ -299,6 +307,26 @@ export interface QueueDrainResult {
 	terminal: number;
 }
 
+export type QueueDispatchReceiptStatus = "queued" | "completed" | "failed";
+
+/**
+ * Secret-free lifecycle projection for one stable logical dispatch.
+ *
+ * `queuedAt` means the Queue adapter accepted publication. `completed` means
+ * the job handler returned successfully. Applications may map completed work
+ * to a domain term such as "sent" only when their handler's terminal action
+ * has that meaning.
+ */
+export interface QueueDispatchReceipt {
+	dispatchId: string;
+	jobName: string;
+	idempotencyKey?: string;
+	status: QueueDispatchReceiptStatus;
+	createdAt: Date;
+	queuedAt: Date | null;
+	handledAt: Date | null;
+}
+
 export interface QueueListenHandle {
 	stop: () => Promise<void>;
 }
@@ -318,7 +346,10 @@ export type QueueJobClient<TJob> = {
 	schedule: (
 		payload: InferJobPayload<TJob>,
 		cron: string,
-		options?: Omit<PublishOptions, "idempotencyKey" | "startAfter">,
+		options?: Omit<
+			PublishOptions,
+			"idempotencyKey" | "startAfter" | "secretPayload"
+		>,
 	) => Promise<void>;
 
 	/**
@@ -388,6 +419,14 @@ export type QueueClient<TJobs extends Record<string, any>> = {
 	 * invoke it from a platform cron trigger for crash recovery.
 	 */
 	drain: (options?: QueueDrainOptions) => Promise<QueueDrainResult>;
+
+	/**
+	 * Read a secret-free receipt for a logical dispatch.
+	 *
+	 * This server-side infrastructure method does not apply product
+	 * authorization. Applications must authorize any route that projects it.
+	 */
+	getReceipt: (dispatchId: string) => Promise<QueueDispatchReceipt | null>;
 
 	/**
 	 * Register recurring cron schedules declared in job options.

--- a/packages/questpie/src/server/modules/core/services/queue.ts
+++ b/packages/questpie/src/server/modules/core/services/queue.ts
@@ -28,6 +28,7 @@ export default service({
 			getDatabase: () => app.db,
 			getApp: () => app,
 			logger: app.logger,
+			secret: app.config.secret,
 		});
 	},
 	dispose: (instance) => (instance as any)?.stop?.(),

--- a/packages/questpie/test/integration/queue-secret-dispatch-postgres.test.ts
+++ b/packages/questpie/test/integration/queue-secret-dispatch-postgres.test.ts
@@ -1,0 +1,971 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+
+import { eq, sql } from "drizzle-orm";
+import pg from "pg";
+import { z } from "zod";
+
+import { job } from "../../src/exports/index.js";
+import { withTransaction } from "../../src/server/collection/crud/shared/transaction.js";
+import { PgBossAdapter } from "../../src/server/modules/core/integrated/queue/adapters/pg-boss.js";
+import { stableQueueDispatchId } from "../../src/server/modules/core/integrated/queue/dispatch-store.js";
+import { questpieQueueDispatchTable } from "../../src/server/modules/core/integrated/queue/dispatch-table.js";
+import { createQueueClient } from "../../src/server/modules/core/integrated/queue/service.js";
+import { buildMockApp } from "../utils/mocks/mock-app-builder.js";
+import { runTestDbMigrations } from "../utils/test-db.js";
+
+const databaseUrl = process.env.QUESTPIE_QUEUE_SECRET_POSTGRES_URL;
+const runPostgresContract = Boolean(databaseUrl);
+const rootSecret = "queue-secret-root-key-at-least-32-bytes";
+const handledPayloads: unknown[] = [];
+let permanentFailureDetail = "";
+let retryAttempts = 0;
+
+const deliveryJob = job({
+	name: "queue-secret-delivery",
+	schema: z.object({
+		invitationId: z.string(),
+		rawSecret: z.string(),
+	}),
+	options: { retryLimit: 0 },
+	handler: async ({ payload }) => {
+		handledPayloads.push(payload);
+	},
+});
+
+const permanentFailureJob = job({
+	name: "queue-secret-permanent-failure",
+	schema: z.object({
+		invitationId: z.string(),
+		rawSecret: z.string(),
+	}),
+	options: { retryLimit: 0 },
+	handler: async () => {
+		throw new Error(permanentFailureDetail);
+	},
+});
+
+const retryJob = job({
+	name: "queue-secret-retry",
+	schema: z.object({
+		invitationId: z.string(),
+		rawSecret: z.string(),
+	}),
+	options: { retryLimit: 1, retryDelay: 0 },
+	handler: async ({ payload }) => {
+		retryAttempts += 1;
+		if (retryAttempts === 1) {
+			throw new Error(`temporary provider failure for ${payload.rawSecret}`);
+		}
+		handledPayloads.push(payload);
+	},
+});
+
+const shortPolicyJob = job({
+	name: "queue-secret-short-policy",
+	schema: z.object({
+		invitationId: z.string(),
+		rawSecret: z.string(),
+	}),
+	options: { queuePolicy: "short", retryLimit: 0 },
+	handler: async ({ payload }) => {
+		handledPayloads.push(payload);
+	},
+});
+
+class FailureInjectedPgBossAdapter extends PgBossAdapter {
+	private publicationFailures = 0;
+	private publicationReceiptFailures = 0;
+
+	failNextPublications(count = 1): void {
+		this.publicationFailures = Math.max(0, count);
+	}
+
+	failNextPublicationReceipts(count = 1): void {
+		this.publicationReceiptFailures = Math.max(0, count);
+	}
+
+	override async publish(
+		jobName: string,
+		payload: unknown,
+		options?: Parameters<PgBossAdapter["publish"]>[2],
+		dispatchId?: string,
+	): Promise<string | null> {
+		if (this.publicationFailures > 0) {
+			this.publicationFailures -= 1;
+			throw new Error(
+				"injected broker publication failure with provider detail",
+			);
+		}
+		const adapterJobId = await super.publish(
+			jobName,
+			payload,
+			options,
+			dispatchId,
+		);
+		if (this.publicationReceiptFailures > 0) {
+			this.publicationReceiptFailures -= 1;
+			throw new Error("injected crash after broker publication");
+		}
+		return adapterJobId;
+	}
+}
+
+describe.skipIf(!runPostgresContract)(
+	"secret-bearing transactional Queue dispatch on PostgreSQL",
+	() => {
+		let setup: Awaited<ReturnType<typeof buildMockApp>>;
+		let queue: ReturnType<
+			typeof createQueueClient<{
+				delivery: typeof deliveryJob;
+				permanentFailure: typeof permanentFailureJob;
+				retry: typeof retryJob;
+				shortPolicy: typeof shortPolicyJob;
+			}>
+		>;
+		let adapter: FailureInjectedPgBossAdapter;
+
+		beforeAll(async () => {
+			const pool = new pg.Pool({ connectionString: databaseUrl! });
+			try {
+				await pool.query("CREATE EXTENSION IF NOT EXISTS pg_trgm");
+				await pool.query(
+					"DROP SCHEMA IF EXISTS pgboss_queue_secret_contract CASCADE",
+				);
+			} finally {
+				await pool.end();
+			}
+			setup = await buildMockApp(
+				{
+					jobs: {
+						delivery: deliveryJob,
+						permanentFailure: permanentFailureJob,
+						retry: retryJob,
+						shortPolicy: shortPolicyJob,
+					},
+				},
+				{
+					db: { url: databaseUrl! },
+					secret: rootSecret,
+				},
+			);
+			await runTestDbMigrations(setup.app);
+
+			adapter = new FailureInjectedPgBossAdapter({
+				connectionString: databaseUrl!,
+				schema: "pgboss_queue_secret_contract",
+				useApplicationTransaction: false,
+			});
+			queue = createQueueClient(
+				{
+					delivery: deliveryJob,
+					permanentFailure: permanentFailureJob,
+					retry: retryJob,
+					shortPolicy: shortPolicyJob,
+				},
+				adapter,
+				{
+					createContext: async () =>
+						setup.app.createContext({
+							accessMode: "system",
+						}),
+					getApp: () => setup.app,
+					getDatabase: () => setup.app.db,
+					secret: rootSecret,
+					logger: {
+						info: () => {},
+						warn: () => {},
+						error: () => {},
+					},
+				},
+			);
+		});
+
+		afterAll(async () => {
+			await queue?.stop();
+			if (!setup) return;
+			await setup.app.migrations.down();
+			await setup.cleanup();
+			const pool = new pg.Pool({ connectionString: databaseUrl! });
+			try {
+				await pool.query(
+					"DROP SCHEMA IF EXISTS pgboss_queue_secret_contract CASCADE",
+				);
+			} finally {
+				await pool.end();
+			}
+		});
+
+		test("commits only ciphertext to the Queue ledger and broker", async () => {
+			const rawSecret = "raw-invitation-token-must-never-be-persisted";
+			const dispatchId = await withTransaction(setup.app.db, () =>
+				queue.delivery.publish(
+					{
+						invitationId: "invitation-1",
+						rawSecret,
+					},
+					{
+						idempotencyKey: "invitation-mail:invitation-1:v1",
+						secretPayload: true,
+					},
+				),
+			);
+
+			const [dispatch] = await setup.app.db
+				.select()
+				.from(questpieQueueDispatchTable)
+				.where(eq(questpieQueueDispatchTable.dispatchId, dispatchId));
+			const brokerRows = await setup.app.db.execute(sql`
+				SELECT data::text AS data
+				FROM pgboss_queue_secret_contract.job
+				WHERE id = ${dispatchId}::uuid
+			`);
+
+			expect(dispatch).toBeDefined();
+			expect(JSON.stringify(dispatch)).not.toContain(rawSecret);
+			expect(JSON.stringify(brokerRows)).not.toContain(rawSecret);
+
+			await queue.runOnce({ jobs: ["queue-secret-delivery"] });
+		});
+
+		test("decrypts only for execution, erases the data key, and retains a safe completion receipt", async () => {
+			const rawSecret = "second-raw-invitation-token";
+			const dispatchId = await withTransaction(setup.app.db, () =>
+				queue.delivery.publish(
+					{
+						invitationId: "invitation-2",
+						rawSecret,
+					},
+					{
+						idempotencyKey: "invitation-mail:invitation-2:v1",
+						secretPayload: true,
+					},
+				),
+			);
+
+			expect(await queue.getReceipt(dispatchId!)).toMatchObject({
+				dispatchId,
+				jobName: "queue-secret-delivery",
+				status: "queued",
+			});
+
+			await queue.runOnce({ jobs: ["queue-secret-delivery"] });
+
+			expect(handledPayloads).toContainEqual({
+				invitationId: "invitation-2",
+				rawSecret,
+			});
+			expect(await queue.getReceipt(dispatchId!)).toMatchObject({
+				dispatchId,
+				jobName: "queue-secret-delivery",
+				status: "completed",
+			});
+			const [terminal] = await setup.app.db
+				.select()
+				.from(questpieQueueDispatchTable)
+				.where(eq(questpieQueueDispatchTable.dispatchId, dispatchId));
+			expect(terminal?.wrappedSecretKey).toBeNull();
+			expect(JSON.stringify(terminal)).not.toContain(rawSecret);
+		});
+
+		test("erases the data key on permanent failure and exposes no provider detail", async () => {
+			const rawSecret = "terminal-raw-invitation-token";
+			permanentFailureDetail = `SMTP provider rejected recipient while handling ${rawSecret}`;
+			const dispatchId = await withTransaction(setup.app.db, () =>
+				queue.permanentFailure.publish(
+					{
+						invitationId: "invitation-terminal",
+						rawSecret,
+					},
+					{
+						idempotencyKey: "invitation-mail:terminal:v1",
+						secretPayload: true,
+					},
+				),
+			);
+
+			const execution = queue.runOnce({
+				jobs: ["queue-secret-permanent-failure"],
+			});
+			await expect(execution).rejects.toThrow(
+				"QUESTPIE Queue secret job handling failed",
+			);
+			await expect(execution).rejects.not.toThrow(rawSecret);
+			await expect(execution).rejects.not.toThrow("SMTP provider");
+
+			const receipt = await queue.getReceipt(dispatchId!);
+			expect(receipt).toMatchObject({
+				dispatchId,
+				jobName: "queue-secret-permanent-failure",
+				status: "failed",
+			});
+			expect(JSON.stringify(receipt)).not.toContain(rawSecret);
+			expect(JSON.stringify(receipt)).not.toContain("SMTP provider");
+
+			const [terminal] = await setup.app.db
+				.select()
+				.from(questpieQueueDispatchTable)
+				.where(eq(questpieQueueDispatchTable.dispatchId, dispatchId));
+			const brokerRows = await setup.app.db.execute(sql`
+				SELECT data::text AS data, output::text AS output
+				FROM pgboss_queue_secret_contract.job
+				WHERE id = ${dispatchId}::uuid
+			`);
+			expect(terminal?.wrappedSecretKey).toBeNull();
+			expect(JSON.stringify({ terminal, brokerRows })).not.toContain(rawSecret);
+			expect(JSON.stringify({ terminal, brokerRows })).not.toContain(
+				"SMTP provider",
+			);
+		});
+
+		test("retains the key across a retry and erases it after the successful attempt", async () => {
+			retryAttempts = 0;
+			const rawSecret = "retry-raw-invitation-token";
+			const dispatchId = await withTransaction(setup.app.db, () =>
+				queue.retry.publish(
+					{
+						invitationId: "invitation-retry",
+						rawSecret,
+					},
+					{
+						idempotencyKey: "invitation-mail:retry:v1",
+						secretPayload: true,
+					},
+				),
+			);
+
+			await expect(
+				queue.runOnce({ jobs: ["queue-secret-retry"] }),
+			).rejects.toThrow("QUESTPIE Queue secret job handling failed");
+			expect(await queue.getReceipt(dispatchId!)).toMatchObject({
+				status: "queued",
+				handledAt: null,
+			});
+			const [retrying] = await setup.app.db
+				.select()
+				.from(questpieQueueDispatchTable)
+				.where(eq(questpieQueueDispatchTable.dispatchId, dispatchId));
+			expect(retrying?.wrappedSecretKey).not.toBeNull();
+
+			await queue.runOnce({ jobs: ["queue-secret-retry"] });
+
+			expect(retryAttempts).toBe(2);
+			expect(handledPayloads).toContainEqual({
+				invitationId: "invitation-retry",
+				rawSecret,
+			});
+			expect(await queue.getReceipt(dispatchId!)).toMatchObject({
+				status: "completed",
+			});
+			const [completed] = await setup.app.db
+				.select()
+				.from(questpieQueueDispatchTable)
+				.where(eq(questpieQueueDispatchTable.dispatchId, dispatchId));
+			expect(completed?.wrappedSecretKey).toBeNull();
+			expect(JSON.stringify(completed)).not.toContain(rawSecret);
+		});
+
+		test("keeps the first encrypted payload when an idempotency key is replayed", async () => {
+			const idempotencyKey = "invitation-mail:stable-version:v1";
+			const first = await withTransaction(setup.app.db, () =>
+				queue.delivery.publish(
+					{
+						invitationId: "invitation-stable-version",
+						rawSecret: "first-version-secret",
+					},
+					{ idempotencyKey, secretPayload: true },
+				),
+			);
+			const replay = await queue.delivery.publish(
+				{
+					invitationId: "invitation-stable-version",
+					rawSecret: "changed-version-secret",
+				},
+				{ idempotencyKey, secretPayload: true },
+			);
+
+			expect(replay).toBe(first);
+			await queue.runOnce({ jobs: ["queue-secret-delivery"] });
+			expect(handledPayloads).toContainEqual({
+				invitationId: "invitation-stable-version",
+				rawSecret: "first-version-secret",
+			});
+			expect(handledPayloads).not.toContainEqual({
+				invitationId: "invitation-stable-version",
+				rawSecret: "changed-version-secret",
+			});
+			expect(await queue.getReceipt(first!)).toMatchObject({
+				status: "completed",
+			});
+		});
+
+		test("rolls back the secret intent with the business transaction", async () => {
+			let dispatchId: string | null = null;
+			await expect(
+				withTransaction(setup.app.db, async () => {
+					dispatchId = await queue.delivery.publish(
+						{
+							invitationId: "invitation-rollback",
+							rawSecret: "rollback-raw-invitation-token",
+						},
+						{
+							idempotencyKey: "invitation-mail:rollback:v1",
+							secretPayload: true,
+						},
+					);
+					throw new Error("roll back invitation issue");
+				}),
+			).rejects.toThrow("roll back invitation issue");
+
+			expect(dispatchId).not.toBeNull();
+			expect(await queue.getReceipt(dispatchId!)).toBeNull();
+			const brokerRows = await setup.app.db.execute(sql`
+				SELECT id
+				FROM pgboss_queue_secret_contract.job
+				WHERE id = ${dispatchId}::uuid
+			`);
+			expect(brokerRows).toHaveLength(0);
+		});
+
+		test("commits the pg-boss job and secret ledger row in the same application transaction", async () => {
+			const transactionalAdapter = new PgBossAdapter({
+				connectionString: databaseUrl!,
+				schema: "pgboss_queue_secret_contract",
+				useApplicationTransaction: true,
+			});
+			const transactionalQueue = createQueueClient(
+				{ delivery: deliveryJob },
+				transactionalAdapter,
+				{
+					createContext: async () =>
+						setup.app.createContext({
+							accessMode: "system",
+						}),
+					getApp: () => setup.app,
+					getDatabase: () => setup.app.db,
+					secret: rootSecret,
+					logger: {
+						info: () => {},
+						warn: () => {},
+						error: () => {},
+					},
+				},
+			);
+
+			try {
+				const committedId = await withTransaction(setup.app.db, () =>
+					transactionalQueue.delivery.publish(
+						{
+							invitationId: "invitation-same-db-commit",
+							rawSecret: "same-db-commit-secret",
+						},
+						{
+							idempotencyKey: "invitation-mail:same-db-commit:v1",
+							secretPayload: true,
+						},
+					),
+				);
+				const committedBrokerRows = await setup.app.db.execute(sql`
+					SELECT id
+					FROM pgboss_queue_secret_contract.job
+					WHERE id = ${committedId}::uuid
+				`);
+				expect(await transactionalQueue.getReceipt(committedId!)).toMatchObject(
+					{
+						status: "queued",
+					},
+				);
+				expect(committedBrokerRows).toHaveLength(1);
+
+				let rolledBackId: string | null = null;
+				await expect(
+					withTransaction(setup.app.db, async () => {
+						rolledBackId = await transactionalQueue.delivery.publish(
+							{
+								invitationId: "invitation-same-db-rollback",
+								rawSecret: "same-db-rollback-secret",
+							},
+							{
+								idempotencyKey: "invitation-mail:same-db-rollback:v1",
+								secretPayload: true,
+							},
+						);
+						throw new Error("roll back same-database dispatch");
+					}),
+				).rejects.toThrow("roll back same-database dispatch");
+				const rolledBackBrokerRows = await setup.app.db.execute(sql`
+					SELECT id
+					FROM pgboss_queue_secret_contract.job
+					WHERE id = ${rolledBackId}::uuid
+				`);
+				expect(await transactionalQueue.getReceipt(rolledBackId!)).toBeNull();
+				expect(rolledBackBrokerRows).toHaveLength(0);
+			} finally {
+				await transactionalQueue.stop();
+			}
+		});
+
+		test("recovers a broker-owned terminal timeout after process restart", async () => {
+			const rawSecret = "broker-timeout-raw-invitation-token";
+			const dispatchId = await withTransaction(setup.app.db, () =>
+				queue.delivery.publish(
+					{
+						invitationId: "invitation-broker-timeout",
+						rawSecret,
+					},
+					{
+						idempotencyKey: "invitation-mail:broker-timeout:v1",
+						secretPayload: true,
+					},
+				),
+			);
+
+			// pg-boss's supervisor owns expiry/heartbeat terminalization. Model the
+			// durable result left for a restarted QUESTPIE process to inspect; this
+			// path does not invoke the QUESTPIE handler or receive finalAttempt.
+			await setup.app.db.execute(sql`
+				UPDATE pgboss_queue_secret_contract.job
+				SET
+					state = 'failed',
+					completed_on = CURRENT_TIMESTAMP,
+					output = '{"value":{"message":"job heartbeat timeout"}}'::jsonb
+				WHERE id = ${dispatchId}::uuid
+			`);
+
+			expect(await queue.getReceipt(dispatchId!)).toMatchObject({
+				status: "queued",
+			});
+			await expect(queue.drain()).resolves.toMatchObject({
+				terminal: 1,
+			});
+			expect(await queue.getReceipt(dispatchId!)).toMatchObject({
+				status: "failed",
+			});
+			const [terminal] = await setup.app.db
+				.select()
+				.from(questpieQueueDispatchTable)
+				.where(eq(questpieQueueDispatchTable.dispatchId, dispatchId));
+			expect(terminal?.wrappedSecretKey).toBeNull();
+			expect(JSON.stringify(terminal)).not.toContain(rawSecret);
+			expect(JSON.stringify(terminal)).not.toContain("heartbeat timeout");
+		});
+
+		test("recovers a committed encrypted intent after broker publication fails", async () => {
+			const rawSecret = "recoverable-raw-invitation-token";
+			adapter.failNextPublications();
+			const dispatchId = await withTransaction(setup.app.db, () =>
+				queue.delivery.publish(
+					{
+						invitationId: "invitation-recover",
+						rawSecret,
+					},
+					{
+						idempotencyKey: "invitation-mail:recover:v1",
+						secretPayload: true,
+					},
+				),
+			);
+
+			expect(await queue.getReceipt(dispatchId!)).toMatchObject({
+				status: "queued",
+				queuedAt: null,
+			});
+			const [pending] = await setup.app.db
+				.select()
+				.from(questpieQueueDispatchTable)
+				.where(eq(questpieQueueDispatchTable.dispatchId, dispatchId));
+			expect(pending?.wrappedSecretKey).not.toBeNull();
+			expect(JSON.stringify(pending)).not.toContain(rawSecret);
+
+			await setup.app.db
+				.update(questpieQueueDispatchTable)
+				.set({ availableAt: new Date(0) })
+				.where(eq(questpieQueueDispatchTable.dispatchId, dispatchId));
+			await expect(queue.drain()).resolves.toMatchObject({
+				accepted: 1,
+			});
+			expect(await queue.getReceipt(dispatchId!)).toMatchObject({
+				status: "queued",
+				queuedAt: expect.any(Date),
+			});
+
+			await queue.runOnce({ jobs: ["queue-secret-delivery"] });
+			expect(await queue.getReceipt(dispatchId!)).toMatchObject({
+				status: "completed",
+			});
+		});
+
+		test("recovers stable pg-boss identity after a crash between broker publication and ledger acceptance", async () => {
+			const rawSecret = "post-publication-crash-raw-invitation-token";
+			adapter.failNextPublicationReceipts();
+			const dispatchId = await withTransaction(setup.app.db, () =>
+				queue.delivery.publish(
+					{
+						invitationId: "invitation-post-publication-crash",
+						rawSecret,
+					},
+					{
+						idempotencyKey: "invitation-mail:post-publication-crash:v1",
+						secretPayload: true,
+					},
+				),
+			);
+
+			const brokerRows = await setup.app.db.execute(sql`
+				SELECT id
+				FROM pgboss_queue_secret_contract.job
+				WHERE id = ${dispatchId}::uuid
+			`);
+			expect(brokerRows).toHaveLength(1);
+			const [unacknowledged] = await setup.app.db
+				.select()
+				.from(questpieQueueDispatchTable)
+				.where(eq(questpieQueueDispatchTable.dispatchId, dispatchId));
+			expect(unacknowledged).toMatchObject({
+				status: "pending",
+				adapterJobId: null,
+			});
+			expect(unacknowledged?.wrappedSecretKey).not.toBeNull();
+
+			await setup.app.db
+				.update(questpieQueueDispatchTable)
+				.set({ availableAt: new Date(0) })
+				.where(eq(questpieQueueDispatchTable.dispatchId, dispatchId));
+			await expect(queue.drain()).resolves.toMatchObject({
+				accepted: 1,
+			});
+			const [recovered] = await setup.app.db
+				.select()
+				.from(questpieQueueDispatchTable)
+				.where(eq(questpieQueueDispatchTable.dispatchId, dispatchId));
+			expect(recovered).toMatchObject({
+				status: "accepted",
+				adapterJobId: dispatchId,
+			});
+
+			await setup.app.db.execute(sql`
+				UPDATE pgboss_queue_secret_contract.job
+				SET
+					state = 'failed',
+					completed_on = CURRENT_TIMESTAMP,
+					output = '{"value":{"message":"job timed out"}}'::jsonb
+				WHERE id = ${dispatchId}::uuid
+			`);
+			await expect(queue.drain()).resolves.toMatchObject({
+				terminal: 1,
+			});
+			expect(await queue.getReceipt(dispatchId!)).toMatchObject({
+				status: "failed",
+			});
+			const [terminal] = await setup.app.db
+				.select()
+				.from(questpieQueueDispatchTable)
+				.where(eq(questpieQueueDispatchTable.dispatchId, dispatchId));
+			expect(terminal?.wrappedSecretKey).toBeNull();
+			expect(JSON.stringify(terminal)).not.toContain(rawSecret);
+		});
+
+		test("does not fabricate acceptance when a short-policy conflict suppresses a distinct dispatch", async () => {
+			const firstPayload = {
+				invitationId: "invitation-short-policy-first",
+				rawSecret: "short-policy-first-secret",
+			};
+			const secondPayload = {
+				invitationId: "invitation-short-policy-second",
+				rawSecret: "short-policy-second-secret",
+			};
+			const firstDispatchId = await withTransaction(setup.app.db, () =>
+				queue.shortPolicy.publish(firstPayload, {
+					idempotencyKey: "invitation-mail:short-policy:first:v1",
+					secretPayload: true,
+				}),
+			);
+			const secondDispatchId = await withTransaction(setup.app.db, () =>
+				queue.shortPolicy.publish(secondPayload, {
+					idempotencyKey: "invitation-mail:short-policy:second:v1",
+					secretPayload: true,
+				}),
+			);
+
+			expect(secondDispatchId).not.toBe(firstDispatchId);
+			const [firstDispatch] = await setup.app.db
+				.select()
+				.from(questpieQueueDispatchTable)
+				.where(eq(questpieQueueDispatchTable.dispatchId, firstDispatchId));
+			const [secondDispatch] = await setup.app.db
+				.select()
+				.from(questpieQueueDispatchTable)
+				.where(eq(questpieQueueDispatchTable.dispatchId, secondDispatchId));
+			const brokerRowsBeforeRelease = await setup.app.db.execute(sql`
+				SELECT id::text AS id
+				FROM pgboss_queue_secret_contract.job
+				WHERE name = 'queue-secret-short-policy'
+				ORDER BY created_on, id
+			`);
+
+			expect(firstDispatch).toMatchObject({
+				status: "accepted",
+				adapterJobId: firstDispatchId,
+			});
+			expect(secondDispatch).toMatchObject({
+				status: "pending",
+				adapterJobId: null,
+				acceptedAt: null,
+			});
+			expect(secondDispatch?.wrappedSecretKey).not.toBeNull();
+			expect(brokerRowsBeforeRelease).toEqual([{ id: firstDispatchId }]);
+			expect(await queue.getReceipt(secondDispatchId!)).toMatchObject({
+				status: "queued",
+				queuedAt: null,
+			});
+
+			await queue.runOnce({ jobs: ["queue-secret-short-policy"] });
+			await setup.app.db
+				.update(questpieQueueDispatchTable)
+				.set({ availableAt: new Date(0) })
+				.where(eq(questpieQueueDispatchTable.dispatchId, secondDispatchId));
+			await expect(queue.drain()).resolves.toMatchObject({
+				accepted: 1,
+				failed: 0,
+			});
+			const secondBrokerRows = await setup.app.db.execute(sql`
+				SELECT id::text AS id
+				FROM pgboss_queue_secret_contract.job
+				WHERE id = ${secondDispatchId}::uuid
+			`);
+			expect(secondBrokerRows).toEqual([{ id: secondDispatchId }]);
+
+			await queue.runOnce({ jobs: ["queue-secret-short-policy"] });
+			expect(handledPayloads).toContainEqual(firstPayload);
+			expect(handledPayloads).toContainEqual(secondPayload);
+			expect(await queue.getReceipt(secondDispatchId!)).toMatchObject({
+				status: "completed",
+			});
+		});
+
+		test("rolls back transactional publication when a short-policy conflict is not the same UUID replay", async () => {
+			const transactionalAdapter = new PgBossAdapter({
+				connectionString: databaseUrl!,
+				schema: "pgboss_queue_secret_contract",
+				useApplicationTransaction: true,
+			});
+			const transactionalQueue = createQueueClient(
+				{ shortPolicy: shortPolicyJob },
+				transactionalAdapter,
+				{
+					createContext: async () =>
+						setup.app.createContext({
+							accessMode: "system",
+						}),
+					getApp: () => setup.app,
+					getDatabase: () => setup.app.db,
+					secret: rootSecret,
+					logger: {
+						info: () => {},
+						warn: () => {},
+						error: () => {},
+					},
+				},
+			);
+			const firstKey = "invitation-mail:short-policy-transactional:first:v1";
+			const secondKey = "invitation-mail:short-policy-transactional:second:v1";
+			const secondDispatchId = await stableQueueDispatchId(
+				"queue-secret-short-policy",
+				secondKey,
+			);
+
+			try {
+				const firstDispatchId = await withTransaction(setup.app.db, () =>
+					transactionalQueue.shortPolicy.publish(
+						{
+							invitationId: "invitation-short-policy-transactional-first",
+							rawSecret: "short-policy-transactional-first-secret",
+						},
+						{ idempotencyKey: firstKey, secretPayload: true },
+					),
+				);
+
+				await expect(
+					withTransaction(setup.app.db, () =>
+						transactionalQueue.shortPolicy.publish(
+							{
+								invitationId: "invitation-short-policy-transactional-second",
+								rawSecret: "short-policy-transactional-second-secret",
+							},
+							{ idempotencyKey: secondKey, secretPayload: true },
+						),
+					),
+				).rejects.toThrow("QUESTPIE pg-boss publication was not accepted");
+				expect(
+					await transactionalQueue.getReceipt(secondDispatchId),
+				).toBeNull();
+				expect(
+					await setup.app.db.execute(sql`
+						SELECT id::text AS id
+						FROM pgboss_queue_secret_contract.job
+						WHERE id = ${secondDispatchId}::uuid
+					`),
+				).toEqual([]);
+
+				await transactionalQueue.runOnce({
+					jobs: ["queue-secret-short-policy"],
+				});
+				expect(
+					await transactionalQueue.getReceipt(firstDispatchId!),
+				).toMatchObject({ status: "completed" });
+
+				await expect(
+					withTransaction(setup.app.db, () =>
+						transactionalQueue.shortPolicy.publish(
+							{
+								invitationId: "invitation-short-policy-transactional-second",
+								rawSecret: "short-policy-transactional-second-secret",
+							},
+							{ idempotencyKey: secondKey, secretPayload: true },
+						),
+					),
+				).resolves.toBe(secondDispatchId);
+				await transactionalQueue.runOnce({
+					jobs: ["queue-secret-short-policy"],
+				});
+				expect(
+					await transactionalQueue.getReceipt(secondDispatchId),
+				).toMatchObject({ status: "completed" });
+			} finally {
+				await transactionalQueue.stop();
+			}
+		});
+
+		test("reconciles a later terminal secret dispatch beyond the first inspection batch", async () => {
+			const dispatchIds: string[] = [];
+			for (let index = 0; index < 3; index += 1) {
+				const dispatchId = await withTransaction(setup.app.db, () =>
+					queue.delivery.publish(
+						{
+							invitationId: `invitation-reconciliation-page-${index}`,
+							rawSecret: `reconciliation-page-secret-${index}`,
+						},
+						{
+							idempotencyKey: `invitation-mail:reconciliation-page-${index}:v1`,
+							secretPayload: true,
+						},
+					),
+				);
+				dispatchIds.push(dispatchId!);
+			}
+			const [first, second, terminalId] = dispatchIds;
+			expect(first).toBeDefined();
+			expect(second).toBeDefined();
+			expect(terminalId).toBeDefined();
+
+			await setup.app.db.execute(sql`
+				UPDATE pgboss_queue_secret_contract.job
+				SET state = 'active', started_on = CURRENT_TIMESTAMP
+				WHERE id IN (${first}::uuid, ${second}::uuid)
+			`);
+			await setup.app.db.execute(sql`
+				UPDATE pgboss_queue_secret_contract.job
+				SET state = 'failed', completed_on = CURRENT_TIMESTAMP
+				WHERE id = ${terminalId}::uuid
+			`);
+
+			await expect(queue.drain({ batchSize: 2 })).resolves.toMatchObject({
+				terminal: 1,
+			});
+			expect(await queue.getReceipt(first!)).toMatchObject({
+				status: "queued",
+			});
+			expect(await queue.getReceipt(second!)).toMatchObject({
+				status: "queued",
+			});
+			expect(await queue.getReceipt(terminalId!)).toMatchObject({
+				status: "failed",
+			});
+			const [terminal] = await setup.app.db
+				.select()
+				.from(questpieQueueDispatchTable)
+				.where(eq(questpieQueueDispatchTable.dispatchId, terminalId));
+			expect(terminal?.wrappedSecretKey).toBeNull();
+		});
+
+		test("erases the data key when broker publication exhausts recovery", async () => {
+			const rawSecret = "relay-terminal-raw-invitation-token";
+			adapter.failNextPublications(25);
+			const dispatchId = await withTransaction(setup.app.db, () =>
+				queue.delivery.publish(
+					{
+						invitationId: "invitation-relay-terminal",
+						rawSecret,
+					},
+					{
+						idempotencyKey: "invitation-mail:relay-terminal:v1",
+						secretPayload: true,
+					},
+				),
+			);
+
+			for (let attempt = 1; attempt < 25; attempt += 1) {
+				await setup.app.db
+					.update(questpieQueueDispatchTable)
+					.set({ availableAt: new Date(0) })
+					.where(eq(questpieQueueDispatchTable.dispatchId, dispatchId));
+				await queue.drain();
+			}
+
+			expect(await queue.getReceipt(dispatchId!)).toMatchObject({
+				status: "failed",
+			});
+			const [terminal] = await setup.app.db
+				.select()
+				.from(questpieQueueDispatchTable)
+				.where(eq(questpieQueueDispatchTable.dispatchId, dispatchId));
+			expect(terminal).toMatchObject({
+				status: "failed",
+				attempts: 25,
+				wrappedSecretKey: null,
+				payload: null,
+			});
+			expect(JSON.stringify(terminal)).not.toContain(rawSecret);
+			expect(JSON.stringify(terminal)).not.toContain(
+				"injected broker publication failure",
+			);
+		});
+
+		test("fails closed and erases the key when broker ciphertext is corrupted", async () => {
+			const rawSecret = "tamper-raw-invitation-token";
+			const dispatchId = await withTransaction(setup.app.db, () =>
+				queue.delivery.publish(
+					{
+						invitationId: "invitation-tamper",
+						rawSecret,
+					},
+					{
+						idempotencyKey: "invitation-mail:tamper:v1",
+						secretPayload: true,
+					},
+				),
+			);
+			await setup.app.db.execute(sql`
+				UPDATE pgboss_queue_secret_contract.job
+				SET data = jsonb_set(
+					data,
+					'{payload,__questpieQueueSecret,ciphertext}',
+					'"tampered"'::jsonb
+				)
+				WHERE id = ${dispatchId}::uuid
+			`);
+
+			await expect(
+				queue.runOnce({ jobs: ["queue-secret-delivery"] }),
+			).rejects.toThrow("QUESTPIE Queue secret job handling failed");
+			expect(await queue.getReceipt(dispatchId!)).toMatchObject({
+				status: "failed",
+			});
+			const [terminal] = await setup.app.db
+				.select()
+				.from(questpieQueueDispatchTable)
+				.where(eq(questpieQueueDispatchTable.dispatchId, dispatchId));
+			expect(terminal?.wrappedSecretKey).toBeNull();
+			expect(JSON.stringify(terminal)).not.toContain(rawSecret);
+		});
+	},
+);

--- a/packages/questpie/test/integration/queue-secret-runtime.test.ts
+++ b/packages/questpie/test/integration/queue-secret-runtime.test.ts
@@ -228,6 +228,7 @@ describe("secret-bearing Queue runtime", () => {
 		expect((captured as Error).message).toBe(
 			"QUESTPIE Queue secret payload validation failed",
 		);
+		expect((captured as Error & { cause?: unknown }).cause).toBeUndefined();
 		expect(JSON.stringify(captured)).not.toContain(rawSecret);
 		expect(JSON.stringify(logLines)).not.toContain(rawSecret);
 		expect(setup.app.mocks.queue.getJobsByName("secret-refinement")).toEqual(

--- a/packages/questpie/test/integration/queue-secret-runtime.test.ts
+++ b/packages/questpie/test/integration/queue-secret-runtime.test.ts
@@ -1,0 +1,246 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { sql } from "drizzle-orm";
+import { z } from "zod";
+
+import { job } from "../../src/exports/index.js";
+import {
+	completeQueueDispatch,
+	failQueueDispatch,
+} from "../../src/server/modules/core/integrated/queue/dispatch-store.js";
+import { createQueueClient } from "../../src/server/modules/core/integrated/queue/service.js";
+import { buildMockApp } from "../utils/mocks/mock-app-builder.js";
+import { runTestDbMigrations } from "../utils/test-db.js";
+
+const rootSecret = "queue-secret-root-key-at-least-32-bytes";
+let handled = 0;
+let providerEffects = 0;
+let providerAttempts = 0;
+let blockHandler = false;
+let signalHandlerStarted: (() => void) | undefined;
+let releaseHandler: (() => void) | undefined;
+const acceptedDispatches = new Set<string>();
+
+const secretDeliveryJob = job({
+	name: "secret-delivery",
+	schema: z.object({ rawSecret: z.string() }),
+	handler: async ({ dispatchId }) => {
+		handled += 1;
+		providerAttempts += 1;
+		if (dispatchId && !acceptedDispatches.has(dispatchId)) {
+			acceptedDispatches.add(dispatchId);
+			providerEffects += 1;
+		}
+		signalHandlerStarted?.();
+		if (blockHandler) {
+			await new Promise<void>((resolve) => {
+				releaseHandler = resolve;
+			});
+		}
+	},
+});
+
+describe("secret-bearing Queue runtime", () => {
+	let setup: Awaited<ReturnType<typeof buildMockApp>>;
+
+	beforeEach(async () => {
+		handled = 0;
+		providerEffects = 0;
+		providerAttempts = 0;
+		blockHandler = false;
+		signalHandlerStarted = undefined;
+		releaseHandler = undefined;
+		acceptedDispatches.clear();
+		setup = await buildMockApp(
+			{ jobs: { secretDelivery: secretDeliveryJob } },
+			{ secret: rootSecret },
+		);
+		await runTestDbMigrations(setup.app);
+		await setup.app.queue.listen({ gracefulShutdown: false });
+	});
+
+	afterEach(async () => {
+		await setup.cleanup();
+	});
+
+	test("acknowledges a duplicate physical delivery after crypto-erasure without running user code again", async () => {
+		await setup.app.queue.secretDelivery.publish(
+			{ rawSecret: "one-time-secret" },
+			{
+				idempotencyKey: "secret-delivery:one",
+				secretPayload: true,
+			},
+		);
+		const [physicalJob] = setup.app.mocks.queue.getJobs();
+		expect(physicalJob).toBeDefined();
+
+		await setup.app.mocks.queue.processJob(physicalJob!.id);
+		await expect(
+			setup.app.mocks.queue.processJob(physicalJob!.id),
+		).resolves.toBeUndefined();
+
+		expect(handled).toBe(1);
+	});
+
+	test("serializes concurrent physical deliveries and lets the successful claimant dominate a final failure", async () => {
+		blockHandler = true;
+		const handlerStarted = new Promise<void>((resolve) => {
+			signalHandlerStarted = resolve;
+		});
+		const dispatchId = await setup.app.queue.secretDelivery.publish(
+			{ rawSecret: "concurrent-one-time-secret" },
+			{
+				idempotencyKey: "secret-delivery:concurrent-success-failure",
+				secretPayload: true,
+			},
+		);
+		const [physicalJob] = setup.app.mocks.queue.getJobs();
+		expect(physicalJob).toBeDefined();
+
+		const successfulDelivery = setup.app.mocks.queue.processJob(
+			physicalJob!.id,
+		);
+		await handlerStarted;
+		const losingDelivery = setup.app.mocks.queue.processJob(physicalJob!.id);
+		await expect(losingDelivery).rejects.toThrow(
+			"QUESTPIE Queue secret job handling failed",
+		);
+
+		releaseHandler?.();
+		await successfulDelivery;
+
+		expect(handled).toBe(1);
+		expect(await setup.app.queue.getReceipt(dispatchId!)).toMatchObject({
+			status: "completed",
+		});
+	});
+
+	test("makes success/success idempotent and completed dominate concurrent or later failure transitions", async () => {
+		const dispatchId = await setup.app.queue.secretDelivery.publish(
+			{ rawSecret: "monotonic-transition-secret" },
+			{
+				idempotencyKey: "secret-delivery:monotonic-transitions",
+				secretPayload: true,
+			},
+		);
+
+		await Promise.all([
+			completeQueueDispatch(setup.app.db, dispatchId!),
+			completeQueueDispatch(setup.app.db, dispatchId!),
+			failQueueDispatch(setup.app.db, dispatchId!),
+		]);
+		await failQueueDispatch(setup.app.db, dispatchId!);
+
+		expect(await setup.app.queue.getReceipt(dispatchId!)).toMatchObject({
+			status: "completed",
+		});
+	});
+
+	test("retries provider acceptance after one receipt-write failure and records one completed receipt", async () => {
+		const dispatchId = await setup.app.queue.secretDelivery.publish(
+			{ rawSecret: "provider-success-receipt-failure-secret" },
+			{
+				idempotencyKey: "secret-delivery:receipt-write-retry",
+				secretPayload: true,
+			},
+		);
+		const [physicalJob] = setup.app.mocks.queue.getJobs();
+		expect(physicalJob).toBeDefined();
+
+		await setup.app.db.execute(
+			sql.raw("CREATE SEQUENCE queue_secret_receipt_failure_once START 1"),
+		);
+		await setup.app.db.execute(
+			sql.raw(`
+			CREATE FUNCTION queue_secret_fail_first_completion()
+			RETURNS trigger
+			LANGUAGE plpgsql
+			AS $$
+			BEGIN
+				IF NEW.dispatch_id::text = '${dispatchId}' AND NEW.status = 'completed'
+					AND nextval('queue_secret_receipt_failure_once') = 1
+				THEN
+					RAISE EXCEPTION 'injected receipt write failure';
+				END IF;
+				RETURN NEW;
+			END;
+			$$
+		`),
+		);
+		await setup.app.db.execute(
+			sql.raw(`
+			CREATE TRIGGER queue_secret_fail_first_completion
+			BEFORE UPDATE ON questpie_queue_dispatch
+			FOR EACH ROW EXECUTE FUNCTION queue_secret_fail_first_completion()
+		`),
+		);
+
+		await expect(
+			setup.app.mocks.queue.processJob(physicalJob!.id),
+		).rejects.toThrow("QUESTPIE Queue secret job handling failed");
+		await setup.app.mocks.queue.processJob(physicalJob!.id);
+
+		expect(providerAttempts).toBe(2);
+		expect(providerEffects).toBe(1);
+		expect(await setup.app.queue.getReceipt(dispatchId!)).toMatchObject({
+			status: "completed",
+		});
+	});
+
+	test("sanitizes secret schema/refinement failures before they leave the framework", async () => {
+		const rawSecret = "schema-refinement-raw-secret";
+		const logLines: string[] = [];
+		const refinementJob = job({
+			name: "secret-refinement",
+			schema: z.object({ rawSecret: z.string() }).superRefine((payload) => {
+				throw new Error(`refinement rejected ${payload.rawSecret}`);
+			}),
+			handler: async () => {},
+		});
+		const queue = createQueueClient(
+			{ refinement: refinementJob },
+			setup.app.mocks.queue,
+			{
+				getDatabase: () => setup.app.db,
+				secret: rootSecret,
+				logger: {
+					info: (...args) => logLines.push(JSON.stringify(args)),
+					warn: (...args) => logLines.push(JSON.stringify(args)),
+					error: (...args) => logLines.push(JSON.stringify(args)),
+				},
+			},
+		);
+
+		let captured: unknown;
+		try {
+			await queue.refinement.publish(
+				{ rawSecret },
+				{
+					idempotencyKey: "secret-refinement:v1",
+					secretPayload: true,
+				},
+			);
+		} catch (error) {
+			captured = error;
+		}
+
+		expect(captured).toBeInstanceOf(Error);
+		expect((captured as Error).message).toBe(
+			"QUESTPIE Queue secret payload validation failed",
+		);
+		expect(JSON.stringify(captured)).not.toContain(rawSecret);
+		expect(JSON.stringify(logLines)).not.toContain(rawSecret);
+		expect(setup.app.mocks.queue.getJobsByName("secret-refinement")).toEqual(
+			[],
+		);
+	});
+
+	test("does not expose execution receipts for ordinary idempotent dispatches", async () => {
+		const dispatchId = await setup.app.queue.secretDelivery.publish(
+			{ rawSecret: "ordinary-payload-for-receipt-scope" },
+			{ idempotencyKey: "ordinary-dispatch:v1" },
+		);
+
+		expect(await setup.app.queue.getReceipt(dispatchId!)).toBeNull();
+	});
+});

--- a/packages/questpie/test/migration/queue-secret-dispatch-migration.test.ts
+++ b/packages/questpie/test/migration/queue-secret-dispatch-migration.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+	generateDrizzleJson,
+	generateMigration,
+} from "drizzle-kit/api-postgres";
+import { sql } from "drizzle-orm";
+import {
+	index,
+	integer,
+	jsonb,
+	pgTable,
+	text,
+	timestamp,
+	uniqueIndex,
+	uuid,
+} from "drizzle-orm/pg-core";
+import pg from "pg";
+
+import { systemTimestamp } from "../../src/server/db/system-columns.js";
+import { questpieQueueDispatchTable } from "../../src/server/modules/core/integrated/queue/dispatch-table.js";
+
+const legacyQueueDispatchTable = pgTable(
+	"questpie_queue_dispatch",
+	{
+		dispatchId: uuid("dispatch_id").primaryKey(),
+		jobName: text("job_name").notNull(),
+		idempotencyKey: text("idempotency_key"),
+		payload: jsonb("payload"),
+		options: jsonb("options"),
+		status: text("status").default("pending").notNull(),
+		attempts: integer("attempts").default(0).notNull(),
+		availableAt: timestamp("available_at", {
+			withTimezone: true,
+			mode: "date",
+		})
+			.defaultNow()
+			.notNull(),
+		leaseToken: uuid("lease_token"),
+		leasedUntil: timestamp("leased_until", {
+			withTimezone: true,
+			mode: "date",
+		}),
+		adapterJobId: text("adapter_job_id"),
+		lastError: text("last_error"),
+		acceptedAt: timestamp("accepted_at", {
+			withTimezone: true,
+			mode: "date",
+		}),
+		createdAt: systemTimestamp("created_at").defaultNow().notNull(),
+		updatedAt: systemTimestamp("updated_at")
+			.defaultNow()
+			.$onUpdate(() => sql`CURRENT_TIMESTAMP`)
+			.notNull(),
+	},
+	(table) => [
+		uniqueIndex("uq_queue_dispatch_idempotency").on(
+			table.jobName,
+			table.idempotencyKey,
+		),
+		index("idx_queue_dispatch_ready").on(
+			table.status,
+			table.availableAt,
+			table.leasedUntil,
+		),
+	],
+);
+
+describe("Queue secret dispatch schema upgrade", () => {
+	test("adds crypto-erasure, secret classification, and execution claim columns to the existing ledger", async () => {
+		const previous = await generateDrizzleJson(
+			{ questpie_queue_dispatch: legacyQueueDispatchTable },
+			"00000000-0000-0000-0000-000000000001",
+		);
+		const current = await generateDrizzleJson(
+			{ questpie_queue_dispatch: questpieQueueDispatchTable },
+			"00000000-0000-0000-0000-000000000002",
+		);
+		const migration = (await generateMigration(previous, current)).join("\n");
+
+		expect(migration).toContain(
+			'ALTER TABLE "questpie_queue_dispatch" ADD COLUMN "wrapped_secret_key" jsonb',
+		);
+		expect(migration).toContain(
+			'ALTER TABLE "questpie_queue_dispatch" ADD COLUMN "completed_at" timestamp with time zone',
+		);
+		expect(migration).toContain(
+			'ALTER TABLE "questpie_queue_dispatch" ADD COLUMN "failed_at" timestamp with time zone',
+		);
+		expect(migration).toContain(
+			'ALTER TABLE "questpie_queue_dispatch" ADD COLUMN "secret_payload" boolean DEFAULT false NOT NULL',
+		);
+		expect(migration).toContain(
+			'ALTER TABLE "questpie_queue_dispatch" ADD COLUMN "execution_claim_token" uuid',
+		);
+		expect(migration).toContain(
+			'ALTER TABLE "questpie_queue_dispatch" ADD COLUMN "execution_claimed_until" timestamp with time zone',
+		);
+		expect(migration).not.toContain("DROP TABLE");
+	});
+
+	test.skipIf(!process.env.QUESTPIE_QUEUE_SECRET_POSTGRES_URL)(
+		"applies the additive upgrade to a populated legacy PostgreSQL table",
+		async () => {
+			const previous = await generateDrizzleJson(
+				{ questpie_queue_dispatch: legacyQueueDispatchTable },
+				"00000000-0000-0000-0000-000000000001",
+			);
+			const current = await generateDrizzleJson(
+				{ questpie_queue_dispatch: questpieQueueDispatchTable },
+				"00000000-0000-0000-0000-000000000002",
+			);
+			const migration = (await generateMigration(previous, current)).join("\n");
+			const client = new pg.Client({
+				connectionString: process.env.QUESTPIE_QUEUE_SECRET_POSTGRES_URL,
+			});
+			await client.connect();
+			try {
+				await client.query("BEGIN");
+				await client.query(`
+					CREATE TEMP TABLE questpie_queue_dispatch (
+						dispatch_id uuid PRIMARY KEY,
+						job_name text NOT NULL,
+						idempotency_key text,
+						payload jsonb,
+						options jsonb,
+						status text DEFAULT 'pending' NOT NULL,
+						attempts integer DEFAULT 0 NOT NULL,
+						available_at timestamptz DEFAULT now() NOT NULL,
+						lease_token uuid,
+						leased_until timestamptz,
+						adapter_job_id text,
+						last_error text,
+						accepted_at timestamptz,
+						created_at timestamptz DEFAULT now() NOT NULL,
+						updated_at timestamptz DEFAULT now() NOT NULL
+					)
+				`);
+				await client.query(`
+					INSERT INTO questpie_queue_dispatch (
+						dispatch_id, job_name, idempotency_key, payload, options
+					) VALUES (
+						'00000000-0000-4000-8000-000000000001',
+						'legacy-mail',
+						'legacy:v1',
+						'{"legacy":"payload"}'::jsonb,
+						'{"retryLimit":1}'::jsonb
+					)
+				`);
+				await client.query(
+					migration.replaceAll("--> statement-breakpoint", ""),
+				);
+				const result = await client.query(`
+					SELECT
+						dispatch_id,
+						secret_payload,
+						wrapped_secret_key,
+						execution_claim_token,
+						execution_claimed_until,
+						completed_at,
+						failed_at
+					FROM questpie_queue_dispatch
+				`);
+
+				expect(result.rows).toEqual([
+					{
+						dispatch_id: "00000000-0000-4000-8000-000000000001",
+						secret_payload: false,
+						wrapped_secret_key: null,
+						execution_claim_token: null,
+						execution_claimed_until: null,
+						completed_at: null,
+						failed_at: null,
+					},
+				]);
+			} finally {
+				await client.query("ROLLBACK").catch(() => {});
+				await client.end();
+			}
+		},
+	);
+});

--- a/packages/questpie/test/units/queue-bullmq-adapter.test.ts
+++ b/packages/questpie/test/units/queue-bullmq-adapter.test.ts
@@ -3,6 +3,30 @@ import { describe, expect, test } from "bun:test";
 import { BullMQAdapter } from "../../src/server/modules/core/integrated/queue/adapters/bullmq.js";
 
 describe("BullMQAdapter logical dispatch", () => {
+	test("fails closed for secret dispatch even though ordinary attempts still expose final-attempt metadata", () => {
+		const adapter = new BullMQAdapter({
+			connection: { host: "127.0.0.1", port: 6379 },
+		});
+
+		expect(adapter.capabilities.executionTerminalState).toBe(false);
+		expect(
+			(adapter as any).toQueueJobRecord({
+				id: "retrying",
+				data: { value: "one" },
+				attemptsMade: 0,
+				opts: { attempts: 2 },
+			}).finalAttempt,
+		).toBe(false);
+		expect(
+			(adapter as any).toQueueJobRecord({
+				id: "terminal",
+				data: { value: "two" },
+				attemptsMade: 1,
+				opts: { attempts: 2 },
+			}).finalAttempt,
+		).toBe(true);
+	});
+
 	test("maps dispatch idempotency and singleton scheduling independently", async () => {
 		const adapter = new BullMQAdapter({
 			connection: { host: "127.0.0.1", port: 6379 },

--- a/packages/questpie/test/units/queue-dispatch-envelope.test.ts
+++ b/packages/questpie/test/units/queue-dispatch-envelope.test.ts
@@ -44,4 +44,37 @@ describe("Queue dispatch envelope", () => {
 			},
 		);
 	});
+
+	test("distinguishes framework-encrypted payloads from user data with the reserved shape", () => {
+		const userPayload = {
+			__questpieQueueSecret: {
+				version: 1,
+				iv: "user-owned",
+				ciphertext: "user-owned",
+			},
+		};
+		const ordinary = encodeQueueDispatchEnvelope(
+			userPayload,
+			dispatchId,
+			"notify:ordinary",
+		);
+		const encrypted = encodeQueueDispatchEnvelope(
+			userPayload,
+			dispatchId,
+			"notify:secret",
+			true,
+		);
+
+		expect(decodeQueueDispatchEnvelope(ordinary, dispatchId)).toEqual({
+			data: userPayload,
+			dispatchId,
+			idempotencyKey: "notify:ordinary",
+		});
+		expect(decodeQueueDispatchEnvelope(encrypted, dispatchId)).toEqual({
+			data: userPayload,
+			dispatchId,
+			idempotencyKey: "notify:secret",
+			secretPayload: true,
+		});
+	});
 });

--- a/packages/questpie/test/units/queue-pg-boss-adapter.test.ts
+++ b/packages/questpie/test/units/queue-pg-boss-adapter.test.ts
@@ -37,7 +37,16 @@ class FakePgBoss {
 		options: Record<string, unknown>;
 	}> = [];
 	public fetchedJobs: any[] = [];
+	public inspectedJobs = new Map<string, any>();
+	public inspectionCalls: Array<{
+		name: string;
+		id: string;
+		options?: Record<string, unknown>;
+	}> = [];
 	public workCallbacks = new Map<string, WorkCallback>();
+	public workOptions = new Map<string, Record<string, unknown>>();
+	public fetchOptions: Record<string, unknown> | undefined;
+	public sendResult: string | null | undefined;
 
 	async start(): Promise<void> {
 		this.started = true;
@@ -52,15 +61,18 @@ class FakePgBoss {
 		name: string,
 		data: unknown,
 		options: Record<string, unknown>,
-	): Promise<string> {
+	): Promise<string | null> {
 		this.sendCalls.push({ name, data, options });
-		return String(options.id ?? "fake-id");
+		return this.sendResult === undefined
+			? String(options.id ?? "fake-id")
+			: this.sendResult;
 	}
 	async work(
 		name: string,
-		_options: unknown,
+		options: Record<string, unknown>,
 		callback: WorkCallback,
 	): Promise<string> {
+		this.workOptions.set(name, options);
 		this.workCallbacks.set(name, callback);
 		return `worker-${name}`;
 	}
@@ -70,8 +82,20 @@ class FakePgBoss {
 	async complete(name: string, id: string): Promise<void> {
 		this.completeCalls.push({ name, id });
 	}
-	async fetch(): Promise<any[]> {
+	async fetch(
+		_name?: string,
+		options?: Record<string, unknown>,
+	): Promise<any[]> {
+		this.fetchOptions = options;
 		return this.fetchedJobs.splice(0);
+	}
+	async getJobById(
+		name: string,
+		id: string,
+		options?: Record<string, unknown>,
+	): Promise<any> {
+		this.inspectionCalls.push({ name, id, options });
+		return this.inspectedJobs.get(`${name}:${id}`) ?? null;
 	}
 }
 
@@ -130,6 +154,95 @@ describe("PgBossAdapter — v10+ work() callback receives Job[]", () => {
 		} as any);
 
 		expect(adapter.transactionalPublishing).toBe(false);
+	});
+
+	it("recovers the caller-supplied physical identity when stable-id replay conflicts", async () => {
+		const { adapter, fake } = makeAdapter();
+		const dispatchId = "0e79a7d5-da2f-55e7-ae4c-3e95c5633071";
+		fake.sendResult = null;
+		fake.inspectedJobs.set(`notify:${dispatchId}`, { id: dispatchId });
+
+		await expect(
+			adapter.publish(
+				"notify",
+				{ value: "replayed" },
+				{ idempotencyKey: "notify:replayed" },
+				dispatchId,
+			),
+		).resolves.toBe(dispatchId);
+		expect(fake.inspectionCalls).toEqual([
+			{ name: "notify", id: dispatchId, options: undefined },
+		]);
+	});
+
+	it("fails publication when null is caused by a different queue-policy conflict", async () => {
+		const { adapter, fake } = makeAdapter();
+		const dispatchId = "0e79a7d5-da2f-55e7-ae4c-3e95c5633071";
+		fake.sendResult = null;
+
+		await expect(
+			adapter.publish(
+				"notify",
+				{ value: "suppressed-by-another-job" },
+				{ idempotencyKey: "notify:distinct", queuePolicy: "short" },
+				dispatchId,
+			),
+		).rejects.toThrow("QUESTPIE pg-boss publication was not accepted");
+		expect(fake.inspectionCalls).toEqual([
+			{ name: "notify", id: dispatchId, options: undefined },
+		]);
+	});
+
+	it("proves transactional replay through the same transaction connection", async () => {
+		const { adapter, fake } = makeAdapter();
+		const dispatchId = "0e79a7d5-da2f-55e7-ae4c-3e95c5633071";
+		const tx = {
+			execute: async () => ({ rows: [] }),
+		};
+		fake.sendResult = null;
+		fake.inspectedJobs.set(`notify:${dispatchId}`, { id: dispatchId });
+
+		await expect(
+			adapter.publishInTransaction(
+				tx,
+				"notify",
+				{ value: "transactional-replay" },
+				{ idempotencyKey: "notify:transactional-replay" },
+				dispatchId,
+			),
+		).resolves.toBe(dispatchId);
+
+		const transactionDb = fake.sendCalls[0]?.options.db;
+		expect(transactionDb).toBeDefined();
+		expect(fake.inspectionCalls).toEqual([
+			{
+				name: "notify",
+				id: dispatchId,
+				options: { db: transactionDb },
+			},
+		]);
+	});
+
+	it("fails transactional publication when the exact physical id is absent", async () => {
+		const { adapter, fake } = makeAdapter();
+		const dispatchId = "0e79a7d5-da2f-55e7-ae4c-3e95c5633071";
+		const tx = {
+			execute: async () => ({ rows: [] }),
+		};
+		fake.sendResult = null;
+
+		await expect(
+			adapter.publishInTransaction(
+				tx,
+				"notify",
+				{ value: "suppressed-by-another-job" },
+				{
+					idempotencyKey: "notify:transactional-distinct",
+					queuePolicy: "short",
+				},
+				dispatchId,
+			),
+		).rejects.toThrow("QUESTPIE pg-boss publication was not accepted");
 	});
 
 	it("completes successful runOnce jobs and fails handler errors", async () => {
@@ -281,5 +394,93 @@ describe("PgBossAdapter — v10+ work() callback receives Job[]", () => {
 		expect((failed.data as { message: string }).message).toBe(
 			"handler exploded on bad-2",
 		);
+	});
+
+	it("reports terminal-attempt metadata from long-running pg-boss work", async () => {
+		const { adapter, fake } = makeAdapter();
+		const attempts: boolean[] = [];
+		await adapter.listen({
+			echo: async ({ finalAttempt }) => {
+				attempts.push(finalAttempt === true);
+			},
+		});
+
+		expect(fake.workOptions.get("echo")).toMatchObject({
+			includeMetadata: true,
+		});
+		await fake.workCallbacks.get("echo")!([
+			{
+				id: "retrying",
+				data: {},
+				retryCount: 0,
+				retryLimit: 1,
+			},
+			{
+				id: "terminal",
+				data: {},
+				retryCount: 1,
+				retryLimit: 1,
+			},
+		]);
+
+		expect(attempts).toEqual([false, true]);
+	});
+
+	it("requests and reports terminal-attempt metadata in runOnce", async () => {
+		const { adapter, fake } = makeAdapter();
+		const attempts: boolean[] = [];
+		fake.fetchedJobs.push(
+			{
+				id: "retrying",
+				data: {},
+				retryCount: 0,
+				retryLimit: 1,
+			},
+			{
+				id: "terminal",
+				data: {},
+				retryCount: 1,
+				retryLimit: 1,
+			},
+		);
+
+		await adapter.runOnce({
+			echo: async ({ finalAttempt }) => {
+				attempts.push(finalAttempt === true);
+			},
+		});
+
+		expect(fake.fetchOptions).toMatchObject({
+			includeMetadata: true,
+		});
+		expect(attempts).toEqual([false, true]);
+	});
+
+	it("source-qualifies broker terminal states for crash-recovery reconciliation", async () => {
+		const { adapter, fake } = makeAdapter();
+		fake.inspectedJobs.set("echo:completed", { state: "completed" });
+		fake.inspectedJobs.set("echo:failed", { state: "failed" });
+		fake.inspectedJobs.set("echo:cancelled", { state: "cancelled" });
+		fake.inspectedJobs.set("echo:active", { state: "active" });
+		fake.inspectedJobs.set("echo:retry", { state: "retry" });
+
+		await expect(
+			adapter.inspectExecutionState!("echo", "completed"),
+		).resolves.toBe("completed");
+		await expect(
+			adapter.inspectExecutionState!("echo", "failed"),
+		).resolves.toBe("failed");
+		await expect(
+			adapter.inspectExecutionState!("echo", "cancelled"),
+		).resolves.toBe("failed");
+		await expect(
+			adapter.inspectExecutionState!("echo", "active"),
+		).resolves.toBe("active");
+		await expect(adapter.inspectExecutionState!("echo", "retry")).resolves.toBe(
+			"pending",
+		);
+		await expect(
+			adapter.inspectExecutionState!("echo", "retained-record-missing"),
+		).resolves.toBe("missing");
 	});
 });

--- a/packages/questpie/test/units/queue-runtime.test.ts
+++ b/packages/questpie/test/units/queue-runtime.test.ts
@@ -522,4 +522,59 @@ describe("queue runtime api", () => {
 			"has cron schedule but schema does not accept an empty payload",
 		);
 	});
+
+	test("secret payloads fail closed without idempotency, root key, or terminal adapter metadata", async () => {
+		const jobs = {
+			notify: {
+				name: "notify",
+				schema: z.object({ secret: z.string() }),
+				handler: async () => {},
+			},
+		};
+		const mockAdapter = new MockQueueAdapter();
+		const withoutRootKey = createQueueClient(jobs, mockAdapter, {
+			getDatabase: () => ({}) as any,
+		});
+
+		await expect(
+			withoutRootKey.notify.publish(
+				{ secret: "value" },
+				{ secretPayload: true },
+			),
+		).rejects.toThrow("require idempotencyKey");
+		await expect(
+			withoutRootKey.notify.publish(
+				{ secret: "value" },
+				{
+					idempotencyKey: "notify:secret",
+					secretPayload: true,
+				},
+			),
+		).rejects.toThrow("runtimeConfig.secret with at least 32 bytes");
+		expect(mockAdapter.getJobs()).toEqual([]);
+
+		const published: unknown[] = [];
+		const cloudflare = cloudflareQueuesAdapter({
+			enqueue: async (message) => {
+				published.push(message);
+				return null;
+			},
+		});
+		const withoutTerminalMetadata = createQueueClient(jobs, cloudflare, {
+			getDatabase: () => ({}) as any,
+			secret: "queue-secret-root-key-at-least-32-bytes",
+		});
+		await expect(
+			withoutTerminalMetadata.notify.publish(
+				{ secret: "value" },
+				{
+					idempotencyKey: "notify:cloudflare-secret",
+					secretPayload: true,
+				},
+			),
+		).rejects.toThrow(
+			"cannot reconcile durable broker terminal execution state",
+		);
+		expect(published).toEqual([]);
+	});
 });

--- a/packages/questpie/test/utils/mocks/queue.adapter.ts
+++ b/packages/questpie/test/utils/mocks/queue.adapter.ts
@@ -15,13 +15,17 @@ export interface MockJob {
 	dispatchId?: string;
 	idempotencyKey?: string;
 	publishedAt: Date;
+	state: "pending" | "active" | "completed" | "failed";
 }
 
 export interface MockScheduledJob {
 	name: string;
 	cron: string;
 	payload: any;
-	options?: Omit<PublishOptions, "idempotencyKey" | "startAfter">;
+	options?: Omit<
+		PublishOptions,
+		"idempotencyKey" | "startAfter" | "secretPayload"
+	>;
 }
 
 export interface MockWorker {
@@ -40,6 +44,7 @@ export class MockQueueAdapter implements QueueAdapter {
 		pushConsumer: false,
 		scheduling: true,
 		singleton: false,
+		executionTerminalState: true,
 	} as const;
 
 	private jobs: MockJob[] = [];
@@ -110,12 +115,21 @@ export class MockQueueAdapter implements QueueAdapter {
 			throw new Error(`No worker registered for job: ${job.name}`);
 		}
 
-		await handler({
-			id: job.id,
-			data: job.payload,
-			dispatchId: job.dispatchId,
-			idempotencyKey: job.idempotencyKey,
-		});
+		job.state = "active";
+		try {
+			await handler({
+				id: job.id,
+				data: job.payload,
+				dispatchId: job.dispatchId,
+				idempotencyKey: job.idempotencyKey,
+				finalAttempt: true,
+				secretPayload: job.options?.secretPayload,
+			});
+			job.state = "completed";
+		} catch (error) {
+			job.state = "failed";
+			throw error;
+		}
 	}
 
 	/**
@@ -126,14 +140,19 @@ export class MockQueueAdapter implements QueueAdapter {
 			const worker = this.workers.find((w) => !!w.handlers[job.name]);
 			const handler = worker?.handlers[job.name];
 			if (handler) {
+				job.state = "active";
 				try {
 					await handler({
 						id: job.id,
 						data: job.payload,
 						dispatchId: job.dispatchId,
 						idempotencyKey: job.idempotencyKey,
+						finalAttempt: true,
+						secretPayload: job.options?.secretPayload,
 					});
+					job.state = "completed";
 				} catch (error) {
+					job.state = "failed";
 					for (const handler of this.errorHandlers) {
 						handler(error as Error);
 					}
@@ -172,17 +191,32 @@ export class MockQueueAdapter implements QueueAdapter {
 			dispatchId,
 			idempotencyKey: options?.idempotencyKey,
 			publishedAt: new Date(),
+			state: "pending",
 		};
 
 		this.jobs.push(job);
 		return job.id;
 	}
 
+	async inspectExecutionState(
+		jobName: string,
+		adapterJobId: string,
+	): Promise<"pending" | "active" | "completed" | "failed" | "missing"> {
+		const job = this.jobs.find(
+			(candidate) =>
+				candidate.name === jobName && candidate.id === adapterJobId,
+		);
+		return job?.state ?? "missing";
+	}
+
 	async schedule(
 		jobName: string,
 		cron: string,
 		payload: any,
-		options?: Omit<PublishOptions, "idempotencyKey" | "startAfter">,
+		options?: Omit<
+			PublishOptions,
+			"idempotencyKey" | "startAfter" | "secretPayload"
+		>,
 	): Promise<void> {
 		// Remove existing scheduled job with same name
 		this.scheduledJobs = this.scheduledJobs.filter(
@@ -229,13 +263,22 @@ export class MockQueueAdapter implements QueueAdapter {
 			const handler = handlers[job.name];
 			if (!handler) continue;
 
-			await handler({
-				id: job.id,
-				data: job.payload,
-				dispatchId: job.dispatchId,
-				idempotencyKey: job.idempotencyKey,
-			});
-			processed += 1;
+			job.state = "active";
+			try {
+				await handler({
+					id: job.id,
+					data: job.payload,
+					dispatchId: job.dispatchId,
+					idempotencyKey: job.idempotencyKey,
+					finalAttempt: true,
+					secretPayload: job.options?.secretPayload,
+				});
+				job.state = "completed";
+				processed += 1;
+			} catch (error) {
+				job.state = "failed";
+				throw error;
+			}
 		}
 
 		return { processed };


### PR DESCRIPTION
## Summary
- add encrypted short-lived Queue secret payloads with payload-free durable receipts
- qualify pg-boss exact physical dispatch recovery in and out of caller transactions
- fail closed for unqualified adapters and erase wrapped keys after terminal outcomes
- document deployment/migration and adapter capability contracts

## Verification
- pg-boss unit: 14 tests / 43 assertions
- real PostgreSQL integration: 15 tests / 92 assertions
- runtime + populated migration: 8 tests / 27 assertions
- packages/questpie typecheck
- root lint and format:check
- docs validation: 183 files, 0 errors/warnings
- two independent adversarial reviews: 0 P0 / 0 P1 after exact-row repair

## Safety
- no Autopilot-local mail queue or mail-specific framework API
- no secret material in durable receipts
- same-transaction pg-boss proof uses the caller transaction connection
- distinct short/stately/exclusive conflicts fail closed

The changeset intentionally bumps the fixed QUESTPIE group through the core `questpie` package.