### PR TITLE
fix(release): regenerate bun.lock as part of the version step

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -212,7 +212,7 @@
     },
     "packages/admin": {
       "name": "@questpie/admin",
-      "version": "3.19.1",
+      "version": "3.19.2",
       "dependencies": {
         "@base-ui/react": "^1.0.0",
         "@dnd-kit/core": "^6.3.1",
@@ -289,7 +289,7 @@
     },
     "packages/crdt-yjs": {
       "name": "@questpie/crdt-yjs",
-      "version": "3.19.1",
+      "version": "3.19.2",
       "dependencies": {
         "yjs": "13.6.31",
       },
@@ -321,7 +321,7 @@
     },
     "packages/elysia": {
       "name": "@questpie/elysia",
-      "version": "3.19.1",
+      "version": "3.19.2",
       "dependencies": {
         "@elysiajs/cors": "^1.2.1",
         "@elysiajs/eden": "^1.2.6",
@@ -339,7 +339,7 @@
     },
     "packages/hono": {
       "name": "@questpie/hono",
-      "version": "3.19.1",
+      "version": "3.19.2",
       "dependencies": {
         "hono": "^4.12.25",
         "questpie": "workspace:*",
@@ -355,7 +355,7 @@
     },
     "packages/mcp": {
       "name": "@questpie/mcp",
-      "version": "3.19.1",
+      "version": "3.19.2",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "questpie": "workspace:*",
@@ -373,7 +373,7 @@
     },
     "packages/next": {
       "name": "@questpie/next",
-      "version": "3.19.1",
+      "version": "3.19.2",
       "dependencies": {
         "questpie": "workspace:*",
       },
@@ -415,7 +415,7 @@
     },
     "packages/openapi": {
       "name": "@questpie/openapi",
-      "version": "3.19.1",
+      "version": "3.19.2",
       "dependencies": {
         "questpie": "workspace:*",
         "zod": "^4.2.1",
@@ -430,7 +430,7 @@
     },
     "packages/questpie": {
       "name": "questpie",
-      "version": "3.19.1",
+      "version": "3.19.2",
       "bin": {
         "questpie": "./dist/cli.mjs",
       },
@@ -495,7 +495,7 @@
     },
     "packages/sandbox": {
       "name": "@questpie/sandbox",
-      "version": "3.19.1",
+      "version": "3.19.2",
       "dependencies": {
         "@questpie/mcp": "workspace:*",
         "questpie": "workspace:*",
@@ -511,7 +511,7 @@
     },
     "packages/tanstack-db": {
       "name": "@questpie/tanstack-db",
-      "version": "3.19.1",
+      "version": "3.19.2",
       "devDependencies": {
         "@tanstack/db": "0.6.16",
         "@tanstack/query-db-collection": "1.1.0",
@@ -530,7 +530,7 @@
     },
     "packages/tanstack-query": {
       "name": "@questpie/tanstack-query",
-      "version": "3.19.1",
+      "version": "3.19.2",
       "devDependencies": {
         "bun-types": "latest",
         "seroval": "1.5.4",
@@ -558,7 +558,7 @@
     },
     "packages/workflows": {
       "name": "@questpie/workflows",
-      "version": "3.19.1",
+      "version": "3.19.2",
       "dependencies": {
         "@iconify/react": "^6.0.2",
         "@questpie/admin": "workspace:*",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 		"test": "QUESTPIE_MIGRATIONS_SILENT=1 bun test",
 		"questpie:generate": "turbo run questpie:generate",
 		"changeset": "changeset",
-		"version": "changeset version",
+		"version": "changeset version && bun install",
 		"release": "turbo run build --filter='./packages/*' && bun run scripts/publish.ts",
 		"validate": "bun run scripts/validate.ts",
 		"validate:docs": "bun run scripts/validate-docs.ts",


### PR DESCRIPTION
**main is fully red again — same cause as #206, one release later.**

`changeset version` bumps every workspace `package.json` and writes the CHANGELOGs, but never touches `bun.lock`. CI's install step is:

```
bun install
git diff --exit-code bun.lock
```

so the moment a release lands, `bun install` rewrites the 12 workspace version entries and the diff check fails — every job, every branch cut from main. 3.19.0 did it, #206 cleaned it up, and 3.19.2 did it again an hour later.

#206 fixed the symptom. This fixes the cause:

- `scripts.version` becomes `changeset version && bun install`, so the lockfile is regenerated inside the version step and `changesets/action` commits it alongside the bumps it already commits. The workflow pins bun 1.3.13, so the lock is written by the same version CI verifies against.
- The current drift is committed, which unblocks main now.

**Verified:** reinstalling leaves `bun.lock` untouched (12 entries at 3.19.2, one at 3.18.0 for `@questpie/observability`, which is correctly not part of the patch train), oxfmt clean, lint 0 errors.