### PR TITLE
fix(channels): fence Pusher disconnect epochs

### DIFF
--- a/.changeset/calm-pushers-fence.md
+++ b/.changeset/calm-pushers-fence.md
@@ -1,0 +1,5 @@
+---
+"questpie": patch
+---
+
+Fence Channel replay, live delivery, presence, and stale subscription callbacks when a shared Pusher connection leaves its connected epoch, then re-admit mounted subscribers only after the fresh subscription replay completes.

--- a/packages/questpie/src/client/channels/pusher.ts
+++ b/packages/questpie/src/client/channels/pusher.ts
@@ -49,6 +49,7 @@ type Entry = {
 		resolve: (members: readonly unknown[]) => void;
 		reject: (error: Error) => void;
 	}>;
+	providerEpochActive: boolean;
 };
 
 type AuthResponse = {
@@ -235,6 +236,7 @@ export class PusherChannelTransport implements ChannelClientTransport {
 			replayGeneration: 0,
 			pendingLive: new BoundedChannelQueue(),
 			presenceWaiters: new Set(),
+			providerEpochActive: false,
 		};
 		this.entries.set(input.resolvedName, entry);
 		void this.mount(entry);
@@ -317,6 +319,7 @@ export class PusherChannelTransport implements ChannelClientTransport {
 				lane: "channel",
 				authorize: (socketId, channelName) =>
 					this.authorize(socketId, channelName),
+				onConnectionEpochEnd: () => this.endConnectionEpoch(entry),
 				...(this.options.config.userAuthentication === true
 					? {
 							authenticateUser: (socketId: string) =>
@@ -337,15 +340,19 @@ export class PusherChannelTransport implements ChannelClientTransport {
 			channel.bind("questpie:channel", (payload) =>
 				this.handleMessage(entry, payload),
 			);
-			channel.bind("pusher:subscription_error", (error) =>
-				this.failEntry(entry, normalizedError(error)),
-			);
+			channel.bind("pusher:subscription_error", (error) => {
+				if (!subscription.isConnectionActive()) return;
+				this.failEntry(entry, normalizedError(error));
+			});
 			channel.bind("pusher:subscription_succeeded", (members) => {
 				try {
+					if (!subscription.isConnectionActive()) return;
 					if (entry.readiness.isReady) {
 						this.notify(entry, new Error("Channel subscription epoch ended"));
 					}
 					entry.readiness.end();
+					entry.providerEpochActive = true;
+					entry.pendingLive.clear();
 					if (entry.input.visibility === "presence") {
 						this.setPresence(entry, collectMembers(members, channel));
 					}
@@ -356,6 +363,12 @@ export class PusherChannelTransport implements ChannelClientTransport {
 			});
 			const refreshPresence = () => {
 				try {
+					if (
+						!entry.providerEpochActive ||
+						!subscription.isConnectionActive()
+					) {
+						return;
+					}
 					if (entry.input.visibility === "presence") {
 						this.setPresence(entry, collectMembers(undefined, channel));
 					}
@@ -372,6 +385,7 @@ export class PusherChannelTransport implements ChannelClientTransport {
 
 	private handleMessage(entry: Entry, payload: unknown): void {
 		try {
+			if (!entry.providerEpochActive) return;
 			const envelope = deserializeCompatibleTypedEventWire<{
 				eventId?: unknown;
 				event?: unknown;
@@ -470,9 +484,24 @@ export class PusherChannelTransport implements ChannelClientTransport {
 	private isReplayCurrent(entry: Entry, generation: number): boolean {
 		return (
 			!this.destroyed &&
+			entry.providerEpochActive &&
 			entry.replayGeneration === generation &&
 			this.entries.get(entry.input.resolvedName) === entry
 		);
+	}
+
+	private endConnectionEpoch(entry: Entry): void {
+		if (
+			this.entries.get(entry.input.resolvedName) !== entry ||
+			!entry.providerEpochActive
+		) {
+			return;
+		}
+		entry.providerEpochActive = false;
+		entry.replayGeneration += 1;
+		entry.replaying = false;
+		entry.pendingLive.clear();
+		this.notify(entry, new Error("Channel connection epoch ended"));
 	}
 
 	private parseReplayMessage(value: unknown): ChannelTransportMessage {
@@ -536,6 +565,7 @@ export class PusherChannelTransport implements ChannelClientTransport {
 	}
 
 	private unmount(name: string, entry: Entry): void {
+		entry.providerEpochActive = false;
 		entry.replayGeneration += 1;
 		entry.replaying = false;
 		entry.pendingLive.clear();

--- a/packages/questpie/src/client/realtime/pusher-connection.ts
+++ b/packages/questpie/src/client/realtime/pusher-connection.ts
@@ -35,11 +35,13 @@ type UserAuthenticator = (socketId: string) => Promise<{
 type ChannelOwner = {
 	authorize: ChannelAuthorizer;
 	authenticateUser?: UserAuthenticator;
+	onConnectionEpochEnd?: () => void;
 	channel?: PusherChannel;
 };
 
 export type ManagedPusherSubscription = {
 	channel: PusherChannel;
+	isConnectionActive(): boolean;
 	release(): void;
 };
 
@@ -84,6 +86,7 @@ export class PusherConnectionManager {
 		lane: "edge" | "channel";
 		authorize: ChannelAuthorizer;
 		authenticateUser?: UserAuthenticator;
+		onConnectionEpochEnd?: () => void;
 	}): Promise<ManagedPusherSubscription> {
 		if (
 			options.lane === "channel" &&
@@ -98,6 +101,7 @@ export class PusherConnectionManager {
 		const owner: ChannelOwner = {
 			authorize: options.authorize,
 			authenticateUser: options.authenticateUser,
+			onConnectionEpochEnd: options.onConnectionEpochEnd,
 		};
 		this.owners.set(options.channelName, owner);
 		try {
@@ -110,6 +114,7 @@ export class PusherConnectionManager {
 			let released = false;
 			return {
 				channel,
+				isConnectionActive: () => pusher.connection.state === "connected",
 				release: () => {
 					if (released) return;
 					released = true;
@@ -224,6 +229,17 @@ export class PusherConnectionManager {
 							}
 						: {}),
 				});
+				pusher.connection.bind("state_change", (change: unknown) => {
+					if (this.pusher !== pusher) return;
+					if (!isConnectionEpochEnd(change)) return;
+					for (const owner of this.owners.values()) {
+						try {
+							owner.onConnectionEpochEnd?.();
+						} catch {
+							// One transport owner cannot suppress the epoch fence for siblings.
+						}
+					}
+				});
 				if (config.userAuthentication === true) pusher.signin();
 				this.pusher = pusher;
 				return pusher;
@@ -247,4 +263,10 @@ export class PusherConnectionManager {
 		this.pusherPromise = null;
 		this.signature = null;
 	}
+}
+
+function isConnectionEpochEnd(value: unknown): boolean {
+	if (!value || typeof value !== "object") return false;
+	const change = value as { previous?: unknown; current?: unknown };
+	return change.previous === "connected" && change.current !== "connected";
 }

--- a/packages/questpie/test/client/client-channels.test.ts
+++ b/packages/questpie/test/client/client-channels.test.ts
@@ -35,9 +35,27 @@ class FakeChannel {
 	}
 }
 
+class FakePusherConnection {
+	private readonly listeners = new Set<(change: unknown) => void>();
+	state = "connected";
+	readonly socket_id = "123.456";
+
+	bind(event: string, callback: (change: unknown) => void): this {
+		if (event === "state_change") this.listeners.add(callback);
+		return this;
+	}
+
+	transition(current: string): void {
+		const previous = this.state;
+		this.state = current;
+		for (const callback of this.listeners) callback({ previous, current });
+	}
+}
+
 class FakePusher {
 	static instances: FakePusher[] = [];
 	readonly channel = new FakeChannel();
+	readonly connection = new FakePusherConnection();
 	disconnected = false;
 
 	constructor(
@@ -889,12 +907,20 @@ describe("channels client", () => {
 		await Promise.resolve();
 		expect(order.slice(-2)).toEqual(["late:ready", "late:members"]);
 
-		provider.channel.memberInfos = [{ id: "member-2" }];
+		const admittedLength = order.length;
+		provider.connection.transition("disconnected");
+		provider.channel.memberInfos = [{ id: "stale-member" }];
+		provider.channel.emit("pusher:member_added", {});
+		expect(order).toHaveLength(admittedLength);
+
+		provider.connection.transition("connected");
+		provider.channel.memberInfos = [{ id: "fresh-member" }];
 		provider.channel.emit(
 			"pusher:subscription_succeeded",
 			provider.channel.members,
 		);
-		expect(order.slice(-4)).toEqual([
+		await waitFor(() => order.length > admittedLength);
+		expect(order.slice(admittedLength)).toEqual([
 			"initial:ready",
 			"initial:members",
 			"late:ready",
@@ -1788,6 +1814,141 @@ describe("channels client", () => {
 		]);
 
 		stop();
+		client.channels.destroy();
+	});
+
+	test("fences a disconnected Pusher replay and re-admits only after fresh recovery", async () => {
+		FakePusher.instances = [];
+		const channelHash = "e".repeat(64);
+		const replayRequests: Record<string, unknown>[] = [];
+		const replayResolvers: Array<(response: Response) => void> = [];
+		const fetcher: typeof fetch = async (input, init) => {
+			const url = String(input);
+			if (url.endsWith("/channels/config")) {
+				return Response.json({
+					transport: "shared-provider",
+					config: { provider: "pusher", key: "public-key" },
+					channels: {
+						news: { pattern: "news", visibility: "public" },
+					},
+				});
+			}
+			if (url.endsWith("/channels/replay")) {
+				replayRequests.push(JSON.parse(String(init?.body)));
+				return new Promise<Response>((resolve) =>
+					replayResolvers.push(resolve),
+				);
+			}
+			throw new Error(`Unexpected request: ${url}`);
+		};
+		const client = createClient<any>({
+			baseURL: "http://localhost:3000",
+			fetch: fetcher,
+		});
+		const lifecycle: string[] = [];
+		const stop = client.channels.news.subscribe(
+			(message: { eventId: string }) =>
+				lifecycle.push(`event:${message.eventId}`),
+			{
+				onReady: () => lifecycle.push("ready"),
+				onError: (error: Error) => lifecycle.push(`error:${error.message}`),
+			},
+		);
+
+		await waitFor(() => FakePusher.instances.length === 1);
+		const provider = FakePusher.instances[0]!;
+		provider.channel.emit("pusher:subscription_succeeded", {});
+		await waitFor(() => lifecycle[0] === "ready");
+		provider.channel.emit("questpie:channel", {
+			eventId: `${channelHash}:1`,
+			event: "updated",
+			data: { value: 1 },
+		});
+		await waitFor(() => lifecycle.includes(`event:${channelHash}:1`));
+
+		provider.channel.emit("pusher:subscription_succeeded", {});
+		await waitFor(() => replayRequests.length === 1);
+		provider.connection.transition("disconnected");
+		provider.connection.transition("connecting");
+		await waitFor(
+			() =>
+				lifecycle.filter(
+					(value) => value === "error:Channel connection epoch ended",
+				).length === 1,
+		);
+		provider.channel.emit("pusher:subscription_succeeded", {});
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		expect(replayRequests).toHaveLength(1);
+		provider.channel.emit(
+			"pusher:subscription_error",
+			new Error("stale subscription error"),
+		);
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		expect(lifecycle).toEqual([
+			"ready",
+			`event:${channelHash}:1`,
+			"error:Channel subscription epoch ended",
+			"error:Channel connection epoch ended",
+		]);
+		provider.channel.emit("questpie:channel", {
+			eventId: `${channelHash}:3`,
+			event: "updated",
+			data: { value: 3 },
+		});
+		replayResolvers[0]?.(
+			Response.json({
+				status: "events",
+				events: [
+					{
+						eventId: `${channelHash}:2`,
+						event: "updated",
+						data: { value: 2 },
+					},
+				],
+				hasMore: false,
+			}),
+		);
+		await new Promise((resolve) => setTimeout(resolve, 10));
+		expect(lifecycle).toEqual([
+			"ready",
+			`event:${channelHash}:1`,
+			"error:Channel subscription epoch ended",
+			"error:Channel connection epoch ended",
+		]);
+
+		provider.connection.transition("connected");
+		provider.channel.emit("pusher:subscription_succeeded", {});
+		await waitFor(() => replayRequests.length === 2);
+		replayResolvers[1]?.(
+			Response.json({
+				status: "events",
+				events: [
+					{
+						eventId: `${channelHash}:2`,
+						event: "updated",
+						data: { value: 2 },
+					},
+				],
+				hasMore: false,
+			}),
+		);
+		await waitFor(
+			() => lifecycle.filter((value) => value === "ready").length === 2,
+		);
+		expect(lifecycle).toEqual([
+			"ready",
+			`event:${channelHash}:1`,
+			"error:Channel subscription epoch ended",
+			"error:Channel connection epoch ended",
+			`event:${channelHash}:2`,
+			"ready",
+		]);
+
+		const finalLifecycle = [...lifecycle];
+		stop();
+		provider.connection.transition("disconnected");
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		expect(lifecycle).toEqual(finalLifecycle);
 		client.channels.destroy();
 	});
 

--- a/packages/questpie/test/client/client-pusher-realtime.test.ts
+++ b/packages/questpie/test/client/client-pusher-realtime.test.ts
@@ -31,9 +31,23 @@ class FakeChannel {
 	}
 }
 
+class FakePusherConnection {
+	readonly state = "connected";
+	readonly socket_id = "123.456";
+	private readonly listeners = new Map<string, Set<(data: unknown) => void>>();
+
+	bind(event: string, callback: (data: unknown) => void): this {
+		const listeners = this.listeners.get(event) ?? new Set();
+		listeners.add(callback);
+		this.listeners.set(event, listeners);
+		return this;
+	}
+}
+
 class FakePusher {
 	static instances: FakePusher[] = [];
 	readonly channel = new FakeChannel();
+	readonly connection = new FakePusherConnection();
 	disconnected = false;
 
 	constructor(

--- a/packages/questpie/test/client/crdt-realtime-session.test.ts
+++ b/packages/questpie/test/client/crdt-realtime-session.test.ts
@@ -54,9 +54,23 @@ class FakePusherChannel {
 	}
 }
 
+class FakePusherConnection {
+	readonly state = "connected";
+	readonly socket_id = "1.2";
+	private readonly listeners = new Map<string, Set<(value: unknown) => void>>();
+
+	bind(event: string, callback: (value: unknown) => void): this {
+		const listeners = this.listeners.get(event) ?? new Set();
+		listeners.add(callback);
+		this.listeners.set(event, listeners);
+		return this;
+	}
+}
+
 class FakePusher {
 	static instances: FakePusher[] = [];
 	readonly channel = new FakePusherChannel();
+	readonly connection = new FakePusherConnection();
 	disconnected = false;
 
 	constructor(

--- a/packages/questpie/test/client/pusher-connection-manager.test.ts
+++ b/packages/questpie/test/client/pusher-connection-manager.test.ts
@@ -28,6 +28,23 @@ class FakeChannel {
 	}
 }
 
+class FakePusherConnection {
+	private readonly listeners = new Set<(change: unknown) => void>();
+	state = "connected";
+	readonly socket_id = "1.2";
+
+	bind(event: string, callback: (change: unknown) => void): this {
+		if (event === "state_change") this.listeners.add(callback);
+		return this;
+	}
+
+	transition(current: string): void {
+		const previous = this.state;
+		this.state = current;
+		for (const callback of this.listeners) callback({ previous, current });
+	}
+}
+
 class FakePusher {
 	readonly channels = new Map<string, FakeChannel>();
 	readonly unsubscribed: string[] = [];
@@ -38,10 +55,7 @@ class FakePusher {
 		signinDonePromise: Promise.resolve(),
 		user_data: { id: "opaque-user" },
 	};
-	readonly connection = {
-		state: "connected",
-		socket_id: "1.2",
-	};
+	readonly connection = new FakePusherConnection();
 	disconnected = false;
 	signinCalls = 0;
 
@@ -118,6 +132,60 @@ function authenticateUser(
 }
 
 describe("PusherConnectionManager", () => {
+	test("isolates epoch callbacks and ignores disposed physical instances", async () => {
+		const fixture = managerFixture();
+		let throwingEnds = 0;
+		let siblingEnds = 0;
+		const first = await fixture.manager.subscribe({
+			config: { provider: "pusher", key: "key" },
+			channelName: "private-room-one",
+			lane: "channel",
+			authorize: async () => ({ auth: "first" }),
+			onConnectionEpochEnd: () => {
+				throwingEnds += 1;
+				throw new Error("consumer callback failed");
+			},
+		});
+		const second = await fixture.manager.subscribe({
+			config: { provider: "pusher", key: "key" },
+			channelName: "private-room-two",
+			lane: "channel",
+			authorize: async () => ({ auth: "second" }),
+			onConnectionEpochEnd: () => {
+				siblingEnds += 1;
+			},
+		});
+		const disposed = fixture.getPusher()!;
+
+		disposed.connection.transition("disconnected");
+		expect({ throwingEnds, siblingEnds }).toEqual({
+			throwingEnds: 1,
+			siblingEnds: 1,
+		});
+		first.release();
+		second.release();
+
+		let freshEnds = 0;
+		const fresh = await fixture.manager.subscribe({
+			config: { provider: "pusher", key: "key" },
+			channelName: "private-room-three",
+			lane: "channel",
+			authorize: async () => ({ auth: "fresh" }),
+			onConnectionEpochEnd: () => {
+				freshEnds += 1;
+			},
+		});
+		const active = fixture.getPusher()!;
+		expect(active).not.toBe(disposed);
+
+		disposed.connection.transition("connected");
+		disposed.connection.transition("unavailable");
+		expect(freshEnds).toBe(0);
+		active.connection.transition("unavailable");
+		expect(freshEnds).toBe(1);
+		fresh.release();
+	});
+
 	test("signs in once and resolves user auth through a currently live shared owner", async () => {
 		const fixture = managerFixture();
 		const first = await fixture.manager.subscribe({


### PR DESCRIPTION
## Summary

- end each mounted Channel readiness epoch when the shared physical Pusher connection leaves `connected`
- fence stale replay, live frames, presence updates, subscription success, and subscription errors
- re-admit mounted subscribers only after a fresh connected subscription and replay
- isolate owner callbacks and ignore state changes from disposed physical Pusher instances

## Why

The 3.20.0 consumer qualification found that a disconnect during deferred replay could emit stale events and a second `onReady`. Additional adversarial cases showed stale presence, stale subscription errors, and disposed Pusher listeners crossing physical connection epochs.

## Verification

- exact scenarios were observed red before their production repairs
- 56 focused tests passed across Channels, Pusher manager/realtime, CRDT, and presence (210 expectations)
- `bun run --cwd packages/questpie check-types`
- targeted Oxlint and Oxfmt checks
- root `bun run lint` and `bun run format:check`
- cache-miss `bun run build --filter=questpie`
- independent GPT-5.6-sol adversarial review: no P0-P3 findings

No Autopilot workaround and no public package entrypoint widening.
