### PR TITLE
fix(context): isolate resolver service access

### DIFF
--- a/.changeset/calm-context-resolvers.md
+++ b/.changeset/calm-context-resolvers.md
@@ -1,0 +1,5 @@
+---
+"questpie": patch
+---
+
+Keep app context resolver services isolated in a system context, including when resolution starts inside an ambient user request such as fresh realtime authorization.

--- a/bun.lock
+++ b/bun.lock
@@ -212,7 +212,7 @@
     },
     "packages/admin": {
       "name": "@questpie/admin",
-      "version": "3.19.0",
+      "version": "3.19.1",
       "dependencies": {
         "@base-ui/react": "^1.0.0",
         "@dnd-kit/core": "^6.3.1",
@@ -289,7 +289,7 @@
     },
     "packages/crdt-yjs": {
       "name": "@questpie/crdt-yjs",
-      "version": "3.19.0",
+      "version": "3.19.1",
       "dependencies": {
         "yjs": "13.6.31",
       },
@@ -321,7 +321,7 @@
     },
     "packages/elysia": {
       "name": "@questpie/elysia",
-      "version": "3.19.0",
+      "version": "3.19.1",
       "dependencies": {
         "@elysiajs/cors": "^1.2.1",
         "@elysiajs/eden": "^1.2.6",
@@ -339,7 +339,7 @@
     },
     "packages/hono": {
       "name": "@questpie/hono",
-      "version": "3.19.0",
+      "version": "3.19.1",
       "dependencies": {
         "hono": "^4.12.25",
         "questpie": "workspace:*",
@@ -355,7 +355,7 @@
     },
     "packages/mcp": {
       "name": "@questpie/mcp",
-      "version": "3.19.0",
+      "version": "3.19.1",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "questpie": "workspace:*",
@@ -373,7 +373,7 @@
     },
     "packages/next": {
       "name": "@questpie/next",
-      "version": "3.19.0",
+      "version": "3.19.1",
       "dependencies": {
         "questpie": "workspace:*",
       },
@@ -415,7 +415,7 @@
     },
     "packages/openapi": {
       "name": "@questpie/openapi",
-      "version": "3.19.0",
+      "version": "3.19.1",
       "dependencies": {
         "questpie": "workspace:*",
         "zod": "^4.2.1",
@@ -430,7 +430,7 @@
     },
     "packages/questpie": {
       "name": "questpie",
-      "version": "3.19.0",
+      "version": "3.19.1",
       "bin": {
         "questpie": "./dist/cli.mjs",
       },
@@ -495,7 +495,7 @@
     },
     "packages/sandbox": {
       "name": "@questpie/sandbox",
-      "version": "3.19.0",
+      "version": "3.19.1",
       "dependencies": {
         "@questpie/mcp": "workspace:*",
         "questpie": "workspace:*",
@@ -511,7 +511,7 @@
     },
     "packages/tanstack-db": {
       "name": "@questpie/tanstack-db",
-      "version": "3.19.0",
+      "version": "3.19.1",
       "devDependencies": {
         "@tanstack/db": "0.6.16",
         "@tanstack/query-db-collection": "1.1.0",
@@ -530,7 +530,7 @@
     },
     "packages/tanstack-query": {
       "name": "@questpie/tanstack-query",
-      "version": "3.19.0",
+      "version": "3.19.1",
       "devDependencies": {
         "bun-types": "latest",
         "seroval": "1.5.4",
@@ -558,7 +558,7 @@
     },
     "packages/workflows": {
       "name": "@questpie/workflows",
-      "version": "3.19.0",
+      "version": "3.19.1",
       "dependencies": {
         "@iconify/react": "^6.0.2",
         "@questpie/admin": "workspace:*",

--- a/packages/questpie/src/server/config/questpie.ts
+++ b/packages/questpie/src/server/config/questpie.ts
@@ -12,7 +12,10 @@ import type {
 	RelationConfig,
 } from "#questpie/server/collection/builder/types.js";
 import { extractAppServices } from "#questpie/server/config/app-context.js";
-import { accessModeForPrincipal } from "#questpie/server/config/context.js";
+import {
+	accessModeForPrincipal,
+	runWithContext,
+} from "#questpie/server/config/context.js";
 import type {
 	Principal,
 	RequestContext,
@@ -1015,6 +1018,9 @@ export class Questpie<TConfig extends QuestpieConfig = QuestpieConfig> {
 			actor?: import("#questpie/server/modules/core/integrated/crdt/authority.js").AuthorityActor;
 			locale?: string;
 			accessMode?: AccessMode;
+			stage?: string;
+			requestId?: string;
+			traceId?: string;
 			db?: any;
 			/** Incoming request (if in HTTP scope) */
 			request?: Request;
@@ -1074,7 +1080,12 @@ export class Questpie<TConfig extends QuestpieConfig = QuestpieConfig> {
 			extensions = await this.resolveContextExtensions({
 				request: userCtx.request,
 				session: userCtx.session,
+				actor: userCtx.actor,
 				db: userCtx.db ?? this.db,
+				locale,
+				stage: userCtx.stage,
+				requestId: userCtx.requestId,
+				traceId: userCtx.traceId,
 			});
 		}
 
@@ -1100,7 +1111,12 @@ export class Questpie<TConfig extends QuestpieConfig = QuestpieConfig> {
 	private async resolveContextExtensions(params: {
 		request: Request;
 		session: { user: User; session: Session } | null | undefined;
+		actor?: import("#questpie/server/modules/core/integrated/crdt/authority.js").AuthorityActor;
 		db: any;
+		locale: string;
+		stage?: string;
+		requestId?: string;
+		traceId?: string;
 	}): Promise<Record<string, unknown> | undefined> {
 		// Loose call signature on purpose: the static `ContextResolver` params
 		// type is the USER-facing contract (augmented per-app by codegen); the
@@ -1110,17 +1126,37 @@ export class Questpie<TConfig extends QuestpieConfig = QuestpieConfig> {
 			| undefined;
 		if (typeof resolver !== "function") return undefined;
 
-		const services = extractAppServices(this, {
-			db: params.db,
-			session: params.session,
-		});
+		const result = await runWithContext(
+			{
+				app: this,
+				db: params.db,
+				session: params.session,
+				principal: { kind: "system" },
+				actor: params.actor,
+				locale: params.locale,
+				accessMode: "system",
+				stage: params.stage,
+				requestId: params.requestId,
+				traceId: params.traceId,
+			},
+			async () => {
+				const services = extractAppServices(this, {
+					db: params.db,
+					session: params.session,
+					locale: params.locale,
+					accessMode: "system",
+					principal: { kind: "system" },
+					actor: params.actor,
+				});
 
-		const result = await resolver({
-			...services,
-			request: params.request,
-			session: params.session,
-			db: params.db,
-		});
+				return resolver({
+					...services,
+					request: params.request,
+					session: params.session,
+					db: params.db,
+				});
+			},
+		);
 		const extensions = (result ?? {}) as Record<string, unknown>;
 
 		if (getNodeEnv() !== "production") {

--- a/packages/questpie/test/context/request-context-extensions.test.ts
+++ b/packages/questpie/test/context/request-context-extensions.test.ts
@@ -22,7 +22,11 @@ import { z } from "zod";
 
 import { collection, global, route } from "../../src/exports/index.js";
 import { createFetchHandler } from "../../src/server/adapters/http.js";
-import { getContext } from "../../src/server/config/context.js";
+import {
+	getContext,
+	runWithContext,
+	tryGetContext,
+} from "../../src/server/config/context.js";
 import { ApiError } from "../../src/server/errors/index.js";
 import { buildMockApp } from "../utils/mocks/mock-app-builder";
 import { runTestDbMigrations } from "../utils/test-db";
@@ -412,6 +416,157 @@ describe("request context extensions (appConfig({ context }))", () => {
 		const reentered = await setup.app.createContext(ctx as any);
 		expect(spy.resolverRuns).toBe(1);
 		expect((reentered as any).tenantId).toBe("tenant-a");
+	});
+});
+
+describe("request context extensions — system resolver boundary", () => {
+	let setup: Awaited<ReturnType<typeof buildMockApp>>;
+	const observations: Array<{
+		accessMode: string | undefined;
+		principalKind: string | undefined;
+		session: unknown;
+		ambientDb: unknown;
+		resolverDb: unknown;
+		locale: string | undefined;
+		stage: string | undefined;
+		requestId: string | undefined;
+		traceId: string | undefined;
+		staleExtension: unknown;
+	}> = [];
+
+	beforeEach(async () => {
+		observations.length = 0;
+		const protectedMemberships = collection("protected_memberships")
+			.fields(({ f }) => ({ userId: f.text().required() }))
+			.access({ read: false, create: false, update: false, delete: false });
+		setup = await buildMockApp({
+			collections: { protectedMemberships },
+			locale: {
+				defaultLocale: "en",
+				locales: [{ code: "en" }, { code: "sk" }],
+			},
+			config: {
+				app: {
+					context: async ({ collections, db, request, session }: any) => {
+						const ambient = tryGetContext();
+						observations.push({
+							accessMode: ambient?.accessMode,
+							principalKind: ambient?.principal?.kind,
+							session: ambient?.session,
+							ambientDb: ambient?.db,
+							resolverDb: db,
+							locale: ambient?.locale,
+							stage: ambient?.stage,
+							requestId: ambient?.requestId,
+							traceId: ambient?.traceId,
+							staleExtension: ambient?.["~contextExtensions"]?.stale,
+						});
+						const count = await collections.protectedMemberships.count({});
+						if (request.headers.get("x-reject") === "yes") {
+							throw ApiError.unauthorized("Resolver rejected the request");
+						}
+						return {
+							hasMembership: count === 1 && session?.user.id === "user-1",
+						};
+					},
+				},
+			},
+		});
+		await runTestDbMigrations(setup.app);
+		await setup.app.collections.protectedMemberships.create({
+			userId: "user-1",
+		});
+	});
+
+	afterEach(async () => {
+		await setup.cleanup();
+	});
+
+	it("isolates resolver services from ambient user ALS and restores the caller", async () => {
+		const session = {
+			user: { id: "user-1" },
+			session: { id: "session-1" },
+		};
+		const principal = {
+			kind: "user" as const,
+			user: session.user,
+			session: session.session,
+		};
+		const outer = {
+			app: setup.app,
+			session,
+			principal: principal as any,
+			db: setup.app.db,
+			locale: "sk",
+			accessMode: "user",
+			stage: "review",
+			requestId: "request-1",
+			traceId: "trace-1",
+			"~contextExtensions": { stale: "must-not-leak" },
+		};
+
+		const resolved = await runWithContext(outer, async () => {
+			const context = await setup.app.createContext({
+				request: new Request("http://localhost/context"),
+				session,
+				principal: principal as any,
+				db: setup.app.db,
+				locale: "sk",
+				accessMode: "user",
+				stage: "review",
+				requestId: "request-1",
+				traceId: "trace-1",
+			});
+			expect(tryGetContext()?.principal).toBe(principal);
+			expect(tryGetContext()?.accessMode).toBe("user");
+			return context;
+		});
+
+		expect(observations[0]).toEqual({
+			accessMode: "system",
+			principalKind: "system",
+			session,
+			ambientDb: setup.app.db,
+			resolverDb: setup.app.db,
+			locale: "sk",
+			stage: "review",
+			requestId: "request-1",
+			traceId: "trace-1",
+			staleExtension: undefined,
+		});
+		expect(resolved).toMatchObject({
+			session,
+			principal,
+			accessMode: "user",
+			locale: "sk",
+			stage: "review",
+			requestId: "request-1",
+			traceId: "trace-1",
+			hasMembership: true,
+		});
+		expect(resolved["~contextExtensions"]).toEqual({
+			hasMembership: true,
+		});
+
+		await runWithContext(outer, async () => {
+			await expect(
+				setup.app.createContext({
+					request: new Request("http://localhost/context", {
+						headers: { "x-reject": "yes" },
+					}),
+					session,
+					principal: principal as any,
+					db: setup.app.db,
+					locale: "sk",
+					accessMode: "user",
+					stage: "review",
+					requestId: "request-1",
+					traceId: "trace-1",
+				}),
+			).rejects.toThrow("Resolver rejected the request");
+			expect(tryGetContext()?.principal).toBe(principal);
+			expect(tryGetContext()?.accessMode).toBe("user");
+		});
 	});
 });
 

--- a/packages/questpie/test/integration/channel-routes.test.ts
+++ b/packages/questpie/test/integration/channel-routes.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 
 import { z } from "zod";
 
+import { collection } from "../../src/exports/index.js";
 import { createFetchHandler } from "../../src/server/adapters/http.js";
 import { channel } from "../../src/server/channels/channel-builder.js";
 import { ChannelTokenBucketLimiter } from "../../src/server/channels/security.js";
@@ -67,6 +68,28 @@ async function readSseEvent(
 		const next = await reader.read();
 		if (next.done) throw new Error(`SSE ended before ${eventType}`);
 		state.buffer += decoder.decode(next.value, { stream: true });
+	}
+}
+
+async function readSseEventWithin(
+	reader: ReadableStreamDefaultReader<Uint8Array>,
+	state: { buffer: string },
+	eventType: string,
+	timeoutMs = 2_000,
+): Promise<Record<string, unknown>> {
+	let timeout: ReturnType<typeof setTimeout> | undefined;
+	try {
+		return await Promise.race([
+			readSseEvent(reader, state, eventType),
+			new Promise<never>((_, reject) => {
+				timeout = setTimeout(
+					() => reject(new Error(`Timed out waiting for SSE ${eventType}`)),
+					timeoutMs,
+				);
+			}),
+		]);
+	} finally {
+		if (timeout) clearTimeout(timeout);
 	}
 }
 
@@ -164,6 +187,91 @@ describe("channel module routes", () => {
 			data: { text: "hello" },
 		});
 		await reader.cancel();
+	});
+
+	test("keeps app context resolver reads system-scoped during fresh channel reauthorization", async () => {
+		let contextResolutions = 0;
+		const memberships = collection("memberships")
+			.fields(({ f }) => ({
+				userId: f.text().required(),
+			}))
+			.access({ read: false, create: false, update: false, delete: false });
+		const setup = await buildMockApp(
+			{
+				collections: { memberships },
+				channels: {
+					workspace: channel("workspace-[workspaceId]")
+						.events({ message: z.object({ text: z.string() }) })
+						.authorize(
+							({ session, hasMembership }: any) =>
+								session?.user.id === "user-1" && hasMembership === true,
+						),
+				},
+				config: {
+					app: {
+						context: async ({ collections, session }: any) => {
+							contextResolutions += 1;
+							const membershipCount = await collections.memberships.count({
+								where: { userId: session?.user.id },
+							});
+							return { hasMembership: membershipCount === 1 };
+						},
+					},
+				},
+			},
+			{
+				app: { url: "https://app.example.com" },
+				realtime: { retentionDays: 0, rowLiveQueries: false },
+			},
+		);
+		cleanup = setup.cleanup;
+		await runTestDbMigrations(setup.app);
+		await setup.app.collections.memberships.create({ userId: "user-1" });
+
+		const handler = createFetchHandler(setup.app, {
+			getSession: async () => ({
+				user: { id: "user-1" },
+				session: { id: "session-1" },
+			}),
+		});
+		const response = await handler(
+			channelRequest("realtime", {
+				channels: [
+					{
+						id: "workspace-one",
+						channel: "workspace",
+						params: { workspaceId: "one" },
+					},
+				],
+			}),
+		);
+		expect(response.status).toBe(200);
+		const reader = response.body!.getReader();
+		const state = { buffer: "" };
+		try {
+			await readSseEventWithin(reader, state, "session");
+
+			for (let attempt = 0; attempt < 100; attempt++) {
+				if (contextResolutions >= 2) break;
+				await new Promise((resolve) => setTimeout(resolve, 5));
+			}
+			expect(contextResolutions).toBeGreaterThanOrEqual(2);
+
+			await setup.app.realtime!.appendChannelEvent({
+				channel: "private-workspace-one",
+				event: "message",
+				schemaIdentity: "workspace:message",
+				data: { text: "still-authorized" },
+			});
+			expect(
+				await readSseEventWithin(reader, state, "channel_event"),
+			).toMatchObject({
+				channel: "private-workspace-one",
+				data: { text: "still-authorized" },
+			});
+		} finally {
+			await reader.cancel().catch(() => {});
+		}
 	});
 
 	test("a held-open SSE stream reruns presence policy and revokes only the exact channel binding", async () => {


### PR DESCRIPTION
## Summary

- isolate trusted `appConfig({ context })` service construction and resolver execution in an explicit nested system AsyncLocalStorage scope
- preserve the caller session, actor, database, locale, workflow stage, request id, and trace id while restoring the outward user context unchanged
- add direct ambient-user isolation coverage and an authenticated held-open SSE fresh-reauthorization regression
- publish the fix as a `questpie` patch changeset

## Root cause

Fresh realtime channel reauthorization rebuilds the adapter context while the original user request ALS is still active. Context-resolver collection calls therefore inherited `accessMode: user`, even though the documented resolver contract is trusted system-mode derivation. A protected collection read could throw 403 before channel policy evaluation; the ledger then correctly failed closed and ended the binding.

## Verification

- Board verify: all 5 commands pass on `9cc71406`
- focused context + channel tests: 30 pass, 0 fail, 170 assertions
- root typecheck: 25/25 tasks
- lint and format check: pass
- docs validation: 186 files, 0 errors, 0 warnings
- full suite: 3984 pass, 50 skip; one unrelated observability trace test failed once and passed isolated rerun 6/6
- independent GPT-5.6-sol adversarial review: no P0/P1 findings

## Known baseline issues

- root build reaches 17/19 tasks; the unchanged `tanstack-barbershop-example` fails because its server env module imports `./env.client`, which TanStack server import protection rejects. The `questpie` package build succeeds.
- `bun run validate` completes codegen, builds, types, and export validation, but its fixed 300-second runner terminates the serialized questpie test command; the same suite takes about 860 seconds and was run separately above.

## Follow-up

PRs #202 and #203 must preserve this explicit system resolver boundary when rebased.
