### PR TITLE
docs: state the delivery guarantee behind onAfterCommit and the dispatch ledger

### DIFF
--- a/apps/docs/content/docs/concepts/hooks.mdx
+++ b/apps/docs/content/docs/concepts/hooks.mdx
@@ -291,7 +291,25 @@ Use `ctx.onAfterCommit(cb)` to defer only those non-transactional side effects u
   immediately as fire-and-forget work. Do not rely on either form to fail or
   roll back the request.
 
-This is exactly how the framework's own realtime and search hooks are written, both subscribe to `afterChange` / `afterDelete` and wrap their broadcast/indexing in `ctx.onAfterCommit`, so events fire only on durable data.
+<Callout type="warn" title="`onAfterCommit` is at-most-once">
+	The callback lives only in the memory of the process that ran the write.
+	Nothing records that it was supposed to run, so it is lost with no trace if
+	the callback throws (the error is logged, never retried) or the process dies
+	in the window between `COMMIT` and the callback finishing. That window is
+	small but it is not zero, and a lost callback looks exactly like one that
+	never needed to run.
+</Callout>
+
+Pick the mechanism by the guarantee the effect actually needs, not by
+convenience:
+
+| The effect                                                      | Use                                          | Guarantee                                                                       |
+| --------------------------------------------------------------- | -------------------------------------------- | ------------------------------------------------------------------------------- |
+| Writes to the same database                                     | the hook body itself (`ctx.db`)              | Atomic with the write; rolls back with it                                       |
+| Must not be lost (verification email, payment capture, webhook) | `queue.<job>.publish()`, awaited in the hook | At-least-once; the dispatch commits with the data ([Jobs](/docs/concepts/jobs)) |
+| Nice to have, safe to lose (cache warm, metric, search reindex) | `ctx.onAfterCommit(cb)`                      | At-most-once; silently dropped on throw or crash                                |
+
+This is exactly how the framework's own realtime and search hooks are written, both subscribe to `afterChange` / `afterDelete` and wrap their broadcast/indexing in `ctx.onAfterCommit`, so events fire only on durable data. They sit in the third row deliberately: a missed reindex is repaired by the next write or a re-index job, so paying for durability would buy nothing.
 
 <Callout type="warn">
 	**Keep direct external effects out of an `after*` hook.** Transactional

--- a/apps/docs/content/docs/concepts/jobs.mdx
+++ b/apps/docs/content/docs/concepts/jobs.mdx
@@ -288,6 +288,26 @@ interface PublishOptions {
 
 `idempotencyKey` is portable and scoped to the durable job name. Reusing it returns the same `dispatchId`; the first accepted payload/options win, even after pg-boss Job retention or an adapter switch. Put the application payload version in this key when a later version must create new work. Accepted idempotent dispatches retain only their identity receipt, not their payload, with no automatic expiry: keep the key non-secret and remove a receipt only when your application can prove the key will never be retried. `singletonKey` is different: it controls adapter-native scheduling/concurrency deduplication while work is queued or active. It is supported by pg-boss queue policies and BullMQ deduplication and ignored by Cloudflare Queues. Combining both keys is rejected because a singleton-suppressed publish has no new logical Job identity. `schedule()` accepts `Omit<PublishOptions, "idempotencyKey" | "startAfter" | "secretPayload">`.
 
+#### Why a dispatch ledger when brokers already deduplicate
+
+QUESTPIE does not reimplement broker deduplication. `dispatchId` is derived
+deterministically from `SHA-256(jobName + idempotencyKey)`, and the adapter
+publishes with that value as the broker's own Job id, so pg-boss and BullMQ
+reject the duplicate themselves.
+
+What a broker cannot offer is a **window**. pg-boss archives and then deletes
+completed jobs; BullMQ drops them under `removeOnComplete`; Cloudflare Queues has
+no deduplication at all. Once the Job row is gone the id is free again, so broker
+deduplication silently means "not twice _while I still remember_". An
+`idempotencyKey` like `charge-invoice:${invoiceId}` is written expecting the
+stronger reading, and the difference surfaces as a duplicate side effect long
+after deployment rather than as an error.
+
+The `questpie_queue_dispatch` receipt keeps that identity after the broker has
+forgotten it, which is also what makes the key portable across an adapter switch.
+It is opt-in: a `publish()` without `idempotencyKey` never touches the table and
+keeps the direct low-latency path.
+
 ### Secret-bearing payloads and safe receipts
 
 Use `secretPayload: true` only when the job must carry a short-lived bearer secret that cannot be resolved from durable application state:


### PR DESCRIPTION
The docs described what `onAfterCommit` and the Queue dispatch ledger do, never
the guarantee each one gives. Choosing between them read as taste.

Docs only, no package touched, so no changeset.

## `hooks.mdx`

`onAfterCommit` is at-most-once. The callback lives only in the memory of the
process that ran the write, so a throw (logged, never retried) or a crash between
`COMMIT` and the callback drops it with no trace. The page already said errors are
swallowed; it did not say the effect can vanish entirely.

Adds a table mapping three mechanisms to the guarantee each gives: a write through
`ctx.db`, `queue.<job>.publish()`, and `onAfterCommit`.

## `jobs.mdx`

New section: why a dispatch ledger exists when brokers already deduplicate.

QUESTPIE does not reimplement broker dedup. `dispatchId` is derived from
`SHA-256(jobName + idempotencyKey)` and passed as the broker's own job id. What a
broker cannot give is a window: pg-boss archives completed jobs, BullMQ drops them
under `removeOnComplete`, Cloudflare Queues has no dedup at all. Broker dedup
therefore means "not twice while I still remember". The receipt keeps that identity
afterwards, and is opt-in — `publish()` without `idempotencyKey` never touches the
table.

## Verified in code

| claim | source |
| --- | --- |
| pg-boss receives our id | `adapters/pg-boss.ts:185` — `id: dispatchId` |
| BullMQ receives our id | `adapters/bullmq.ts:121` — `opts.jobId = dispatchId` |
| Cloudflare has no dedup | `adapters/cloudflare-queues.ts:45` — `send()` returns no physical id |
| afterCommit swallows errors | `crud/shared/transaction.ts:350` |
| the ledger is opt-in | `queue/service.ts:737` — `if (options.idempotencyKey)` |

`fumadocs-mdx` and `tsc --noEmit` pass; oxfmt clean.

## Not verified by running

That pg-boss archives and deletes completed jobs, and that BullMQ drops them under
`removeOnComplete`, comes from their documented upstream behaviour, not a test
here. It is the load-bearing claim of the `jobs.mdx` section. An integration test
against a real pg-boss — publish with a key, force archival, publish again, assert
the broker would let it through but the ledger does not — would lock it against
regression.