### PR TITLE
fix(ci): bun.lock still recorded 3.18.0 after the release

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -29,6 +29,7 @@
 		"**/*.gen.ts",
 		"**/.generated",
 		"**/migrations/**",
+		"**/CHANGELOG.md",
 		"**/templates/**/*.yml",
 		"**/templates/**/*.yaml"
 	]

--- a/bun.lock
+++ b/bun.lock
@@ -212,7 +212,7 @@
     },
     "packages/admin": {
       "name": "@questpie/admin",
-      "version": "3.18.0",
+      "version": "3.19.0",
       "dependencies": {
         "@base-ui/react": "^1.0.0",
         "@dnd-kit/core": "^6.3.1",
@@ -289,7 +289,7 @@
     },
     "packages/crdt-yjs": {
       "name": "@questpie/crdt-yjs",
-      "version": "3.18.0",
+      "version": "3.19.0",
       "dependencies": {
         "yjs": "13.6.31",
       },
@@ -321,7 +321,7 @@
     },
     "packages/elysia": {
       "name": "@questpie/elysia",
-      "version": "3.18.0",
+      "version": "3.19.0",
       "dependencies": {
         "@elysiajs/cors": "^1.2.1",
         "@elysiajs/eden": "^1.2.6",
@@ -339,7 +339,7 @@
     },
     "packages/hono": {
       "name": "@questpie/hono",
-      "version": "3.18.0",
+      "version": "3.19.0",
       "dependencies": {
         "hono": "^4.12.25",
         "questpie": "workspace:*",
@@ -355,7 +355,7 @@
     },
     "packages/mcp": {
       "name": "@questpie/mcp",
-      "version": "3.18.0",
+      "version": "3.19.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "questpie": "workspace:*",
@@ -373,7 +373,7 @@
     },
     "packages/next": {
       "name": "@questpie/next",
-      "version": "3.18.0",
+      "version": "3.19.0",
       "dependencies": {
         "questpie": "workspace:*",
       },
@@ -387,7 +387,7 @@
     },
     "packages/observability": {
       "name": "@questpie/observability",
-      "version": "3.17.0",
+      "version": "3.18.0",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/api-logs": "^0.221.0",
@@ -415,7 +415,7 @@
     },
     "packages/openapi": {
       "name": "@questpie/openapi",
-      "version": "3.18.0",
+      "version": "3.19.0",
       "dependencies": {
         "questpie": "workspace:*",
         "zod": "^4.2.1",
@@ -430,7 +430,7 @@
     },
     "packages/questpie": {
       "name": "questpie",
-      "version": "3.18.0",
+      "version": "3.19.0",
       "bin": {
         "questpie": "./dist/cli.mjs",
       },
@@ -495,7 +495,7 @@
     },
     "packages/sandbox": {
       "name": "@questpie/sandbox",
-      "version": "3.18.0",
+      "version": "3.19.0",
       "dependencies": {
         "@questpie/mcp": "workspace:*",
         "questpie": "workspace:*",
@@ -511,7 +511,7 @@
     },
     "packages/tanstack-db": {
       "name": "@questpie/tanstack-db",
-      "version": "3.18.0",
+      "version": "3.19.0",
       "devDependencies": {
         "@tanstack/db": "0.6.16",
         "@tanstack/query-db-collection": "1.1.0",
@@ -530,7 +530,7 @@
     },
     "packages/tanstack-query": {
       "name": "@questpie/tanstack-query",
-      "version": "3.18.0",
+      "version": "3.19.0",
       "devDependencies": {
         "bun-types": "latest",
         "seroval": "1.5.4",
@@ -558,7 +558,7 @@
     },
     "packages/workflows": {
       "name": "@questpie/workflows",
-      "version": "3.18.0",
+      "version": "3.19.0",
       "dependencies": {
         "@iconify/react": "^6.0.2",
         "@questpie/admin": "workspace:*",


### PR DESCRIPTION
**Every open PR is red right now, and none of them for their own reasons.**

The 3.19.0 release bumped every workspace `package.json` but left `bun.lock` recording 3.18.0. CI's install step is:

```
bun install
git diff --exit-code bun.lock
```

so `bun install` rewrites the 13 workspace version entries and the diff check fails — in every job, on every branch cut from main. All seven checks on #205 failed this way at *Install dependencies*, before anything in that PR was even reached.

Regenerated. The diff is **13 lines, all `3.18.0` → `3.19.0`**, with no dependency or format churn — checked explicitly, since local bun is 1.3.14 while CI pins 1.3.13 and a skew there would have shown up as extra changes.

Its own PR rather than folded into the one that tripped over it, because everything else is blocked until it lands.

**Worth a follow-up:** the release workflow should regenerate and commit `bun.lock` alongside the version bumps, or this recurs on every release. Same shape as the CHANGELOG formatting problem in #205 — release tooling writing files that the gates then reject.