### PR TITLE
fix(realtime): Redis Streams dropped wakes published right after start()

### DIFF
--- a/.changeset/redis-streams-start-window.md
+++ b/.changeset/redis-streams-start-window.md
@@ -1,0 +1,32 @@
+---
+"questpie": patch
+---
+
+Fix Redis Streams dropping wakes published right after `start()`.
+
+`RedisStreamsChangeBroker.start()` connected its reader and then launched the
+read loop **without awaiting it**, and the loop opened with `XREAD … id="$"`.
+`$` means "messages that arrive after this call reaches the server", so anything
+published between `start()` resolving and the loop's first read was silently
+dropped and never redelivered:
+
+```ts
+await broker.start({ onWake });
+await broker.publish(wake); // could vanish
+```
+
+`pg-notify` never had this problem — its `start()` awaits `LISTEN`, so the
+subscription exists before it returns. Two implementations of one `ChangeBroker`
+interface were giving different delivery guarantees.
+
+`start()` now resolves the concrete stream id first and reads from there, so it
+means "subscribed from here" rather than "reader connected". Clients that cannot
+report stream info fall back to `$`, which is no worse than before.
+
+This is what a flaky CI failure in the realtime driver matrix turned out to be —
+the test timed out on the full deadline rather than near it, which is the
+signature of a message that never arrives rather than a slow one.
+
+Also stops `oxfmt` from flagging generated `CHANGELOG.md` files, which the
+release tooling rewrites on every publish and which therefore turned the format
+gate red after each release.

--- a/.changeset/redis-streams-start-window.md
+++ b/.changeset/redis-streams-start-window.md
@@ -26,7 +26,3 @@ report stream info fall back to `$`, which is no worse than before.
 This is what a flaky CI failure in the realtime driver matrix turned out to be —
 the test timed out on the full deadline rather than near it, which is the
 signature of a message that never arrives rather than a slow one.
-
-Also stops `oxfmt` from flagging generated `CHANGELOG.md` files, which the
-release tooling rewrites on every publish and which therefore turned the format
-gate red after each release.

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -29,6 +29,7 @@
 		"**/*.gen.ts",
 		"**/.generated",
 		"**/migrations/**",
+		"**/CHANGELOG.md",
 		"**/templates/**/*.yml",
 		"**/templates/**/*.yaml"
 	]

--- a/packages/questpie/src/server/modules/core/integrated/realtime/adapters/redis-streams.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/adapters/redis-streams.ts
@@ -29,6 +29,12 @@ export type RedisStreamsClient = {
 		streams: Array<{ key: string; id: string }>,
 		options?: { COUNT?: number; BLOCK?: number },
 	) => Promise<unknown>;
+	/**
+	 * Used to resolve the subscribe position at `start()` time. Optional: a
+	 * client without it falls back to `$`, which reopens the delivery gap
+	 * described on `resolveStartId`.
+	 */
+	xInfoStream?: (stream: string) => Promise<unknown>;
 	duplicate?: () => RedisStreamsClient;
 	connect?: () => Promise<unknown>;
 	close?: () => Promise<void>;
@@ -85,10 +91,52 @@ class RedisStreamsDriver {
 		if (this.running) return;
 
 		await this.ensureReader();
+		// Resolve the subscribe position BEFORE returning, so `start()` means
+		// "subscribed from here" rather than "reader connected". See
+		// resolveStartId for why `$` alone loses messages.
+		const startId = await this.resolveStartId();
 		this.running = true;
-		this.readLoopPromise = this.runReadLoop().catch((error) => {
+		this.readLoopPromise = this.runReadLoop(startId).catch((error) => {
 			this.reportError("[Realtime] Redis Streams read loop stopped", error);
 		});
+	}
+
+	/**
+	 * The concrete stream id the read loop should start after.
+	 *
+	 * `XREAD` with `$` means "messages that arrive after THIS call is issued" —
+	 * and `start()` used to launch the read loop without awaiting it, so
+	 * anything published between `start()` resolving and the loop's first
+	 * `xRead` reaching the server was silently dropped. The window is small but
+	 * real, and it is exactly the shape a caller hits when it starts a broker
+	 * and immediately publishes:
+	 *
+	 *     await broker.start({ onWake });
+	 *     await broker.publish(wake);   // could never arrive
+	 *
+	 * Resolving the id here closes it: whatever is added after this point has
+	 * an id greater than the one we captured, so the loop picks it up no matter
+	 * how late it starts. `pg-notify` already had this property because its
+	 * `start()` awaits `LISTEN`; this brings the two implementations of the
+	 * same interface back to the same guarantee.
+	 *
+	 * Falls back to `$` when the client cannot report stream info, which is no
+	 * worse than the previous behaviour.
+	 */
+	private async resolveStartId(): Promise<string> {
+		const reader = this.reader;
+		if (!reader?.xInfoStream) return "$";
+		try {
+			const info = (await reader.xInfoStream(this.stream)) as
+				| Record<string, unknown>
+				| undefined;
+			const lastId = info?.["last-generated-id"] ?? info?.lastGeneratedId;
+			return typeof lastId === "string" && lastId.length > 0 ? lastId : "$";
+		} catch {
+			// A stream that does not exist yet has nothing to miss; start from the
+			// beginning so the first publish is still delivered.
+			return "0-0";
+		}
 	}
 
 	async startPublisher(): Promise<void> {}
@@ -157,11 +205,11 @@ class RedisStreamsDriver {
 		);
 	}
 
-	private async readLoop(): Promise<void> {
+	private async readLoop(startId: string): Promise<void> {
 		const reader = this.reader;
 		if (!reader) throw new Error("Redis Streams reader is not initialized");
 
-		let lastId = "$";
+		let lastId = startId;
 		while (this.running) {
 			try {
 				const response = await reader.xRead(
@@ -238,9 +286,9 @@ class RedisStreamsDriver {
 		this.reader.on("error", this.readerErrorHandler);
 	}
 
-	private async runReadLoop(): Promise<void> {
+	private async runReadLoop(startId: string): Promise<void> {
 		try {
-			await this.readLoop();
+			await this.readLoop(startId);
 		} finally {
 			this.running = false;
 			this.readLoopPromise = null;

--- a/packages/questpie/test/realtime/redis-streams-start-window.test.ts
+++ b/packages/questpie/test/realtime/redis-streams-start-window.test.ts
@@ -1,0 +1,195 @@
+/**
+ * `start()` must mean "subscribed", not "reader connected".
+ *
+ * `RedisStreamsChangeBroker.start()` connected the reader and then launched the
+ * read loop WITHOUT awaiting it, and the loop opened with `XREAD ... id="$"`.
+ * `$` means "messages that arrive after this call reaches the server", so
+ * anything published in the gap between `start()` resolving and the loop's
+ * first `xRead` was dropped and never redelivered:
+ *
+ *     await broker.start({ onWake });
+ *     await broker.publish(wake);   // could vanish
+ *
+ * `pg-notify` never had this problem — its `start()` awaits `LISTEN`, so the
+ * subscription exists before it returns. Two implementations of one
+ * `ChangeBroker` interface were giving different delivery guarantees.
+ *
+ * This surfaced as a flaky CI failure in the driver matrix
+ * (`redis streams matrix delivery timed out`, the full 10s deadline rather than
+ * a near-miss, which is the signature of a message that never arrives rather
+ * than a slow one).
+ *
+ * The fake below pins the ordering that the real race only hits sometimes:
+ * `xRead` waits on a gate the test opens *after* publishing, so the publish is
+ * guaranteed to land before the first read. Under `$` semantics that message is
+ * unobservable; the assertion is that it is delivered anyway.
+ */
+import { describe, expect, test } from "bun:test";
+
+import {
+	RedisStreamsChangeBroker,
+	type RedisStreamsClient,
+} from "../../src/server/modules/core/integrated/realtime/adapters/redis-streams.js";
+import type { ChangeWake } from "../../src/server/modules/core/integrated/realtime/transport.js";
+
+type Entry = { id: string; fields: Record<string, string> };
+
+/**
+ * Minimal in-memory Redis Streams stand-in with real `$` semantics: a read
+ * issued with `$` resolves the position at CALL time, so it cannot see anything
+ * added earlier.
+ */
+function createFakeRedis(gate: Promise<void>) {
+	const entries: Entry[] = [];
+	let seq = 0;
+	let firstRead = true;
+
+	const client: RedisStreamsClient = {
+		async xAdd(_stream, _id, fields) {
+			seq += 1;
+			const id = `1-${seq}`;
+			entries.push({ id, fields });
+			return id;
+		},
+		async xRead(streams, options) {
+			// Hold the very first read until the test says go, forcing the publish
+			// to happen first. This is the race, made deterministic.
+			if (firstRead) {
+				firstRead = false;
+				await gate;
+			}
+			const requested = streams[0]!;
+			const after =
+				requested.id === "$"
+					? (entries.at(-1)?.id ?? "0-0") // `$` = only what comes later
+					: requested.id;
+			const fresh = entries.filter((e) => e.id > after);
+			if (fresh.length === 0) {
+				// Honour BLOCK. Returning immediately would make the broker's read
+				// loop spin on microtasks, which starves the macrotask queue and
+				// hangs any timer the test is waiting on — the fake has to block
+				// like the real client does.
+				await new Promise((resolve) =>
+					setTimeout(resolve, options?.BLOCK ?? 5),
+				);
+				return null;
+			}
+			return [{ name: requested.key, messages: fresh }];
+		},
+		async xInfoStream() {
+			return { "last-generated-id": entries.at(-1)?.id ?? "0-0" };
+		},
+	};
+	return client;
+}
+
+const WAKE: ChangeWake = {
+	kind: "outbox-maybe-advanced",
+	highWaterSeq: 7,
+	reason: "publish",
+};
+
+describe("RedisStreamsChangeBroker start window", () => {
+	test("delivers a wake published immediately after start() resolves", async () => {
+		let openGate!: () => void;
+		const gate = new Promise<void>((resolve) => {
+			openGate = resolve;
+		});
+		const client = createFakeRedis(gate);
+
+		const received: ChangeWake[] = [];
+		let resolveWake!: () => void;
+		const gotWake = new Promise<void>((resolve) => {
+			resolveWake = resolve;
+		});
+
+		const broker = new RedisStreamsChangeBroker({
+			client,
+			reader: client,
+			stream: "test-stream",
+			blockMs: 5,
+		});
+
+		await broker.start({
+			onWake: (wake) => {
+				received.push(wake);
+				resolveWake();
+			},
+			onError: () => {},
+		});
+
+		// `stop()` must run even when the assertion below fails, or the read loop
+		// keeps spinning and the whole test file hangs instead of reporting.
+		try {
+			// The gap: start() has resolved, the read loop has not read yet.
+			await broker.publish(WAKE);
+			openGate();
+
+			await Promise.race([
+				gotWake,
+				new Promise<never>((_, reject) =>
+					setTimeout(
+						() => reject(new Error("wake was never delivered")),
+						2_000,
+					),
+				),
+			]);
+
+			expect(received).toHaveLength(1);
+			expect(received[0]?.highWaterSeq).toBe(7);
+		} finally {
+			await broker.stop();
+		}
+	});
+
+	test("subscribes from a concrete id, never from $", async () => {
+		// The direct statement of the fix, and the one that cannot hang: `$` is
+		// resolved at read time by the server, so using it at all reopens the gap
+		// regardless of how fast the loop starts. Asserting the id the first read
+		// carries is a stronger and faster check than waiting for a delivery.
+		const seenIds: string[] = [];
+		const base = createFakeRedis(Promise.resolve());
+		const client: RedisStreamsClient = {
+			...base,
+			async xRead(streams, options) {
+				seenIds.push(streams[0]!.id);
+				return base.xRead(streams, options);
+			},
+		};
+
+		const broker = new RedisStreamsChangeBroker({
+			client,
+			reader: client,
+			stream: "test-stream",
+			blockMs: 5,
+		});
+		try {
+			await broker.start({ onWake: () => {}, onError: () => {} });
+			// Give the loop a turn to issue its first read.
+			await new Promise((resolve) => setTimeout(resolve, 20));
+		} finally {
+			await broker.stop();
+		}
+
+		expect(seenIds.length).toBeGreaterThan(0);
+		expect(seenIds[0]).not.toBe("$");
+	});
+
+	test("falls back safely when the client cannot report stream info", async () => {
+		// A client without xInfoStream keeps the old `$` behaviour rather than
+		// throwing — the gap returns, but nothing breaks.
+		const gate = Promise.resolve();
+		const client = createFakeRedis(gate);
+		const { xInfoStream: _dropped, ...withoutInfo } = client;
+
+		const broker = new RedisStreamsChangeBroker({
+			client: withoutInfo as RedisStreamsClient,
+			reader: withoutInfo as RedisStreamsClient,
+			stream: "test-stream",
+			blockMs: 5,
+		});
+
+		await broker.start({ onWake: () => {}, onError: () => {} });
+		await broker.stop();
+	});
+});


### PR DESCRIPTION
Filed as a flaky test. It was not — it was a real delivery bug in the Redis Streams broker.

## The bug

`RedisStreamsChangeBroker.start()` connected its reader and then launched the read loop **without awaiting it**, and the loop opened with `XREAD … id="$"`. In Redis Streams `$` means *"messages that arrive after this call reaches the server"*, so anything published in the gap between `start()` resolving and the loop's first read was dropped and never redelivered:

```ts
await broker.start({ onWake });
await broker.publish(wake);   // could vanish
```

`pg-notify` never had this problem — its `start()` awaits `LISTEN`, so the subscription exists before it returns. **Two implementations of one `ChangeBroker` interface were handing callers different delivery guarantees.**

## What pointed here rather than at slowness

The CI failure burned the **full 10-second deadline**, not a near-miss. A slow round-trip lands just under or just over it; a message that never arrives burns the whole timeout.

That is also why the deadline in the driver matrix is **left exactly as it was**. Softening it — the obvious "fix the flaky test" move — would have hidden this class of bug rather than surfacing it.

## The fix

`start()` resolves the concrete stream id before launching the loop and reads from there, so it means "subscribed from here" rather than "reader connected". A client that cannot report stream info falls back to `$` (no worse than before); a stream that does not exist yet starts from `0-0` so its first publish still arrives.

## Tests

Three, against a fake client — no live Redis, no wall-clock sensitivity. Teeth confirmed by reverting to `$`: **2 of 3 fail**, cleanly.

The strongest asserts the id the first read actually carries. It cannot hang, and it states the invariant directly instead of inferring it from a delivery.

## Two things that fell out of writing it

**The fake initially answered instantly**, which made the broker's read loop spin on microtasks and starve the macrotask queue — the test *hung* instead of failing. A test that hangs on failure is nearly as bad as a flaky one. The fake now honours `BLOCK` like the real client, and the delivery assertion stops the broker in a `finally`.

**`main` was already red on formatting.** changesets generates `CHANGELOG.md` files that oxfmt rejects, so the format gate breaks after *every* release. Reformatting them would rewrite published changelog history on each publish, so `**/CHANGELOG.md` joins `*.gen.ts` and `.generated` in `ignorePatterns` — same category, generated output owned by tooling.

## Verification

2,919 tests / 0 fail · tsc clean · `bun run lint` 0 errors · oxfmt clean repo-wide · five ratchets green.
