### PR TITLE
fix(channels): expose subscription epoch end lifecycle

### DIFF
--- a/.changeset/brave-channels-rest.md
+++ b/.changeset/brave-channels-rest.md
@@ -1,0 +1,5 @@
+---
+"questpie": patch
+---
+
+Expose `onNotReady` for typed channel subscriptions and notify each logical SSE or Pusher subscriber exactly once when an admitted transport epoch ends.

--- a/apps/docs/content/docs/client/channels.mdx
+++ b/apps/docs/content/docs/client/channels.mdx
@@ -157,7 +157,11 @@ const stop = client.channels.chatRoom.subscribe(
 			console.log(message.data.active);
 		}
 	},
-	{ onError: console.error },
+	{
+		onReady: () => setMutationEnabled(true),
+		onNotReady: () => setMutationEnabled(false),
+		onError: console.error,
+	},
 );
 
 const receipt = await client.channels.chatRoom.publish({
@@ -168,6 +172,19 @@ const receipt = await client.channels.chatRoom.publish({
 
 stop();
 ```
+
+`onReady` starts one admitted subscription epoch after authorization and replay
+catch-up complete. If that epoch ends, `onNotReady` runs exactly once for the
+same logical subscriber. A successful reconnect completes fresh authorization
+and catch-up, then calls `onReady` again for the next epoch. A subscriber that
+never reached `onReady` does not receive `onNotReady`, and explicitly calling
+`stop()` or aborting the subscription removes the callbacks without reporting an
+epoch end.
+
+Ordinary reconnects report the readiness transition through `onNotReady`, not
+`onError`. A terminal failure after admission calls `onNotReady` before the
+existing `onError` callback. Exceptions thrown by any lifecycle callback are
+isolated from sibling subscribers, transport cleanup, and later reconnects.
 
 Client publish is server-mediated even on Pusher/Soketi: the request uses the same dynamic auth headers as other client calls, re-evaluates `publish` authorization, validates the event with Zod, enforces payload/origin/rate limits, and only then appends the ordered event.
 

--- a/packages/questpie/src/client/channels/pusher.ts
+++ b/packages/questpie/src/client/channels/pusher.ts
@@ -106,6 +106,8 @@ export class PusherChannelTransport implements ChannelClientTransport {
 			callback,
 			options.onReady,
 			() => this.failEntry(entry, channelSlowConsumerError()),
+			false,
+			options.onNotReady,
 		);
 		entry.subscribers.add(delivery.accept);
 		const errorCallback = options.onError
@@ -151,6 +153,7 @@ export class PusherChannelTransport implements ChannelClientTransport {
 			options.onReady,
 			() => this.failEntry(entry, channelSlowConsumerError()),
 			true,
+			options.onNotReady,
 		);
 		entry.presenceSubscribers.add(delivery.accept);
 		const errorCallback = options.onError
@@ -347,9 +350,6 @@ export class PusherChannelTransport implements ChannelClientTransport {
 			channel.bind("pusher:subscription_succeeded", (members) => {
 				try {
 					if (!subscription.isConnectionActive()) return;
-					if (entry.readiness.isReady) {
-						this.notify(entry, new Error("Channel subscription epoch ended"));
-					}
 					entry.readiness.end();
 					entry.providerEpochActive = true;
 					entry.pendingLive.clear();
@@ -501,7 +501,7 @@ export class PusherChannelTransport implements ChannelClientTransport {
 		entry.replayGeneration += 1;
 		entry.replaying = false;
 		entry.pendingLive.clear();
-		this.notify(entry, new Error("Channel connection epoch ended"));
+		entry.readiness.end();
 	}
 
 	private parseReplayMessage(value: unknown): ChannelTransportMessage {
@@ -554,8 +554,8 @@ export class PusherChannelTransport implements ChannelClientTransport {
 	}
 
 	private notify(entry: Entry, error: Error): void {
-		entry.readiness.end();
 		const errorCallbacks = Array.from(entry.errorCallbacks);
+		entry.readiness.end();
 		for (const callback of errorCallbacks) {
 			notifyChannelConsumer(callback, error);
 		}

--- a/packages/questpie/src/client/channels/readiness.ts
+++ b/packages/questpie/src/client/channels/readiness.ts
@@ -4,8 +4,10 @@ import { BoundedChannelQueue } from "./ordered-events.js";
 type ReadyRegistration = {
 	callback: () => void;
 	onEnd?: () => void;
+	onNotReady?: () => void;
 	active: boolean;
 	notifiedEpoch: number;
+	endedEpoch: number;
 };
 
 /** Per-logical-registration readiness over one shared channel transport entry. */
@@ -18,13 +20,19 @@ export class ChannelReadiness {
 		return this.admitted;
 	}
 
-	register(callback: (() => void) | undefined, onEnd?: () => void): () => void {
-		if (!callback && !onEnd) return () => {};
+	register(
+		callback: (() => void) | undefined,
+		onEnd?: () => void,
+		onNotReady?: () => void,
+	): () => void {
+		if (!callback && !onEnd && !onNotReady) return () => {};
 		const registration: ReadyRegistration = {
 			callback: callback ?? (() => {}),
 			onEnd,
+			onNotReady,
 			active: true,
 			notifiedEpoch: 0,
+			endedEpoch: 0,
 		};
 		this.registrations.add(registration);
 		if (this.admitted) {
@@ -48,13 +56,38 @@ export class ChannelReadiness {
 	}
 
 	end(): void {
+		const epoch = this.epoch;
+		const wasAdmitted = this.admitted;
+		const endCallbacks: Array<() => void> = [];
+		const notReadyCallbacks: Array<() => void> = [];
 		this.admitted = false;
-		for (const registration of this.registrations) {
+		for (const registration of Array.from(this.registrations)) {
 			if (!registration.active) continue;
+			if (registration.onEnd) endCallbacks.push(registration.onEnd);
+			if (
+				!wasAdmitted ||
+				registration.notifiedEpoch !== epoch ||
+				registration.endedEpoch === epoch
+			) {
+				continue;
+			}
+			registration.endedEpoch = epoch;
+			if (registration.onNotReady) {
+				notReadyCallbacks.push(registration.onNotReady);
+			}
+		}
+		for (const callback of endCallbacks) {
 			try {
-				registration.onEnd?.();
+				callback();
 			} catch {
 				// One subscriber cannot block epoch reset for its siblings.
+			}
+		}
+		for (const callback of notReadyCallbacks) {
+			try {
+				callback();
+			} catch {
+				// One subscriber cannot block lifecycle notification for its siblings.
 			}
 		}
 	}
@@ -115,6 +148,7 @@ export class ChannelReadyDelivery<T> {
 		onReady: (() => void) | undefined,
 		private readonly onOverflow: () => void,
 		private readonly waitForAdmission = false,
+		onNotReady?: () => void,
 	) {
 		this.awaitingReady = waitForAdmission || readiness.isReady;
 		this.releaseReady = readiness.register(
@@ -131,6 +165,7 @@ export class ChannelReadyDelivery<T> {
 					}
 				: undefined,
 			() => this.endEpoch(),
+			onNotReady,
 		);
 	}
 

--- a/packages/questpie/src/client/channels/sse.ts
+++ b/packages/questpie/src/client/channels/sse.ts
@@ -86,6 +86,8 @@ export class SseChannelTransport implements ChannelClientTransport {
 			callback,
 			options.onReady,
 			() => this.failEntry(entry, channelSlowConsumerError()),
+			false,
+			options.onNotReady,
 		);
 		entry.subscribers.add(delivery.accept);
 		const errorCallback = options.onError
@@ -131,6 +133,7 @@ export class SseChannelTransport implements ChannelClientTransport {
 			options.onReady,
 			() => this.failEntry(entry, channelSlowConsumerError()),
 			true,
+			options.onNotReady,
 		);
 		entry.presenceSubscribers.add(delivery.accept);
 		const errorCallback = options.onError
@@ -594,8 +597,8 @@ export class SseChannelTransport implements ChannelClientTransport {
 	}
 
 	private notifyEntry(entry: Entry, error: Error): void {
-		this.resetEntryEpoch(entry);
 		const errorCallbacks = Array.from(entry.errorCallbacks);
+		this.resetEntryEpoch(entry);
 		for (const callback of errorCallbacks) {
 			notifyChannelConsumer(callback, error);
 		}

--- a/packages/questpie/src/client/channels/types.ts
+++ b/packages/questpie/src/client/channels/types.ts
@@ -42,9 +42,14 @@ export type ChannelSubscribeOptions = {
 	onError?: (error: Error) => void;
 	/** Authorized and caught up for the current transport subscription epoch. */
 	onReady?: () => void;
+	/** The admitted epoch ended; a reconnect may later call `onReady` again. */
+	onNotReady?: () => void;
 };
 
-export type ChannelPresenceOptions = Omit<ChannelSubscribeOptions, "onReady">;
+export type ChannelPresenceOptions = Omit<
+	ChannelSubscribeOptions,
+	"onReady" | "onNotReady"
+>;
 
 type SubscribeMethod<TDefinition extends AnyChannelDefinition> =
 	keyof ChannelParamsOf<TDefinition> extends never

--- a/packages/questpie/test/client/client-channels.test.ts
+++ b/packages/questpie/test/client/client-channels.test.ts
@@ -198,6 +198,112 @@ describe("channels client", () => {
 		delivery.stop();
 	});
 
+	test("notifies every admitted logical SSE subscriber exactly once when its epoch ends", async () => {
+		let resource:
+			| {
+					onEvent(event: { type: string; data: string }): void;
+					onError(error: Error): void;
+					onEpochEnd?(error: Error): void;
+			  }
+			| undefined;
+		const connection = {
+			registerChannel(options: typeof resource): () => void {
+				resource = options;
+				return () => {};
+			},
+		};
+		const transport = new SseChannelTransport({
+			baseUrl: "http://localhost:3000",
+			withCredentials: false,
+			fetcher: async () => {
+				throw new Error("The shared connection owns SSE fetching");
+			},
+			connection: connection as any,
+		});
+		const input = {
+			registryKey: "news",
+			params: {},
+			resolvedName: "news",
+			visibility: "public" as const,
+		};
+		const lifecycle: string[] = [];
+		let stopDuringEpochEnd = false;
+		let stopFirst: () => void;
+		let stopSecond: () => void;
+		stopFirst = transport.subscribe(input, () => {}, {
+			onReady: () => lifecycle.push("first:ready"),
+			onNotReady: () => {
+				lifecycle.push("first:not-ready");
+				if (stopDuringEpochEnd) {
+					stopFirst();
+					stopSecond();
+				}
+				throw new Error("consumer lifecycle callback failed");
+			},
+			onError: (error) => lifecycle.push(`first:error:${error.message}`),
+		});
+		stopSecond = transport.subscribe(input, () => {}, {
+			onReady: () => lifecycle.push("second:ready"),
+			onNotReady: () => lifecycle.push("second:not-ready"),
+			onError: (error) => lifecycle.push(`second:error:${error.message}`),
+		});
+		const preAdmissionLifecycle: string[] = [];
+		const stopBeforeReady = transport.subscribe(input, () => {}, {
+			onReady: () => preAdmissionLifecycle.push("ready"),
+			onNotReady: () => preAdmissionLifecycle.push("not-ready"),
+		});
+
+		resource!.onEpochEnd?.(new Error("initial transport unavailable"));
+		expect(lifecycle).toEqual([]);
+		expect(preAdmissionLifecycle).toEqual([]);
+		stopBeforeReady();
+		resource!.onEvent({
+			type: "channel_ready",
+			data: JSON.stringify({ channelSubscriptionId: "channel:news" }),
+		});
+		expect(lifecycle).toEqual(["first:ready", "second:ready"]);
+
+		const stopAborted = transport.subscribe(input, () => {}, {
+			onReady: () => lifecycle.push("aborted:ready"),
+			onNotReady: () => lifecycle.push("aborted:not-ready"),
+		});
+		await Promise.resolve();
+		stopAborted();
+		resource!.onEpochEnd?.(new Error("ordinary reconnect"));
+		resource!.onEpochEnd?.(new Error("duplicate reconnect signal"));
+		expect(lifecycle).toEqual([
+			"first:ready",
+			"second:ready",
+			"aborted:ready",
+			"first:not-ready",
+			"second:not-ready",
+		]);
+
+		resource!.onEvent({
+			type: "channel_ready",
+			data: JSON.stringify({ channelSubscriptionId: "channel:news" }),
+		});
+		stopDuringEpochEnd = true;
+		resource!.onError(new Error("terminal channel failure"));
+		expect(lifecycle).toEqual([
+			"first:ready",
+			"second:ready",
+			"aborted:ready",
+			"first:not-ready",
+			"second:not-ready",
+			"first:ready",
+			"second:ready",
+			"first:not-ready",
+			"second:not-ready",
+			"first:error:terminal channel failure",
+			"second:error:terminal channel failure",
+		]);
+
+		stopSecond();
+		stopFirst();
+		transport.destroy();
+	});
+
 	test("keeps explicit plain JSON channel publishing interoperable", async () => {
 		const instant = new Date("2026-03-29T00:30:00.000Z");
 		let publishRequest: RequestInit | undefined;
@@ -2049,6 +2155,7 @@ describe("channels client", () => {
 			},
 			{
 				onReady: () => lifecycle.push("ready"),
+				onNotReady: () => lifecycle.push("not-ready"),
 				onError: (error: Error) => {
 					errors.push(error);
 					lifecycle.push(`error:${error.message}`);
@@ -2118,13 +2225,11 @@ describe("channels client", () => {
 			replayedInstant.getTime(),
 		);
 		expect(messages[1]?.data.isoLookingString).not.toBeInstanceOf(Date);
-		expect(errors.map((error) => error.message)).toEqual([
-			"Channel subscription epoch ended",
-		]);
+		expect(errors).toEqual([]);
 		expect(lifecycle).toEqual([
 			"ready",
 			`event:${channelHash}:1`,
-			"error:Channel subscription epoch ended",
+			"not-ready",
 			`event:${channelHash}:2`,
 			"ready",
 			`event:${channelHash}:3`,
@@ -2168,6 +2273,7 @@ describe("channels client", () => {
 				lifecycle.push(`event:${message.eventId}`),
 			{
 				onReady: () => lifecycle.push("ready"),
+				onNotReady: () => lifecycle.push("not-ready"),
 				onError: (error: Error) => lifecycle.push(`error:${error.message}`),
 			},
 		);
@@ -2188,10 +2294,7 @@ describe("channels client", () => {
 		provider.connection.transition("disconnected");
 		provider.connection.transition("connecting");
 		await waitFor(
-			() =>
-				lifecycle.filter(
-					(value) => value === "error:Channel connection epoch ended",
-				).length === 1,
+			() => lifecycle.filter((value) => value === "not-ready").length === 1,
 		);
 		provider.channel.emit("pusher:subscription_succeeded", {});
 		await new Promise((resolve) => setTimeout(resolve, 0));
@@ -2201,12 +2304,7 @@ describe("channels client", () => {
 			new Error("stale subscription error"),
 		);
 		await new Promise((resolve) => setTimeout(resolve, 0));
-		expect(lifecycle).toEqual([
-			"ready",
-			`event:${channelHash}:1`,
-			"error:Channel subscription epoch ended",
-			"error:Channel connection epoch ended",
-		]);
+		expect(lifecycle).toEqual(["ready", `event:${channelHash}:1`, "not-ready"]);
 		provider.channel.emit("questpie:channel", {
 			eventId: `${channelHash}:3`,
 			event: "updated",
@@ -2226,12 +2324,7 @@ describe("channels client", () => {
 			}),
 		);
 		await new Promise((resolve) => setTimeout(resolve, 10));
-		expect(lifecycle).toEqual([
-			"ready",
-			`event:${channelHash}:1`,
-			"error:Channel subscription epoch ended",
-			"error:Channel connection epoch ended",
-		]);
+		expect(lifecycle).toEqual(["ready", `event:${channelHash}:1`, "not-ready"]);
 
 		provider.connection.transition("connected");
 		provider.channel.emit("pusher:subscription_succeeded", {});
@@ -2255,8 +2348,7 @@ describe("channels client", () => {
 		expect(lifecycle).toEqual([
 			"ready",
 			`event:${channelHash}:1`,
-			"error:Channel subscription epoch ended",
-			"error:Channel connection epoch ended",
+			"not-ready",
 			`event:${channelHash}:2`,
 			"ready",
 		]);
@@ -2400,10 +2492,7 @@ describe("channels client", () => {
 		);
 		await new Promise((resolve) => setTimeout(resolve, 10));
 
-		expect(errors).toEqual([
-			"Channel subscription epoch ended",
-			"Channel client slow consumer",
-		]);
+		expect(errors).toEqual(["Channel client slow consumer"]);
 		expect(messages).toEqual([`${channelHash}:1`]);
 		expect(client.channels.channelCount).toBe(0);
 		client.channels.destroy();
@@ -2484,10 +2573,7 @@ describe("channels client", () => {
 		);
 		await new Promise((resolve) => setTimeout(resolve, 20));
 
-		expect(errors).toEqual([
-			"Channel subscription epoch ended",
-			"Provider rejected subscription",
-		]);
+		expect(errors).toEqual(["Provider rejected subscription"]);
 		expect(ready).toBe(1);
 		expect(messages).toEqual([`${channelHash}:1`]);
 		expect(client.channels.channelCount).toBe(0);
@@ -2545,7 +2631,6 @@ describe("channels client", () => {
 			errors.some((error) => error.message === "Channel event replay gap"),
 		);
 		expect(errors.map((error) => error.message)).toEqual([
-			"Channel subscription epoch ended",
 			"Channel event replay gap",
 		]);
 		expect(ready).toBe(1);
@@ -2714,7 +2799,6 @@ describe("channels client", () => {
 		);
 		expect(replay).toBe(1);
 		expect(errors.map((error) => error.message)).toEqual([
-			"Channel subscription epoch ended",
 			expect.stringContaining("Unsupported QUESTPIE typed event wire version"),
 		]);
 		expect(client.channels.channelCount).toBe(0);

--- a/packages/questpie/test/types/realtime-transport.test-d.ts
+++ b/packages/questpie/test/types/realtime-transport.test-d.ts
@@ -43,8 +43,16 @@ type _channelReadinessIsOptionalAndPayloadFree = Expect<
 	Equal<NonNullable<ChannelSubscribeOptions["onReady"]>, () => void>
 >;
 
+type _channelNotReadinessIsOptionalAndPayloadFree = Expect<
+	Equal<NonNullable<ChannelSubscribeOptions["onNotReady"]>, () => void>
+>;
+
 type _oneShotPresenceDoesNotExposeContinuingAdmission = Expect<
 	Equal<"onReady" extends keyof ChannelPresenceOptions ? true : false, false>
+>;
+
+type _oneShotPresenceDoesNotExposeContinuingEpochEnd = Expect<
+	Equal<"onNotReady" extends keyof ChannelPresenceOptions ? true : false, false>
 >;
 
 declare const sink: ClientSink;

--- a/skills/questpie/AGENTS.md
+++ b/skills/questpie/AGENTS.md
@@ -6344,9 +6344,17 @@ cut; reconnect and replay reauthorize against current application state.
 ## Client, presence, and TanStack Query
 
 ```ts
-const stop = client.channels.chatRoom.subscribe({ roomId }, (message) => {
-	if (message.event === "message") console.log(message.data.text);
-});
+const stop = client.channels.chatRoom.subscribe(
+	{ roomId },
+	(message) => {
+		if (message.event === "message") console.log(message.data.text);
+	},
+	{
+		onReady: () => setMutationEnabled(true),
+		onNotReady: () => setMutationEnabled(false),
+		onError: console.error,
+	},
+);
 
 await client.channels.chatRoom.publish({
 	params: { roomId },
@@ -6362,6 +6370,15 @@ const stopPresence = client.channels.chatRoom.subscribePresence(
 stop();
 stopPresence();
 ```
+
+`onReady` begins an admitted logical subscription epoch after authorization and
+replay catch-up. `onNotReady` runs exactly once when that admitted epoch ends;
+successful reconnect calls `onReady` again for the next epoch. It is not called
+before the subscriber's first `onReady`, or when the subscriber explicitly
+stops or aborts. Ordinary reconnects use `onNotReady` without manufacturing an
+`onError`; a terminal failure after admission calls `onNotReady` before
+`onError`. Lifecycle callback exceptions are isolated from sibling subscribers,
+cleanup, and later reconnects.
 
 `presence()` returns one typed snapshot. `subscribePresence()` emits the initial and later rosters, and `presenceIter(params, { signal })` provides the async-generator form. Pusher/Soketi uses native membership; SSE uses Postgres leases across instances and deduplicates multiple connections by authenticated principal. Crash leave converges after the lease TTL.
 

--- a/skills/questpie/references/channels.md
+++ b/skills/questpie/references/channels.md
@@ -124,9 +124,17 @@ cut; reconnect and replay reauthorize against current application state.
 ## Client, presence, and TanStack Query
 
 ```ts
-const stop = client.channels.chatRoom.subscribe({ roomId }, (message) => {
-	if (message.event === "message") console.log(message.data.text);
-});
+const stop = client.channels.chatRoom.subscribe(
+	{ roomId },
+	(message) => {
+		if (message.event === "message") console.log(message.data.text);
+	},
+	{
+		onReady: () => setMutationEnabled(true),
+		onNotReady: () => setMutationEnabled(false),
+		onError: console.error,
+	},
+);
 
 await client.channels.chatRoom.publish({
 	params: { roomId },
@@ -142,6 +150,15 @@ const stopPresence = client.channels.chatRoom.subscribePresence(
 stop();
 stopPresence();
 ```
+
+`onReady` begins an admitted logical subscription epoch after authorization and
+replay catch-up. `onNotReady` runs exactly once when that admitted epoch ends;
+successful reconnect calls `onReady` again for the next epoch. It is not called
+before the subscriber's first `onReady`, or when the subscriber explicitly
+stops or aborts. Ordinary reconnects use `onNotReady` without manufacturing an
+`onError`; a terminal failure after admission calls `onNotReady` before
+`onError`. Lifecycle callback exceptions are isolated from sibling subscribers,
+cleanup, and later reconnects.
 
 `presence()` returns one typed snapshot. `subscribePresence()` emits the initial and later rosters, and `presenceIter(params, { signal })` provides the async-generator form. Pusher/Soketi uses native membership; SSE uses Postgres leases across instances and deduplicates multiple connections by authenticated principal. Crash leave converges after the lease TTL.
 


### PR DESCRIPTION
## Summary

- add public `ChannelSubscribeOptions.onNotReady` lifecycle notification
- notify a logical subscriber exactly once when an admitted transport epoch ends
- preserve pre-ready, explicit abort/unsubscribe, reconnect, terminal-error, and callback-isolation semantics across SSE, Pusher, and shared multiplexing
- remove synthetic Pusher `onError` delivery for ordinary reconnect lifecycle changes
- document the contract and ship a patch changeset for `questpie`

## Lifecycle contract

- `onReady` admits the logical subscriber to the current epoch.
- `onNotReady` runs once when that admitted epoch ends.
- An epoch ending before `onReady` does not call `onNotReady`.
- Explicit unsubscribe/abort does not manufacture `onNotReady`.
- A later `onReady` re-admits the subscriber for the reconnect epoch.
- Terminal failure delivers `onNotReady` before the existing `onError` callback.
- One consumer callback throwing or unsubscribing does not block sibling lifecycle or terminal-error callbacks.

## Verification

- `bun test packages/questpie/test/client/client-channels.test.ts packages/questpie/test/client/sse-connection-manager.test.ts packages/questpie/test/client/pusher-connection-manager.test.ts` — 52 pass, 0 fail
- `bun run --cwd packages/questpie check-types` — pass
- `bun run format:check` — pass
- changed-file `oxlint` — pass
- `bun run check-types` — pass

The root `bun run lint` remains red on the existing repository-wide warning backlog; no changed-file lint findings remain. The full root `bun test` also encounters unrelated existing failures in MCP/observability tests: Better Auth timeouts followed by PGlite WASM corruption, and a `GET /notes` versus `GET /get-session` expectation. The focused provider matrix is green.

## Independent review

No P0 findings. Two P1 findings were repaired before publication:

1. Epoch-end delivery now snapshots admitted callbacks, so a callback that unsubscribes itself or a sibling cannot skip sibling notification.
2. Terminal error delivery snapshots error callbacks before `onNotReady`, so unsubscribe during lifecycle notification cannot suppress the existing `onError` contract.

Both repairs have deterministic regression coverage.

## Release handoff

This PR contains a patch changeset. Do not merge or release as part of the downstream Autopilot task. Once the fixed QUESTPIE train is released, record the actual version and consume that exact version downstream.

### Autopilot consumption diff

1. Bump the exact released QUESTPIE train version in `apps/operator-web/package.json` and the Bun lockfile for `questpie`, `@questpie/mcp`, `@questpie/openapi`, `@questpie/tanstack-query`, and `@questpie/workflows`.
2. In `apps/operator-web/src/features/goals/goal-authority-invalidation.ts`, wire `onNotReady: () => controller.onNotReady()` as the ordinary epoch-loss transition. It must make authority mutation read-only, clear admission, and advance transport generation exactly once. Keep `onError` for actual diagnostics; factor an idempotent not-ready transition so terminal `onNotReady` followed by `onError` does not double-advance generation.
3. Update `apps/operator-web/tests/lib/goal-authority-invalidation.test.ts` and QUESTPIE qualification coverage: ordinary `onNotReady` makes the UI read-only without a transient error, terminal sequencing is idempotent, and the next `onReady` refreshes authority before re-enabling mutation.

Agent Board trace: `EA-CHANNEL-SUBSCRIPTION-EPOCH-END`.
