### PR TITLE
fix(realtime): reconnect retryable SSE failures

### DIFF
--- a/.changeset/red-bikes-join.md
+++ b/.changeset/red-bikes-join.md
@@ -1,0 +1,5 @@
+---
+"questpie": patch
+---
+
+Reconnect retryable SSE transport failures without terminating channel consumers, while preserving fail-closed authorization, protocol, and replay-gap errors.

--- a/packages/questpie/src/client/channels/readiness.ts
+++ b/packages/questpie/src/client/channels/readiness.ts
@@ -3,6 +3,7 @@ import { BoundedChannelQueue } from "./ordered-events.js";
 
 type ReadyRegistration = {
 	callback: () => void;
+	onEnd?: () => void;
 	active: boolean;
 	notifiedEpoch: number;
 };
@@ -17,10 +18,11 @@ export class ChannelReadiness {
 		return this.admitted;
 	}
 
-	register(callback: (() => void) | undefined): () => void {
-		if (!callback) return () => {};
+	register(callback: (() => void) | undefined, onEnd?: () => void): () => void {
+		if (!callback && !onEnd) return () => {};
 		const registration: ReadyRegistration = {
-			callback,
+			callback: callback ?? (() => {}),
+			onEnd,
 			active: true,
 			notifiedEpoch: 0,
 		};
@@ -47,6 +49,14 @@ export class ChannelReadiness {
 
 	end(): void {
 		this.admitted = false;
+		for (const registration of this.registrations) {
+			if (!registration.active) continue;
+			try {
+				registration.onEnd?.();
+			} catch {
+				// One subscriber cannot block epoch reset for its siblings.
+			}
+		}
 	}
 
 	destroy(): void {
@@ -120,7 +130,14 @@ export class ChannelReadyDelivery<T> {
 						}
 					}
 				: undefined,
+			() => this.endEpoch(),
 		);
+	}
+
+	private endEpoch(): void {
+		if (!this.active || !this.waitForAdmission) return;
+		this.pending.clear();
+		this.awaitingReady = true;
 	}
 
 	private drain(): void {

--- a/packages/questpie/src/client/channels/sse.ts
+++ b/packages/questpie/src/client/channels/sse.ts
@@ -109,7 +109,7 @@ export class SseChannelTransport implements ChannelClientTransport {
 				current.presenceWaiters.size > 0
 			)
 				return;
-			this.removeEntry(input.resolvedName);
+			this.removeEntry(input.resolvedName, current);
 		};
 		options.signal?.addEventListener("abort", stop, { once: true });
 		if (options.signal?.aborted) stop();
@@ -155,7 +155,7 @@ export class SseChannelTransport implements ChannelClientTransport {
 				current.presenceWaiters.size > 0
 			)
 				return;
-			this.removeEntry(input.resolvedName);
+			this.removeEntry(input.resolvedName, current);
 		};
 		options.signal?.addEventListener("abort", stop, { once: true });
 		if (options.signal?.aborted) stop();
@@ -253,13 +253,16 @@ export class SseChannelTransport implements ChannelClientTransport {
 							? { lastEventId: entry.cursor.eventId }
 							: {}),
 					}),
-					onEvent: (event) => this.handleEvent(event),
-					onError: (error) => this.notifyEntry(entry!, error),
-					onEpochEnd: (error) => this.notifyAdmittedEntry(entry!, error),
+					onEvent: (event) => {
+						if (this.entries.get(input.resolvedName) !== entry) return;
+						this.handleEvent(event);
+					},
+					onError: (error) => this.failEntry(entry!, error),
+					onEpochEnd: () => this.endEntryEpoch(entry!),
 				});
 			} catch (error) {
 				queueMicrotask(() =>
-					this.notifyEntry(
+					this.failEntry(
 						entry!,
 						error instanceof Error ? error : new Error(String(error)),
 					),
@@ -271,12 +274,12 @@ export class SseChannelTransport implements ChannelClientTransport {
 		return entry;
 	}
 
-	private removeEntry(name: string): void {
+	private removeEntry(name: string, expected: Entry): void {
 		const entry = this.entries.get(name);
-		if (!entry) return;
+		if (entry !== expected) return;
 		entry.sharedRelease?.();
 		entry.readiness.destroy();
-		this.entries.delete(name);
+		if (this.entries.get(name) === entry) this.entries.delete(name);
 		if (this.options.connection) return;
 		if (this.entries.size === 0) {
 			this.abortController?.abort();
@@ -288,7 +291,7 @@ export class SseChannelTransport implements ChannelClientTransport {
 	private failEntry(entry: Entry, error: Error): void {
 		if (this.entries.get(entry.input.resolvedName) !== entry) return;
 		this.notifyEntry(entry, error);
-		this.removeEntry(entry.input.resolvedName);
+		this.removeEntry(entry.input.resolvedName, entry);
 	}
 
 	private scheduleConnect(delayMs: number): void {
@@ -504,8 +507,7 @@ export class SseChannelTransport implements ChannelClientTransport {
 				const decision = entry.cursor.accept(message);
 				if (decision.status === "duplicate") return;
 				if (decision.status === "gap") {
-					this.notifyEntry(entry, channelGapError());
-					this.removeEntry(entry.input.resolvedName);
+					this.failEntry(entry, channelGapError());
 					return;
 				}
 				this.retryAttempt = 0;
@@ -526,14 +528,13 @@ export class SseChannelTransport implements ChannelClientTransport {
 			} else if (event.type === "channel_gap") {
 				const entry = this.entryForFrame(frame);
 				if (entry) {
-					this.notifyEntry(entry, channelGapError());
-					this.removeEntry(entry.input.resolvedName);
+					this.failEntry(entry, channelGapError());
 				}
 			} else if (event.type === "error") {
 				const id = frame.channelSubscriptionId;
 				const entry = [...this.entries.values()].find((item) => item.id === id);
 				if (entry) {
-					this.notifyEntry(
+					this.failEntry(
 						entry,
 						new Error(String(frame.message ?? "Channel error")),
 					);
@@ -565,14 +566,13 @@ export class SseChannelTransport implements ChannelClientTransport {
 		if (channel) {
 			const entry = this.entries.get(channel);
 			if (entry) {
-				this.notifyEntry(entry, error);
-				this.removeEntry(channel);
+				this.failEntry(entry, error);
 				return;
 			}
 		}
-		for (const entry of this.entries.values()) {
-			this.notifyEntry(entry, error);
-			this.removeEntry(entry.input.resolvedName);
+		const failedEntries = Array.from(this.entries.values());
+		for (const entry of failedEntries) {
+			this.failEntry(entry, error);
 		}
 	}
 
@@ -594,7 +594,7 @@ export class SseChannelTransport implements ChannelClientTransport {
 	}
 
 	private notifyEntry(entry: Entry, error: Error): void {
-		entry.readiness.end();
+		this.resetEntryEpoch(entry);
 		const errorCallbacks = Array.from(entry.errorCallbacks);
 		for (const callback of errorCallbacks) {
 			notifyChannelConsumer(callback, error);
@@ -606,6 +606,17 @@ export class SseChannelTransport implements ChannelClientTransport {
 
 	private notifyAll(error: Error): void {
 		for (const entry of this.entries.values()) this.notifyEntry(entry, error);
+	}
+
+	private endEntryEpoch(entry: Entry): void {
+		if (this.entries.get(entry.input.resolvedName) !== entry) return;
+		this.resetEntryEpoch(entry);
+	}
+
+	private resetEntryEpoch(entry: Entry): void {
+		entry.readiness.end();
+		entry.presence = undefined;
+		entry.presenceSignature = undefined;
 	}
 
 	private notifyAdmittedEntry(entry: Entry, error: Error): void {

--- a/packages/questpie/src/client/realtime/sse-connection.ts
+++ b/packages/questpie/src/client/realtime/sse-connection.ts
@@ -31,8 +31,8 @@ class DispatchedRealtimeControlError extends Error {
 	}
 }
 
-class PermanentInitialSseError extends Error {
-	override readonly name = "PermanentInitialSseError";
+class TerminalSseError extends Error {
+	override readonly name = "TerminalSseError";
 }
 
 function normalizedError(error: unknown): Error {
@@ -61,7 +61,6 @@ export class SseConnectionManager {
 	private desiredRevision = 0;
 	private flushPromise: Promise<void> | null = null;
 	private holdCount = 0;
-	private hasEstablishedSession = false;
 	private readonly sessionWaiters = new Set<{
 		resolve(session: ControlSession): void;
 		reject(error: Error): void;
@@ -241,7 +240,6 @@ export class SseConnectionManager {
 
 	private applyTopologyChange(): void {
 		if (!this.hasDemand()) {
-			this.hasEstablishedSession = false;
 			if (this.reconnectTimer) clearTimeout(this.reconnectTimer);
 			this.reconnectTimer = null;
 			this.abortController?.abort();
@@ -308,20 +306,13 @@ export class SseConnectionManager {
 				const error = new Error(
 					`Realtime connection failed: ${response.status}`,
 				);
-				if (
-					!this.hasEstablishedSession &&
-					isPermanentInitialStatus(response.status)
-				) {
-					throw new PermanentInitialSseError(error.message);
+				if (isTerminalHttpStatus(response.status)) {
+					throw new TerminalSseError(error.message);
 				}
 				throw error;
 			}
 			if (!response.body) {
-				const error = new Error("Realtime response has no body");
-				if (!this.hasEstablishedSession) {
-					throw new PermanentInitialSseError(error.message);
-				}
-				throw error;
+				throw new TerminalSseError("Realtime response has no body");
 			}
 			this.armWatchdog();
 			await this.readStream(response.body);
@@ -329,7 +320,7 @@ export class SseConnectionManager {
 		} catch (error) {
 			const normalized = normalizedError(error);
 			if (!this.hasDemand()) return;
-			if (normalized instanceof PermanentInitialSseError) {
+			if (normalized instanceof TerminalSseError) {
 				this.rejectSessionWaiters(normalized);
 				this.notifyAll(normalized);
 				this.reconnectPending = false;
@@ -342,12 +333,6 @@ export class SseConnectionManager {
 					}
 				}
 				return;
-			}
-			if (
-				!this.watchdogTriggered &&
-				normalized.message !== "Realtime stream closed"
-			) {
-				this.notifyAll(normalized);
 			}
 			for (const resource of this.resources.values()) {
 				resource.onEpochEnd?.(normalized);
@@ -432,12 +417,21 @@ export class SseConnectionManager {
 							const payload = (await response.json().catch(() => null)) as {
 								error?: unknown;
 							} | null;
+							if (isExpiredControlSession(response.status, payload?.error)) {
+								throw new Error(`Realtime control failed: ${response.status}`);
+							}
 							if (payload?.error && this.dispatchControlError(payload.error)) {
 								throw new DispatchedRealtimeControlError(
 									new Error(`Realtime control failed: ${response.status}`),
 								);
 							}
-							throw new Error(`Realtime control failed: ${response.status}`);
+							const error = new Error(
+								`Realtime control failed: ${response.status}`,
+							);
+							if (isTerminalControlStatus(response.status)) {
+								throw new TerminalSseError(error.message);
+							}
+							throw error;
 						}
 					});
 				this.controlOperation = operation;
@@ -447,8 +441,15 @@ export class SseConnectionManager {
 			}
 		})()
 			.catch((error) => {
-				if (!(error instanceof DispatchedRealtimeControlError)) {
-					this.notifyAll(normalizedError(error));
+				const normalized = normalizedError(error);
+				if (normalized instanceof TerminalSseError) {
+					this.reconnectPending = false;
+					try {
+						this.notifyAll(normalized);
+					} finally {
+						this.abortController?.abort();
+					}
+					return;
 				}
 				this.reconnectPending = true;
 				this.abortController?.abort();
@@ -520,22 +521,16 @@ export class SseConnectionManager {
 					sessionId: session.sessionId,
 					token: session.token,
 				};
-				this.hasEstablishedSession = true;
 				for (const waiter of this.sessionWaiters) {
 					waiter.resolve(this.controlSession);
 				}
 				void this.flushDesiredTopology();
 			} catch (error) {
 				const normalized = normalizedError(error);
-				if (!this.hasEstablishedSession) {
-					const permanent = new PermanentInitialSseError(normalized.message);
-					this.rejectSessionWaiters(permanent);
-					this.notifyAll(permanent);
-					this.reconnectPending = false;
-				} else {
-					this.notifyAll(normalized);
-					this.reconnectPending = true;
-				}
+				const terminal = new TerminalSseError(normalized.message);
+				this.rejectSessionWaiters(terminal);
+				this.notifyAll(terminal);
+				this.reconnectPending = false;
 				this.abortController?.abort();
 			}
 			return;
@@ -637,7 +632,13 @@ export class SseConnectionManager {
 	}
 
 	private notifyAll(error: Error): void {
-		for (const resource of this.resources.values()) resource.onError(error);
+		for (const resource of this.resources.values()) {
+			try {
+				resource.onError(error);
+			} catch {
+				// One consumer callback cannot break terminal delivery to its siblings.
+			}
+		}
 	}
 
 	private rejectSessionWaiters(error: Error): void {
@@ -662,12 +663,23 @@ export class SseConnectionManager {
 	}
 }
 
-function isPermanentInitialStatus(status: number): boolean {
+function isTerminalHttpStatus(status: number): boolean {
 	return (
 		status >= 400 &&
 		status < 500 &&
 		status !== 408 &&
 		status !== 425 &&
 		status !== 429
+	);
+}
+
+function isTerminalControlStatus(status: number): boolean {
+	return isTerminalHttpStatus(status);
+}
+
+function isExpiredControlSession(status: number, value: unknown): boolean {
+	if (status !== 404 || !value || typeof value !== "object") return false;
+	return (
+		(value as Record<string, unknown>).code === "REALTIME_CONTROL_UNAVAILABLE"
 	);
 }

--- a/packages/questpie/test/client/client-channels.test.ts
+++ b/packages/questpie/test/client/client-channels.test.ts
@@ -175,6 +175,29 @@ describe("channels client", () => {
 		delivery.stop();
 	});
 
+	test("retains a late message buffered before its ready microtask across an epoch end", async () => {
+		const readiness = new ChannelReadiness();
+		readiness.admit();
+		const order: string[] = [];
+		const delivery = new ChannelReadyDelivery(
+			readiness,
+			(value: number) => order.push(`message:${value}`),
+			() => order.push("ready"),
+			() => {
+				throw new Error("unexpected overflow");
+			},
+		);
+
+		delivery.accept(1);
+		readiness.end();
+		await Promise.resolve();
+		expect(order).toEqual([]);
+
+		readiness.admit();
+		expect(order).toEqual(["ready", "message:1"]);
+		delivery.stop();
+	});
+
 	test("keeps explicit plain JSON channel publishing interoperable", async () => {
 		const instant = new Date("2026-03-29T00:30:00.000Z");
 		let publishRequest: RequestInit | undefined;
@@ -395,7 +418,7 @@ describe("channels client", () => {
 		client.channels.destroy();
 	});
 
-	test("orders SSE replay then readiness then live delivery for every logical subscriber", async () => {
+	test("orders SSE replay and readiness for every logical subscriber across a silent reconnect", async () => {
 		const streamControllers: ReadableStreamDefaultController<Uint8Array>[] = [];
 		const encoder = new TextEncoder();
 		const fetcher: typeof fetch = async (input) => {
@@ -508,11 +531,8 @@ describe("channels client", () => {
 			),
 		);
 		await waitFor(() => order.filter((item) => item === "ready").length === 4);
-		expect(order.slice(-3)).toEqual([
-			"error:Realtime stream closed",
-			"ready",
-			"ready",
-		]);
+		expect(order.slice(-2)).toEqual(["ready", "ready"]);
+		expect(order.some((item) => item.startsWith("error:"))).toBe(false);
 
 		stopActiveLate();
 		stopSecond();
@@ -573,10 +593,18 @@ describe("channels client", () => {
 		await waitFor(() => errors.length === 1);
 		expect(errors).toEqual(["Channel subscription is denied"]);
 		expect(ready).toBe(0);
+		expect(client.channels.channelCount).toBe(0);
+		streamController!.enqueue(
+			encoder.encode(
+				`event: channel_ready\ndata: ${JSON.stringify({ channelSubscriptionId: "channel:news" })}\n\n`,
+			),
+		);
+		await Bun.sleep(10);
+		expect(ready).toBe(0);
 		client.channels.destroy();
 	});
 
-	test("ends an admitted sibling epoch before reconnecting after a targeted SSE topology rejection", async () => {
+	test("silently ends an admitted sibling epoch before reconnecting after a targeted SSE topology rejection", async () => {
 		const streamControllers: ReadableStreamDefaultController<Uint8Array>[] = [];
 		const encoder = new TextEncoder();
 		let rejectRoom = true;
@@ -692,7 +720,7 @@ describe("channels client", () => {
 		);
 
 		await waitFor(() => newsMessages.length === 1);
-		expect(newsLifecycle).toEqual(["ready", "error:Aborted", "ready"]);
+		expect(newsLifecycle).toEqual(["ready", "ready"]);
 		expect(newsMessages).toEqual([`${hash}:1`]);
 		stopRoom();
 		stopNews();
@@ -861,6 +889,295 @@ describe("channels client", () => {
 
 		stopLate();
 		stopInitial();
+		transport.destroy();
+	});
+
+	test("drops presence buffered before a retryable SSE epoch ends", async () => {
+		let resource:
+			| {
+					onEvent(event: { type: string; data: string }): void;
+					onEpochEnd?(error: Error): void;
+			  }
+			| undefined;
+		const connection = {
+			registerChannel(options: typeof resource): () => void {
+				resource = options;
+				return () => {};
+			},
+		};
+		const transport = new SseChannelTransport({
+			baseUrl: "http://localhost:3000",
+			withCredentials: false,
+			fetcher: async () => {
+				throw new Error("The shared connection owns SSE fetching");
+			},
+			connection: connection as any,
+		});
+		const input = {
+			registryKey: "room",
+			params: { roomId: "one" },
+			resolvedName: "presence-room-one",
+			visibility: "presence" as const,
+		};
+		const rosters: string[] = [];
+		let ready = 0;
+		const stop = transport.subscribePresence(
+			input,
+			(members) => rosters.push((members[0] as { id: string }).id),
+			{ onReady: () => (ready += 1) },
+		);
+
+		resource!.onEvent({
+			type: "channel_presence",
+			data: JSON.stringify({
+				channel: "presence-room-one",
+				members: [{ id: "member-a" }],
+			}),
+		});
+		resource!.onEpochEnd?.(new Error("retryable socket failure"));
+		resource!.onEvent({
+			type: "channel_presence",
+			data: JSON.stringify({
+				channel: "presence-room-one",
+				members: [{ id: "member-b" }],
+			}),
+		});
+		resource!.onEvent({
+			type: "channel_ready",
+			data: JSON.stringify({
+				channelSubscriptionId: "channel:presence-room-one",
+			}),
+		});
+
+		expect(ready).toBe(1);
+		expect(rosters).toEqual(["member-b"]);
+
+		stop();
+		transport.destroy();
+	});
+
+	test("does not return a cached SSE presence roster after a terminal channel error", async () => {
+		let resource:
+			| {
+					onEvent(event: { type: string; data: string }): void;
+					onError(error: Error): void;
+			  }
+			| undefined;
+		const connection = {
+			registerChannel(options: typeof resource): () => void {
+				resource = options;
+				return () => {};
+			},
+		};
+		const transport = new SseChannelTransport({
+			baseUrl: "http://localhost:3000",
+			withCredentials: false,
+			fetcher: async () => {
+				throw new Error("The shared connection owns SSE fetching");
+			},
+			connection: connection as any,
+		});
+		const input = {
+			registryKey: "room",
+			params: { roomId: "one" },
+			resolvedName: "presence-room-one",
+			visibility: "presence" as const,
+		};
+		const rosters: (readonly unknown[])[] = [];
+		const errors: Error[] = [];
+		const stop = transport.subscribePresence(
+			input,
+			(members) => rosters.push(members),
+			{ onError: (error) => errors.push(error) },
+		);
+
+		resource!.onEvent({
+			type: "channel_presence",
+			data: JSON.stringify({
+				channel: "presence-room-one",
+				members: [{ id: "member-1" }],
+			}),
+		});
+		resource!.onEvent({
+			type: "channel_ready",
+			data: JSON.stringify({
+				channelSubscriptionId: "channel:presence-room-one",
+			}),
+		});
+		expect(rosters).toEqual([[{ id: "member-1" }]]);
+
+		resource!.onError(new Error("Channel authorization was revoked"));
+		expect(errors.map((error) => error.message)).toEqual([
+			"Channel authorization was revoked",
+		]);
+		let settled = false;
+		const freshPresence = transport.presence(input).then((members) => {
+			settled = true;
+			return members;
+		});
+		await Bun.sleep(10);
+		expect(settled).toBe(false);
+
+		resource!.onEvent({
+			type: "channel_presence",
+			data: JSON.stringify({
+				channel: "presence-room-one",
+				members: [{ id: "member-2" }],
+			}),
+		});
+		await expect(freshPresence).resolves.toEqual([{ id: "member-2" }]);
+
+		stop();
+		transport.destroy();
+	});
+
+	test("removes a shared SSE entry after a terminal resource error", () => {
+		let resource:
+			| {
+					onEvent(event: { type: string; data: string }): void;
+					onError(error: Error): void;
+			  }
+			| undefined;
+		let releases = 0;
+		const connection = {
+			registerChannel(options: typeof resource): () => void {
+				resource = options;
+				return () => {
+					releases += 1;
+				};
+			},
+		};
+		const transport = new SseChannelTransport({
+			baseUrl: "http://localhost:3000",
+			withCredentials: false,
+			fetcher: async () => {
+				throw new Error("The shared connection owns SSE fetching");
+			},
+			connection: connection as any,
+		});
+		const input = {
+			registryKey: "news",
+			params: {},
+			resolvedName: "news",
+			visibility: "public" as const,
+		};
+		const lifecycle: string[] = [];
+		const stop = transport.subscribe(
+			input,
+			(message) => lifecycle.push(`message:${message.eventId}`),
+			{
+				onReady: () => lifecycle.push("ready"),
+				onError: (error) => lifecycle.push(`error:${error.message}`),
+			},
+		);
+
+		resource!.onError(new Error("Channel authorization was revoked"));
+		expect(lifecycle).toEqual(["error:Channel authorization was revoked"]);
+		expect(releases).toBe(1);
+		expect(transport.channelCount).toBe(0);
+
+		resource!.onEvent({
+			type: "channel_ready",
+			data: JSON.stringify({ channelSubscriptionId: "channel:news" }),
+		});
+		resource!.onEvent({
+			type: "channel_event",
+			data: stringifyCompatibleTypedEventWire({
+				channel: "news",
+				event: "updated",
+				eventId: `${"7".repeat(64)}:1`,
+				data: {},
+			}),
+		});
+		expect(lifecycle).toEqual(["error:Channel authorization was revoked"]);
+		expect(releases).toBe(1);
+
+		stop();
+		transport.destroy();
+	});
+
+	test("preserves a re-entrant replacement after a terminal shared SSE error", () => {
+		type Resource = {
+			onEvent(event: { type: string; data: string }): void;
+			onError(error: Error): void;
+		};
+		const resources: Resource[] = [];
+		const releases: number[] = [];
+		const connection = {
+			registerChannel(options: Resource): () => void {
+				const index = resources.push(options) - 1;
+				return () => releases.push(index);
+			},
+		};
+		const transport = new SseChannelTransport({
+			baseUrl: "http://localhost:3000",
+			withCredentials: false,
+			fetcher: async () => {
+				throw new Error("The shared connection owns SSE fetching");
+			},
+			connection: connection as any,
+		});
+		const input = {
+			registryKey: "news",
+			params: {},
+			resolvedName: "news",
+			visibility: "public" as const,
+		};
+		const replacementLifecycle: string[] = [];
+		let stopReplacement = () => {};
+		const stopOld = transport.subscribe(input, () => {}, {
+			onError: () => {
+				stopOld();
+				stopReplacement = transport.subscribe(
+					input,
+					(message) => replacementLifecycle.push(`message:${message.eventId}`),
+					{ onReady: () => replacementLifecycle.push("ready") },
+				);
+			},
+		});
+
+		resources[0]!.onError(new Error("Channel authorization was revoked"));
+		expect(resources).toHaveLength(2);
+		expect(releases).toEqual([0]);
+		expect(transport.channelCount).toBe(1);
+
+		const eventId = `${"8".repeat(64)}:1`;
+		for (const oldFrame of [
+			{
+				type: "channel_ready",
+				data: JSON.stringify({ channelSubscriptionId: "channel:news" }),
+			},
+			{
+				type: "channel_event",
+				data: stringifyCompatibleTypedEventWire({
+					channel: "news",
+					event: "updated",
+					eventId,
+					data: {},
+				}),
+			},
+		]) {
+			resources[0]!.onEvent(oldFrame);
+		}
+		expect(replacementLifecycle).toEqual([]);
+
+		resources[1]!.onEvent({
+			type: "channel_ready",
+			data: JSON.stringify({ channelSubscriptionId: "channel:news" }),
+		});
+		resources[1]!.onEvent({
+			type: "channel_event",
+			data: stringifyCompatibleTypedEventWire({
+				channel: "news",
+				event: "updated",
+				eventId,
+				data: {},
+			}),
+		});
+		expect(replacementLifecycle).toEqual(["ready", `message:${eventId}`]);
+
+		stopReplacement();
+		expect(releases).toEqual([0, 1]);
 		transport.destroy();
 	});
 
@@ -1164,7 +1481,7 @@ describe("channels client", () => {
 		});
 
 		stopFirst();
-		resource!.onEpochEnd?.(new Error("subscription epoch ended"));
+		resource!.onError(new Error("subscription denied"));
 
 		expect(errorCalls).toBe(1);
 		transport.destroy();

--- a/packages/questpie/test/client/crdt-realtime-session.test.ts
+++ b/packages/questpie/test/client/crdt-realtime-session.test.ts
@@ -220,6 +220,170 @@ describe("internal CRDT realtime session", () => {
 		capability.release();
 	});
 
+	test("reconnects an established SSE epoch after a retryable socket failure without a terminal resource error", async () => {
+		const opens: Record<string, unknown>[] = [];
+		const streamControllers: ReadableStreamDefaultController<Uint8Array>[] = [];
+		const delivered: number[] = [];
+		const errors: Error[] = [];
+		const epochEnds: Error[] = [];
+		let sinceSeq = 0;
+		const manager = new SseConnectionManager({
+			baseUrl: "http://localhost:3000",
+			withCredentials: true,
+			fetcher: async (_input, init) => {
+				opens.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+				const streamIndex = opens.length - 1;
+				return new Response(
+					new ReadableStream<Uint8Array>({
+						start(controller) {
+							streamControllers.push(controller);
+							controller.enqueue(
+								encoder.encode(
+									`event: session\ndata: ${JSON.stringify({
+										sessionId: `edge-${streamIndex + 1}`,
+										token: `control-${streamIndex + 1}`,
+										control: {
+											protocol: "questpie-realtime-topology",
+											versions: [2],
+										},
+									})}\n\n`,
+								),
+							);
+						},
+					}),
+					{ headers: { "content-type": "text/event-stream" } },
+				);
+			},
+			debounceMs: 0,
+			retryBaseMs: 1,
+			maxRetryMs: 1,
+			random: () => 0,
+		});
+		const release = manager.registerChannel({
+			id: "channel:news",
+			openPayload: () => ({
+				id: "channel:news",
+				channel: "news",
+				sinceSeq,
+			}),
+			desiredPayload: () => ({
+				kind: "channel",
+				id: "channel:news",
+				channel: "news",
+				sinceSeq,
+			}),
+			onEvent: (event) => {
+				const payload = JSON.parse(event.data) as { seq?: unknown };
+				if (typeof payload.seq !== "number") return;
+				sinceSeq = payload.seq;
+				delivered.push(payload.seq);
+			},
+			onError: (error) => errors.push(error),
+			onEpochEnd: (error) => epochEnds.push(error),
+		});
+
+		await waitFor(() => streamControllers.length === 1);
+		streamControllers[0]!.enqueue(
+			encoder.encode(
+				`event: channel_event\ndata: ${JSON.stringify({ topologyEntryId: "channel:news", seq: 1 })}\n\n`,
+			),
+		);
+		await waitFor(() => delivered.length === 1);
+		streamControllers[0]!.error(
+			new Error("The socket connection was closed unexpectedly"),
+		);
+
+		await waitFor(() => streamControllers.length === 2);
+		expect(opens).toEqual([
+			{
+				topics: [],
+				channels: [{ id: "channel:news", channel: "news", sinceSeq: 0 }],
+			},
+			{
+				topics: [],
+				channels: [{ id: "channel:news", channel: "news", sinceSeq: 1 }],
+			},
+		]);
+		streamControllers[1]!.enqueue(
+			encoder.encode(
+				[
+					`event: channel_event\ndata: ${JSON.stringify({ topologyEntryId: "channel:news", seq: 2 })}`,
+					`event: channel_event\ndata: ${JSON.stringify({ topologyEntryId: "channel:news", seq: 3 })}`,
+					"",
+				].join("\n\n"),
+			),
+		);
+		await waitFor(() => delivered.length === 3);
+
+		expect(delivered).toEqual([1, 2, 3]);
+		expect(epochEnds.map((error) => error.message)).toEqual([
+			"The socket connection was closed unexpectedly",
+		]);
+		expect(errors).toEqual([]);
+		release();
+	});
+
+	test("fails closed when an established SSE resource reconnect receives a permanent authorization response", async () => {
+		let requests = 0;
+		let streamController:
+			| ReadableStreamDefaultController<Uint8Array>
+			| undefined;
+		const errors: Error[] = [];
+		const manager = new SseConnectionManager({
+			baseUrl: "http://localhost:3000",
+			withCredentials: true,
+			fetcher: async () => {
+				requests += 1;
+				if (requests > 1) {
+					return Response.json({ error: "unauthorized" }, { status: 401 });
+				}
+				return new Response(
+					new ReadableStream<Uint8Array>({
+						start(controller) {
+							streamController = controller;
+							controller.enqueue(
+								encoder.encode(
+									`event: session\ndata: ${JSON.stringify({
+										sessionId: "authorized-edge",
+										token: "authorized-control",
+										control: {
+											protocol: "questpie-realtime-topology",
+											versions: [2],
+										},
+									})}\n\n`,
+								),
+							);
+						},
+					}),
+				);
+			},
+			debounceMs: 0,
+			retryBaseMs: 1,
+			maxRetryMs: 1,
+			random: () => 0,
+		});
+		const release = manager.registerChannel({
+			id: "channel:private",
+			openPayload: () => ({ id: "channel:private" }),
+			desiredPayload: () => ({ kind: "channel", id: "channel:private" }),
+			onEvent: () => {},
+			onError: (error) => errors.push(error),
+		});
+
+		try {
+			await waitFor(() => !!streamController);
+			streamController!.error(new Error("socket closed"));
+			await waitFor(() => requests >= 2);
+			await Bun.sleep(20);
+			expect(errors.map((error) => error.message)).toEqual([
+				"Realtime connection failed: 401",
+			]);
+			expect(requests).toBe(2);
+		} finally {
+			release();
+		}
+	});
+
 	test("opens one control-only SSE edge for CRDT and releases it after the final reference", async () => {
 		const opens: Record<string, unknown>[] = [];
 		let streamController:
@@ -639,6 +803,94 @@ describe("internal CRDT realtime session", () => {
 		} catch {
 			// The failed control request may already have aborted the stream.
 		}
+	});
+
+	test("releases a CRDT binding after retryable SSE control failure so the caller can retry", async () => {
+		const opens: Record<string, unknown>[] = [];
+		let controls = 0;
+		const streamControllers: ReadableStreamDefaultController<Uint8Array>[] = [];
+		const fetcher: typeof fetch = async (input, init) => {
+			const url = String(input);
+			if (!url.endsWith("/realtime")) {
+				throw new Error(`Unexpected request: ${url}`);
+			}
+			const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+			if (body.sessionId) {
+				controls += 1;
+				return Response.json(
+					{ error: { code: "REALTIME_TOPOLOGY_STORAGE_UNAVAILABLE" } },
+					{ status: 503 },
+				);
+			}
+			opens.push(body);
+			const sequence = opens.length;
+			return new Response(
+				new ReadableStream<Uint8Array>({
+					start(controller) {
+						streamControllers.push(controller);
+						controller.enqueue(
+							encoder.encode(
+								`event: session\ndata: ${JSON.stringify({
+									sessionId: `retryable-edge-${sequence}`,
+									token: `retryable-control-${sequence}`,
+									control: {
+										protocol: "questpie-realtime-topology",
+										versions: [2],
+									},
+								})}\n\n`,
+							),
+						);
+						init?.signal?.addEventListener(
+							"abort",
+							() => controller.error(new DOMException("Aborted", "AbortError")),
+							{ once: true },
+						);
+					},
+				}),
+				{ headers: { "content-type": "text/event-stream" } },
+			);
+		};
+		const manager = new SseConnectionManager({
+			baseUrl: "http://localhost:3000",
+			withCredentials: true,
+			fetcher,
+			debounceMs: 0,
+			retryBaseMs: 1,
+			maxRetryMs: 1,
+			random: () => 0,
+		});
+		const capability = await manager.acquire();
+		let dirty = 0;
+		const errors: Error[] = [];
+
+		await expect(
+			capability.register({
+				kind: "crdt",
+				id: "crdt:retryable",
+				bindingId: "binding-retryable",
+				onDirty: () => {
+					dirty += 1;
+				},
+				onError: (error) => errors.push(error),
+			}),
+		).rejects.toThrow("Realtime CRDT topology registration failed");
+		await waitFor(() => streamControllers.length === 2);
+		expect(controls).toBe(1);
+		expect(opens).toEqual([
+			{ topics: [], channels: [], crdtHold: true },
+			{ topics: [], channels: [], crdtHold: true },
+		]);
+		expect(errors).toEqual([]);
+
+		streamControllers[1]!.enqueue(
+			encoder.encode(
+				`event: crdt_dirty\ndata: ${JSON.stringify({ topologyEntryId: "crdt:retryable" })}\n\n`,
+			),
+		);
+		await Bun.sleep(10);
+		expect(dirty).toBe(0);
+
+		capability.release();
 	});
 
 	test("holds a zero-query Pusher edge and coalesces targeted CRDT dirty notices", async () => {

--- a/packages/questpie/test/client/sse-connection-manager.test.ts
+++ b/packages/questpie/test/client/sse-connection-manager.test.ts
@@ -1,0 +1,391 @@
+import { describe, expect, test } from "bun:test";
+
+import { SseConnectionManager } from "../../src/client/realtime/sse-connection.js";
+
+const encoder = new TextEncoder();
+
+async function waitFor(
+	assertion: () => boolean,
+	timeoutMs = 3_000,
+): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (assertion()) return;
+		await Bun.sleep(5);
+	}
+	throw new Error("Timed out waiting for assertion");
+}
+
+function sessionFrame(sequence: number): Uint8Array {
+	return encoder.encode(
+		`event: session\ndata: ${JSON.stringify({
+			sessionId: `edge-${sequence}`,
+			token: `control-${sequence}`,
+			control: {
+				protocol: "questpie-realtime-topology",
+				versions: [2],
+			},
+		})}\n\n`,
+	);
+}
+
+function openStream(
+	sequence: number,
+	signal: AbortSignal | null | undefined,
+	controllers: ReadableStreamDefaultController<Uint8Array>[],
+): Response {
+	return new Response(
+		new ReadableStream<Uint8Array>({
+			start(controller) {
+				controllers.push(controller);
+				controller.enqueue(sessionFrame(sequence));
+				signal?.addEventListener(
+					"abort",
+					() => controller.error(new DOMException("Aborted", "AbortError")),
+					{ once: true },
+				);
+			},
+		}),
+		{ headers: { "content-type": "text/event-stream" } },
+	);
+}
+
+function registerChannel(
+	manager: SseConnectionManager,
+	id: string,
+	errors: Error[],
+	epochEnds: Error[],
+): () => void {
+	return manager.registerChannel({
+		id,
+		openPayload: () => ({ id, channel: id }),
+		desiredPayload: () => ({ kind: "channel", id, channel: id }),
+		onEvent: () => {},
+		onError: (error) => errors.push(error),
+		onEpochEnd: (error) => epochEnds.push(error),
+	});
+}
+
+describe("SSE connection manager failure classification", () => {
+	test("backs off and retries an initial transport failure without a terminal resource error", async () => {
+		let requests = 0;
+		const controllers: ReadableStreamDefaultController<Uint8Array>[] = [];
+		const errors: Error[] = [];
+		const epochEnds: Error[] = [];
+		const manager = new SseConnectionManager({
+			baseUrl: "http://localhost:3000",
+			withCredentials: true,
+			fetcher: async (_input, init) => {
+				requests += 1;
+				if (requests === 1) throw new Error("socket unavailable");
+				return openStream(requests, init?.signal, controllers);
+			},
+			debounceMs: 0,
+			retryBaseMs: 40,
+			maxRetryMs: 40,
+			random: () => 0,
+		});
+		const release = registerChannel(manager, "channel:news", errors, epochEnds);
+
+		await waitFor(() => requests === 1);
+		await Bun.sleep(10);
+		expect(requests).toBe(1);
+		expect(errors).toEqual([]);
+		await waitFor(() => controllers.length === 1);
+		expect(requests).toBe(2);
+		expect(epochEnds.map((error) => error.message)).toEqual([
+			"socket unavailable",
+		]);
+
+		release();
+		await Bun.sleep(30);
+		expect(requests).toBe(2);
+		expect(errors).toEqual([]);
+	});
+
+	test("reconnects after a retryable control response without a terminal resource error", async () => {
+		const opens: Record<string, unknown>[] = [];
+		let controls = 0;
+		const streamControllers: ReadableStreamDefaultController<Uint8Array>[] = [];
+		const firstErrors: Error[] = [];
+		const secondErrors: Error[] = [];
+		const firstEpochEnds: Error[] = [];
+		const secondEpochEnds: Error[] = [];
+		const manager = new SseConnectionManager({
+			baseUrl: "http://localhost:3000",
+			withCredentials: true,
+			fetcher: async (_input, init) => {
+				const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+				if (body.sessionId) {
+					controls += 1;
+					return Response.json({ error: "unavailable" }, { status: 503 });
+				}
+				opens.push(body);
+				return openStream(opens.length, init?.signal, streamControllers);
+			},
+			debounceMs: 0,
+			retryBaseMs: 1,
+			maxRetryMs: 1,
+			random: () => 0,
+		});
+		const releaseFirst = registerChannel(
+			manager,
+			"channel:first",
+			firstErrors,
+			firstEpochEnds,
+		);
+		await waitFor(() => streamControllers.length === 1);
+		const releaseSecond = registerChannel(
+			manager,
+			"channel:second",
+			secondErrors,
+			secondEpochEnds,
+		);
+
+		await waitFor(() => streamControllers.length === 2);
+		expect(controls).toBe(1);
+		expect(opens[1]).toMatchObject({
+			channels: [{ id: "channel:first" }, { id: "channel:second" }],
+		});
+		expect(firstErrors).toEqual([]);
+		expect(secondErrors).toEqual([]);
+		expect(firstEpochEnds).toHaveLength(1);
+		expect(secondEpochEnds).toHaveLength(1);
+
+		releaseSecond();
+		releaseFirst();
+	});
+
+	test("reopens an expired topology session after control reports unavailable", async () => {
+		let opens = 0;
+		let controls = 0;
+		const streamControllers: ReadableStreamDefaultController<Uint8Array>[] = [];
+		const firstErrors: Error[] = [];
+		const secondErrors: Error[] = [];
+		const manager = new SseConnectionManager({
+			baseUrl: "http://localhost:3000",
+			withCredentials: true,
+			fetcher: async (_input, init) => {
+				const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+				if (body.sessionId) {
+					controls += 1;
+					return Response.json(
+						{
+							error: {
+								code: "REALTIME_CONTROL_UNAVAILABLE",
+								message: "Realtime control session is unavailable",
+							},
+						},
+						{ status: 404 },
+					);
+				}
+				opens += 1;
+				return openStream(opens, init?.signal, streamControllers);
+			},
+			debounceMs: 0,
+			retryBaseMs: 1,
+			maxRetryMs: 1,
+			random: () => 0,
+		});
+		const releaseFirst = registerChannel(
+			manager,
+			"channel:first",
+			firstErrors,
+			[],
+		);
+		await waitFor(() => streamControllers.length === 1);
+		const releaseSecond = registerChannel(
+			manager,
+			"channel:second",
+			secondErrors,
+			[],
+		);
+
+		await waitFor(() => streamControllers.length === 2);
+		expect(controls).toBe(1);
+		expect(opens).toBe(2);
+		expect(firstErrors).toEqual([]);
+		expect(secondErrors).toEqual([]);
+
+		releaseSecond();
+		releaseFirst();
+	});
+
+	test("surfaces a terminal control authorization response once and stops reconnecting", async () => {
+		let opens = 0;
+		let controls = 0;
+		const streamControllers: ReadableStreamDefaultController<Uint8Array>[] = [];
+		const firstErrors: Error[] = [];
+		const secondErrors: Error[] = [];
+		const manager = new SseConnectionManager({
+			baseUrl: "http://localhost:3000",
+			withCredentials: true,
+			fetcher: async (_input, init) => {
+				const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+				if (body.sessionId) {
+					controls += 1;
+					return Response.json({ error: "unauthorized" }, { status: 401 });
+				}
+				opens += 1;
+				return openStream(opens, init?.signal, streamControllers);
+			},
+			debounceMs: 0,
+			retryBaseMs: 1,
+			maxRetryMs: 1,
+			random: () => 0,
+		});
+		const releaseFirst = registerChannel(
+			manager,
+			"channel:first",
+			firstErrors,
+			[],
+		);
+		await waitFor(() => streamControllers.length === 1);
+		const releaseSecond = registerChannel(
+			manager,
+			"channel:second",
+			secondErrors,
+			[],
+		);
+
+		await waitFor(() => firstErrors.length === 1 && secondErrors.length === 1);
+		await Bun.sleep(20);
+		expect(firstErrors.map((error) => error.message)).toEqual([
+			"Realtime control failed: 401",
+		]);
+		expect(secondErrors.map((error) => error.message)).toEqual([
+			"Realtime control failed: 401",
+		]);
+		expect(controls).toBe(1);
+		expect(opens).toBe(1);
+
+		releaseSecond();
+		releaseFirst();
+	});
+
+	test("surfaces an undispatched control conflict once and stops reconnecting", async () => {
+		let opens = 0;
+		let controls = 0;
+		const streamControllers: ReadableStreamDefaultController<Uint8Array>[] = [];
+		const firstErrors: Error[] = [];
+		const secondErrors: Error[] = [];
+		const manager = new SseConnectionManager({
+			baseUrl: "http://localhost:3000",
+			withCredentials: true,
+			fetcher: async (_input, init) => {
+				const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+				if (body.sessionId) {
+					controls += 1;
+					return Response.json({ error: "conflict" }, { status: 409 });
+				}
+				opens += 1;
+				return openStream(opens, init?.signal, streamControllers);
+			},
+			debounceMs: 0,
+			retryBaseMs: 1,
+			maxRetryMs: 1,
+			random: () => 0,
+		});
+		const releaseFirst = registerChannel(
+			manager,
+			"channel:first",
+			firstErrors,
+			[],
+		);
+		await waitFor(() => streamControllers.length === 1);
+		const releaseSecond = registerChannel(
+			manager,
+			"channel:second",
+			secondErrors,
+			[],
+		);
+
+		await waitFor(() => firstErrors.length === 1 && secondErrors.length === 1);
+		await Bun.sleep(20);
+		expect(firstErrors.map((error) => error.message)).toEqual([
+			"Realtime control failed: 409",
+		]);
+		expect(secondErrors.map((error) => error.message)).toEqual([
+			"Realtime control failed: 409",
+		]);
+		expect(controls).toBe(1);
+		expect(opens).toBe(1);
+
+		releaseSecond();
+		releaseFirst();
+	});
+
+	test("isolates a throwing consumer while terminating a control authorization failure", async () => {
+		let opens = 0;
+		let controls = 0;
+		let openSignal: AbortSignal | null | undefined;
+		const unhandled: unknown[] = [];
+		const onUnhandled = (reason: unknown) => unhandled.push(reason);
+		const streamControllers: ReadableStreamDefaultController<Uint8Array>[] = [];
+		const siblingErrors: Error[] = [];
+		process.on("unhandledRejection", onUnhandled);
+		try {
+			const manager = new SseConnectionManager({
+				baseUrl: "http://localhost:3000",
+				withCredentials: true,
+				fetcher: async (_input, init) => {
+					const body = JSON.parse(String(init?.body)) as Record<
+						string,
+						unknown
+					>;
+					if (body.sessionId) {
+						controls += 1;
+						return Response.json({ error: "unauthorized" }, { status: 401 });
+					}
+					opens += 1;
+					openSignal = init?.signal;
+					return openStream(opens, init?.signal, streamControllers);
+				},
+				debounceMs: 0,
+				retryBaseMs: 1,
+				maxRetryMs: 1,
+				random: () => 0,
+			});
+			const releaseThrowing = manager.registerChannel({
+				id: "channel:throwing",
+				openPayload: () => ({
+					id: "channel:throwing",
+					channel: "channel:throwing",
+				}),
+				desiredPayload: () => ({
+					kind: "channel",
+					id: "channel:throwing",
+					channel: "channel:throwing",
+				}),
+				onEvent: () => {},
+				onError: () => {
+					throw new Error("consumer terminal callback failed");
+				},
+				onEpochEnd: () => {},
+			});
+			await waitFor(() => streamControllers.length === 1);
+			const releaseSibling = registerChannel(
+				manager,
+				"channel:sibling",
+				siblingErrors,
+				[],
+			);
+
+			await waitFor(
+				() => siblingErrors.length === 1 && openSignal?.aborted === true,
+			);
+			await Bun.sleep(20);
+			expect(siblingErrors.map((error) => error.message)).toEqual([
+				"Realtime control failed: 401",
+			]);
+			expect(unhandled).toEqual([]);
+			expect(controls).toBe(1);
+			expect(opens).toBe(1);
+
+			releaseSibling();
+			releaseThrowing();
+		} finally {
+			process.off("unhandledRejection", onUnhandled);
+		}
+	});
+});


### PR DESCRIPTION
## Summary

Repair the shared SSE connection and Channel lifecycle after the QUESTPIE 3.20.1 qualification was rejected: an established retryable socket failure was broadcast as a terminal public Channel error instead of ending the physical epoch and reconnecting.

Agent Board task: `release-questpie-authorized-subscription-admission-and-client-readiness`.

## Failure classification

- Retryable physical socket, EOF, watchdog, transient open, and control 408/425/429/5xx failures silently end the resource epoch and reconnect with backoff, exact topology, and replay.
- Open permanent 4xx responses (except 408/425/429), missing bodies, incompatible session protocols, and permanent authorization failures remain terminal and fail closed.
- Control permanent 4xx responses are terminal except the exact structured 404 `REALTIME_CONTROL_UNAVAILABLE` expired-session response, which reopens and reconciles.
- Structured per-entry control rejection remains targeted to the exact resource.
- Protocol errors and replay gaps remain terminal.
- Terminal fan-out isolates throwing consumers and always aborts/stops the physical connection.

## Channel lifecycle and negative oracles

The regression suite proves:

- initial transient failures back off without a public terminal error or tight retry loop;
- control 503 reconnects silently, structured expired-session 404 reopens, generic 409 and authorization 401 terminate exactly once with no reopen;
- one throwing terminal callback cannot block sibling notification or physical abort;
- retryable CRDT registration failure rejects the caller, releases the binding, and leaves no stale dirty callback;
- retryable epoch reset clears readiness and cached presence;
- presence A buffered before readiness is discarded after epoch end, while presence B is delivered only after the new ready signal;
- an ordinary late message racing its ready microtask is retained across epoch end because the shared cursor has already advanced;
- terminal resource and targeted error frames release/remove the exact Channel entry, leave `channelCount` at zero, and ignore late frames;
- re-entrant stop-and-resubscribe preserves the replacement entry, releases the old resource once, and fences old physical callbacks;
- replay gap remains exact, explicit query refetch resets from a fresh stream, and clean abort/resubscribe performs no replay.

## Validation

- Independent adversarial review: **SHIP**, no P0–P3 findings.
- Focused manager + Channels/SSE/Pusher + CRDT: **59 passed, 0 failed, 223 assertions**.
- Unchanged source-linked Autopilot four-phase harness: **4 passed, 0 failed, 20 assertions**.
- Root typecheck: **25/25 tasks successful**.
- Docs validation: **186 files, 0 errors, 0 warnings**.
- Root lint, format check, diff check, package build, package typecheck, and changeset status: passed.
- This PR includes a patch changeset. Current main is QUESTPIE 3.21.0 from Auth release #219 at `c042ed4`, so the eventual homogeneous version is determined from current main and is expected to be the next 3.21.x patch train.

## Release safety

This is a **draft** for review only. Do **not merge or release** from this PR without separate explicit authorization. Released 3.20.1 remains rejected for this qualification seam; after a fixed homogeneous train is published, Autopilot will qualify that exact published train.
