### PR TITLE
feat(auth): bridge verification dispatch to transactional queue

### DIFF
--- a/.changeset/quiet-auth-queues.md
+++ b/.changeset/quiet-auth-queues.md
@@ -1,0 +1,5 @@
+---
+"questpie": minor
+---
+
+Add a typed Better Auth integration bridge that atomically commits Auth state and an encrypted, idempotent QUESTPIE Queue dispatch.

--- a/apps/docs/content/docs/admin/auth.mdx
+++ b/apps/docs/content/docs/admin/auth.mdx
@@ -85,6 +85,44 @@ Use Better Auth's dedicated identity flows for email, password, verification,
 session, and provider changes. Do not weaken these collection rules to make an
 identity screen work.
 
+### Atomic Auth verification dispatch
+
+When a Better Auth plugin must change Auth state and enqueue a verification
+message as one operation, use `withAuthTransactionalQueue()` from
+`questpie/auth`. The callback receives a transaction-scoped Better Auth adapter
+and a deliberately narrow publisher. Pass the concrete job definition; QUESTPIE
+accepts only a definition registered by the running app.
+
+```ts
+import { withAuthTransactionalQueue } from "questpie/auth";
+
+await withAuthTransactionalQueue(ctx, async ({ auth, publish }) => {
+	const claim = await auth.consumeOne({
+		model: "verification",
+		where: [{ field: "id", value: verificationId }],
+	});
+	if (!claim) return null;
+
+	return publish(
+		sendAuthVerificationJob,
+		{ verificationId, token },
+		{ idempotencyKey: `auth-verification:${verificationId}` },
+	);
+});
+```
+
+The Auth mutation and Queue-owned `questpie_queue_dispatch` reservation use the
+same database transaction. A throw before commit leaves neither state behind;
+retries with the same job name and idempotency key resolve to one logical
+dispatch. The bridge always encrypts the payload, so configure a stable runtime
+secret of at least 32 bytes and a Queue adapter qualified for secret-payload
+terminal-state recovery. Keep the idempotency key non-secret.
+
+Do not call an email or identity provider inside the callback. The registered
+job handler performs that external effect after commit. The bridge exposes no
+application context, raw database, general Queue client, scheduling, or
+singleton options.
+
 QUESTPIE also hardens Better Auth's session list/revoke wire contract. The
 `list-sessions` response never returns reusable bearer session tokens. For
 compatibility with Better Auth clients, its historical `token` property contains

--- a/packages/questpie/src/exports/auth.ts
+++ b/packages/questpie/src/exports/auth.ts
@@ -4,6 +4,13 @@ export {
 	type MergeAuthOptions,
 } from "#questpie/server/modules/core/integrated/auth/merge.js";
 export * from "#questpie/server/modules/core/integrated/auth/types.js";
+export {
+	type AuthTransactionalQueueContext,
+	type AuthTransactionalQueuePublish,
+	type AuthTransactionalQueuePublishOptions,
+	type AuthTransactionalQueueTransaction,
+	withAuthTransactionalQueue,
+} from "#questpie/server/modules/core/integrated/auth/transactional-queue.js";
 export type { AuthConfig } from "#questpie/server/config/module-types.js";
 export {
 	type AccessRuleEvaluationContext,

--- a/packages/questpie/src/server/modules/core/integrated/auth/transactional-queue.ts
+++ b/packages/questpie/src/server/modules/core/integrated/auth/transactional-queue.ts
@@ -82,16 +82,17 @@ function createAuthTransactionalQueuePublish(options: {
 			);
 		}
 
-		const registered = Object.values(options.jobs).find(
-			(job) => job.name === definition.name,
+		const registered = Object.entries(options.jobs).find(
+			([, job]) => job === definition,
 		);
-		if (registered !== definition) {
+		if (!registered) {
 			throw new Error(
 				`QUESTPIE: Auth transactional Queue job "${definition.name}" is not registered by this app`,
 			);
 		}
 
-		const client = options.getQueue()[definition.name];
+		const [registrationKey] = registered;
+		const client = options.getQueue()[registrationKey];
 		if (!client) {
 			throw new Error(
 				`QUESTPIE: Auth transactional Queue job "${definition.name}" has no Queue client`,

--- a/packages/questpie/src/server/modules/core/integrated/auth/transactional-queue.ts
+++ b/packages/questpie/src/server/modules/core/integrated/auth/transactional-queue.ts
@@ -1,0 +1,148 @@
+import type { BetterAuthPlugin, DBTransactionAdapter } from "better-auth";
+
+import { withTransaction } from "#questpie/server/collection/crud/shared/transaction.js";
+import type {
+	JobDefinition,
+	QueueClient,
+	QueueConfig,
+} from "#questpie/server/modules/core/integrated/queue/types.js";
+
+type RegisteredJobs = QueueConfig["jobs"];
+
+export interface AuthTransactionalQueueContext {
+	context: {
+		adapter: {
+			transaction: <T>(
+				callback: (auth: DBTransactionAdapter) => Promise<T>,
+			) => Promise<T>;
+		};
+	};
+}
+
+export interface AuthTransactionalQueuePublishOptions {
+	/** Stable, non-secret identity for one logical verification dispatch. */
+	idempotencyKey: string;
+}
+
+export type AuthTransactionalQueuePublish = <
+	TPayload,
+	TResult,
+	TName extends string,
+>(
+	job: JobDefinition<TPayload, TResult, TName>,
+	payload: TPayload,
+	options: AuthTransactionalQueuePublishOptions,
+) => Promise<string>;
+
+// Bind through Better Auth's stable adapter identity without adding an
+// enumerable or reflectable capability to the shared plugin context.
+const authTransactionalQueuePublishers = new WeakMap<
+	object,
+	AuthTransactionalQueuePublish
+>();
+
+export interface AuthTransactionalQueueTransaction {
+	/** Transaction-scoped Better Auth adapter for the protected Auth mutation. */
+	auth: DBTransactionAdapter;
+	/** Publish one registered, typed job as an encrypted durable dispatch. */
+	publish: AuthTransactionalQueuePublish;
+}
+
+/**
+ * Commit a Better Auth mutation and an encrypted Queue dispatch atomically.
+ *
+ * The callback sees only Better Auth's transaction adapter and a publisher for
+ * concrete job definitions registered by the app. Provider calls belong in the
+ * job handler, after this transaction commits.
+ */
+export async function withAuthTransactionalQueue<T>(
+	ctx: AuthTransactionalQueueContext,
+	callback: (transaction: AuthTransactionalQueueTransaction) => Promise<T>,
+): Promise<T> {
+	const publish = authTransactionalQueuePublishers.get(ctx.context.adapter);
+	if (!publish) {
+		throw new Error(
+			"QUESTPIE: Auth transactional Queue bridge is unavailable on this Auth context",
+		);
+	}
+
+	return ctx.context.adapter.transaction(async (auth) => {
+		return callback({ auth, publish });
+	});
+}
+
+function createAuthTransactionalQueuePublish(options: {
+	jobs: RegisteredJobs;
+	getQueue: () => QueueClient<RegisteredJobs>;
+}): AuthTransactionalQueuePublish {
+	return async (definition, payload, publishOptions) => {
+		if (!publishOptions.idempotencyKey.trim()) {
+			throw new Error(
+				"QUESTPIE: Auth transactional Queue publication requires a non-empty idempotencyKey",
+			);
+		}
+
+		const registered = Object.values(options.jobs).find(
+			(job) => job.name === definition.name,
+		);
+		if (registered !== definition) {
+			throw new Error(
+				`QUESTPIE: Auth transactional Queue job "${definition.name}" is not registered by this app`,
+			);
+		}
+
+		const client = options.getQueue()[definition.name];
+		if (!client) {
+			throw new Error(
+				`QUESTPIE: Auth transactional Queue job "${definition.name}" has no Queue client`,
+			);
+		}
+
+		const dispatchId = await client.publish(payload, {
+			idempotencyKey: publishOptions.idempotencyKey,
+			secretPayload: true,
+		});
+		if (!dispatchId) {
+			throw new Error(
+				`QUESTPIE: Auth transactional Queue job "${definition.name}" did not return a durable dispatch id`,
+			);
+		}
+		return dispatchId;
+	};
+}
+
+/** @internal Better Auth plugin that binds the app's narrow Queue capability. */
+export function createAuthTransactionalQueuePlugin(options: {
+	jobs: RegisteredJobs;
+	getQueue: () => QueueClient<RegisteredJobs>;
+}): BetterAuthPlugin {
+	return {
+		id: "questpie-auth-transactional-queue",
+		init(context) {
+			authTransactionalQueuePublishers.set(
+				context.adapter,
+				createAuthTransactionalQueuePublish(options),
+			);
+		},
+	};
+}
+
+/**
+ * Preserve Drizzle's complete database surface while joining Better Auth's
+ * adapter transaction to QUESTPIE's ambient transaction context.
+ *
+ * @internal
+ */
+export function createAuthTransactionalDatabase<TDatabase extends object>(
+	database: TDatabase,
+): TDatabase {
+	return new Proxy(database, {
+		get(target, property, receiver) {
+			if (property === "transaction") {
+				return <T>(callback: (transaction: unknown) => Promise<T>) =>
+					withTransaction(target, callback);
+			}
+			return Reflect.get(target, property, receiver);
+		},
+	});
+}

--- a/packages/questpie/src/server/modules/core/services/auth.ts
+++ b/packages/questpie/src/server/modules/core/services/auth.ts
@@ -30,11 +30,13 @@ export default service({
 			secret: app.config.secret,
 			...authOptions,
 			plugins: [
-				...(authOptions.plugins ?? []),
+				// Better Auth initializes plugins in array order. Bind only the
+				// framework adapter so a later user replacement fails closed.
 				createAuthTransactionalQueuePlugin({
 					jobs,
 					getQueue: () => app.queue,
 				}),
+				...(authOptions.plugins ?? []),
 			],
 			database: drizzleAdapter(createAuthTransactionalDatabase(app.db), {
 				provider: "pg",

--- a/packages/questpie/src/server/modules/core/services/auth.ts
+++ b/packages/questpie/src/server/modules/core/services/auth.ts
@@ -2,6 +2,10 @@ import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 
 import { applyOAuthScopeCatalog } from "#questpie/server/modules/core/integrated/auth/scope-catalog.js";
+import {
+	createAuthTransactionalDatabase,
+	createAuthTransactionalQueuePlugin,
+} from "#questpie/server/modules/core/integrated/auth/transactional-queue.js";
 import { service } from "#questpie/server/services/define-service.js";
 
 /**
@@ -20,11 +24,19 @@ export default service({
 	lifecycle: "singleton",
 	create: ({ app }) => {
 		const authOptions = applyOAuthScopeCatalog(app, app.config.auth ?? {});
+		const jobs = app.config.queue?.jobs ?? {};
 		return betterAuth({
 			baseURL: app.config.app.url,
 			secret: app.config.secret,
 			...authOptions,
-			database: drizzleAdapter(app.db, {
+			plugins: [
+				...(authOptions.plugins ?? []),
+				createAuthTransactionalQueuePlugin({
+					jobs,
+					getQueue: () => app.queue,
+				}),
+			],
+			database: drizzleAdapter(createAuthTransactionalDatabase(app.db), {
 				provider: "pg",
 				schema: app.getSchema(),
 				transaction: true,

--- a/packages/questpie/test/integration/auth-transactional-queue.test.ts
+++ b/packages/questpie/test/integration/auth-transactional-queue.test.ts
@@ -1,0 +1,353 @@
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	setDefaultTimeout,
+	test,
+} from "bun:test";
+
+import { eq } from "drizzle-orm";
+import { z } from "zod";
+
+import { withAuthTransactionalQueue } from "../../src/exports/auth.js";
+import { job } from "../../src/exports/index.js";
+import { questpieQueueDispatchTable } from "../../src/server/modules/core/integrated/queue/dispatch-table.js";
+import verification from "../../src/server/modules/starter/collections/verification.js";
+import { buildMockApp } from "../utils/mocks/mock-app-builder.js";
+import { runTestDbMigrations } from "../utils/test-db.js";
+
+const sendVerificationJob = job({
+	name: "send-auth-verification",
+	schema: z.object({ verificationId: z.string(), token: z.string() }),
+	handler: async () => {},
+});
+
+setDefaultTimeout(30_000);
+
+describe("Auth transactional Queue bridge", () => {
+	let setup: Awaited<ReturnType<typeof buildMockApp>>;
+
+	function verificationData(id: string) {
+		return {
+			id,
+			identifier: "user@example.test",
+			value: "hashed-value",
+			expiresAt: new Date(Date.now() + 60_000),
+			createdAt: new Date(),
+			updatedAt: new Date(),
+		};
+	}
+
+	beforeEach(async () => {
+		setup = await buildMockApp(
+			{
+				collections: { verification },
+				jobs: { sendVerification: sendVerificationJob },
+			},
+			{ secret: "test-auth-queue-secret-at-least-32-bytes" },
+		);
+		await runTestDbMigrations(setup.app);
+	});
+
+	afterEach(async () => {
+		await setup?.cleanup();
+	});
+
+	test("rolls back Auth state and dispatch together after publication", async () => {
+		const context = await setup.app.auth.$context;
+
+		await expect(
+			withAuthTransactionalQueue({ context }, async ({ auth, publish }) => {
+				await auth.create({
+					model: "verification",
+					data: verificationData("verification-rollback"),
+					forceAllowId: true,
+				});
+				await publish(
+					sendVerificationJob,
+					{
+						verificationId: "verification-rollback",
+						token: "raw-secret-token",
+					},
+					{ idempotencyKey: "auth-verification:rollback" },
+				);
+				throw new Error("simulated crash after publication");
+			}),
+		).rejects.toThrow("simulated crash after publication");
+
+		expect(
+			await context.adapter.findOne({
+				model: "verification",
+				where: [{ field: "id", value: "verification-rollback" }],
+			}),
+		).toBeNull();
+		expect(
+			await setup.app.db
+				.select()
+				.from(questpieQueueDispatchTable)
+				.where(
+					eq(
+						questpieQueueDispatchTable.idempotencyKey,
+						"auth-verification:rollback",
+					),
+				),
+		).toEqual([]);
+		expect(setup.app.mocks.queue.getJobs()).toEqual([]);
+	});
+
+	test("commits Auth state and one encrypted durable dispatch together", async () => {
+		const context = await setup.app.auth.$context;
+		const dispatchId = await withAuthTransactionalQueue(
+			{ context },
+			async ({ auth, publish }) => {
+				await auth.create({
+					model: "verification",
+					data: verificationData("verification-commit"),
+					forceAllowId: true,
+				});
+				return publish(
+					sendVerificationJob,
+					{
+						verificationId: "verification-commit",
+						token: "raw-secret-token",
+					},
+					{ idempotencyKey: "auth-verification:commit" },
+				);
+			},
+		);
+
+		expect(
+			await context.adapter.findOne({
+				model: "verification",
+				where: [{ field: "id", value: "verification-commit" }],
+			}),
+		).toMatchObject({ id: "verification-commit" });
+		expect(dispatchId).toBeString();
+		expect(setup.app.mocks.queue.getJobs()).toHaveLength(1);
+		const [dispatch] = await setup.app.db
+			.select()
+			.from(questpieQueueDispatchTable)
+			.where(eq(questpieQueueDispatchTable.dispatchId, dispatchId));
+		expect(dispatch).toMatchObject({
+			dispatchId,
+			idempotencyKey: "auth-verification:commit",
+			jobName: "send-auth-verification",
+			status: "accepted",
+			payload: null,
+		});
+		expect(JSON.stringify(dispatch)).not.toContain("raw-secret-token");
+	});
+
+	test("a crash before publication rolls back Auth state without a dispatch", async () => {
+		const context = await setup.app.auth.$context;
+
+		await expect(
+			withAuthTransactionalQueue({ context }, async ({ auth }) => {
+				await auth.create({
+					model: "verification",
+					data: verificationData("verification-before-publish"),
+					forceAllowId: true,
+				});
+				throw new Error("simulated crash before publication");
+			}),
+		).rejects.toThrow("simulated crash before publication");
+
+		expect(
+			await context.adapter.findOne({
+				model: "verification",
+				where: [{ field: "id", value: "verification-before-publish" }],
+			}),
+		).toBeNull();
+		expect(
+			await setup.app.db.select().from(questpieQueueDispatchTable),
+		).toEqual([]);
+	});
+
+	test("recovers a committed Auth dispatch when adapter publication is interrupted", async () => {
+		const context = await setup.app.auth.$context;
+		setup.app.mocks.queue.failNextPublishes(1);
+
+		const dispatchId = await withAuthTransactionalQueue(
+			{ context },
+			async ({ auth, publish }) => {
+				await auth.create({
+					model: "verification",
+					data: verificationData("verification-recovery"),
+					forceAllowId: true,
+				});
+				return publish(
+					sendVerificationJob,
+					{
+						verificationId: "verification-recovery",
+						token: "raw-secret-token",
+					},
+					{ idempotencyKey: "auth-verification:recovery" },
+				);
+			},
+		);
+
+		expect(
+			await context.adapter.findOne({
+				model: "verification",
+				where: [{ field: "id", value: "verification-recovery" }],
+			}),
+		).toMatchObject({ id: "verification-recovery" });
+		expect(setup.app.mocks.queue.getJobs()).toEqual([]);
+		expect(
+			await setup.app.db
+				.select()
+				.from(questpieQueueDispatchTable)
+				.where(eq(questpieQueueDispatchTable.dispatchId, dispatchId)),
+		).toMatchObject([{ dispatchId, status: "pending" }]);
+
+		await setup.app.db
+			.update(questpieQueueDispatchTable)
+			.set({ availableAt: new Date(0) })
+			.where(eq(questpieQueueDispatchTable.dispatchId, dispatchId));
+		await setup.app.queue.drain();
+
+		expect(setup.app.mocks.queue.getJobs()).toHaveLength(1);
+		expect(await setup.app.queue.getReceipt(dispatchId)).toMatchObject({
+			dispatchId,
+			status: "queued",
+		});
+	});
+
+	test("two racing Auth claims create one logical dispatch", async () => {
+		const context = await setup.app.auth.$context;
+		await context.adapter.create({
+			model: "verification",
+			data: verificationData("verification-race"),
+			forceAllowId: true,
+		});
+
+		const results = await Promise.all(
+			["first", "second"].map((attempt) =>
+				withAuthTransactionalQueue({ context }, async ({ auth, publish }) => {
+					const claim = await auth.consumeOne({
+						model: "verification",
+						where: [{ field: "id", value: "verification-race" }],
+					});
+					if (!claim) return null;
+					return publish(
+						sendVerificationJob,
+						{
+							verificationId: "verification-race",
+							token: `raw-secret-${attempt}`,
+						},
+						{ idempotencyKey: "auth-verification:race" },
+					);
+				}),
+			),
+		);
+
+		expect(results.filter(Boolean)).toHaveLength(1);
+		expect(setup.app.mocks.queue.getJobs()).toHaveLength(1);
+		expect(
+			await setup.app.db
+				.select()
+				.from(questpieQueueDispatchTable)
+				.where(
+					eq(
+						questpieQueueDispatchTable.idempotencyKey,
+						"auth-verification:race",
+					),
+				),
+		).toHaveLength(1);
+	});
+
+	test("leaves ordinary Better Auth adapter use unchanged when the bridge is unused", async () => {
+		const context = await setup.app.auth.$context;
+		await context.adapter.create({
+			model: "verification",
+			data: verificationData("verification-ordinary"),
+			forceAllowId: true,
+		});
+
+		expect(
+			await context.adapter.findOne({
+				model: "verification",
+				where: [{ field: "id", value: "verification-ordinary" }],
+			}),
+		).toMatchObject({ id: "verification-ordinary" });
+		expect(
+			await setup.app.db.select().from(questpieQueueDispatchTable),
+		).toEqual([]);
+		expect(setup.app.mocks.queue.getJobs()).toEqual([]);
+	});
+
+	test("rejects an unregistered job capability and rolls back Auth state", async () => {
+		const context = await setup.app.auth.$context;
+		const unregisteredJob = job({
+			name: "unregistered-auth-job",
+			schema: z.object({ token: z.string() }),
+			handler: async () => {},
+		});
+
+		await expect(
+			withAuthTransactionalQueue({ context }, async ({ auth, publish }) => {
+				await auth.create({
+					model: "verification",
+					data: verificationData("verification-unregistered"),
+					forceAllowId: true,
+				});
+				await publish(
+					unregisteredJob,
+					{ token: "raw-secret-token" },
+					{ idempotencyKey: "auth-verification:unregistered" },
+				);
+			}),
+		).rejects.toThrow("is not registered by this app");
+
+		expect(
+			await context.adapter.findOne({
+				model: "verification",
+				where: [{ field: "id", value: "verification-unregistered" }],
+			}),
+		).toBeNull();
+		expect(
+			await setup.app.db.select().from(questpieQueueDispatchTable),
+		).toEqual([]);
+	});
+
+	test("keeps the bridge on Better Auth request-scoped context clones", async () => {
+		const context = await setup.app.auth.$context;
+		const requestContext = { ...context };
+
+		await expect(
+			withAuthTransactionalQueue(
+				{ context: requestContext },
+				async ({ publish }) =>
+					publish(
+						sendVerificationJob,
+						{
+							verificationId: "verification-request-context",
+							token: "raw-secret-token",
+						},
+						{ idempotencyKey: "auth-verification:request-context" },
+					),
+			),
+		).resolves.toBeString();
+	});
+
+	test("does not expose the general Queue capability to sibling Auth plugins", async () => {
+		const context = await setup.app.auth.$context;
+		const descriptors = Object.getOwnPropertyDescriptors(context);
+		const ownValues = Reflect.ownKeys(context).map(
+			(key) => descriptors[key as keyof typeof descriptors]?.value,
+		);
+		const leakedRuntime = ownValues.find((value): value is object => {
+			if (!value || typeof value !== "object") return false;
+			return (
+				"getQueue" in value &&
+				typeof (value as { getQueue?: unknown }).getQueue === "function"
+			);
+		});
+
+		expect(leakedRuntime).toBeUndefined();
+		expect(Reflect.ownKeys(context).map((key) => String(key))).not.toContain(
+			"Symbol(questpie.authTransactionalQueueRuntime)",
+		);
+	});
+});

--- a/packages/questpie/test/integration/auth-transactional-queue.test.ts
+++ b/packages/questpie/test/integration/auth-transactional-queue.test.ts
@@ -7,6 +7,7 @@ import {
 	test,
 } from "bun:test";
 
+import type { BetterAuthPlugin } from "better-auth";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
 
@@ -19,6 +20,12 @@ import { runTestDbMigrations } from "../utils/test-db.js";
 
 const sendVerificationJob = job({
 	name: "send-auth-verification",
+	schema: z.object({ verificationId: z.string(), token: z.string() }),
+	handler: async () => {},
+});
+
+const collidingRegistrationJob = job({
+	name: "different-auth-job",
 	schema: z.object({ verificationId: z.string(), token: z.string() }),
 	handler: async () => {},
 });
@@ -349,5 +356,101 @@ describe("Auth transactional Queue bridge", () => {
 		expect(Reflect.ownKeys(context).map((key) => String(key))).not.toContain(
 			"Symbol(questpie.authTransactionalQueueRuntime)",
 		);
+	});
+
+	test("fails closed when a user plugin replaces the framework-owned Auth adapter", async () => {
+		await setup.cleanup();
+		const replaceAdapterPlugin = {
+			id: "replace-framework-auth-adapter",
+			init(context) {
+				const frameworkAdapter = context.adapter;
+				return {
+					context: {
+						adapter: {
+							...frameworkAdapter,
+							transaction: async (callback) => callback(frameworkAdapter),
+						},
+					},
+				};
+			},
+		} satisfies BetterAuthPlugin;
+		setup = await buildMockApp(
+			{
+				collections: { verification },
+				jobs: { sendVerification: sendVerificationJob },
+				auth: { plugins: [replaceAdapterPlugin] },
+			},
+			{ secret: "test-auth-queue-secret-at-least-32-bytes" },
+		);
+		await runTestDbMigrations(setup.app);
+		const context = await setup.app.auth.$context;
+
+		await expect(
+			withAuthTransactionalQueue({ context }, async ({ auth, publish }) => {
+				await auth.create({
+					model: "verification",
+					data: verificationData("verification-replaced-adapter"),
+					forceAllowId: true,
+				});
+				await publish(
+					sendVerificationJob,
+					{
+						verificationId: "verification-replaced-adapter",
+						token: "raw-secret-token",
+					},
+					{ idempotencyKey: "auth-verification:replaced-adapter" },
+				);
+				throw new Error("hostile adapter bypassed the framework transaction");
+			}),
+		).rejects.toThrow(
+			"Auth transactional Queue bridge is unavailable on this Auth context",
+		);
+
+		expect(
+			await context.adapter.findOne({
+				model: "verification",
+				where: [{ field: "id", value: "verification-replaced-adapter" }],
+			}),
+		).toBeNull();
+		expect(
+			await setup.app.db.select().from(questpieQueueDispatchTable),
+		).toEqual([]);
+		expect(setup.app.mocks.queue.getJobs()).toEqual([]);
+	});
+
+	test("publishes through the matched registration key when a job name collides", async () => {
+		await setup.cleanup();
+		setup = await buildMockApp(
+			{
+				collections: { verification },
+				jobs: {
+					safeVerification: sendVerificationJob,
+					"send-auth-verification": collidingRegistrationJob,
+				},
+			},
+			{ secret: "test-auth-queue-secret-at-least-32-bytes" },
+		);
+		await runTestDbMigrations(setup.app);
+		const context = await setup.app.auth.$context;
+
+		await withAuthTransactionalQueue({ context }, async ({ publish }) =>
+			publish(
+				sendVerificationJob,
+				{
+					verificationId: "verification-registration-collision",
+					token: "raw-secret-token",
+				},
+				{ idempotencyKey: "auth-verification:registration-collision" },
+			),
+		);
+
+		expect(setup.app.mocks.queue.getJobs()).toMatchObject([
+			{ name: "send-auth-verification" },
+		]);
+		expect(
+			await setup.app.db
+				.select({ jobName: questpieQueueDispatchTable.jobName })
+				.from(questpieQueueDispatchTable),
+		).toEqual([{ jobName: "send-auth-verification" }]);
 	});
 });

--- a/packages/questpie/test/types/auth-transactional-queue.test-d.ts
+++ b/packages/questpie/test/types/auth-transactional-queue.test-d.ts
@@ -1,0 +1,50 @@
+import type { DBTransactionAdapter } from "better-auth";
+import { z } from "zod";
+
+import type { AuthTransactionalQueueTransaction } from "../../src/exports/auth.js";
+import { job } from "../../src/exports/index.js";
+
+const verificationJob = job({
+	name: "send-auth-verification",
+	schema: z.object({ verificationId: z.string(), token: z.string() }),
+	handler: async () => {},
+});
+
+declare const transaction: AuthTransactionalQueueTransaction;
+
+const authAdapter: DBTransactionAdapter = transaction.auth;
+void authAdapter;
+
+transaction.publish(
+	verificationJob,
+	{ verificationId: "verification-1", token: "secret" },
+	{ idempotencyKey: "auth-verification:verification-1" },
+);
+
+transaction.publish(
+	verificationJob,
+	{
+		// @ts-expect-error payloads stay coupled to the concrete registered job type
+		verificationId: 42,
+		token: "secret",
+	},
+	{
+		idempotencyKey: "auth-verification:verification-1",
+	},
+);
+
+// @ts-expect-error Auth dispatch always requires an idempotency identity
+transaction.publish(verificationJob, {
+	verificationId: "verification-1",
+	token: "secret",
+});
+
+transaction.publish(
+	verificationJob,
+	{ verificationId: "verification-1", token: "secret" },
+	{
+		idempotencyKey: "auth-verification:verification-1",
+		// @ts-expect-error the bridge does not expose general Queue scheduling options
+		startAfter: 60,
+	},
+);

--- a/skills/questpie/AGENTS.md
+++ b/skills/questpie/AGENTS.md
@@ -4113,7 +4113,7 @@ Job handlers receive the base `AppContext` (see [Handler Context](#handler-conte
 
 Jobs require a queue adapter in `questpie.config.ts` (`runtimeConfig({ queue: { adapter } })`). Adapter shapes (pg-boss, BullMQ, Cloudflare Queues) and connection options: `references/infrastructure-adapters.md`.
 
-Email delivery is an application recipe, not a second subsystem: define a typed send-mail Job, call `email.sendTemplate()` in its handler, and dispatch it with `queue.<job>.publish()`. There is no `email.enqueueTemplate()` or mail-specific outbox. Avoid secret-bearing Queue payloads; generic payload encryption is a separate Queue security follow-up.
+Email delivery is an application recipe, not a second subsystem: define a typed send-mail Job, call `email.sendTemplate()` in its handler, and dispatch it with `queue.<job>.publish()`. There is no `email.enqueueTemplate()` or mail-specific outbox.
 
 When a Better Auth mutation and its verification dispatch must commit atomically,
 use `withAuthTransactionalQueue()` from `questpie/auth` inside a Better Auth

--- a/skills/questpie/AGENTS.md
+++ b/skills/questpie/AGENTS.md
@@ -4115,6 +4115,30 @@ Jobs require a queue adapter in `questpie.config.ts` (`runtimeConfig({ queue: { 
 
 Email delivery is an application recipe, not a second subsystem: define a typed send-mail Job, call `email.sendTemplate()` in its handler, and dispatch it with `queue.<job>.publish()`. There is no `email.enqueueTemplate()` or mail-specific outbox. Avoid secret-bearing Queue payloads; generic payload encryption is a separate Queue security follow-up.
 
+When a Better Auth mutation and its verification dispatch must commit atomically,
+use `withAuthTransactionalQueue()` from `questpie/auth` inside a Better Auth
+plugin hook. The callback exposes only the transaction-scoped Auth adapter and a
+publisher for a concrete Job registered by the app:
+
+```ts
+import { withAuthTransactionalQueue } from "questpie/auth";
+
+await withAuthTransactionalQueue(ctx, async ({ auth, publish }) => {
+	await auth.create({ model: "verification", data: verification });
+	await publish(
+		sendVerificationJob,
+		{ verificationId: verification.id },
+		{
+			idempotencyKey: `auth-verification:${verification.id}`,
+		},
+	);
+});
+```
+
+The Queue intent joins the Auth database transaction and is encrypted at rest.
+Provider I/O still belongs in the Job handler after commit; the bridge does not
+expose the general Queue client to sibling Auth plugins.
+
 ## Raw Routes
 
 Raw routes (`route().raw()`) give raw HTTP request/response handling for webhooks, OAuth callbacks, health checks, file downloads, and streaming. The handler receives the standard `Request` and must return a `Response`.

--- a/skills/questpie/references/business-logic.md
+++ b/skills/questpie/references/business-logic.md
@@ -269,6 +269,30 @@ Jobs require a queue adapter in `questpie.config.ts` (`runtimeConfig({ queue: { 
 
 Email delivery is an application recipe, not a second subsystem: define a typed send-mail Job, call `email.sendTemplate()` in its handler, and dispatch it with `queue.<job>.publish()`. There is no `email.enqueueTemplate()` or mail-specific outbox. Avoid secret-bearing Queue payloads; generic payload encryption is a separate Queue security follow-up.
 
+When a Better Auth mutation and its verification dispatch must commit atomically,
+use `withAuthTransactionalQueue()` from `questpie/auth` inside a Better Auth
+plugin hook. The callback exposes only the transaction-scoped Auth adapter and a
+publisher for a concrete Job registered by the app:
+
+```ts
+import { withAuthTransactionalQueue } from "questpie/auth";
+
+await withAuthTransactionalQueue(ctx, async ({ auth, publish }) => {
+	await auth.create({ model: "verification", data: verification });
+	await publish(
+		sendVerificationJob,
+		{ verificationId: verification.id },
+		{
+			idempotencyKey: `auth-verification:${verification.id}`,
+		},
+	);
+});
+```
+
+The Queue intent joins the Auth database transaction and is encrypted at rest.
+Provider I/O still belongs in the Job handler after commit; the bridge does not
+expose the general Queue client to sibling Auth plugins.
+
 ## Raw Routes
 
 Raw routes (`route().raw()`) give raw HTTP request/response handling for webhooks, OAuth callbacks, health checks, file downloads, and streaming. The handler receives the standard `Request` and must return a `Response`.

--- a/skills/questpie/references/business-logic.md
+++ b/skills/questpie/references/business-logic.md
@@ -267,7 +267,7 @@ Job handlers receive the base `AppContext` (see [Handler Context](#handler-conte
 
 Jobs require a queue adapter in `questpie.config.ts` (`runtimeConfig({ queue: { adapter } })`). Adapter shapes (pg-boss, BullMQ, Cloudflare Queues) and connection options: `references/infrastructure-adapters.md`.
 
-Email delivery is an application recipe, not a second subsystem: define a typed send-mail Job, call `email.sendTemplate()` in its handler, and dispatch it with `queue.<job>.publish()`. There is no `email.enqueueTemplate()` or mail-specific outbox. Avoid secret-bearing Queue payloads; generic payload encryption is a separate Queue security follow-up.
+Email delivery is an application recipe, not a second subsystem: define a typed send-mail Job, call `email.sendTemplate()` in its handler, and dispatch it with `queue.<job>.publish()`. There is no `email.enqueueTemplate()` or mail-specific outbox.
 
 When a Better Auth mutation and its verification dispatch must commit atomically,
 use `withAuthTransactionalQueue()` from `questpie/auth` inside a Better Auth


### PR DESCRIPTION
## Summary
- add a narrow Better Auth transactional Queue bridge
- atomically commit Auth state and encrypted idempotent Queue dispatches
- keep provider I/O outside the transaction and hide the general Queue capability from sibling plugins

## Evidence
- 9 focused PostgreSQL integration scenarios pass
- package full-app typecheck passes
- diff check passes

## Scope
Generic QUESTPIE framework seam only. No Autopilot-local mail queue and no second outbox API.