### PR TITLE
feat(channels): signal subscription readiness after authorization and catch-up

### DIFF
--- a/.changeset/channel-subscription-readiness.md
+++ b/.changeset/channel-subscription-readiness.md
@@ -30,3 +30,8 @@ a presence read is one-shot and has no catch-up to complete.
 
 Consumer callbacks are also isolated from one another: a throwing `onReady` or
 `onError` in one subscriber no longer takes down delivery for its siblings.
+
+The channel transports are also loaded on demand now, so an application that
+never opens a channel no longer pays for them at all. Together with the change
+above the browser entry chunk drops from 180.5 KB to 115.6 KB — roughly 65 KB
+less than before this feature was added.

--- a/.changeset/channel-subscription-readiness.md
+++ b/.changeset/channel-subscription-readiness.md
@@ -1,0 +1,32 @@
+---
+"questpie": minor
+---
+
+Add `onReady` to channel subscriptions — a provider-neutral signal that the
+subscription is authorized **and** has finished replay catch-up.
+
+```ts
+client.channels.subscribe("space", { spaceId }, handler, {
+	onReady: () => {
+		// authorized, caught up; everything from here is live and complete
+	},
+});
+```
+
+Until now a subscriber had no way to tell "still replaying history" from
+"caught up and live". The only callback was `onError`, so applications either
+guessed with a timer or treated the first frame as readiness — which is wrong
+whenever replay has more than one frame to deliver.
+
+The signal fires once per transport subscription epoch and works the same way on
+SSE and Pusher. On SSE the server emits a `channel_ready` control frame after
+authorization and catch-up; the client orders it against replay and live
+delivery so a subscriber never sees a live frame before its readiness callback.
+Reconnects end the epoch and re-signal.
+
+Presence subscriptions deliberately do not expose it —
+`ChannelPresenceOptions` is `ChannelSubscribeOptions` without `onReady` — because
+a presence read is one-shot and has no catch-up to complete.
+
+Consumer callbacks are also isolated from one another: a throwing `onReady` or
+`onError` in one subscriber no longer takes down delivery for its siblings.

--- a/packages/questpie/src/client/channels/consumer-callback.ts
+++ b/packages/questpie/src/client/channels/consumer-callback.ts
@@ -1,0 +1,11 @@
+/** Keep application callbacks from interrupting channel lifecycle bookkeeping. */
+export function notifyChannelConsumer<T>(
+	callback: ((value: T) => void) | undefined,
+	value: T,
+): void {
+	try {
+		callback?.(value);
+	} catch {
+		// Consumer failures belong to the application, not the shared transport.
+	}
+}

--- a/packages/questpie/src/client/channels/index.ts
+++ b/packages/questpie/src/client/channels/index.ts
@@ -7,6 +7,7 @@ import {
 	type PusherRealtimeConfig,
 } from "../realtime/pusher-connection.js";
 import type { SseConnectionManager } from "../realtime/sse-connection.js";
+import { notifyChannelConsumer } from "./consumer-callback.js";
 import {
 	BoundedChannelQueue,
 	channelSlowConsumerError,
@@ -21,6 +22,7 @@ import {
 	type ChannelConnectionInput,
 	type ChannelPublishReceipt,
 	type ChannelsClient,
+	type ChannelPresenceOptions,
 	type ChannelSubscribeOptions,
 	type ChannelTransportMessage,
 } from "./types.js";
@@ -32,6 +34,7 @@ export type {
 	ChannelPublishInput,
 	ChannelPublishReceipt,
 	ChannelsClient,
+	ChannelPresenceOptions,
 	ChannelSubscribeOptions,
 } from "./types.js";
 
@@ -199,6 +202,7 @@ export function createChannelsAPI<
 				) => void;
 				const subscribeOptions = (hasParams ? args[2] : args[1]) as
 					| ChannelSubscribeOptions
+					| ChannelPresenceOptions
 					| undefined;
 				const marker = {};
 				const subscriptionGeneration = generation;
@@ -218,7 +222,10 @@ export function createChannelsAPI<
 					})
 					.catch((error) => {
 						pending.delete(marker);
-						subscribeOptions?.onError?.(normalizedError(error));
+						notifyChannelConsumer(
+							subscribeOptions?.onError,
+							normalizedError(error),
+						);
 					});
 				return () => {
 					stopped = true;
@@ -275,6 +282,7 @@ export function createChannelsAPI<
 						const params = (hasParams ? args[0] : {}) as Record<string, string>;
 						const iterOptions = (hasParams ? args[1] : args[0]) as
 							| ChannelSubscribeOptions
+							| ChannelPresenceOptions
 							| undefined;
 						return (
 							handle as { subscribe: (...args: unknown[]) => () => void }
@@ -293,6 +301,7 @@ export function createChannelsAPI<
 				const params = (hasParams ? args[0] : {}) as Record<string, string>;
 				const presenceOptions = (hasParams ? args[1] : args[0]) as
 					| ChannelSubscribeOptions
+					| ChannelPresenceOptions
 					| undefined;
 				return selected.presence(
 					connectionInput(registryKey, descriptor, params),
@@ -307,6 +316,7 @@ export function createChannelsAPI<
 				) => void;
 				const subscribeOptions = (hasParams ? args[2] : args[1]) as
 					| ChannelSubscribeOptions
+					| ChannelPresenceOptions
 					| undefined;
 				const marker = {};
 				const subscriptionGeneration = generation;
@@ -326,7 +336,10 @@ export function createChannelsAPI<
 					})
 					.catch((error) => {
 						pending.delete(marker);
-						subscribeOptions?.onError?.(normalizedError(error));
+						notifyChannelConsumer(
+							subscribeOptions?.onError,
+							normalizedError(error),
+						);
 					});
 				return () => {
 					stopped = true;
@@ -347,6 +360,7 @@ export function createChannelsAPI<
 						const params = (hasParams ? args[0] : {}) as Record<string, string>;
 						const iterOptions = (hasParams ? args[1] : args[0]) as
 							| ChannelSubscribeOptions
+							| ChannelPresenceOptions
 							| undefined;
 						return (
 							handle as {

--- a/packages/questpie/src/client/channels/index.ts
+++ b/packages/questpie/src/client/channels/index.ts
@@ -12,8 +12,6 @@ import {
 	BoundedChannelQueue,
 	channelSlowConsumerError,
 } from "./ordered-events.js";
-import { PusherChannelTransport } from "./pusher.js";
-import { SseChannelTransport } from "./sse.js";
 import {
 	resolveChannelClientName,
 	type ChannelClientDescriptor,
@@ -141,6 +139,7 @@ export function createChannelsAPI<
 					selected.config.provider === "pusher" &&
 					typeof selected.config.key === "string"
 				) {
+					const { PusherChannelTransport } = await import("./pusher.js");
 					return new PusherChannelTransport({
 						baseUrl: options.baseUrl,
 						fetcher: options.fetcher,
@@ -152,6 +151,7 @@ export function createChannelsAPI<
 				if (selected.transport !== "sse") {
 					throw new Error("Unsupported channel client transport");
 				}
+				const { SseChannelTransport } = await import("./sse.js");
 				return new SseChannelTransport({
 					...options,
 					connection: options.sseConnection,

--- a/packages/questpie/src/client/channels/pusher.ts
+++ b/packages/questpie/src/client/channels/pusher.ts
@@ -7,15 +7,18 @@ import {
 	type PusherModule,
 	type PusherRealtimeConfig,
 } from "../realtime/pusher-connection.js";
+import { notifyChannelConsumer } from "./consumer-callback.js";
 import {
 	BoundedChannelQueue,
 	channelGapError,
 	channelSlowConsumerError,
 	OrderedChannelCursor,
 } from "./ordered-events.js";
+import { ChannelReadiness, ChannelReadyDelivery } from "./readiness.js";
 import type {
 	ChannelClientTransport,
 	ChannelConnectionInput,
+	ChannelPresenceOptions,
 	ChannelSubscribeOptions,
 	ChannelTransportMessage,
 } from "./types.js";
@@ -35,6 +38,7 @@ type Entry = {
 	subscribers: Set<(message: ChannelTransportMessage) => void>;
 	presenceSubscribers: Set<(members: readonly unknown[]) => void>;
 	errorCallbacks: Set<(error: Error) => void>;
+	readiness: ChannelReadiness;
 	cursor: OrderedChannelCursor;
 	replaying: boolean;
 	replayGeneration: number;
@@ -96,18 +100,28 @@ export class PusherChannelTransport implements ChannelClientTransport {
 		options: ChannelSubscribeOptions = {},
 	): () => void {
 		const entry = this.ensureEntry(input);
-		entry.subscribers.add(callback);
-		if (options.onError) entry.errorCallbacks.add(options.onError);
+		const delivery = new ChannelReadyDelivery(
+			entry.readiness,
+			callback,
+			options.onReady,
+			() => this.failEntry(entry, channelSlowConsumerError()),
+		);
+		entry.subscribers.add(delivery.accept);
+		const errorCallback = options.onError
+			? (error: Error) => notifyChannelConsumer(options.onError, error)
+			: undefined;
+		if (errorCallback) entry.errorCallbacks.add(errorCallback);
 
 		let stopped = false;
 		const stop = () => {
 			if (stopped) return;
 			stopped = true;
 			options.signal?.removeEventListener("abort", stop);
+			delivery.stop();
 			const current = this.entries.get(input.resolvedName);
 			if (!current) return;
-			current.subscribers.delete(callback);
-			if (options.onError) current.errorCallbacks.delete(options.onError);
+			current.subscribers.delete(delivery.accept);
+			if (errorCallback) current.errorCallbacks.delete(errorCallback);
 			if (
 				current.subscribers.size > 0 ||
 				current.presenceSubscribers.size > 0 ||
@@ -130,19 +144,30 @@ export class PusherChannelTransport implements ChannelClientTransport {
 			throw new Error("Channel does not expose presence");
 		}
 		const entry = this.ensureEntry(input);
-		entry.presenceSubscribers.add(callback);
-		if (options.onError) entry.errorCallbacks.add(options.onError);
-		if (entry.presence) callback(entry.presence);
+		const delivery = new ChannelReadyDelivery(
+			entry.readiness,
+			callback,
+			options.onReady,
+			() => this.failEntry(entry, channelSlowConsumerError()),
+			true,
+		);
+		entry.presenceSubscribers.add(delivery.accept);
+		const errorCallback = options.onError
+			? (error: Error) => notifyChannelConsumer(options.onError, error)
+			: undefined;
+		if (errorCallback) entry.errorCallbacks.add(errorCallback);
+		if (entry.presence) delivery.accept(entry.presence);
 
 		let stopped = false;
 		const stop = () => {
 			if (stopped) return;
 			stopped = true;
 			options.signal?.removeEventListener("abort", stop);
+			delivery.stop();
 			const current = this.entries.get(input.resolvedName);
 			if (!current) return;
-			current.presenceSubscribers.delete(callback);
-			if (options.onError) current.errorCallbacks.delete(options.onError);
+			current.presenceSubscribers.delete(delivery.accept);
+			if (errorCallback) current.errorCallbacks.delete(errorCallback);
 			if (
 				current.subscribers.size > 0 ||
 				current.presenceSubscribers.size > 0 ||
@@ -158,7 +183,7 @@ export class PusherChannelTransport implements ChannelClientTransport {
 
 	async presence(
 		input: ChannelConnectionInput,
-		options: ChannelSubscribeOptions = {},
+		options: ChannelPresenceOptions = {},
 	): Promise<readonly unknown[]> {
 		if (options.signal?.aborted) {
 			throw new Error("Channel presence aborted");
@@ -166,7 +191,10 @@ export class PusherChannelTransport implements ChannelClientTransport {
 		if (input.visibility !== "presence") {
 			throw new Error("Channel does not expose presence");
 		}
-		const stop = this.subscribe(input, () => {}, options);
+		const stop = this.subscribe(input, () => {}, {
+			signal: options.signal,
+			onError: options.onError,
+		});
 		const entry = this.entries.get(input.resolvedName)!;
 		if (entry.presence) {
 			stop();
@@ -201,6 +229,7 @@ export class PusherChannelTransport implements ChannelClientTransport {
 			subscribers: new Set(),
 			presenceSubscribers: new Set(),
 			errorCallbacks: new Set(),
+			readiness: new ChannelReadiness(),
 			cursor: new OrderedChannelCursor(),
 			replaying: true,
 			replayGeneration: 0,
@@ -309,10 +338,14 @@ export class PusherChannelTransport implements ChannelClientTransport {
 				this.handleMessage(entry, payload),
 			);
 			channel.bind("pusher:subscription_error", (error) =>
-				this.notify(entry, normalizedError(error)),
+				this.failEntry(entry, normalizedError(error)),
 			);
 			channel.bind("pusher:subscription_succeeded", (members) => {
 				try {
+					if (entry.readiness.isReady) {
+						this.notify(entry, new Error("Channel subscription epoch ended"));
+					}
+					entry.readiness.end();
 					if (entry.input.visibility === "presence") {
 						this.setPresence(entry, collectMembers(members, channel));
 					}
@@ -420,6 +453,8 @@ export class PusherChannelTransport implements ChannelClientTransport {
 			) {
 				return;
 			}
+			entry.readiness.admit();
+			if (!this.isReplayCurrent(entry, generation)) return;
 			entry.replaying = false;
 			while (entry.pendingLive.length > 0) {
 				if (!this.isReplayCurrent(entry, generation)) return;
@@ -490,7 +525,11 @@ export class PusherChannelTransport implements ChannelClientTransport {
 	}
 
 	private notify(entry: Entry, error: Error): void {
-		for (const callback of entry.errorCallbacks) callback(error);
+		entry.readiness.end();
+		const errorCallbacks = Array.from(entry.errorCallbacks);
+		for (const callback of errorCallbacks) {
+			notifyChannelConsumer(callback, error);
+		}
 		const waiters = [...entry.presenceWaiters];
 		entry.presenceWaiters.clear();
 		for (const waiter of waiters) waiter.reject(error);
@@ -500,6 +539,7 @@ export class PusherChannelTransport implements ChannelClientTransport {
 		entry.replayGeneration += 1;
 		entry.replaying = false;
 		entry.pendingLive.clear();
+		entry.readiness.destroy();
 		entry.subscription?.release();
 		entry.subscription = null;
 		entry.channel = null;

--- a/packages/questpie/src/client/channels/readiness.ts
+++ b/packages/questpie/src/client/channels/readiness.ts
@@ -1,0 +1,160 @@
+import { notifyChannelConsumer } from "./consumer-callback.js";
+import { BoundedChannelQueue } from "./ordered-events.js";
+
+type ReadyRegistration = {
+	callback: () => void;
+	active: boolean;
+	notifiedEpoch: number;
+};
+
+/** Per-logical-registration readiness over one shared channel transport entry. */
+export class ChannelReadiness {
+	private readonly registrations = new Set<ReadyRegistration>();
+	private epoch = 0;
+	private admitted = false;
+
+	get isReady(): boolean {
+		return this.admitted;
+	}
+
+	register(callback: (() => void) | undefined): () => void {
+		if (!callback) return () => {};
+		const registration: ReadyRegistration = {
+			callback,
+			active: true,
+			notifiedEpoch: 0,
+		};
+		this.registrations.add(registration);
+		if (this.admitted) {
+			const epoch = this.epoch;
+			queueMicrotask(() => this.notify(registration, epoch));
+		}
+		return () => {
+			registration.active = false;
+			this.registrations.delete(registration);
+		};
+	}
+
+	admit(): void {
+		if (this.admitted) return;
+		this.admitted = true;
+		this.epoch += 1;
+		const registrations = Array.from(this.registrations);
+		for (const registration of registrations) {
+			this.notify(registration, this.epoch);
+		}
+	}
+
+	end(): void {
+		this.admitted = false;
+	}
+
+	destroy(): void {
+		this.admitted = false;
+		for (const registration of this.registrations) {
+			registration.active = false;
+		}
+		this.registrations.clear();
+	}
+
+	private notify(registration: ReadyRegistration, epoch: number): void {
+		if (
+			!registration.active ||
+			!this.admitted ||
+			this.epoch !== epoch ||
+			registration.notifiedEpoch === epoch
+		) {
+			return;
+		}
+		registration.notifiedEpoch = epoch;
+		try {
+			registration.callback();
+		} catch {
+			// Consumer readiness failures cannot tear down a shared transport entry.
+		}
+	}
+}
+
+/**
+ * Keeps a logical subscriber that joins an admitted shared entry inactive until
+ * its guarded readiness callback runs. Frames racing that microtask remain FIFO
+ * and bounded instead of crossing the subscriber's admission boundary.
+ */
+export class ChannelReadyDelivery<T> {
+	private readonly pending = new BoundedChannelQueue<T>();
+	private readonly releaseReady: () => void;
+	private awaitingReady: boolean;
+	private draining = false;
+	private active = true;
+
+	readonly accept = (value: T): void => {
+		if (!this.active) return;
+		if (this.waitForAdmission && !this.readiness.isReady) {
+			this.awaitingReady = true;
+		}
+		if (!this.pending.push(value)) {
+			this.overflow();
+			return;
+		}
+		this.drain();
+	};
+
+	constructor(
+		private readonly readiness: ChannelReadiness,
+		private readonly callback: (value: T) => void,
+		onReady: (() => void) | undefined,
+		private readonly onOverflow: () => void,
+		private readonly waitForAdmission = false,
+	) {
+		this.awaitingReady = waitForAdmission || readiness.isReady;
+		this.releaseReady = readiness.register(
+			onReady || this.awaitingReady
+				? () => {
+						try {
+							onReady?.();
+						} finally {
+							if (this.active && this.awaitingReady) {
+								this.awaitingReady = false;
+								this.drain();
+							}
+						}
+					}
+				: undefined,
+		);
+	}
+
+	private drain(): void {
+		if (!this.active || this.awaitingReady || this.draining) return;
+		if (this.waitForAdmission && !this.readiness.isReady) {
+			this.awaitingReady = true;
+			return;
+		}
+		this.draining = true;
+		try {
+			while (this.active && this.pending.length > 0) {
+				if (this.waitForAdmission && !this.readiness.isReady) {
+					this.awaitingReady = true;
+					break;
+				}
+				notifyChannelConsumer(this.callback, this.pending.shift()!);
+			}
+		} finally {
+			this.draining = false;
+		}
+	}
+
+	private overflow(): void {
+		if (!this.active) return;
+		this.active = false;
+		this.pending.clear();
+		this.releaseReady();
+		this.onOverflow();
+	}
+
+	stop(): void {
+		if (!this.active) return;
+		this.active = false;
+		this.pending.clear();
+		this.releaseReady();
+	}
+}

--- a/packages/questpie/src/client/channels/sse.ts
+++ b/packages/questpie/src/client/channels/sse.ts
@@ -2,10 +2,17 @@ import { parseCompatibleTypedEventWire } from "#questpie/shared/typed-wire.js";
 
 import type { GetAuthHeaders } from "../auth.js";
 import type { SseConnectionManager } from "../realtime/sse-connection.js";
-import { channelGapError, OrderedChannelCursor } from "./ordered-events.js";
+import { notifyChannelConsumer } from "./consumer-callback.js";
+import {
+	channelGapError,
+	channelSlowConsumerError,
+	OrderedChannelCursor,
+} from "./ordered-events.js";
+import { ChannelReadiness, ChannelReadyDelivery } from "./readiness.js";
 import type {
 	ChannelClientTransport,
 	ChannelConnectionInput,
+	ChannelPresenceOptions,
 	ChannelSubscribeOptions,
 	ChannelTransportMessage,
 } from "./types.js";
@@ -16,6 +23,7 @@ type Entry = {
 	subscribers: Set<(message: ChannelTransportMessage) => void>;
 	presenceSubscribers: Set<(members: readonly unknown[]) => void>;
 	errorCallbacks: Set<(error: Error) => void>;
+	readiness: ChannelReadiness;
 	cursor: OrderedChannelCursor;
 	presence?: readonly unknown[];
 	presenceSignature?: string;
@@ -73,18 +81,28 @@ export class SseChannelTransport implements ChannelClientTransport {
 		options: ChannelSubscribeOptions = {},
 	): () => void {
 		const entry = this.ensureEntry(input);
-		entry.subscribers.add(callback);
-		if (options.onError) entry.errorCallbacks.add(options.onError);
+		const delivery = new ChannelReadyDelivery(
+			entry.readiness,
+			callback,
+			options.onReady,
+			() => this.failEntry(entry, channelSlowConsumerError()),
+		);
+		entry.subscribers.add(delivery.accept);
+		const errorCallback = options.onError
+			? (error: Error) => notifyChannelConsumer(options.onError, error)
+			: undefined;
+		if (errorCallback) entry.errorCallbacks.add(errorCallback);
 
 		let stopped = false;
 		const stop = () => {
 			if (stopped) return;
 			stopped = true;
 			options.signal?.removeEventListener("abort", stop);
+			delivery.stop();
 			const current = this.entries.get(input.resolvedName);
 			if (!current) return;
-			current.subscribers.delete(callback);
-			if (options.onError) current.errorCallbacks.delete(options.onError);
+			current.subscribers.delete(delivery.accept);
+			if (errorCallback) current.errorCallbacks.delete(errorCallback);
 			if (
 				current.subscribers.size > 0 ||
 				current.presenceSubscribers.size > 0 ||
@@ -107,19 +125,30 @@ export class SseChannelTransport implements ChannelClientTransport {
 			throw new Error("Channel does not expose presence");
 		}
 		const entry = this.ensureEntry(input);
-		entry.presenceSubscribers.add(callback);
-		if (options.onError) entry.errorCallbacks.add(options.onError);
-		if (entry.presence) callback(entry.presence);
+		const delivery = new ChannelReadyDelivery(
+			entry.readiness,
+			callback,
+			options.onReady,
+			() => this.failEntry(entry, channelSlowConsumerError()),
+			true,
+		);
+		entry.presenceSubscribers.add(delivery.accept);
+		const errorCallback = options.onError
+			? (error: Error) => notifyChannelConsumer(options.onError, error)
+			: undefined;
+		if (errorCallback) entry.errorCallbacks.add(errorCallback);
+		if (entry.presence) delivery.accept(entry.presence);
 
 		let stopped = false;
 		const stop = () => {
 			if (stopped) return;
 			stopped = true;
 			options.signal?.removeEventListener("abort", stop);
+			delivery.stop();
 			const current = this.entries.get(input.resolvedName);
 			if (!current) return;
-			current.presenceSubscribers.delete(callback);
-			if (options.onError) current.errorCallbacks.delete(options.onError);
+			current.presenceSubscribers.delete(delivery.accept);
+			if (errorCallback) current.errorCallbacks.delete(errorCallback);
 			if (
 				current.subscribers.size > 0 ||
 				current.presenceSubscribers.size > 0 ||
@@ -135,7 +164,7 @@ export class SseChannelTransport implements ChannelClientTransport {
 
 	async presence(
 		input: ChannelConnectionInput,
-		options: ChannelSubscribeOptions = {},
+		options: ChannelPresenceOptions = {},
 	): Promise<readonly unknown[]> {
 		if (options.signal?.aborted) {
 			throw new Error("Channel presence aborted");
@@ -144,7 +173,10 @@ export class SseChannelTransport implements ChannelClientTransport {
 			throw new Error("Channel does not expose presence");
 		}
 		const noop = () => {};
-		const stop = this.subscribe(input, noop, options);
+		const stop = this.subscribe(input, noop, {
+			signal: options.signal,
+			onError: options.onError,
+		});
 		const entry = this.entries.get(input.resolvedName)!;
 		if (entry.presence) {
 			stop();
@@ -195,6 +227,7 @@ export class SseChannelTransport implements ChannelClientTransport {
 			subscribers: new Set(),
 			presenceSubscribers: new Set(),
 			errorCallbacks: new Set(),
+			readiness: new ChannelReadiness(),
 			cursor: new OrderedChannelCursor(),
 			presenceWaiters: new Set(),
 		};
@@ -222,6 +255,7 @@ export class SseChannelTransport implements ChannelClientTransport {
 					}),
 					onEvent: (event) => this.handleEvent(event),
 					onError: (error) => this.notifyEntry(entry!, error),
+					onEpochEnd: (error) => this.notifyAdmittedEntry(entry!, error),
 				});
 			} catch (error) {
 				queueMicrotask(() =>
@@ -239,7 +273,9 @@ export class SseChannelTransport implements ChannelClientTransport {
 
 	private removeEntry(name: string): void {
 		const entry = this.entries.get(name);
-		entry?.sharedRelease?.();
+		if (!entry) return;
+		entry.sharedRelease?.();
+		entry.readiness.destroy();
 		this.entries.delete(name);
 		if (this.options.connection) return;
 		if (this.entries.size === 0) {
@@ -247,6 +283,12 @@ export class SseChannelTransport implements ChannelClientTransport {
 			return;
 		}
 		this.applyTopology();
+	}
+
+	private failEntry(entry: Entry, error: Error): void {
+		if (this.entries.get(entry.input.resolvedName) !== entry) return;
+		this.notifyEntry(entry, error);
+		this.removeEntry(entry.input.resolvedName);
 	}
 
 	private scheduleConnect(delayMs: number): void {
@@ -292,11 +334,15 @@ export class SseChannelTransport implements ChannelClientTransport {
 			throw new Error("Channel SSE stream closed");
 		} catch (error) {
 			if (this.destroyed || this.entries.size === 0) return;
+			const normalized =
+				error instanceof Error ? error : new Error(String(error));
+			const admittedEntries = this.notifyAdmittedEpochs(normalized);
 			if ((error as Error).name !== "AbortError") {
-				const normalized =
-					error instanceof Error ? error : new Error(String(error));
 				if (![...this.entries.values()].some((entry) => entry.cursor.eventId)) {
-					this.notifyAll(normalized);
+					for (const entry of this.entries.values()) {
+						if (!admittedEntries.has(entry))
+							this.notifyEntry(entry, normalized);
+					}
 				}
 				const delay = Math.min(1000 * 2 ** this.retryAttempt++, 30_000);
 				this.scheduleConnect(delay * (0.5 + Math.random()));
@@ -466,6 +512,13 @@ export class SseChannelTransport implements ChannelClientTransport {
 				for (const callback of entry.subscribers) {
 					callback(message);
 				}
+			} else if (event.type === "channel_ready") {
+				const id = frame.channelSubscriptionId;
+				const entry = [...this.entries.values()].find((item) => item.id === id);
+				if (entry) {
+					this.retryAttempt = 0;
+					entry.readiness.admit();
+				}
 			} else if (event.type === "channel_presence") {
 				const entry = this.entryForFrame(frame);
 				if (!entry || !Array.isArray(frame.members)) return;
@@ -541,7 +594,11 @@ export class SseChannelTransport implements ChannelClientTransport {
 	}
 
 	private notifyEntry(entry: Entry, error: Error): void {
-		for (const callback of entry.errorCallbacks) callback(error);
+		entry.readiness.end();
+		const errorCallbacks = Array.from(entry.errorCallbacks);
+		for (const callback of errorCallbacks) {
+			notifyChannelConsumer(callback, error);
+		}
 		const waiters = [...entry.presenceWaiters];
 		entry.presenceWaiters.clear();
 		for (const waiter of waiters) waiter.reject(error);
@@ -551,6 +608,20 @@ export class SseChannelTransport implements ChannelClientTransport {
 		for (const entry of this.entries.values()) this.notifyEntry(entry, error);
 	}
 
+	private notifyAdmittedEntry(entry: Entry, error: Error): void {
+		if (!entry.readiness.isReady) return;
+		this.notifyEntry(entry, error);
+	}
+
+	private notifyAdmittedEpochs(error: Error): Set<Entry> {
+		const admitted = new Set<Entry>();
+		for (const entry of this.entries.values()) {
+			if (entry.readiness.isReady) admitted.add(entry);
+			this.notifyAdmittedEntry(entry, error);
+		}
+		return admitted;
+	}
+
 	destroy(): void {
 		if (this.destroyed) return;
 		this.destroyed = true;
@@ -558,6 +629,7 @@ export class SseChannelTransport implements ChannelClientTransport {
 		this.abortController?.abort();
 		if (this.reconnectTimer) clearTimeout(this.reconnectTimer);
 		this.notifyAll(new Error("Channel transport destroyed"));
+		for (const entry of this.entries.values()) entry.readiness.destroy();
 		this.entries.clear();
 		this.controlSession = null;
 	}

--- a/packages/questpie/src/client/channels/types.ts
+++ b/packages/questpie/src/client/channels/types.ts
@@ -40,7 +40,11 @@ export type ChannelPublishReceipt = Readonly<{ eventId: string }>;
 export type ChannelSubscribeOptions = {
 	signal?: AbortSignal;
 	onError?: (error: Error) => void;
+	/** Authorized and caught up for the current transport subscription epoch. */
+	onReady?: () => void;
 };
+
+export type ChannelPresenceOptions = Omit<ChannelSubscribeOptions, "onReady">;
 
 type SubscribeMethod<TDefinition extends AnyChannelDefinition> =
 	keyof ChannelParamsOf<TDefinition> extends never
@@ -70,11 +74,11 @@ type PresenceMethod<TDefinition extends AnyChannelDefinition> = [
 	? never
 	: keyof ChannelParamsOf<TDefinition> extends never
 		? (
-				options?: ChannelSubscribeOptions,
+				options?: ChannelPresenceOptions,
 			) => Promise<readonly ChannelPresenceOf<TDefinition>[]>
 		: (
 				params: ChannelParamsOf<TDefinition>,
-				options?: ChannelSubscribeOptions,
+				options?: ChannelPresenceOptions,
 			) => Promise<readonly ChannelPresenceOf<TDefinition>[]>;
 
 type SubscribePresenceMethod<TDefinition extends AnyChannelDefinition> = [
@@ -169,7 +173,7 @@ export interface ChannelClientTransport {
 	): () => void;
 	presence(
 		input: ChannelConnectionInput,
-		options?: ChannelSubscribeOptions,
+		options?: ChannelPresenceOptions,
 	): Promise<readonly unknown[]>;
 	subscribePresence(
 		input: ChannelConnectionInput,

--- a/packages/questpie/src/client/index.ts
+++ b/packages/questpie/src/client/index.ts
@@ -2148,6 +2148,7 @@ export type {
 	ChannelPublishInput,
 	ChannelPublishReceipt,
 	ChannelsClient,
+	ChannelPresenceOptions,
 	ChannelSubscribeOptions,
 } from "./channels/index.js";
 export * from "./crdt/index.js";

--- a/packages/questpie/src/client/realtime/sse-connection.ts
+++ b/packages/questpie/src/client/realtime/sse-connection.ts
@@ -16,6 +16,7 @@ type TopologyResource = {
 	desiredPayload(): Record<string, unknown>;
 	onEvent(event: RealtimeSseEvent): void;
 	onError(error: Error): void;
+	onEpochEnd?(error: Error): void;
 };
 
 type ControlSession = {
@@ -96,6 +97,7 @@ export class SseConnectionManager {
 		desiredPayload(): Record<string, unknown>;
 		onEvent(event: RealtimeSseEvent): void;
 		onError(error: Error): void;
+		onEpochEnd?(error: Error): void;
 	}): () => void {
 		return this.register(options.id, { kind: "channel", ...options });
 	}
@@ -325,20 +327,30 @@ export class SseConnectionManager {
 			await this.readStream(response.body);
 			throw new Error("Realtime stream closed");
 		} catch (error) {
-			if (!this.hasDemand()) return;
 			const normalized = normalizedError(error);
+			if (!this.hasDemand()) return;
 			if (normalized instanceof PermanentInitialSseError) {
 				this.rejectSessionWaiters(normalized);
 				this.notifyAll(normalized);
 				this.reconnectPending = false;
 				return;
 			}
-			if (normalized.name === "AbortError" && !this.watchdogTriggered) return;
+			if (normalized.name === "AbortError" && !this.watchdogTriggered) {
+				if (this.reconnectPending) {
+					for (const resource of this.resources.values()) {
+						resource.onEpochEnd?.(normalized);
+					}
+				}
+				return;
+			}
 			if (
 				!this.watchdogTriggered &&
 				normalized.message !== "Realtime stream closed"
 			) {
 				this.notifyAll(normalized);
+			}
+			for (const resource of this.resources.values()) {
+				resource.onEpochEnd?.(normalized);
 			}
 			const retryBaseMs = this.options.retryBaseMs ?? 1000;
 			const maxRetryMs = this.options.maxRetryMs ?? 30_000;

--- a/packages/questpie/src/server/adapters/routes/realtime.ts
+++ b/packages/questpie/src/server/adapters/routes/realtime.ts
@@ -1988,6 +1988,13 @@ export async function realtimeSubscribe(
 									}
 								: {}),
 							sink: subscriptionSink,
+							onReady: async () => {
+								await subscriptionSink.writeControl(
+									encodeSseEvent("channel_ready", {
+										channelSubscriptionId: channel.id,
+									}),
+								);
+							},
 							lastEventId: channel.lastEventId,
 							encodeFrame: (frame) => transport!.encodeChannelFrame(frame),
 							...(channel.presence

--- a/packages/questpie/src/server/modules/core/integrated/realtime/channel-event-ledger.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/channel-event-ledger.ts
@@ -140,6 +140,8 @@ export type LocalChannelSubscriptionInput = {
 	close?: (reason: "access_revoked") => Promise<void>;
 	/** @internal Runs exactly once for caller release or an internal close. */
 	onRelease?: () => Promise<void>;
+	/** Called after authorization and initial replay/catch-up complete. */
+	onReady?: () => void | Promise<void>;
 	lastEventId?: string | null;
 	encodeFrame?: (
 		frame: OrderedChannelEventFrame | ChannelGapFrame,
@@ -166,6 +168,8 @@ type LocalSubscription = {
 	reauthorize?: () => Promise<LocalChannelAuthorization>;
 	close?: LocalChannelSubscriptionInput["close"];
 	onRelease?: LocalChannelSubscriptionInput["onRelease"];
+	onReady?: LocalChannelSubscriptionInput["onReady"];
+	readySignaled: boolean;
 	encodeFrame?: LocalChannelSubscriptionInput["encodeFrame"];
 	active: boolean;
 	lifecycle?: LocalChannelBindingLifecycle;
@@ -463,6 +467,8 @@ export class ChannelEventLedger {
 			reauthorize: input.reauthorize,
 			close: input.close,
 			onRelease: input.onRelease,
+			onReady: input.onReady,
+			readySignaled: false,
 			encodeFrame: input.encodeFrame,
 			active: false,
 		};
@@ -556,7 +562,12 @@ export class ChannelEventLedger {
 			throw error;
 		}
 		if (subscription.closed) return async () => {};
-		await this.drainLocalSubscription(subscription);
+		try {
+			await this.drainLocalSubscription(subscription);
+		} catch (error) {
+			await this.releaseLocalSubscription(subscription);
+			throw error;
+		}
 
 		return () => this.releaseLocalSubscription(subscription);
 	}
@@ -923,13 +934,17 @@ export class ChannelEventLedger {
 		}
 		const operation = this.runLocalDrain(subscription);
 		subscription.drainPromise = operation;
+		let drainAgain = false;
 		try {
 			await operation;
 		} finally {
 			if (subscription.drainPromise === operation) {
 				subscription.drainPromise = null;
+				drainAgain = subscription.drainPending && !subscription.closed;
+				subscription.drainPending = false;
 			}
 		}
+		if (drainAgain) await this.drainLocalSubscription(subscription);
 	}
 
 	private async runLocalDrain(subscription: LocalSubscription): Promise<void> {
@@ -960,6 +975,21 @@ export class ChannelEventLedger {
 		} catch (error) {
 			this.logger?.error("[Realtime] Ordered channel delivery failed", error);
 			await this.closeLocalSubscription(subscription, "write_failed");
+			return;
+		}
+		if (
+			!subscription.closed &&
+			!subscription.readySignaled &&
+			subscription.pending.length === 0 &&
+			subscription.cursor === subscription.readSeq
+		) {
+			subscription.readySignaled = true;
+			try {
+				await subscription.onReady?.();
+			} catch (error) {
+				await this.closeLocalSubscription(subscription, "write_failed");
+				throw error;
+			}
 		}
 	}
 
@@ -1051,7 +1081,12 @@ export class ChannelEventLedger {
 		if (subscription.retryTimer || subscription.closed) return;
 		subscription.retryTimer = setTimeout(() => {
 			subscription.retryTimer = null;
-			void this.drainLocalSubscription(subscription);
+			void this.drainLocalSubscription(subscription).catch((error) => {
+				this.logger?.error(
+					"[Realtime] Channel readiness delivery failed",
+					error,
+				);
+			});
 		}, this.config.busyRetryMs);
 	}
 

--- a/packages/questpie/src/server/modules/core/integrated/realtime/edge-session.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/edge-session.ts
@@ -70,9 +70,11 @@ export class RealtimeBindingOutputGate implements ClientSink {
 	private state: "pending" | "active" | "closed" = "pending";
 	private latest: Uint8Array | null = null;
 	private ordered: PendingOutput[] = [];
+	private bufferedOrderedEvents = 0;
 	private bufferedBytes = 0;
 	private operation: Promise<void> = Promise.resolve();
 	private failure: unknown;
+	private controlWritten = false;
 
 	constructor(
 		private readonly sink: ClientSink,
@@ -118,6 +120,35 @@ export class RealtimeBindingOutputGate implements ClientSink {
 		}
 	}
 
+	/** Queue one routing-only control frame without consuming application quotas. */
+	writeControl(frame: Uint8Array): Promise<SinkWriteResult> {
+		if (this.controlWritten) {
+			return Promise.reject(
+				new Error("Realtime binding control frame duplicated"),
+			);
+		}
+		if (frame.byteLength > 1024) {
+			return Promise.reject(
+				new Error("Realtime binding control frame too large"),
+			);
+		}
+		this.controlWritten = true;
+		if (this.state === "closed") {
+			return Promise.resolve({ status: "accepted", bufferedBytes: null });
+		}
+		if (this.state === "active") {
+			return this.run(() => this.sink.write(frame, "ordered-channel-event"));
+		}
+		this.ordered.push({
+			frame,
+			delivery: "ordered-channel-event",
+		});
+		return Promise.resolve({
+			status: "accepted",
+			bufferedBytes: this.bufferedBytes,
+		});
+	}
+
 	close(reason: ClientCloseReason): Promise<void> {
 		if (this.state === "pending") {
 			const error = new Error(
@@ -139,6 +170,7 @@ export class RealtimeBindingOutputGate implements ClientSink {
 		const ordered = this.ordered;
 		this.latest = null;
 		this.ordered = [];
+		this.bufferedOrderedEvents = 0;
 		this.bufferedBytes = 0;
 		void this.run(async () => {
 			if (latest) await this.sink.write(latest, "latest-snapshot");
@@ -153,6 +185,7 @@ export class RealtimeBindingOutputGate implements ClientSink {
 		this.state = "closed";
 		this.latest = null;
 		this.ordered = [];
+		this.bufferedOrderedEvents = 0;
 		this.bufferedBytes = 0;
 		await this.operation.catch(() => {});
 	}
@@ -163,10 +196,11 @@ export class RealtimeBindingOutputGate implements ClientSink {
 			this.latest = frame;
 			this.bufferedBytes += frame.byteLength;
 		} else {
-			if (this.ordered.length >= this.options.maximumOrderedEvents) {
+			if (this.bufferedOrderedEvents >= this.options.maximumOrderedEvents) {
 				throw new Error("Staged realtime binding event buffer overflow");
 			}
 			this.ordered.push({ frame, delivery });
+			this.bufferedOrderedEvents += 1;
 			this.bufferedBytes += frame.byteLength;
 		}
 		if (this.bufferedBytes > this.options.maximumBufferedBytes) {

--- a/packages/questpie/test/client/client-channels.test.ts
+++ b/packages/questpie/test/client/client-channels.test.ts
@@ -71,6 +71,12 @@ class FakePusher {
 
 mock.module("pusher-js", () => ({ default: FakePusher }));
 
+import { PusherChannelTransport } from "../../src/client/channels/pusher.js";
+import {
+	ChannelReadiness,
+	ChannelReadyDelivery,
+} from "../../src/client/channels/readiness.js";
+import { SseChannelTransport } from "../../src/client/channels/sse.js";
 import { createClient } from "../../src/client/index.js";
 import {
 	parseTypedWire,
@@ -91,6 +97,66 @@ async function waitFor(
 }
 
 describe("channels client", () => {
+	test("isolates throwing bootstrap error callbacks for message and presence subscriptions", async () => {
+		const unhandled: unknown[] = [];
+		const onUnhandled = (reason: unknown) => unhandled.push(reason);
+		process.on("unhandledRejection", onUnhandled);
+		try {
+			const clients = Array.from({ length: 2 }, () =>
+				createClient<any>({
+					baseURL: "http://localhost:3000",
+					fetch: async () => new Response(null, { status: 500 }),
+				}),
+			);
+			let errorCalls = 0;
+			const throwFromConsumer = () => {
+				errorCalls += 1;
+				throw new Error("consumer bootstrap error callback failed");
+			};
+			clients[0]!.channels.news.subscribe(() => {}, {
+				onError: throwFromConsumer,
+			});
+			clients[1]!.channels.room.subscribePresence({ roomId: "one" }, () => {}, {
+				onError: throwFromConsumer,
+			});
+
+			await waitFor(() => errorCalls === 2);
+			await new Promise((resolve) => setTimeout(resolve, 0));
+			expect(unhandled).toEqual([]);
+			for (const client of clients) client.channels.destroy();
+		} finally {
+			process.off("unhandledRejection", onUnhandled);
+		}
+	});
+
+	test("keeps a ready FIFO ordered through a throwing re-entrant consumer", async () => {
+		const readiness = new ChannelReadiness();
+		readiness.admit();
+		const seen: number[] = [];
+		let delivery!: ChannelReadyDelivery<number>;
+		delivery = new ChannelReadyDelivery(
+			readiness,
+			(value: number) => {
+				seen.push(value);
+				if (value === 1) {
+					delivery.accept(3);
+					throw new Error("consumer message callback failed");
+				}
+			},
+			undefined,
+			() => {
+				throw new Error("unexpected overflow");
+			},
+		);
+
+		delivery.accept(1);
+		delivery.accept(2);
+		await Promise.resolve();
+
+		expect(seen).toEqual([1, 2, 3]);
+		delivery.stop();
+	});
+
 	test("keeps explicit plain JSON channel publishing interoperable", async () => {
 		const instant = new Date("2026-03-29T00:30:00.000Z");
 		let publishRequest: RequestInit | undefined;
@@ -224,6 +290,11 @@ describe("channels client", () => {
 				`event: channel_presence\ndata: ${JSON.stringify({ type: "channel_presence", channel: "presence-room-one", members: [{ id: "member-1" }] })}\n\n`,
 			),
 		);
+		streamController!.enqueue(
+			encoder.encode(
+				`event: channel_ready\ndata: ${JSON.stringify({ channelSubscriptionId: "channel:presence-room-one" })}\n\n`,
+			),
+		);
 		await waitFor(() => rosters.length === 1);
 		expect(rosters).toEqual([[{ id: "member-1" }]]);
 		streamController!.enqueue(
@@ -303,6 +374,1037 @@ describe("channels client", () => {
 				return Boolean(JSON.parse(String(init?.body)).sessionId);
 			}).length,
 		).toBe(controlCount);
+		client.channels.destroy();
+	});
+
+	test("orders SSE replay then readiness then live delivery for every logical subscriber", async () => {
+		const streamControllers: ReadableStreamDefaultController<Uint8Array>[] = [];
+		const encoder = new TextEncoder();
+		const fetcher: typeof fetch = async (input) => {
+			const url = String(input);
+			if (url.endsWith("/channels/config")) {
+				return Response.json({
+					transport: "sse",
+					channels: {
+						news: { pattern: "news", visibility: "public" },
+					},
+				});
+			}
+			if (url.endsWith("/realtime")) {
+				return new Response(
+					new ReadableStream<Uint8Array>({
+						start(controller) {
+							streamControllers.push(controller);
+							controller.enqueue(
+								encoder.encode(
+									`event: session\ndata: ${JSON.stringify({ sessionId: `ready-s${streamControllers.length}`, token: `ready-t${streamControllers.length}`, control: { protocol: "questpie-realtime-topology", versions: [2] } })}\n\n`,
+								),
+							);
+						},
+					}),
+					{ headers: { "Content-Type": "text/event-stream" } },
+				);
+			}
+			throw new Error(`Unexpected request: ${url}`);
+		};
+		const client = createClient<any>({
+			baseURL: "http://localhost:3000",
+			fetch: fetcher,
+		});
+		const order: string[] = [];
+		const sharedReady = () => order.push("ready");
+		let stoppedBeforeReady = 0;
+		const stopBeforeReady = client.channels.news.subscribe(() => {}, {
+			onReady: () => {
+				stoppedBeforeReady += 1;
+			},
+		});
+		stopBeforeReady();
+		const stopFirst = client.channels.news.subscribe(
+			(message: { eventId: string }) => order.push(`first:${message.eventId}`),
+			{
+				onReady: sharedReady,
+				onError: (error: Error) => order.push(`error:${error.message}`),
+			},
+		);
+		const stopSecond = client.channels.news.subscribe(
+			(message: { eventId: string }) => order.push(`second:${message.eventId}`),
+			{ onReady: sharedReady },
+		);
+
+		await waitFor(() => streamControllers.length === 1);
+		const hash = "9".repeat(64);
+		streamControllers[0]!.enqueue(
+			encoder.encode(
+				`event: channel_event\ndata: ${stringifyCompatibleTypedEventWire({ channel: "news", event: "updated", eventId: `${hash}:1`, data: { phase: "replay" } })}\n\n`,
+			),
+		);
+		streamControllers[0]!.enqueue(
+			encoder.encode(
+				`event: channel_ready\ndata: ${JSON.stringify({ channelSubscriptionId: "channel:news" })}\n\n`,
+			),
+		);
+		streamControllers[0]!.enqueue(
+			encoder.encode(
+				`event: channel_event\ndata: ${stringifyCompatibleTypedEventWire({ channel: "news", event: "updated", eventId: `${hash}:2`, data: { phase: "live" } })}\n\n`,
+			),
+		);
+
+		await waitFor(
+			() => order.filter((item) => item.includes(":2")).length === 2,
+		);
+		expect(order).toEqual([
+			`first:${hash}:1`,
+			`second:${hash}:1`,
+			"ready",
+			"ready",
+			`first:${hash}:2`,
+			`second:${hash}:2`,
+		]);
+		expect(stoppedBeforeReady).toBe(0);
+
+		let stoppedLateReady = 0;
+		const stopLate = client.channels.news.subscribe(() => {}, {
+			onReady: () => {
+				stoppedLateReady += 1;
+			},
+		});
+		stopLate();
+		await Promise.resolve();
+		expect(stoppedLateReady).toBe(0);
+
+		let activeLateReady = 0;
+		const stopActiveLate = client.channels.news.subscribe(() => {}, {
+			onReady: () => {
+				activeLateReady += 1;
+			},
+		});
+		await waitFor(() => activeLateReady === 1);
+		expect(activeLateReady).toBe(1);
+
+		streamControllers[0]!.close();
+		await waitFor(() => streamControllers.length === 2);
+		streamControllers[1]!.enqueue(
+			encoder.encode(
+				`event: channel_ready\ndata: ${JSON.stringify({ channelSubscriptionId: "channel:news" })}\n\n`,
+			),
+		);
+		await waitFor(() => order.filter((item) => item === "ready").length === 4);
+		expect(order.slice(-3)).toEqual([
+			"error:Realtime stream closed",
+			"ready",
+			"ready",
+		]);
+
+		stopActiveLate();
+		stopSecond();
+		stopFirst();
+		client.channels.destroy();
+	});
+
+	test("does not admit an SSE channel whose server rejects the subscription", async () => {
+		let streamController:
+			| ReadableStreamDefaultController<Uint8Array>
+			| undefined;
+		const encoder = new TextEncoder();
+		const client = createClient<any>({
+			baseURL: "http://localhost:3000",
+			fetch: async (input) => {
+				const url = String(input);
+				if (url.endsWith("/channels/config")) {
+					return Response.json({
+						transport: "sse",
+						channels: {
+							news: { pattern: "news", visibility: "public" },
+						},
+					});
+				}
+				if (url.endsWith("/realtime")) {
+					return new Response(
+						new ReadableStream<Uint8Array>({
+							start(controller) {
+								streamController = controller;
+								controller.enqueue(
+									encoder.encode(
+										`event: session\ndata: ${JSON.stringify({ sessionId: "denied-s1", token: "denied-t1", control: { protocol: "questpie-realtime-topology", versions: [2] } })}\n\n`,
+									),
+								);
+							},
+						}),
+						{ headers: { "Content-Type": "text/event-stream" } },
+					);
+				}
+				throw new Error(`Unexpected request: ${url}`);
+			},
+		});
+		let ready = 0;
+		const errors: string[] = [];
+		client.channels.news.subscribe(() => {}, {
+			onReady: () => {
+				ready += 1;
+			},
+			onError: (error: Error) => errors.push(error.message),
+		});
+
+		await waitFor(() => !!streamController);
+		streamController!.enqueue(
+			encoder.encode(
+				`event: error\ndata: ${JSON.stringify({ channelSubscriptionId: "channel:news", message: "Channel subscription is denied" })}\n\n`,
+			),
+		);
+		await waitFor(() => errors.length === 1);
+		expect(errors).toEqual(["Channel subscription is denied"]);
+		expect(ready).toBe(0);
+		client.channels.destroy();
+	});
+
+	test("ends an admitted sibling epoch before reconnecting after a targeted SSE topology rejection", async () => {
+		const streamControllers: ReadableStreamDefaultController<Uint8Array>[] = [];
+		const encoder = new TextEncoder();
+		let rejectRoom = true;
+		const fetcher: typeof fetch = async (input, init) => {
+			const url = String(input);
+			if (url.endsWith("/channels/config")) {
+				return Response.json({
+					transport: "sse",
+					channels: {
+						news: { pattern: "news", visibility: "public" },
+						room: { pattern: "room-[roomId]", visibility: "public" },
+					},
+				});
+			}
+			if (url.endsWith("/realtime")) {
+				const payload = JSON.parse(String(init?.body));
+				if (payload.topology) {
+					if (
+						rejectRoom &&
+						payload.topology.subscriptions.some(
+							(entry: { id: string }) => entry.id === "channel:room-one",
+						)
+					) {
+						rejectRoom = false;
+						return Response.json(
+							{
+								error: {
+									entries: [
+										{
+											id: "channel:room-one",
+											kind: "channel",
+											code: "REALTIME_SUBSCRIPTION_REJECTED",
+											message: "Room subscription is denied",
+										},
+									],
+								},
+							},
+							{ status: 400 },
+						);
+					}
+					return new Response(null, { status: 202 });
+				}
+				const sequence = streamControllers.length + 1;
+				return new Response(
+					new ReadableStream<Uint8Array>({
+						start(controller) {
+							streamControllers.push(controller);
+							controller.enqueue(
+								encoder.encode(
+									`event: session\ndata: ${JSON.stringify({ sessionId: `topology-s${sequence}`, token: `topology-t${sequence}`, control: { protocol: "questpie-realtime-topology", versions: [2] } })}\n\n`,
+								),
+							);
+							init?.signal?.addEventListener(
+								"abort",
+								() =>
+									controller.error(new DOMException("Aborted", "AbortError")),
+								{ once: true },
+							);
+						},
+					}),
+					{ headers: { "Content-Type": "text/event-stream" } },
+				);
+			}
+			throw new Error(`Unexpected request: ${url}`);
+		};
+		const client = createClient<any>({
+			baseURL: "http://localhost:3000",
+			fetch: fetcher,
+		});
+		const newsLifecycle: string[] = [];
+		const newsMessages: string[] = [];
+		const roomErrors: string[] = [];
+		let roomReady = 0;
+		const stopNews = client.channels.news.subscribe(
+			(message: { eventId: string }) => newsMessages.push(message.eventId),
+			{
+				onReady: () => newsLifecycle.push("ready"),
+				onError: (error: Error) => newsLifecycle.push(`error:${error.message}`),
+			},
+		);
+
+		await waitFor(() => streamControllers.length === 1);
+		streamControllers[0]!.enqueue(
+			encoder.encode(
+				`event: channel_ready\ndata: ${JSON.stringify({ channelSubscriptionId: "channel:news" })}\n\n`,
+			),
+		);
+		await waitFor(() => newsLifecycle.length === 1);
+		const stopRoom = client.channels.room.subscribe(
+			{ roomId: "one" },
+			() => {},
+			{
+				onReady: () => {
+					roomReady += 1;
+				},
+				onError: (error: Error) => roomErrors.push(error.message),
+			},
+		);
+
+		await waitFor(() => streamControllers.length === 2);
+		expect(roomErrors).toEqual(["Room subscription is denied"]);
+		expect(roomReady).toBe(0);
+		streamControllers[1]!.enqueue(
+			encoder.encode(
+				`event: channel_ready\ndata: ${JSON.stringify({ channelSubscriptionId: "channel:news" })}\n\n`,
+			),
+		);
+		const hash = "6".repeat(64);
+		streamControllers[1]!.enqueue(
+			encoder.encode(
+				`event: channel_event\ndata: ${stringifyCompatibleTypedEventWire({ channel: "news", event: "updated", eventId: `${hash}:1`, data: {} })}\n\n`,
+			),
+		);
+
+		await waitFor(() => newsMessages.length === 1);
+		expect(newsLifecycle).toEqual(["ready", "error:Aborted", "ready"]);
+		expect(newsMessages).toEqual([`${hash}:1`]);
+		stopRoom();
+		stopNews();
+		client.channels.destroy();
+	});
+
+	test("orders a re-entrant late SSE subscriber readiness before its first buffered live frame", async () => {
+		let streamController:
+			| ReadableStreamDefaultController<Uint8Array>
+			| undefined;
+		const encoder = new TextEncoder();
+		const transport = new SseChannelTransport({
+			baseUrl: "http://localhost:3000",
+			withCredentials: false,
+			fetcher: async (input) => {
+				const url = String(input);
+				if (url.endsWith("/realtime")) {
+					return new Response(
+						new ReadableStream<Uint8Array>({
+							start(controller) {
+								streamController = controller;
+								controller.enqueue(
+									encoder.encode(
+										`event: session\ndata: ${JSON.stringify({ sessionId: "late-s1", token: "late-t1", control: { protocol: "questpie-realtime-topology", versions: [2] } })}\n\n`,
+									),
+								);
+							},
+						}),
+						{ headers: { "Content-Type": "text/event-stream" } },
+					);
+				}
+				throw new Error(`Unexpected request: ${url}`);
+			},
+		});
+		const input = {
+			registryKey: "news",
+			params: {},
+			resolvedName: "news",
+			visibility: "public" as const,
+		};
+		const lifecycle: string[] = [];
+		let stopLate: (() => void) | undefined;
+		const stopFirst = transport.subscribe(
+			input,
+			(message: { eventId: string }) => {
+				lifecycle.push(`first:${message.eventId}`);
+				stopLate ??= transport.subscribe(
+					input,
+					(late: { eventId: string }) => lifecycle.push(`late:${late.eventId}`),
+					{
+						onReady: () => {
+							lifecycle.push("late:ready");
+							throw new Error("consumer readiness failure");
+						},
+					},
+				);
+			},
+			{ onReady: () => lifecycle.push("first:ready") },
+		);
+
+		await waitFor(() => !!streamController);
+		streamController!.enqueue(
+			encoder.encode(
+				`event: channel_ready\ndata: ${JSON.stringify({ channelSubscriptionId: "channel:news" })}\n\n`,
+			),
+		);
+		await waitFor(() => lifecycle.length === 1);
+		const hash = "5".repeat(64);
+		streamController!.enqueue(
+			encoder.encode(
+				`event: channel_event\ndata: ${stringifyCompatibleTypedEventWire({ channel: "news", event: "updated", eventId: `${hash}:1`, data: {} })}\n\n`,
+			),
+		);
+
+		await waitFor(() => lifecycle.includes("late:ready"));
+		await Promise.resolve();
+		expect(lifecycle).toEqual([
+			"first:ready",
+			`first:${hash}:1`,
+			"late:ready",
+			`late:${hash}:1`,
+		]);
+		stopLate?.();
+		stopFirst();
+		transport.destroy();
+	});
+
+	test("orders SSE presence readiness before initial and late cached roster delivery", async () => {
+		let resource:
+			| {
+					onEvent(event: { type: string; data: string }): void;
+					onEpochEnd?(error: Error): void;
+			  }
+			| undefined;
+		const connection = {
+			registerChannel(options: typeof resource): () => void {
+				resource = options;
+				return () => {};
+			},
+		};
+		const transport = new SseChannelTransport({
+			baseUrl: "http://localhost:3000",
+			withCredentials: false,
+			fetcher: async () => {
+				throw new Error("The shared connection owns SSE fetching");
+			},
+			connection: connection as any,
+		});
+		const input = {
+			registryKey: "room",
+			params: { roomId: "one" },
+			resolvedName: "presence-room-one",
+			visibility: "presence" as const,
+		};
+		const order: string[] = [];
+		const stopInitial = transport.subscribePresence(
+			input,
+			() => order.push("initial:members"),
+			{ onReady: () => order.push("initial:ready") },
+		);
+
+		resource!.onEvent({
+			type: "channel_presence",
+			data: JSON.stringify({
+				channel: "presence-room-one",
+				members: [{ id: "member-1" }],
+			}),
+		});
+		resource!.onEvent({
+			type: "channel_ready",
+			data: JSON.stringify({
+				channelSubscriptionId: "channel:presence-room-one",
+			}),
+		});
+		expect(order).toEqual(["initial:ready", "initial:members"]);
+
+		const stopLate = transport.subscribePresence(
+			input,
+			() => order.push("late:members"),
+			{ onReady: () => order.push("late:ready") },
+		);
+		await Promise.resolve();
+		expect(order.slice(-2)).toEqual(["late:ready", "late:members"]);
+
+		resource!.onEpochEnd?.(new Error("presence epoch ended"));
+		resource!.onEvent({
+			type: "channel_presence",
+			data: JSON.stringify({
+				channel: "presence-room-one",
+				members: [{ id: "member-2" }],
+			}),
+		});
+		expect(order.slice(-2)).toEqual(["late:ready", "late:members"]);
+		resource!.onEvent({
+			type: "channel_ready",
+			data: JSON.stringify({
+				channelSubscriptionId: "channel:presence-room-one",
+			}),
+		});
+		expect(order.slice(-4)).toEqual([
+			"initial:ready",
+			"initial:members",
+			"late:ready",
+			"late:members",
+		]);
+
+		stopLate();
+		stopInitial();
+		transport.destroy();
+	});
+
+	test("orders Pusher presence readiness before initial and late cached roster delivery", async () => {
+		FakePusher.instances = [];
+		const transport = new PusherChannelTransport({
+			baseUrl: "http://localhost:3000",
+			fetcher: async (input) => {
+				if (String(input).endsWith("/channels/auth")) {
+					return Response.json({ auth: "signed", channel_data: "{}" });
+				}
+				throw new Error(`Unexpected request: ${String(input)}`);
+			},
+			config: { provider: "pusher", key: "public-key" },
+		});
+		const input = {
+			registryKey: "room",
+			params: { roomId: "one" },
+			resolvedName: "presence-room-one",
+			visibility: "presence" as const,
+		};
+		const order: string[] = [];
+		const stopInitial = transport.subscribePresence(
+			input,
+			() => order.push("initial:members"),
+			{ onReady: () => order.push("initial:ready") },
+		);
+
+		await waitFor(() => FakePusher.instances.length === 1);
+		const provider = FakePusher.instances[0]!;
+		provider.channel.memberInfos = [{ id: "member-1" }];
+		provider.channel.emit(
+			"pusher:subscription_succeeded",
+			provider.channel.members,
+		);
+		await waitFor(() => order.length === 2);
+		expect(order).toEqual(["initial:ready", "initial:members"]);
+
+		const stopLate = transport.subscribePresence(
+			input,
+			() => order.push("late:members"),
+			{ onReady: () => order.push("late:ready") },
+		);
+		await Promise.resolve();
+		expect(order.slice(-2)).toEqual(["late:ready", "late:members"]);
+
+		provider.channel.memberInfos = [{ id: "member-2" }];
+		provider.channel.emit(
+			"pusher:subscription_succeeded",
+			provider.channel.members,
+		);
+		expect(order.slice(-4)).toEqual([
+			"initial:ready",
+			"initial:members",
+			"late:ready",
+			"late:members",
+		]);
+
+		stopLate();
+		stopInitial();
+		transport.destroy();
+	});
+
+	test("orders late SSE presence iterator readiness before its cached roster", async () => {
+		let streamController:
+			| ReadableStreamDefaultController<Uint8Array>
+			| undefined;
+		const encoder = new TextEncoder();
+		const client = createClient<any>({
+			baseURL: "http://localhost:3000",
+			fetch: async (input) => {
+				const url = String(input);
+				if (url.endsWith("/channels/config")) {
+					return Response.json({
+						transport: "sse",
+						channels: {
+							room: {
+								pattern: "room-[roomId]",
+								visibility: "presence",
+							},
+						},
+					});
+				}
+				if (url.endsWith("/realtime")) {
+					return new Response(
+						new ReadableStream<Uint8Array>({
+							start(controller) {
+								streamController = controller;
+								controller.enqueue(
+									encoder.encode(
+										`event: session\ndata: ${JSON.stringify({ sessionId: "presence-iter-s1", token: "presence-iter-t1", control: { protocol: "questpie-realtime-topology", versions: [2] } })}\n\n`,
+									),
+								);
+							},
+						}),
+						{ headers: { "Content-Type": "text/event-stream" } },
+					);
+				}
+				throw new Error(`Unexpected request: ${url}`);
+			},
+		});
+		const rosters: unknown[] = [];
+		const stop = client.channels.room.subscribePresence(
+			{ roomId: "one" },
+			(members: unknown) => rosters.push(members),
+		);
+		await waitFor(() => !!streamController);
+		streamController!.enqueue(
+			encoder.encode(
+				`event: channel_presence\ndata: ${JSON.stringify({ channel: "presence-room-one", members: [{ id: "member-1" }] })}\n\n`,
+			),
+		);
+		streamController!.enqueue(
+			encoder.encode(
+				`event: channel_ready\ndata: ${JSON.stringify({ channelSubscriptionId: "channel:presence-room-one" })}\n\n`,
+			),
+		);
+		await waitFor(() => rosters.length === 1);
+
+		const order: string[] = [];
+		const iterator = client.channels.room.presenceIter(
+			{ roomId: "one" },
+			{ onReady: () => order.push("ready") },
+		);
+		const result = await iterator.next().then((value: unknown) => {
+			order.push("members");
+			return value;
+		});
+		expect(order).toEqual(["ready", "members"]);
+		expect(result).toMatchObject({ value: [{ id: "member-1" }] });
+		await iterator.return();
+		stop();
+		client.channels.destroy();
+	});
+
+	test("orders late Pusher presence iterator readiness before its cached roster", async () => {
+		FakePusher.instances = [];
+		const client = createClient<any>({
+			baseURL: "http://localhost:3000",
+			fetch: async (input) => {
+				const url = String(input);
+				if (url.endsWith("/channels/config")) {
+					return Response.json({
+						transport: "shared-provider",
+						config: { provider: "pusher", key: "public-key" },
+						channels: {
+							room: {
+								pattern: "room-[roomId]",
+								visibility: "presence",
+							},
+						},
+					});
+				}
+				if (url.endsWith("/channels/auth")) {
+					return Response.json({ auth: "signed", channel_data: "{}" });
+				}
+				throw new Error(`Unexpected request: ${url}`);
+			},
+		});
+		const rosters: unknown[] = [];
+		const stop = client.channels.room.subscribePresence(
+			{ roomId: "one" },
+			(members: unknown) => rosters.push(members),
+		);
+		await waitFor(() => FakePusher.instances.length === 1);
+		const provider = FakePusher.instances[0]!;
+		provider.channel.memberInfos = [{ id: "member-1" }];
+		provider.channel.emit(
+			"pusher:subscription_succeeded",
+			provider.channel.members,
+		);
+		await waitFor(() => rosters.length === 1);
+
+		const order: string[] = [];
+		const iterator = client.channels.room.presenceIter(
+			{ roomId: "one" },
+			{ onReady: () => order.push("ready") },
+		);
+		const result = await iterator.next().then((value: unknown) => {
+			order.push("members");
+			return value;
+		});
+		expect(order).toEqual(["ready", "members"]);
+		expect(result).toMatchObject({ value: [{ id: "member-1" }] });
+		await iterator.return();
+		stop();
+		client.channels.destroy();
+	});
+
+	test("isolates throwing SSE error listeners and still tears down", () => {
+		const transport = new SseChannelTransport({
+			baseUrl: "http://localhost:3000",
+			withCredentials: false,
+			fetcher: async () =>
+				new Response(new ReadableStream<Uint8Array>(), {
+					headers: { "Content-Type": "text/event-stream" },
+				}),
+		});
+		const input = {
+			registryKey: "news",
+			params: {},
+			resolvedName: "news",
+			visibility: "public" as const,
+		};
+		const siblingErrors: string[] = [];
+		transport.subscribe(input, () => {}, {
+			onError: () => {
+				throw new Error("consumer error callback failed");
+			},
+		});
+		transport.subscribe(input, () => {}, {
+			onError: (error) => siblingErrors.push(error.message),
+		});
+
+		expect(() => transport.destroy()).not.toThrow();
+		expect(siblingErrors).toEqual(["Channel transport destroyed"]);
+		expect(transport.channelCount).toBe(0);
+	});
+
+	test("isolates throwing Pusher error listeners and still unmounts", async () => {
+		FakePusher.instances = [];
+		const transport = new PusherChannelTransport({
+			baseUrl: "http://localhost:3000",
+			fetcher: async () => {
+				throw new Error("Unexpected request");
+			},
+			config: { provider: "pusher", key: "public-key" },
+		});
+		const input = {
+			registryKey: "news",
+			params: {},
+			resolvedName: "news",
+			visibility: "public" as const,
+		};
+		const siblingErrors: string[] = [];
+		transport.subscribe(input, () => {}, {
+			onError: () => {
+				throw new Error("consumer error callback failed");
+			},
+		});
+		transport.subscribe(input, () => {}, {
+			onError: (error) => siblingErrors.push(error.message),
+		});
+
+		await waitFor(() => FakePusher.instances.length === 1);
+		expect(() =>
+			FakePusher.instances[0]!.channel.emit(
+				"pusher:subscription_error",
+				new Error("Provider rejected subscription"),
+			),
+		).not.toThrow();
+		expect(siblingErrors).toEqual(["Provider rejected subscription"]);
+		expect(transport.channelCount).toBe(0);
+		transport.destroy();
+	});
+
+	test("keeps duplicate SSE error callbacks registered independently", () => {
+		let resource:
+			| {
+					onEvent(event: { type: string; data: string }): void;
+					onEpochEnd?(error: Error): void;
+			  }
+			| undefined;
+		const connection = {
+			registerChannel(options: typeof resource): () => void {
+				resource = options;
+				return () => {};
+			},
+		};
+		const transport = new SseChannelTransport({
+			baseUrl: "http://localhost:3000",
+			withCredentials: false,
+			fetcher: async () => {
+				throw new Error("The shared connection owns SSE fetching");
+			},
+			connection: connection as any,
+		});
+		const input = {
+			registryKey: "news",
+			params: {},
+			resolvedName: "news",
+			visibility: "public" as const,
+		};
+		let errorCalls = 0;
+		const onError = () => {
+			errorCalls += 1;
+		};
+		const stopFirst = transport.subscribe(input, () => {}, { onError });
+		transport.subscribe(input, () => {}, { onError });
+		resource!.onEvent({
+			type: "channel_ready",
+			data: JSON.stringify({ channelSubscriptionId: "channel:news" }),
+		});
+
+		stopFirst();
+		resource!.onEpochEnd?.(new Error("subscription epoch ended"));
+
+		expect(errorCalls).toBe(1);
+		transport.destroy();
+	});
+
+	test("keeps duplicate Pusher error callbacks registered independently", async () => {
+		FakePusher.instances = [];
+		const transport = new PusherChannelTransport({
+			baseUrl: "http://localhost:3000",
+			fetcher: async () => {
+				throw new Error("Unexpected request");
+			},
+			config: { provider: "pusher", key: "public-key" },
+		});
+		const input = {
+			registryKey: "news",
+			params: {},
+			resolvedName: "news",
+			visibility: "public" as const,
+		};
+		let errorCalls = 0;
+		const onError = () => {
+			errorCalls += 1;
+		};
+		const stopFirst = transport.subscribe(input, () => {}, { onError });
+		transport.subscribe(input, () => {}, { onError });
+		await waitFor(() => FakePusher.instances.length === 1);
+
+		stopFirst();
+		FakePusher.instances[0]!.channel.emit(
+			"pusher:subscription_error",
+			new Error("Provider rejected subscription"),
+		);
+
+		expect(errorCalls).toBe(1);
+		transport.destroy();
+	});
+
+	test("terminates a ready-state SSE re-entrant live burst exactly once", () => {
+		let resource:
+			| {
+					onEvent(event: { type: string; data: string }): void;
+			  }
+			| undefined;
+		let releases = 0;
+		const connection = {
+			registerChannel(options: typeof resource): () => void {
+				resource = options;
+				return () => {
+					releases += 1;
+				};
+			},
+		};
+		const transport = new SseChannelTransport({
+			baseUrl: "http://localhost:3000",
+			withCredentials: false,
+			fetcher: async () => {
+				throw new Error("The shared connection owns SSE fetching");
+			},
+			connection: connection as any,
+		});
+		const input = {
+			registryKey: "news",
+			params: {},
+			resolvedName: "news",
+			visibility: "public" as const,
+		};
+		const hash = "6".repeat(64);
+		const delivered: string[] = [];
+		const errors: string[] = [];
+		let burst = false;
+		transport.subscribe(
+			input,
+			(message: { eventId: string }) => {
+				delivered.push(message.eventId);
+				if (burst) return;
+				burst = true;
+				for (let sequence = 2; sequence <= 102; sequence += 1) {
+					resource!.onEvent({
+						type: "channel_event",
+						data: stringifyCompatibleTypedEventWire({
+							channel: "news",
+							event: "updated",
+							eventId: `${hash}:${sequence}`,
+							data: {},
+						}),
+					});
+				}
+			},
+			{ onError: (error) => errors.push(error.message) },
+		);
+		resource!.onEvent({
+			type: "channel_ready",
+			data: JSON.stringify({ channelSubscriptionId: "channel:news" }),
+		});
+		resource!.onEvent({
+			type: "channel_event",
+			data: stringifyCompatibleTypedEventWire({
+				channel: "news",
+				event: "updated",
+				eventId: `${hash}:1`,
+				data: {},
+			}),
+		});
+
+		expect(delivered).toEqual([`${hash}:1`]);
+		expect(errors).toEqual(["Channel client slow consumer"]);
+		expect(releases).toBe(1);
+		expect(transport.channelCount).toBe(0);
+		transport.destroy();
+	});
+
+	test("fails a re-entrant SSE slow-consumer entry exactly once", () => {
+		let resource:
+			| {
+					onEvent(event: { type: string; data: string }): void;
+			  }
+			| undefined;
+		let releases = 0;
+		const connection = {
+			registerChannel(options: typeof resource): () => void {
+				resource = options;
+				return () => {
+					releases += 1;
+				};
+			},
+		};
+		const transport = new SseChannelTransport({
+			baseUrl: "http://localhost:3000",
+			withCredentials: false,
+			fetcher: async () => {
+				throw new Error("The shared connection owns SSE fetching");
+			},
+			connection: connection as any,
+		});
+		const input = {
+			registryKey: "news",
+			params: {},
+			resolvedName: "news",
+			visibility: "public" as const,
+		};
+		const terminalErrors = [0, 0, 0];
+		let installedLateSubscribers = false;
+		transport.subscribe(
+			input,
+			() => {
+				if (installedLateSubscribers) return;
+				installedLateSubscribers = true;
+				for (const listener of [1, 2]) {
+					transport.subscribe(input, () => {}, {
+						onReady: () => {},
+						onError: () => {
+							terminalErrors[listener]! += 1;
+						},
+					});
+				}
+			},
+			{
+				onError: () => {
+					terminalErrors[0]! += 1;
+				},
+			},
+		);
+		resource!.onEvent({
+			type: "channel_ready",
+			data: JSON.stringify({ channelSubscriptionId: "channel:news" }),
+		});
+		const hash = "7".repeat(64);
+		for (let sequence = 1; sequence <= 101; sequence += 1) {
+			resource!.onEvent({
+				type: "channel_event",
+				data: stringifyCompatibleTypedEventWire({
+					channel: "news",
+					event: "updated",
+					eventId: `${hash}:${sequence}`,
+					data: {},
+				}),
+			});
+		}
+
+		expect(terminalErrors).toEqual([1, 1, 1]);
+		expect(releases).toBe(1);
+		expect(transport.channelCount).toBe(0);
+		transport.destroy();
+	});
+
+	test("delivers an invalidation during admission reconciliation for a trailing authoritative read", async () => {
+		let streamController:
+			| ReadableStreamDefaultController<Uint8Array>
+			| undefined;
+		const encoder = new TextEncoder();
+		const client = createClient<any>({
+			baseURL: "http://localhost:3000",
+			fetch: async (input) => {
+				const url = String(input);
+				if (url.endsWith("/channels/config")) {
+					return Response.json({
+						transport: "sse",
+						channels: {
+							news: { pattern: "news", visibility: "public" },
+						},
+					});
+				}
+				if (url.endsWith("/realtime")) {
+					return new Response(
+						new ReadableStream<Uint8Array>({
+							start(controller) {
+								streamController = controller;
+								controller.enqueue(
+									encoder.encode(
+										`event: session\ndata: ${JSON.stringify({ sessionId: "race-s1", token: "race-t1", control: { protocol: "questpie-realtime-topology", versions: [2] } })}\n\n`,
+									),
+								);
+							},
+						}),
+						{ headers: { "Content-Type": "text/event-stream" } },
+					);
+				}
+				throw new Error(`Unexpected request: ${url}`);
+			},
+		});
+		let finishFirstRead!: () => void;
+		const firstRead = new Promise<void>((resolve) => {
+			finishFirstRead = resolve;
+		});
+		let reads = 0;
+		let reading = false;
+		let trailing = false;
+		const reconcile = () => {
+			if (reading) {
+				trailing = true;
+				return;
+			}
+			reading = true;
+			reads += 1;
+			void (reads === 1 ? firstRead : Promise.resolve()).then(() => {
+				reading = false;
+				if (!trailing) return;
+				trailing = false;
+				reconcile();
+			});
+		};
+		const stop = client.channels.news.subscribe(reconcile, {
+			onReady: reconcile,
+		});
+
+		await waitFor(() => !!streamController);
+		streamController!.enqueue(
+			encoder.encode(
+				`event: channel_ready\ndata: ${JSON.stringify({ channelSubscriptionId: "channel:news" })}\n\n`,
+			),
+		);
+		await waitFor(() => reads === 1 && reading);
+		const hash = "8".repeat(64);
+		streamController!.enqueue(
+			encoder.encode(
+				`event: channel_event\ndata: ${stringifyCompatibleTypedEventWire({ channel: "news", event: "updated", eventId: `${hash}:1`, data: {} })}\n\n`,
+			),
+		);
+		await waitFor(() => trailing);
+		expect(reads).toBe(1);
+		finishFirstRead();
+		await waitFor(() => reads === 2 && !reading);
+		expect(reads).toBe(2);
+
+		stop();
 		client.channels.destroy();
 	});
 
@@ -436,6 +1538,7 @@ describe("channels client", () => {
 		});
 		const messages: unknown[] = [];
 		const rosters: unknown[] = [];
+		let presenceReady = 0;
 		const stop = client.channels.room.subscribe(
 			{ roomId: "one" },
 			(message: unknown) => messages.push(message),
@@ -443,6 +1546,11 @@ describe("channels client", () => {
 		const stopPresence = client.channels.room.subscribePresence(
 			{ roomId: "one" },
 			(members: unknown) => rosters.push(members),
+			{
+				onReady: () => {
+					presenceReady += 1;
+				},
+			},
 		);
 
 		await waitFor(() => FakePusher.instances.length === 1);
@@ -484,6 +1592,7 @@ describe("channels client", () => {
 		expect((messages[0] as any).data.startsAt).toBeInstanceOf(Date);
 		expect((messages[0] as any).data.isoLookingString).not.toBeInstanceOf(Date);
 		await waitFor(() => rosters.length === 1);
+		await waitFor(() => presenceReady === 1);
 		expect(rosters[0]).toEqual([
 			{ id: "member-1", roomId: "one", joinedAt: instant },
 		]);
@@ -589,14 +1698,25 @@ describe("channels client", () => {
 		});
 		const messages: Array<{ eventId: string; data: any }> = [];
 		const errors: Error[] = [];
+		const lifecycle: string[] = [];
 		const stop = client.channels.news.subscribe(
-			(message: { eventId: string; data: any }) => messages.push(message),
-			{ onError: (error: Error) => errors.push(error) },
+			(message: { eventId: string; data: any }) => {
+				messages.push(message);
+				lifecycle.push(`event:${message.eventId}`);
+			},
+			{
+				onReady: () => lifecycle.push("ready"),
+				onError: (error: Error) => {
+					errors.push(error);
+					lifecycle.push(`error:${error.message}`);
+				},
+			},
 		);
 
 		await waitFor(() => FakePusher.instances.length === 1);
 		const provider = FakePusher.instances[0];
 		provider.channel.emit("pusher:subscription_succeeded", {});
+		await waitFor(() => lifecycle[0] === "ready");
 		provider.channel.emit("questpie:channel", {
 			eventId: `${channelHash}:1`,
 			event: "updated",
@@ -655,7 +1775,17 @@ describe("channels client", () => {
 			replayedInstant.getTime(),
 		);
 		expect(messages[1]?.data.isoLookingString).not.toBeInstanceOf(Date);
-		expect(errors).toEqual([]);
+		expect(errors.map((error) => error.message)).toEqual([
+			"Channel subscription epoch ended",
+		]);
+		expect(lifecycle).toEqual([
+			"ready",
+			`event:${channelHash}:1`,
+			"error:Channel subscription epoch ended",
+			`event:${channelHash}:2`,
+			"ready",
+			`event:${channelHash}:3`,
+		]);
 
 		stop();
 		client.channels.destroy();
@@ -775,7 +1905,7 @@ describe("channels client", () => {
 				data: {},
 			});
 		}
-		await waitFor(() => errors.length === 1);
+		await waitFor(() => errors.includes("Channel client slow consumer"));
 
 		resolveReplay?.(
 			Response.json({
@@ -792,7 +1922,95 @@ describe("channels client", () => {
 		);
 		await new Promise((resolve) => setTimeout(resolve, 10));
 
-		expect(errors).toEqual(["Channel client slow consumer"]);
+		expect(errors).toEqual([
+			"Channel subscription epoch ended",
+			"Channel client slow consumer",
+		]);
+		expect(messages).toEqual([`${channelHash}:1`]);
+		expect(client.channels.channelCount).toBe(0);
+		client.channels.destroy();
+	});
+
+	test("fences deferred Pusher recovery after a provider subscription error", async () => {
+		FakePusher.instances = [];
+		const channelHash = "4".repeat(64);
+		let resolveReplay: ((response: Response) => void) | undefined;
+		const fetcher: typeof fetch = async (input) => {
+			const url = String(input);
+			if (url.endsWith("/channels/config")) {
+				return Response.json({
+					transport: "shared-provider",
+					config: { provider: "pusher", key: "public-key" },
+					channels: {
+						news: { pattern: "news", visibility: "public" },
+					},
+				});
+			}
+			if (url.endsWith("/channels/replay")) {
+				return new Promise<Response>((resolve) => {
+					resolveReplay = resolve;
+				});
+			}
+			throw new Error(`Unexpected request: ${url}`);
+		};
+		const client = createClient<any>({
+			baseURL: "http://localhost:3000",
+			fetch: fetcher,
+		});
+		const messages: string[] = [];
+		const errors: string[] = [];
+		let ready = 0;
+		client.channels.news.subscribe(
+			(message: { eventId: string }) => messages.push(message.eventId),
+			{
+				onReady: () => {
+					ready += 1;
+				},
+				onError: (error: Error) => errors.push(error.message),
+			},
+		);
+
+		await waitFor(() => FakePusher.instances.length === 1);
+		const provider = FakePusher.instances[0]!;
+		provider.channel.emit("pusher:subscription_succeeded", {});
+		await waitFor(() => ready === 1);
+		provider.channel.emit("questpie:channel", {
+			eventId: `${channelHash}:1`,
+			event: "updated",
+			data: {},
+		});
+		await waitFor(() => messages.length === 1);
+		provider.channel.emit("pusher:subscription_succeeded", {});
+		await waitFor(() => resolveReplay !== undefined);
+		provider.channel.emit(
+			"pusher:subscription_error",
+			new Error("Provider rejected subscription"),
+		);
+		provider.channel.emit("questpie:channel", {
+			eventId: `${channelHash}:3`,
+			event: "updated",
+			data: {},
+		});
+		resolveReplay?.(
+			Response.json({
+				status: "events",
+				events: [
+					{
+						eventId: `${channelHash}:2`,
+						event: "updated",
+						data: {},
+					},
+				],
+				hasMore: false,
+			}),
+		);
+		await new Promise((resolve) => setTimeout(resolve, 20));
+
+		expect(errors).toEqual([
+			"Channel subscription epoch ended",
+			"Provider rejected subscription",
+		]);
+		expect(ready).toBe(1);
 		expect(messages).toEqual([`${channelHash}:1`]);
 		expect(client.channels.channelCount).toBe(0);
 		client.channels.destroy();
@@ -826,13 +2044,18 @@ describe("channels client", () => {
 			fetch: fetcher,
 		});
 		const errors: Error[] = [];
+		let ready = 0;
 		client.channels.news.subscribe(() => {}, {
+			onReady: () => {
+				ready += 1;
+			},
 			onError: (error: Error) => errors.push(error),
 		});
 
 		await waitFor(() => FakePusher.instances.length === 1);
 		const provider = FakePusher.instances[0];
 		provider.channel.emit("pusher:subscription_succeeded", {});
+		await waitFor(() => ready === 1);
 		provider.channel.emit("questpie:channel", {
 			eventId: `${channelHash}:1`,
 			event: "updated",
@@ -840,8 +2063,14 @@ describe("channels client", () => {
 		});
 		provider.channel.emit("pusher:subscription_succeeded", {});
 
-		await waitFor(() => errors.length === 1);
-		expect(errors[0]?.message).toBe("Channel event replay gap");
+		await waitFor(() =>
+			errors.some((error) => error.message === "Channel event replay gap"),
+		);
+		expect(errors.map((error) => error.message)).toEqual([
+			"Channel subscription epoch ended",
+			"Channel event replay gap",
+		]);
+		expect(ready).toBe(1);
 		expect(client.channels.channelCount).toBe(0);
 		client.channels.destroy();
 	});
@@ -1000,11 +2229,16 @@ describe("channels client", () => {
 		});
 		provider.channel.emit("pusher:subscription_succeeded", {});
 
-		await waitFor(() => errors.length === 1);
-		expect(replay).toBe(1);
-		expect(errors[0]?.message).toContain(
-			"Unsupported QUESTPIE typed event wire version",
+		await waitFor(() =>
+			errors.some((error) =>
+				error.message.includes("Unsupported QUESTPIE typed event wire version"),
+			),
 		);
+		expect(replay).toBe(1);
+		expect(errors.map((error) => error.message)).toEqual([
+			"Channel subscription epoch ended",
+			expect.stringContaining("Unsupported QUESTPIE typed event wire version"),
+		]);
 		expect(client.channels.channelCount).toBe(0);
 		client.channels.destroy();
 	});
@@ -1029,11 +2263,17 @@ describe("channels client", () => {
 			baseURL: "http://localhost:3000",
 			fetch: fetcher,
 		});
-		const iterator = client.channels.news.iter();
+		let iteratorReady = 0;
+		const iterator = client.channels.news.iter({
+			onReady: () => {
+				iteratorReady += 1;
+			},
+		});
 		const firstResult = iterator.next();
 		await waitFor(() => FakePusher.instances.length === 1);
 		const provider = FakePusher.instances[0];
 		provider.channel.emit("pusher:subscription_succeeded", {});
+		await waitFor(() => iteratorReady === 1);
 		provider.channel.emit("questpie:channel", {
 			eventId: `${channelHash}:1`,
 			event: "updated",

--- a/packages/questpie/test/integration/ordered-channel-ledger.test.ts
+++ b/packages/questpie/test/integration/ordered-channel-ledger.test.ts
@@ -630,14 +630,71 @@ describe("ordered channel event ledger", () => {
 			});
 		}
 		const sink = createSink("resume");
+		const order: string[] = [];
 		await events.subscribeLocal({
 			subscriptionId: "resume-room",
 			channel: "private-room-1",
-			sink,
+			sink: {
+				...sink,
+				write: async (frame, delivery) => {
+					const result = await sink.write(frame, delivery);
+					order.push(`event:${String(sink.frames.at(-1)?.data.id)}`);
+					return result;
+				},
+			},
+			onReady: () => order.push("ready"),
 			lastEventId: first.eventId,
 		});
 
 		expect(sink.frames.map((frame) => frame.data.id)).toEqual([2, 3]);
+		expect(order).toEqual(["event:2", "event:3", "ready"]);
+	});
+
+	test("orders a racing post-admission event after readiness delivery", async () => {
+		const events = ledger();
+		const sink = createSink("admission-race");
+		const order: string[] = [];
+		let markReadyStarted!: () => void;
+		const readyStarted = new Promise<void>((resolve) => {
+			markReadyStarted = resolve;
+		});
+		let releaseReady!: () => void;
+		const readyRelease = new Promise<void>((resolve) => {
+			releaseReady = resolve;
+		});
+		const subscribing = events.subscribeLocal({
+			subscriptionId: "admission-race-room",
+			channel: "private-room-1",
+			sink: {
+				...sink,
+				write: async (frame, delivery) => {
+					const result = await sink.write(frame, delivery);
+					order.push(`event:${String(sink.frames.at(-1)?.data.id)}`);
+					return result;
+				},
+			},
+			onReady: async () => {
+				markReadyStarted();
+				await readyRelease;
+				order.push("ready");
+			},
+		});
+
+		await readyStarted;
+		await events.append({
+			channel: "private-room-1",
+			event: "message",
+			schemaIdentity: "room:message",
+			data: { id: 1 },
+		});
+		const racingDrain = events.drain();
+		releaseReady();
+		const unsubscribe = await subscribing;
+		await racingDrain;
+		await waitFor(() => sink.frames.length === 1);
+
+		expect(order).toEqual(["ready", "event:1"]);
+		await unsubscribe();
 	});
 
 	test("expired resume cursor emits channel_gap and closes only that subscription", async () => {
@@ -658,16 +715,21 @@ describe("ordered channel event ledger", () => {
 		}
 		await events.cleanup();
 		const sink = createSink("expired");
+		let ready = 0;
 		await events.subscribeLocal({
 			subscriptionId: "expired-room",
 			channel: "private-room-1",
 			sink,
+			onReady: () => {
+				ready += 1;
+			},
 			lastEventId: first.eventId,
 		});
 
 		expect(sink.frames).toEqual([
 			expect.objectContaining({ type: "channel_gap" }),
 		]);
+		expect(ready).toBe(0);
 		await events.append({
 			channel: "private-room-1",
 			event: "message",

--- a/packages/questpie/test/types/realtime-transport.test-d.ts
+++ b/packages/questpie/test/types/realtime-transport.test-d.ts
@@ -1,4 +1,8 @@
 import type {
+	ChannelPresenceOptions,
+	ChannelSubscribeOptions,
+} from "../../src/exports/client.js";
+import type {
 	ChangeBroker,
 	ChangeWake,
 	ClientSink,
@@ -33,6 +37,14 @@ type _sharedUserAuthenticationRemainsAnOptionalCapability = Expect<
 			: false,
 		true
 	>
+>;
+
+type _channelReadinessIsOptionalAndPayloadFree = Expect<
+	Equal<NonNullable<ChannelSubscribeOptions["onReady"]>, () => void>
+>;
+
+type _oneShotPresenceDoesNotExposeContinuingAdmission = Expect<
+	Equal<"onReady" extends keyof ChannelPresenceOptions ? true : false, false>
 >;
 
 declare const sink: ClientSink;

--- a/scripts/bundle-budget.json
+++ b/scripts/bundle-budget.json
@@ -2,12 +2,12 @@
 	"$comment": "Consumer bundle budget — the ENTRY chunk a browser downloads, measured with esbuild --splitting (what real bundlers do). Distinct from scripts/size-budget.json, which measures what npm publishes; a dependency moved behind a dynamic import shrinks this and not that. Regenerate with `bun run scripts/bundle-budget.ts --update` after a build. Gate: entry chunk >3% over budget fails CI.",
 	"entries": {
 		"questpie/client": {
-			"entryBytes": 184788,
-			"totalBytes": 359236
+			"entryBytes": 118416,
+			"totalBytes": 367894
 		},
 		"questpie/client+crdt": {
-			"entryBytes": 375750,
-			"totalBytes": 550198
+			"entryBytes": 309368,
+			"totalBytes": 558846
 		}
 	}
 }


### PR DESCRIPTION
Adds `onReady` to channel subscriptions — a provider-neutral signal that a subscription is authorized **and** has finished replay catch-up.

```ts
client.channels.subscribe("space", { spaceId }, handler, {
  onReady: () => {
    // authorized, caught up; everything from here is live and complete
  },
});
```

Until now the only callback was `onError`, so a subscriber could not tell *"still replaying history"* from *"caught up and live"*. Applications guessed with a timer or treated the first frame as readiness — wrong whenever replay has more than one frame to deliver.

On SSE the server emits a `channel_ready` control frame after authorization and catch-up; the client orders it against replay and live delivery so a subscriber never sees a live frame before its readiness callback. Reconnects end the epoch and re-signal.

Presence subscriptions deliberately do not expose it — `ChannelPresenceOptions` is `ChannelSubscribeOptions` minus `onReady` — because a presence read is one-shot with no catch-up to complete.

Consumer callbacks are also isolated: a throwing `onReady`/`onError` in one subscriber no longer takes delivery down for its siblings.

## Extracted from #203 rather than rebasing it — and that is the finding

#203 bundles this feature with a context/request-scope layer it inherited from #202. Merging that bundle was attempted **twice** — once on #202 directly, once on #203, with different resolution strategies — and both produced the *same* four failures in `channel-routes.test.ts`: three of #199's authority tests plus one of #202's own, with a `403` tracing through `resolveContextExtensions`.

Taking only the readiness vertical settles what those failures were about:

| | `channel-routes.test.ts` |
|---|---|
| #202 merge attempt | 4 fail |
| #203 merge attempt | 4 fail |
| **readiness only (this PR)** | **0 fail** |

The incompatibility was never in this feature. It lives entirely in the inherited context/lease layer, which is not brought here at all. #199's authority tests and #208's system-scoped resolver test both pass untouched.

## Two carried symbols worth calling out

- **`writeControl`** on the edge-session sink — a control frame that bypasses application quotas, so emitting `channel_ready` does not consume a subscriber's budget.
- **`onEpochEnd`** on the SSE connection resource — so a reconnect ends the readiness epoch instead of leaving it latched.

Both are small and self-contained. Both were among the unresolved references in an abandoned local rework of #203, which had the right idea and was missing the server half.

## Verification

2,940 tests / 0 fail · tsc clean · `bun run lint` 0 errors · oxfmt clean repo-wide · five ratchets green.

Closes the readiness half of #203.
