### PR TITLE
feat(realtime): ship atomic realtime and CRDT acknowledgement

### DIFF
--- a/.changeset/realtime-lock-free-capture.md
+++ b/.changeset/realtime-lock-free-capture.md
@@ -1,0 +1,30 @@
+---
+"questpie": minor
+---
+
+Remove the fleet-wide realtime capture mutex without allowing the outbox drain
+to skip committed changes.
+
+Capture is now one transactional log insert. Readers drain the settled prefix in
+`(txid, seq)` order below PostgreSQL's snapshot frontier, so inverted sequence
+and commit order no longer require every writer in every replica to update one
+shared head row. In the checked-in PostgreSQL probe this changed 16-writer
+throughput from 35 to 267 captures/s and p99 from 2404 ms to 222 ms.
+
+Outbox retention now starts when a row is first observed below the settlement
+frontier, not at transaction start. A long-running or prepared transaction can
+therefore delay delivery, but cleanup cannot delete the committed rows it holds
+back before any node is allowed to drain them. This adds the nullable
+`questpie_realtime_log.settled_at` column and its cleanup index; generate and
+apply a migration before deploying the new readers.
+
+The settlement retry also covers the race where the blocking transaction ends
+between an empty drain and its follow-up probe, so the newly readable change is
+retried promptly instead of waiting for the reconciliation poll.
+
+Expose `crdt.projection.prepareAcknowledgement` as the atomic consumer boundary
+for a complete collaborative aggregate cut. The hook can validate and
+canonicalize CRDT field values, write exact application relations through the
+framework-owned transaction, and return ordinary owner projections such as a
+content hash or plain-text form. A rejection rolls every callback write back
+together with canonical fields, projection cursors and the realtime outbox.

--- a/.changeset/realtime-lock-free-capture.md
+++ b/.changeset/realtime-lock-free-capture.md
@@ -36,3 +36,6 @@ Restore compiled `RAW` predicates returned by collection read access rules.
 Strict access compilation still fails closed for missing fields, unresolved
 relations and unknown operators, while realtime snapshots can now reuse a
 prechecked SQL predicate without rejecting its `RAW` compiler callback.
+
+Expose `onNotReady` for typed channel subscriptions and notify each logical SSE
+or Pusher subscriber exactly once when an admitted transport epoch ends.

--- a/.changeset/realtime-lock-free-capture.md
+++ b/.changeset/realtime-lock-free-capture.md
@@ -11,6 +11,9 @@ and commit order no longer require every writer in every replica to update one
 shared head row. In the checked-in PostgreSQL probe this changed 16-writer
 throughput from 35 to 267 captures/s and p99 from 2404 ms to 222 ms.
 
+Remove the obsolete `questpie_realtime_head` table entirely. The generated
+migration drops it because `(txid, seq)` is now the only realtime drain cursor.
+
 Outbox retention now starts when a row is first observed below the settlement
 frontier, not at transaction start. A long-running or prepared transaction can
 therefore delay delivery, but cleanup cannot delete the committed rows it holds

--- a/.changeset/realtime-lock-free-capture.md
+++ b/.changeset/realtime-lock-free-capture.md
@@ -31,3 +31,8 @@ canonicalize CRDT field values, write exact application relations through the
 framework-owned transaction, and return ordinary owner projections such as a
 content hash or plain-text form. A rejection rolls every callback write back
 together with canonical fields, projection cursors and the realtime outbox.
+
+Restore compiled `RAW` predicates returned by collection read access rules.
+Strict access compilation still fails closed for missing fields, unresolved
+relations and unknown operators, while realtime snapshots can now reuse a
+prechecked SQL predicate without rejecting its `RAW` compiler callback.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,10 +206,14 @@ jobs:
 
       - name: Run PostgreSQL txid ordering acceptance
         working-directory: packages/questpie
-        run: bun test test/integration/realtime-txid-postgres.test.ts
+        run: |
+          bun test test/integration/realtime-txid-postgres.test.ts
+          bun test test/integration/realtime-drain-cursor-postgres.test.ts
+          bun test test/integration/ordered-channel-ledger-postgres.test.ts
         env:
           QUESTPIE_MIGRATIONS_SILENT: "1"
           QUESTPIE_REALTIME_TXID_DATABASE_URL: postgresql://questpie:questpie@127.0.0.1:54329/questpie_realtime
+          QUESTPIE_CHANNEL_LEDGER_DATABASE_URL: postgresql://questpie:questpie@127.0.0.1:54329/questpie_realtime
 
       - name: Run physical-purge transaction and storage-lock contracts
         working-directory: packages/questpie

--- a/apps/docs/content/docs/client/channels.mdx
+++ b/apps/docs/content/docs/client/channels.mdx
@@ -291,7 +291,7 @@ Provider client events bypass QUESTPIE's publish route, per-verb authorization, 
 - Ordered events, replay, and presence preserve nested `Date` values through
   SSE and Pusher/Soketi without heuristic ISO-string revival. The compatible
   versioned wire format and reserved metadata key are specified in
-  [Temporal values](/docs/concepts/temporal-values).
+  [Temporal values](/docs/schema/fields/temporal-values).
 - Cookie-authenticated authority routes require an exact trusted `Origin`. Additional origins belong in `realtime.channelSecurity.trustedOrigins`.
 - Client publishes use independent per-session and per-principal token buckets (defaults: 10/s, burst 20).
 
@@ -299,5 +299,5 @@ Provider client events bypass QUESTPIE's publish route, per-verb authorization, 
 
 - [Reactive Apps & Performance](/docs/client/reactive-apps), channel sizing, bounded event state, React isolation, and live presence lifecycle.
 - [Realtime](/docs/client/realtime), live collection/global snapshots.
-- [Realtime adapter](/docs/adapters/realtime), SSE versus Pusher/Soketi selection, reconciliation, admission, and privacy.
+- [Realtime adapter](/docs/infrastructure/realtime), SSE versus Pusher/Soketi selection, reconciliation, admission, and privacy.
 - [TanStack Query](/docs/client/tanstack-query), the complete option-builder surface.

--- a/apps/docs/content/docs/client/channels.mdx
+++ b/apps/docs/content/docs/client/channels.mdx
@@ -112,10 +112,18 @@ Contextless writes have no ambient scope.
 function that stops it.
 
 ```ts
-const stop = client.channels.chatRoom.subscribe({ roomId }, (message) => {
-	if (message.event === "message") console.log(message.data.text);
-	else console.log(message.data.active);
-});
+const stop = client.channels.chatRoom.subscribe(
+	{ roomId },
+	(message) => {
+		if (message.event === "message") console.log(message.data.text);
+		else console.log(message.data.active);
+	},
+	{
+		onReady: () => setMutationEnabled(true),
+		onNotReady: () => setMutationEnabled(false),
+		onError: console.error,
+	},
+);
 
 await client.channels.chatRoom.publish({
 	params: { roomId },
@@ -125,6 +133,19 @@ await client.channels.chatRoom.publish({
 
 stop();
 ```
+
+`onReady` starts one admitted subscription epoch after authorization and replay
+catch-up complete. If that epoch ends, `onNotReady` runs exactly once for the
+same logical subscriber. A successful reconnect completes fresh authorization
+and catch-up, then calls `onReady` again for the next epoch. A subscriber that
+never reached `onReady` does not receive `onNotReady`, and explicitly calling
+`stop()` or aborting the subscription removes the callbacks without reporting an
+epoch end.
+
+Ordinary reconnects report the readiness transition through `onNotReady`, not
+`onError`. A terminal failure after admission calls `onNotReady` before the
+existing `onError` callback. Exceptions thrown by any lifecycle callback are
+isolated from sibling subscribers, transport cleanup, and later reconnects.
 
 `message` is a union over your event names. Narrow on `message.event` and
 `message.data` narrows with it. Use `iter()` when an `AbortSignal` fits the

--- a/apps/docs/content/docs/client/channels.mdx
+++ b/apps/docs/content/docs/client/channels.mdx
@@ -1,19 +1,13 @@
 ---
 title: Channels
-description: A channel is a typed event stream you declare in a file. Codegen puts it on the server context, on the typed client and on the TanStack Query proxy, all carrying the Zod schemas you wrote.
-kind: guide
-package: questpie
+description: Define schema-validated application events with channel(), authorize subscribe and publish separately, then use the generated server, client, presence, and TanStack APIs over SSE or Pusher/Soketi.
 ---
 
-Live queries push rows. Reach for a channel when the thing you want to send is
-not a row. A chat message, a progress tick, a "user is typing" flag. Nothing has
-to be stored for it to arrive.
+Channels are typed application event streams built on the same realtime runtime as live queries. Define each channel once in `channels/`; codegen adds it to request contexts as `channels`, to the generated `AppConfig`, and to `client.channels`. The application API stays the same whether delivery uses the zero-infrastructure SSE path or the managed Pusher/Soketi path.
 
-## Declare it
+Use channels for transient events such as chat notifications, progress, typing, or presence. The bounded replay ledger is delivery infrastructure, **not** queryable application history. Persist messages that users must retrieve later in a collection.
 
-Put a file under your `channels/` directory. Import `channel` from
-`questpie/channels`. That entrypoint is separate from the root export because
-the API is still experimental.
+## Define a channel
 
 ```ts title="src/questpie/server/channels/chat-room.ts"
 import { channel } from "questpie/channels";
@@ -27,72 +21,72 @@ export default channel("chat-room-[roomId]")
 	.authorize({
 		subscribe: async ({ params, session, collections }) => {
 			if (!session?.user) return false;
-			const member = await collections.roomMembers.findOne({
-				where: { room: params.roomId, user: session.user.id },
-			});
-			return member !== null;
+			return Boolean(
+				await collections.rooms.findOne({
+					where: { id: params.roomId, members: { contains: session.user.id } },
+				}),
+			);
 		},
-		publish: true,
-	});
+		publish: async ({ params, session, collections }) => {
+			if (!session?.user) return false;
+			return Boolean(
+				await collections.rooms.findOne({
+					where: { id: params.roomId, members: { contains: session.user.id } },
+				}),
+			);
+		},
+	})
+	.presence(({ params, session }) => ({
+		id: session!.user.id,
+		roomId: params.roomId,
+		name: session!.user.name,
+	}));
 ```
 
-Then build the surface:
+The registry/API key is `chatRoom`, derived from the default-export filename. The explicit builder string is the stable wire pattern. Renaming the file changes the typed API and causes compile errors at call sites; it does **not** silently rename the wire channel. `[roomId]` becomes a required `{ roomId: string }` parameter everywhere.
+
+Run codegen after adding or renaming a channel:
 
 ```bash
-questpie generate
+bunx questpie generate
 ```
 
-`questpie add channel chat-room` writes the file and runs codegen for you.
+### Visibility and authorization
 
-## What that file produced
+| Builder state                         | Visibility | Subscribe          | Publish                                    |
+| ------------------------------------- | ---------- | ------------------ | ------------------------------------------ |
+| `channel(...).events(...)`            | public     | allowed by default | client publish denied by default           |
+| `.authorize(rule)`                    | private    | `rule`             | falls back to the same `rule`              |
+| `.authorize({ subscribe, publish })`  | private    | explicit rule      | explicit rule, or `subscribe` when omitted |
+| `.presence(resolver)` after authorize | presence   | authorize first    | authorize first                            |
 
-| Surface  | Where it shows up                                        |
-| -------- | -------------------------------------------------------- |
-| Server   | `ctx.channels` in every route, hook, job and workflow    |
-| Client   | `client.channels.chatRoom`                               |
-| TanStack | `q.channels.chatRoom.subscription()`                     |
-| Wire     | `private-chat-room-<roomId>`, one name per resolved room |
+Authorization receives the generated `AppContext` plus typed `params`. Use `session`, `collections`, `db`, and services directly. A false result, thrown error, or authorization timeout denies the operation. Server/system contexts may publish without a client publish grant; browser publishes still go through the framework route, authorization, rate limits, and Zod parsing.
 
-The registry key is `chatRoom`. A default export takes it from the filename,
-kebab-case turned to camelCase. A named export uses the export name instead. The
-string you pass to `channel()` is the wire pattern, not the key. Rename the file
-and your call sites break at compile time, but the wire name stays put.
+## Publish on the server
 
-Every `[param]` becomes a required string. `[roomId]` means every call needs
-`{ roomId }`, and each value resolves to its own channel. Wire patterns must be
-unique across your app and its modules, and codegen fails when two collide.
+Framework handlers receive a generated, request-bound `channels` service:
 
-## Publish from the server
-
-Handlers get a request-bound `channels` service. The event name and the payload
-type both come from the schemas you declared.
-
-```ts title="src/questpie/server/routes/send-message.post.ts"
+```ts title="src/questpie/server/routes/send-message.ts"
 import { route } from "questpie/services";
 import { z } from "zod";
 
 export default route()
 	.post()
-	.schema(z.object({ roomId: z.string(), text: z.string() }))
-	.handler(async ({ input, channels, collections }) => {
-		const message = await collections.messages.create({
-			room: input.roomId,
-			text: input.text,
-		});
+	.schema(z.object({ roomId: z.string(), id: z.string(), text: z.string() }))
+	.handler(async ({ input, channels }) => {
 		return channels.publish("chatRoom", {
 			params: { roomId: input.roomId },
 			event: "message",
-			data: { id: message.id, text: message.text },
+			data: { id: input.id, text: input.text },
 		});
 	});
 ```
 
-Zod parses `data` before the event is stored. `publish()` resolves to
-`{ eventId }`, the id that orders the channel and lets clients drop a repeat.
+The event name and input are inferred from the channel's Zod schemas. Zod transforms run before the event enters the ledger. `publish()` resolves to `{ eventId }`, the channel-local ordered id clients use for replay and deduplication.
 
-Hooks work the same way. Take `channels` off the hook argument. Do not import
-the generated `app`, and do not reach for the service through an ambient lookup.
-Contextless writes have no ambient scope.
+### Publish from collection or global hooks
+
+Use the hook's injected `{ channels }` argument. It carries the same generated types and the mutation-bound database context:
 
 ```ts
 .hooks({
@@ -106,17 +100,62 @@ Contextless writes have no ambient scope.
 })
 ```
 
-## Subscribe from the browser
+Do not import the generated `app` into a collection/hook file, and do not resolve channels later through ambient `getContext()`. Contextless update/delete calls do not guarantee an ambient scope; the injected hook argument is the reliable and transaction-aware path.
 
-`client.channels` carries one handle per channel. `subscribe()` hands back the
-function that stops it.
+## Revoke delivery authority after a domain change
+
+When a membership or authorization write removes access, call the request-bound
+service in the same transaction:
+
+```ts
+await channels.revokeAuthority("chatRoom", {
+	params: { roomId },
+	subject: { kind: "user", id: removedUserId },
+	idempotencyKey: `chat-room:${roomId}:${removedUserId}:membership-v2`,
+});
+```
+
+The command advances a durable generation for the exact resolved
+channel/subject and returns `{ generation, scope }`. With SSE,
+`scope: "exact-subscription"` closes only that logical binding with
+`access_revoked`; other channel bindings on the multiplexed stream remain
+active. Fresh request context, subscribe authorization, and the presence
+resolver are evaluated outside database locks, then a short generation check
+publishes the binding, latest freshly resolved presence payload, and optional
+presence lease atomically. A stale result and stale member payload publish
+nothing. Dropped authority notices heal through a demand-driven ledger poll
+that also stops when internal revocation closes the last local binding.
+
+Pusher/Soketi reports `scope: "principal-connections"` because its termination
+API is user-wide. QUESTPIE signs the browser into Pusher with an opaque user id,
+terminates every current connection for that user, and lets reconnect obtain
+fresh user and per-channel authorization. Channel authorization waits for
+signed-user completion and rejects stale sockets or owners. An unrelated
+still-authorized binding can reconnect; the removed binding cannot.
+Provider channel auth is explicitly side-effect-free signed-blob encoding; a
+concurrent authority cut discards the blob before it can reach the browser.
+
+<Callout type="warn" title="Managed providers have an in-flight frame window">
+	Pusher cannot guarantee that a frame already accepted by the physical
+	connection will not arrive while termination is in flight. QUESTPIE's durable
+	fence blocks new ordered provider dispatch across a pending cut, and reconnect
+	plus replay reauthorize against current application state. This is
+	intentionally not described as zero-frame atomic revocation.
+</Callout>
+
+## Subscribe and publish on the client
+
+`createClient<AppConfig>()` exposes one handle per generated channel:
 
 ```ts
 const stop = client.channels.chatRoom.subscribe(
 	{ roomId },
 	(message) => {
-		if (message.event === "message") console.log(message.data.text);
-		else console.log(message.data.active);
+		if (message.event === "message") {
+			console.log(message.eventId, message.data.text);
+		} else {
+			console.log(message.data.active);
+		}
 	},
 	{
 		onReady: () => setMutationEnabled(true),
@@ -125,7 +164,7 @@ const stop = client.channels.chatRoom.subscribe(
 	},
 );
 
-await client.channels.chatRoom.publish({
+const receipt = await client.channels.chatRoom.publish({
 	params: { roomId },
 	event: "typing",
 	data: { active: true },
@@ -147,74 +186,118 @@ Ordinary reconnects report the readiness transition through `onNotReady`, not
 existing `onError` callback. Exceptions thrown by any lifecycle callback are
 isolated from sibling subscribers, transport cleanup, and later reconnects.
 
-`message` is a union over your event names. Narrow on `message.event` and
-`message.data` narrows with it. Use `iter()` when an `AbortSignal` fits the
-consumer better:
+Client publish is server-mediated even on Pusher/Soketi: the request uses the same dynamic auth headers as other client calls, re-evaluates `publish` authorization, validates the event with Zod, enforces payload/origin/rate limits, and only then appends the ordered event.
+
+For async iteration:
 
 ```ts
-for await (const m of client.channels.chatRoom.iter({ roomId }, { signal })) {
-	consume(m);
+for await (const message of client.channels.chatRoom.iter(
+	{ roomId },
+	{ signal: controller.signal },
+)) {
+	consume(message);
 }
 ```
 
-A client publish never touches the transport directly. It posts to
-`/channels/publish`. The server runs the publish rule there and parses the
-payload with Zod. It spends a rate-limit token last, before the event exists.
-
-<Callout type="warn" title="A channel with no `.authorize()` refuses publishes">
-	`channel("x").events({})` is public. Anyone may subscribe, and no user context
-	may publish, including your own route handlers. Add `.authorize()`.
-</Callout>
+Call `client.channels.destroy()` only when disposing the whole client-side channel runtime. Normal components should call the subscription's `stop()` function or abort their iterator.
 
 ## Presence
 
-Chain `.presence(resolver)` after `.authorize()` and the channel gains a roster.
-Only then do the roster methods appear on the client handle.
+Only a channel with `.presence()` has a callable presence API:
 
 ```ts
-// in the channel file
-.presence(({ session }) => ({ id: session!.user.id, name: session!.user.name }));
-
-// in the browser
 const members = await client.channels.chatRoom.presence({ roomId });
-const stop = client.channels.chatRoom.subscribePresence({ roomId }, render);
+// readonly Array<{ id: string; roomId: string; name: string }>
 ```
 
-Your resolver decides the member shape. The client sees it typed.
+Use `subscribePresence()` for a live typed roster, or `presenceIter()` when an `AbortSignal` fits the consumer better:
 
-## Read it with TanStack Query
+```ts
+const stop = client.channels.chatRoom.subscribePresence({ roomId }, (members) =>
+	renderRoster(members),
+);
 
-The query-options proxy covers both streams. No extra provider, no custom hook.
+for await (const members of client.channels.chatRoom.presenceIter(
+	{ roomId },
+	{ signal },
+)) {
+	renderRoster(members);
+}
+```
+
+Pusher/Soketi uses native provider presence. SSE uses Postgres leases shared by every app instance and aggregates multiple connections into one member per authenticated principal. Graceful leave is immediate; an ungraceful disconnect converges after the lease expires (30s by default).
+
+## TanStack Query
+
+The query-options proxy exposes channel subscriptions without adding a separate React provider or bespoke hook:
 
 ```tsx
 const { data: messages = [] } = useQuery(
 	q.channels.chatRoom.subscription({ roomId }),
 );
+
 const { data: members = [] } = useQuery(
 	q.channels.chatRoom.presence({ roomId }),
 );
 ```
 
-`subscription()` starts at `[]` and appends each message. `presence()` keeps
-only the latest roster. Both abort their iterator on unmount.
+The subscription query starts with `[]` and appends each typed `{ event, eventId, data }` message. The presence query keeps only the latest roster snapshot. Both abort their underlying iterator on unmount.
 
-<Callout type="warn" title="A channel is not a message log">
-	Events are kept so a reconnect can replay them, 24 hours by default, then
-	deleted. Anything a user must be able to read later belongs in a collection.
+## Transport selection
+
+SSE is the default edge transport. Channel subscribe uses the framework SSE/control routes, publish uses HTTP POST, and presence uses the application Postgres database as a cross-instance lease register. No client configuration changes are needed.
+
+To use managed WebSockets and native presence, install the optional Pusher peers and select the preset under `realtime`:
+
+```ts title="src/questpie/server/questpie.config.ts"
+import { pusherRealtime } from "questpie/adapters/pusher";
+import { runtimeConfig } from "questpie/app";
+
+const managed = pusherRealtime({
+	appId: env.PUSHER_APP_ID,
+	key: env.PUSHER_KEY,
+	secret: env.PUSHER_SECRET,
+	cluster: env.PUSHER_CLUSTER,
+	// For Soketi, provide host/wsHost/ports instead.
+});
+
+export default runtimeConfig({
+	realtime: { ...managed },
+});
+```
+
+The client discovers the selected transport from `/channels/config`; `client.channels.*` call sites do not change. After a managed-provider reconnect, the established subscription reauthorizes a bounded `/channels/replay` drain from its last applied event id. Live provider events arriving during that drain are buffered behind the replay cursor, then deduplicated and released in order.
+
+Pusher signed-user authentication uses the current dynamic auth headers and
+cookies. If login or logout changes identity without replacing the browser
+socket, call both `client.realtime.destroy()` and `client.channels.destroy()`
+(or recreate the client) before subscribing again so the shared provider
+connection is recreated under the new identity.
+
+<Callout type="warn" title="Direct Pusher client events are a separate unsafe capability">
+Provider client events bypass QUESTPIE's publish route, per-verb authorization, Zod schemas, ordered ledger, replay, and rate limits. They are off by default. Enabling `clientEvents` requires `acknowledgeProviderWideRisk: true`; its `allowedChannels` list is only an SDK affordance and a raw provider client can bypass it. Prefer `client.channels.<name>.publish()`.
 </Callout>
 
-## Where each topic lives
+## Delivery and security contracts
 
-| Topic                                        | Page                                                 |
-| -------------------------------------------- | ---------------------------------------------------- |
-| Who may subscribe, who may publish, revoking | [Authorization](/docs/client/channels/authorization) |
-| The roster, its limits and its lifecycle     | [Presence](/docs/client/channels/presence)           |
-| SSE by default, or managed Pusher/Soketi     | [Transports](/docs/client/channels/transports)       |
-| Ordering, replay, readiness, gaps and limits | [Delivery](/docs/client/channels/delivery)           |
-| Live rows instead of events                  | [Realtime](/docs/client/realtime)                    |
-| Picking between the reactive primitives      | [Reactive apps](/docs/client/reactive-apps)          |
+- Framework events are ordered per resolved channel and are never coalesced. Reconnect may replay an event id; clients deduplicate it.
+- Falling behind the bounded replay horizon produces an explicit channel gap rather than invented state. Recover from a persisted collection or subscribe from now.
+- Server delivery queues, managed-provider replay races, and client async iterators are bounded by event count and serialized UTF-8 bytes. A slow consumer terminates with an explicit error; ordered events are not silently dropped.
+- A managed-provider edge sends an authenticated control probe every 15 seconds. Missing three probes expires the independent client lease and releases admission, query, and CRDT bindings even when the provider cannot report an abrupt browser disappearance.
+- Payloads must be JSON-serializable. The complete canonical
+  `{ eventId, event, data }` envelope must fit 10,000 UTF-8 bytes, so the
+  application `data` budget is slightly smaller and varies with the event id
+  and event name. Typed datetime metadata is part of those measured bytes.
+- Ordered events, replay, and presence preserve nested `Date` values through
+  SSE and Pusher/Soketi without heuristic ISO-string revival. The compatible
+  versioned wire format and reserved metadata key are specified in
+  [Temporal values](/docs/concepts/temporal-values).
+- Cookie-authenticated authority routes require an exact trusted `Origin`. Additional origins belong in `realtime.channelSecurity.trustedOrigins`.
+- Client publishes use independent per-session and per-principal token buckets (defaults: 10/s, burst 20).
 
-## Next
+## Related
 
-**[Authorization](/docs/client/channels/authorization)** is the part that bites
-first. Subscribe and publish are separate rules, and the default is strict.
+- [Reactive Apps & Performance](/docs/client/reactive-apps), channel sizing, bounded event state, React isolation, and live presence lifecycle.
+- [Realtime](/docs/client/realtime), live collection/global snapshots.
+- [Realtime adapter](/docs/adapters/realtime), SSE versus Pusher/Soketi selection, reconciliation, admission, and privacy.
+- [TanStack Query](/docs/client/tanstack-query), the complete option-builder surface.

--- a/apps/docs/content/docs/client/realtime/deltas.mdx
+++ b/apps/docs/content/docs/client/realtime/deltas.mdx
@@ -40,10 +40,10 @@ export default runtimeConfig({
 });
 ```
 
-Deploy that in a second pass, not the first. Every writer appends to the outbox
-under a head lock so sequence order matches commit order. Deltas are only safe
-once no old writer is still appending without it. Ship the code, wait for the
-fleet, then flip the flag.
+Deploy that in a second pass, not the first. Writers append to the outbox without
+a lock, and readers order it by `(txid, seq)` under PostgreSQL's visibility
+watermark. A node still running an older reader orders by sequence alone, which
+can skip a row. Ship the code, wait for the fleet, then flip the flag.
 
 Step two is the topic. Deltas are opt-in per subscription, and only through the
 raw API.

--- a/apps/docs/content/docs/client/realtime/raw-api.mdx
+++ b/apps/docs/content/docs/client/realtime/raw-api.mdx
@@ -114,17 +114,21 @@ internally.
 
 | Function                   | For                                  |
 | -------------------------- | ------------------------------------ |
-| `applyRealtimeFindEvent`   | An unwindowed `find` result          |
+| `applyRealtimeFindEvent`   | A `find` result, windowed or not     |
 | `applyRealtimeScalarEvent` | A `count` topic, which is one number |
 | `applyRealtimeSingleEvent` | A collection `get` or a global       |
 
 They all take `(current, event)` and return the next value. Reach for them when
 you consume `streamEvents()` but still want a whole result at the end.
 
-`applyRealtimeFindEvent` passes a snapshot straight through. On a keyed event it
-recomputes the page metadata as a single page. So `hasNextPage` reads `false`
-after the first row event. Keep your own paging state if you subscribed with a
-`limit`.
+`applyRealtimeFindEvent` passes a snapshot straight through, and the first one
+carries the page window. Every later frame keeps that window, because `limit`
+and `offset` belong to the topic and cannot change under a subscription. A keyed
+event moves rows and shifts `totalDocs` by however many it added or removed. A
+totals frame then replaces that count with the server's. `totalPages`,
+`hasNextPage` and the rest are recomputed from the window each time, by the same
+formula the server's paginator uses, so a live `find` with a `limit` reports the
+page counts a `find()` would.
 
 ## Wait for your own write
 

--- a/apps/docs/content/docs/infrastructure/realtime/tuning.mdx
+++ b/apps/docs/content/docs/infrastructure/realtime/tuning.mdx
@@ -29,13 +29,15 @@ import type { RealtimeConfig } from "questpie/realtime";
 | `channelSecurity`          | see below                                                 | Trusted origins, publish rate, authorization deadline                                                      |
 | `pollIntervalMs`           | `15000` with push, `2000` without                         | Reconciliation interval. `0` gives up that recovery path                                                   |
 | `batchSize`                | `500`                                                     | Maximum outbox rows read per drain                                                                         |
-| `retentionDays`            | `3`                                                       | Time horizon for outbox cleanup. `0` disables it                                                           |
+| `retentionDays`            | `3`                                                       | Minimum time a row remains after it first becomes drainable. `0` disables cleanup                          |
 | `keepAliveIntervalMs`      | `8000`                                                    | Ping interval on each SSE stream                                                                           |
 
 The poll runs alongside a broker rather than instead of it, and a provider
-failure temporarily tightens it to at most 2000 ms. Cleanup is time-based only,
-because a process-local watermark could delete rows another instance has not
-drained yet.
+failure temporarily tightens it to at most 2000 ms. Cleanup never uses a
+process-local cursor: it first marks the fleet-wide prefix below PostgreSQL's
+settlement frontier, then retains that prefix for `retentionDays`. A transaction
+held open for days therefore delays cleanup instead of letting cleanup erase
+committed rows before any instance is allowed to drain them.
 
 <Callout type="warn" title="Keep `keepAliveIntervalMs` under your idle timeout">
 	`8000` is deliberately under Bun's 10s default `idleTimeout`, so streams
@@ -104,14 +106,15 @@ it, but the whole runtime reads from it.
 
 | Column                | Notes                                                                                                                                                                                               |
 | --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `seq`                 | `bigserial` primary key, the ordering every subscriber watermarks against                                                                                                                           |
-| `txid`                | `xid8`, defaults to `pg_current_xact_id()`, which is why Postgres 13 is the floor                                                                                                                   |
+| `seq`                 | `bigserial` primary key, allocated when the row is inserted, not when its transaction commits                                                                                                       |
+| `txid`                | `xid8`, defaults to `pg_current_xact_id()`, which is why Postgres 13 is the floor. With `seq` it forms the `(txid, seq)` order every reader drains in                                               |
 | `resource_type`       | `collection` or `global`                                                                                                                                                                            |
 | `resource`            | The collection or global name                                                                                                                                                                       |
 | `operation`           | `create`, `update`, `delete`, `bulk_update`, `bulk_delete`                                                                                                                                          |
 | `record_id`, `locale` | Nullable, set when the change is specific to one record or locale                                                                                                                                   |
 | `payload`             | `jsonb`, server-side only. Single writes store shallow scalar `{ before, after }` projections, bulk writes store `{ count, recordIds }`. Nested objects, arrays and hydrated relations are excluded |
-| `created_at`          | Powers `retentionDays` cleanup                                                                                                                                                                      |
+| `created_at`          | Capture time, used for delivery-lag observability                                                                                                                                                   |
+| `settled_at`          | First cleanup observation below the PostgreSQL settlement frontier. `retentionDays` starts here, never at transaction start                                                                         |
 
 Channels, presence, authority fences and topology each own their own table
 beside it, injected into that same schema.

--- a/apps/docs/content/docs/schema/collaborative-documents/runtime.mdx
+++ b/apps/docs/content/docs/schema/collaborative-documents/runtime.mdx
@@ -61,6 +61,61 @@ Pick one credential per request. A request carrying both a cookie and an
 	service reports itself unavailable rather than throwing.
 </Callout>
 
+## Validate and project an acknowledged cut
+
+Use `crdt.projection.prepareAcknowledgement` when the canonical collaborative
+value and application-owned projections must advance together. The callback
+runs after QUESTPIE has materialized and locked one complete aggregate cut, but
+before it writes canonical fields, projection cursors, owner metadata or the
+realtime outbox event:
+
+```ts
+import { sql } from "drizzle-orm";
+import { runtimeConfig } from "questpie/app";
+
+export default runtimeConfig({
+	db: { url: process.env.DATABASE_URL! },
+	crdt: {
+		namespace: "my-app",
+		engines: { text: yjsServerEngine() },
+		projection: {
+			async prepareAcknowledgement(input) {
+				const markdown = String(input.values.get("content"));
+				const canonical = validateAndNormalizeMarkdown(markdown);
+				const references = extractReferences(canonical);
+
+				await input.transaction.execute(sql`
+					DELETE FROM article_references
+					WHERE article_id = ${input.owner.recordId}
+				`);
+				// Insert the exact validated relation set through the same transaction.
+
+				return {
+					values: new Map(input.values).set("content", canonical),
+					ownerValues: {
+						contentHash: hash(canonical),
+						plainText: toPlainText(canonical),
+					},
+				};
+			},
+		},
+	},
+});
+```
+
+`values` is the complete authoritative aggregate cut; `changed` identifies the
+CRDT fields whose cursors advanced. `contributors` identifies every Human or
+verified Agent commit included since the previous projected cut, so the
+consumer can recheck application authority without treating the hook as a new
+grant.
+
+Throw to reject the cut. Callback writes, canonical values, `ownerValues`,
+projection cursors and the realtime event then roll back together. The callback
+may be retried, so derived writes must be deterministic and idempotent. A
+returned `values` map must contain exactly the same field paths and value kinds
+as the input. `ownerValues` may update only ordinary owner columns; CRDT fields
+and system identity/revision/timestamp columns remain framework-owned.
+
 ## The text engine
 
 `yjsServerEngine()` merges untrusted bytes in worker threads inside the process

--- a/apps/docs/content/docs/ship/scaling.mdx
+++ b/apps/docs/content/docs/ship/scaling.mdx
@@ -137,11 +137,15 @@ because they build the same app object.
 [The connection budget](/docs/ship/scaling/connections) does the arithmetic and
 covers PgBouncer.
 
-**The outbox head row.** Capture runs on every collection and global write. Each
-capture locks one shared row and holds it until the transaction commits. That is
-what makes outbox order commit order. It also serializes your writes against
-each other. Keep write transactions short. Prefer one bulk call over a loop,
-because a batch captures a single outbox row rather than one per record.
+**The outbox.** Capture runs on every collection and global write and appends one
+row. It takes no shared lock, so writers do not queue behind each other and more
+nodes mean more write capacity. Readers get their order from `(txid, seq)` under
+PostgreSQL's own visibility watermark, which means a change is delivered once
+every transaction that was already open when it committed has ended. So keep
+write transactions short: a long one delays delivery of everything committing
+alongside it. Retention starts only after the row first falls below that
+watermark, so the delay cannot turn into cleanup loss. Prefer one bulk call over
+a loop, because a batch captures a single outbox row rather than one per record.
 
 ## Shutting down
 

--- a/bun.lock
+++ b/bun.lock
@@ -632,7 +632,7 @@
     "brace-expansion": "5.0.9",
     "fast-uri": "^3.1.5",
     "hono": "^4.12.25",
-    "js-yaml": "^4.3.0",
+    "js-yaml": "^4.3.1",
     "linkify-it": "^5.0.2",
     "postcss": "^8.5.18",
     "read-yaml-file": "^2.1.0",
@@ -2462,7 +2462,7 @@
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
-    "js-yaml": ["js-yaml@4.3.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q=="],
+    "js-yaml": ["js-yaml@4.3.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ=="],
 
     "jsbi": ["jsbi@4.3.2", "", {}, "sha512-9fqMSQbhJykSeii05nxKl4m6Eqn2P6rOlYiS+C5Dr/HPIU/7yZxu5qzbs40tgaFORiw2Amd0mirjxatXYMkIew=="],
 

--- a/examples/city-portal/src/questpie/server/.generated/app-factory.ts
+++ b/examples/city-portal/src/questpie/server/.generated/app-factory.ts
@@ -29,6 +29,8 @@ import _mig_20260730T182023_optimisticConcurrencyRevisions from "../migrations/2
 import _mig_20260731T000040_realtimeIdempotency1 from "../migrations/20260731T000040_realtime-idempotency-1";
 import _mig_20260731T084648_realtimeIdempotency1 from "../migrations/20260731T084648_realtime-idempotency-1";
 import _mig_20260804T091856_uploadMultipleColumn from "../migrations/20260804T091856_upload-multiple-column";
+import _mig_20260805T165224_realtimeDrainCursorIndex from "../migrations/20260805T165224_realtime-drain-cursor-index";
+import _mig_20260805T180807_realtimeSettlementRetention from "../migrations/20260805T180807_realtime-settlement-retention";
 
 // ── Blocks ─────────────────────────────────────────────────
 import { accordionBlock as _bloc_accordion } from "../blocks/accordion";
@@ -71,7 +73,7 @@ const _appDefinition = ({
 	globals: {
 		site_settings: _glob_site_settings,
 	},
-	migrations: [_mig_20260725T184252_realtimeV3Umbrella, _mig_20260726T163039_queueTransactionalDispatch, _mig_20260730T182023_optimisticConcurrencyRevisions, _mig_20260731T000040_realtimeIdempotency1, _mig_20260731T084648_realtimeIdempotency1, _mig_20260804T091856_uploadMultipleColumn],
+	migrations: [_mig_20260725T184252_realtimeV3Umbrella, _mig_20260726T163039_queueTransactionalDispatch, _mig_20260730T182023_optimisticConcurrencyRevisions, _mig_20260731T000040_realtimeIdempotency1, _mig_20260731T084648_realtimeIdempotency1, _mig_20260804T091856_uploadMultipleColumn, _mig_20260805T165224_realtimeDrainCursorIndex, _mig_20260805T180807_realtimeSettlementRetention],
 	blocks: {
 		[_bloc_accordion.state.name]: _bloc_accordion,
 		[_bloc_announcementBanner.state.name]: _bloc_announcementBanner,

--- a/examples/city-portal/src/questpie/server/.generated/app-factory.ts
+++ b/examples/city-portal/src/questpie/server/.generated/app-factory.ts
@@ -31,6 +31,7 @@ import _mig_20260731T084648_realtimeIdempotency1 from "../migrations/20260731T08
 import _mig_20260804T091856_uploadMultipleColumn from "../migrations/20260804T091856_upload-multiple-column";
 import _mig_20260805T165224_realtimeDrainCursorIndex from "../migrations/20260805T165224_realtime-drain-cursor-index";
 import _mig_20260805T180807_realtimeSettlementRetention from "../migrations/20260805T180807_realtime-settlement-retention";
+import _mig_20260806T151904_removeRealtimeHead from "../migrations/20260806T151904_remove-realtime-head";
 
 // ── Blocks ─────────────────────────────────────────────────
 import { accordionBlock as _bloc_accordion } from "../blocks/accordion";
@@ -73,7 +74,7 @@ const _appDefinition = ({
 	globals: {
 		site_settings: _glob_site_settings,
 	},
-	migrations: [_mig_20260725T184252_realtimeV3Umbrella, _mig_20260726T163039_queueTransactionalDispatch, _mig_20260730T182023_optimisticConcurrencyRevisions, _mig_20260731T000040_realtimeIdempotency1, _mig_20260731T084648_realtimeIdempotency1, _mig_20260804T091856_uploadMultipleColumn, _mig_20260805T165224_realtimeDrainCursorIndex, _mig_20260805T180807_realtimeSettlementRetention],
+	migrations: [_mig_20260725T184252_realtimeV3Umbrella, _mig_20260726T163039_queueTransactionalDispatch, _mig_20260730T182023_optimisticConcurrencyRevisions, _mig_20260731T000040_realtimeIdempotency1, _mig_20260731T084648_realtimeIdempotency1, _mig_20260804T091856_uploadMultipleColumn, _mig_20260805T165224_realtimeDrainCursorIndex, _mig_20260805T180807_realtimeSettlementRetention, _mig_20260806T151904_removeRealtimeHead],
 	blocks: {
 		[_bloc_accordion.state.name]: _bloc_accordion,
 		[_bloc_announcementBanner.state.name]: _bloc_announcementBanner,

--- a/examples/city-portal/src/questpie/server/.generated/context.gen.ts
+++ b/examples/city-portal/src/questpie/server/.generated/context.gen.ts
@@ -30,6 +30,7 @@ import _mig_20260731T084648_realtimeIdempotency1 from "../migrations/20260731T08
 import _mig_20260804T091856_uploadMultipleColumn from "../migrations/20260804T091856_upload-multiple-column";
 import _mig_20260805T165224_realtimeDrainCursorIndex from "../migrations/20260805T165224_realtime-drain-cursor-index";
 import _mig_20260805T180807_realtimeSettlementRetention from "../migrations/20260805T180807_realtime-settlement-retention";
+import _mig_20260806T151904_removeRealtimeHead from "../migrations/20260806T151904_remove-realtime-head";
 
 // ── Blocks ─────────────────────────────────────────────────
 import { accordionBlock as _bloc_accordion } from "../blocks/accordion";

--- a/examples/city-portal/src/questpie/server/.generated/context.gen.ts
+++ b/examples/city-portal/src/questpie/server/.generated/context.gen.ts
@@ -28,6 +28,8 @@ import _mig_20260730T182023_optimisticConcurrencyRevisions from "../migrations/2
 import _mig_20260731T000040_realtimeIdempotency1 from "../migrations/20260731T000040_realtime-idempotency-1";
 import _mig_20260731T084648_realtimeIdempotency1 from "../migrations/20260731T084648_realtime-idempotency-1";
 import _mig_20260804T091856_uploadMultipleColumn from "../migrations/20260804T091856_upload-multiple-column";
+import _mig_20260805T165224_realtimeDrainCursorIndex from "../migrations/20260805T165224_realtime-drain-cursor-index";
+import _mig_20260805T180807_realtimeSettlementRetention from "../migrations/20260805T180807_realtime-settlement-retention";
 
 // ── Blocks ─────────────────────────────────────────────────
 import { accordionBlock as _bloc_accordion } from "../blocks/accordion";

--- a/examples/city-portal/src/questpie/server/.generated/entities.gen.ts
+++ b/examples/city-portal/src/questpie/server/.generated/entities.gen.ts
@@ -29,6 +29,8 @@ import _mig_20260730T182023_optimisticConcurrencyRevisions from "../migrations/2
 import _mig_20260731T000040_realtimeIdempotency1 from "../migrations/20260731T000040_realtime-idempotency-1";
 import _mig_20260731T084648_realtimeIdempotency1 from "../migrations/20260731T084648_realtime-idempotency-1";
 import _mig_20260804T091856_uploadMultipleColumn from "../migrations/20260804T091856_upload-multiple-column";
+import _mig_20260805T165224_realtimeDrainCursorIndex from "../migrations/20260805T165224_realtime-drain-cursor-index";
+import _mig_20260805T180807_realtimeSettlementRetention from "../migrations/20260805T180807_realtime-settlement-retention";
 
 // ── Blocks ─────────────────────────────────────────────────
 import { accordionBlock as _bloc_accordion } from "../blocks/accordion";

--- a/examples/city-portal/src/questpie/server/.generated/entities.gen.ts
+++ b/examples/city-portal/src/questpie/server/.generated/entities.gen.ts
@@ -31,6 +31,7 @@ import _mig_20260731T084648_realtimeIdempotency1 from "../migrations/20260731T08
 import _mig_20260804T091856_uploadMultipleColumn from "../migrations/20260804T091856_upload-multiple-column";
 import _mig_20260805T165224_realtimeDrainCursorIndex from "../migrations/20260805T165224_realtime-drain-cursor-index";
 import _mig_20260805T180807_realtimeSettlementRetention from "../migrations/20260805T180807_realtime-settlement-retention";
+import _mig_20260806T151904_removeRealtimeHead from "../migrations/20260806T151904_remove-realtime-head";
 
 // ── Blocks ─────────────────────────────────────────────────
 import { accordionBlock as _bloc_accordion } from "../blocks/accordion";

--- a/examples/city-portal/src/questpie/server/.generated/index.ts
+++ b/examples/city-portal/src/questpie/server/.generated/index.ts
@@ -38,6 +38,7 @@ import _mig_20260731T084648_realtimeIdempotency1 from "../migrations/20260731T08
 import _mig_20260804T091856_uploadMultipleColumn from "../migrations/20260804T091856_upload-multiple-column";
 import _mig_20260805T165224_realtimeDrainCursorIndex from "../migrations/20260805T165224_realtime-drain-cursor-index";
 import _mig_20260805T180807_realtimeSettlementRetention from "../migrations/20260805T180807_realtime-settlement-retention";
+import _mig_20260806T151904_removeRealtimeHead from "../migrations/20260806T151904_remove-realtime-head";
 
 // ── Blocks ─────────────────────────────────────────────────
 import { accordionBlock as _bloc_accordion } from "../blocks/accordion";

--- a/examples/city-portal/src/questpie/server/.generated/index.ts
+++ b/examples/city-portal/src/questpie/server/.generated/index.ts
@@ -36,6 +36,8 @@ import _mig_20260730T182023_optimisticConcurrencyRevisions from "../migrations/2
 import _mig_20260731T000040_realtimeIdempotency1 from "../migrations/20260731T000040_realtime-idempotency-1";
 import _mig_20260731T084648_realtimeIdempotency1 from "../migrations/20260731T084648_realtime-idempotency-1";
 import _mig_20260804T091856_uploadMultipleColumn from "../migrations/20260804T091856_upload-multiple-column";
+import _mig_20260805T165224_realtimeDrainCursorIndex from "../migrations/20260805T165224_realtime-drain-cursor-index";
+import _mig_20260805T180807_realtimeSettlementRetention from "../migrations/20260805T180807_realtime-settlement-retention";
 
 // ── Blocks ─────────────────────────────────────────────────
 import { accordionBlock as _bloc_accordion } from "../blocks/accordion";

--- a/examples/city-portal/src/questpie/server/migrations/20260805T165224_realtime-drain-cursor-index.ts
+++ b/examples/city-portal/src/questpie/server/migrations/20260805T165224_realtime-drain-cursor-index.ts
@@ -1,0 +1,17 @@
+import { migration } from "questpie/services"
+import type { OperationSnapshot } from "questpie/migration"
+import { sql } from "drizzle-orm"
+import snapshotJson from "./snapshots/20260805T165224_realtime-drain-cursor-index.json"
+
+const snapshot = snapshotJson as OperationSnapshot
+
+export default migration({
+	id: "realtimeDrainCursorIndex20260805T165224",
+	async up({ db }) {
+		await db.execute(sql`CREATE INDEX "idx_realtime_log_txid_seq" ON "questpie_realtime_log" ("txid","seq");`)
+	},
+	async down({ db }) {
+		await db.execute(sql`DROP INDEX "idx_realtime_log_txid_seq";`)
+	},
+	snapshot,
+})

--- a/examples/city-portal/src/questpie/server/migrations/20260805T180807_realtime-settlement-retention.ts
+++ b/examples/city-portal/src/questpie/server/migrations/20260805T180807_realtime-settlement-retention.ts
@@ -1,0 +1,19 @@
+import { migration } from "questpie/services"
+import type { OperationSnapshot } from "questpie/migration"
+import { sql } from "drizzle-orm"
+import snapshotJson from "./snapshots/20260805T180807_realtime-settlement-retention.json"
+
+const snapshot = snapshotJson as OperationSnapshot
+
+export default migration({
+	id: "realtimeSettlementRetention20260805T180807",
+	async up({ db }) {
+		await db.execute(sql`ALTER TABLE "questpie_realtime_log" ADD COLUMN "settled_at" timestamp(3);`)
+		await db.execute(sql`CREATE INDEX "idx_realtime_log_settled_at" ON "questpie_realtime_log" ("settled_at");`)
+	},
+	async down({ db }) {
+		await db.execute(sql`DROP INDEX "idx_realtime_log_settled_at";`)
+		await db.execute(sql`ALTER TABLE "questpie_realtime_log" DROP COLUMN "settled_at";`)
+	},
+	snapshot,
+})

--- a/examples/city-portal/src/questpie/server/migrations/20260806T151904_remove-realtime-head.ts
+++ b/examples/city-portal/src/questpie/server/migrations/20260806T151904_remove-realtime-head.ts
@@ -1,0 +1,21 @@
+import { migration } from "questpie/services"
+import type { OperationSnapshot } from "questpie/migration"
+import { sql } from "drizzle-orm"
+import snapshotJson from "./snapshots/20260806T151904_remove-realtime-head.json"
+
+const snapshot = snapshotJson as OperationSnapshot
+
+export default migration({
+	id: "removeRealtimeHead20260806T151904",
+	async up({ db }) {
+		await db.execute(sql`DROP TABLE "questpie_realtime_head";`)
+	},
+	async down({ db }) {
+		await db.execute(sql`CREATE TABLE "questpie_realtime_head" (
+	"id" text PRIMARY KEY,
+	"last_seq" bigint DEFAULT 0 NOT NULL,
+	"updated_at" timestamp(3) DEFAULT now() NOT NULL
+);`)
+	},
+	snapshot,
+})

--- a/examples/city-portal/src/questpie/server/migrations/snapshots/20260805T165224_realtime-drain-cursor-index.json
+++ b/examples/city-portal/src/questpie/server/migrations/snapshots/20260805T165224_realtime-drain-cursor-index.json
@@ -1,0 +1,43 @@
+{
+  "operations": [
+    {
+      "type": "set",
+      "path": "ddl.index__COLON__public__DOT__questpie_realtime_log__DOT__idx_realtime_log_txid_seq",
+      "value": {
+        "nameExplicit": true,
+        "columns": [
+          {
+            "value": "txid",
+            "isExpression": false,
+            "asc": true,
+            "nullsFirst": false,
+            "opclass": null
+          },
+          {
+            "value": "seq",
+            "isExpression": false,
+            "asc": true,
+            "nullsFirst": false,
+            "opclass": null
+          }
+        ],
+        "isUnique": false,
+        "where": null,
+        "with": "",
+        "method": "btree",
+        "concurrently": false,
+        "name": "idx_realtime_log_txid_seq",
+        "entityType": "indexes",
+        "schema": "public",
+        "table": "questpie_realtime_log"
+      },
+      "timestamp": "2026-08-05T16:52:26.568Z",
+      "migrationId": "realtimeDrainCursorIndex20260805T165224"
+    }
+  ],
+  "metadata": {
+    "migrationId": "realtimeDrainCursorIndex20260805T165224",
+    "timestamp": "2026-08-05T16:52:28.883Z",
+    "prevId": "00000000-0000-0000-0000-000000000000"
+  }
+}

--- a/examples/city-portal/src/questpie/server/migrations/snapshots/20260805T180807_realtime-settlement-retention.json
+++ b/examples/city-portal/src/questpie/server/migrations/snapshots/20260805T180807_realtime-settlement-retention.json
@@ -1,0 +1,55 @@
+{
+  "operations": [
+    {
+      "type": "set",
+      "path": "ddl.column__COLON__public__DOT__questpie_realtime_log__DOT__settled_at",
+      "value": {
+        "type": "timestamp(3)",
+        "typeSchema": null,
+        "notNull": false,
+        "dimensions": 0,
+        "default": null,
+        "generated": null,
+        "identity": null,
+        "name": "settled_at",
+        "entityType": "columns",
+        "schema": "public",
+        "table": "questpie_realtime_log"
+      },
+      "timestamp": "2026-08-05T18:08:07.794Z",
+      "migrationId": "realtimeSettlementRetention20260805T180807"
+    },
+    {
+      "type": "set",
+      "path": "ddl.index__COLON__public__DOT__questpie_realtime_log__DOT__idx_realtime_log_settled_at",
+      "value": {
+        "nameExplicit": true,
+        "columns": [
+          {
+            "value": "settled_at",
+            "isExpression": false,
+            "asc": true,
+            "nullsFirst": false,
+            "opclass": null
+          }
+        ],
+        "isUnique": false,
+        "where": null,
+        "with": "",
+        "method": "btree",
+        "concurrently": false,
+        "name": "idx_realtime_log_settled_at",
+        "entityType": "indexes",
+        "schema": "public",
+        "table": "questpie_realtime_log"
+      },
+      "timestamp": "2026-08-05T18:08:07.794Z",
+      "migrationId": "realtimeSettlementRetention20260805T180807"
+    }
+  ],
+  "metadata": {
+    "migrationId": "realtimeSettlementRetention20260805T180807",
+    "timestamp": "2026-08-05T18:08:07.964Z",
+    "prevId": "00000000-0000-0000-0000-000000000000"
+  }
+}

--- a/examples/city-portal/src/questpie/server/migrations/snapshots/20260806T151904_remove-realtime-head.json
+++ b/examples/city-portal/src/questpie/server/migrations/snapshots/20260806T151904_remove-realtime-head.json
@@ -1,0 +1,39 @@
+{
+  "operations": [
+    {
+      "type": "remove",
+      "path": "ddl.table__COLON__public__DOT__questpie_realtime_head",
+      "timestamp": "2026-08-06T15:19:04.519Z",
+      "migrationId": "removeRealtimeHead20260806T151904"
+    },
+    {
+      "type": "remove",
+      "path": "ddl.column__COLON__public__DOT__questpie_realtime_head__DOT__id",
+      "timestamp": "2026-08-06T15:19:04.519Z",
+      "migrationId": "removeRealtimeHead20260806T151904"
+    },
+    {
+      "type": "remove",
+      "path": "ddl.column__COLON__public__DOT__questpie_realtime_head__DOT__last_seq",
+      "timestamp": "2026-08-06T15:19:04.519Z",
+      "migrationId": "removeRealtimeHead20260806T151904"
+    },
+    {
+      "type": "remove",
+      "path": "ddl.column__COLON__public__DOT__questpie_realtime_head__DOT__updated_at",
+      "timestamp": "2026-08-06T15:19:04.519Z",
+      "migrationId": "removeRealtimeHead20260806T151904"
+    },
+    {
+      "type": "remove",
+      "path": "ddl.pk__COLON__public__DOT__questpie_realtime_head__DOT__questpie_realtime_head_pkey",
+      "timestamp": "2026-08-06T15:19:04.519Z",
+      "migrationId": "removeRealtimeHead20260806T151904"
+    }
+  ],
+  "metadata": {
+    "migrationId": "removeRealtimeHead20260806T151904",
+    "timestamp": "2026-08-06T15:19:04.698Z",
+    "prevId": "00000000-0000-0000-0000-000000000000"
+  }
+}

--- a/examples/tanstack-barbershop/src/questpie/server/.generated/app-factory.ts
+++ b/examples/tanstack-barbershop/src/questpie/server/.generated/app-factory.ts
@@ -65,6 +65,7 @@ import _mig_20260731T000041_realtimeIdempotency1 from "../migrations/20260731T00
 import _mig_20260731T084650_realtimeIdempotency1 from "../migrations/20260731T084650_realtime-idempotency-1";
 import _mig_20260805T165255_realtimeDrainCursorIndex from "../migrations/20260805T165255_realtime-drain-cursor-index";
 import _mig_20260805T180812_realtimeSettlementRetention from "../migrations/20260805T180812_realtime-settlement-retention";
+import _mig_20260806T151905_removeRealtimeHead from "../migrations/20260806T151905_remove-realtime-head";
 
 // ── Seeds ──────────────────────────────────────────────────
 import _seed_blogPosts from "../seeds/blog-posts";
@@ -139,7 +140,7 @@ const _appDefinition = ({
 		appointmentConfirmation: _email_appointmentConfirmation,
 		newBlogPost: _email_newBlogPost,
 	},
-	migrations: [_mig_20260206T174642_gentle_azure_eagle, _mig_20260206T180920_fancy_green_tiger, _mig_20260211T100836_calm_blue_phoenix, _mig_20260218T195452_calm_blue_dragon, _mig_20260218T223923_fancy_blue_panda, _mig_20260218T235924_kind_crimson_falcon, _mig_20260307T122102_eager_red_eagle, _mig_20260307T135142_fancy_orange_tiger, _mig_20260424T221327_bold_yellow_phoenix, _mig_20260427T093217_eager_blue_phoenix, _mig_20260429T170546_kind_yellow_eagle, _mig_20260615T084209_swift_orange_eagle, _mig_20260712T094709_bold_red_griffin, _mig_20260712T195414_eager_red_tiger, _mig_20260725T184252_realtimeV3Umbrella, _mig_20260726T163042_queueTransactionalDispatch, _mig_20260730T182023_optimisticConcurrencyRevisions, _mig_20260731T000041_realtimeIdempotency1, _mig_20260731T084650_realtimeIdempotency1, _mig_20260805T165255_realtimeDrainCursorIndex, _mig_20260805T180812_realtimeSettlementRetention],
+	migrations: [_mig_20260206T174642_gentle_azure_eagle, _mig_20260206T180920_fancy_green_tiger, _mig_20260211T100836_calm_blue_phoenix, _mig_20260218T195452_calm_blue_dragon, _mig_20260218T223923_fancy_blue_panda, _mig_20260218T235924_kind_crimson_falcon, _mig_20260307T122102_eager_red_eagle, _mig_20260307T135142_fancy_orange_tiger, _mig_20260424T221327_bold_yellow_phoenix, _mig_20260427T093217_eager_blue_phoenix, _mig_20260429T170546_kind_yellow_eagle, _mig_20260615T084209_swift_orange_eagle, _mig_20260712T094709_bold_red_griffin, _mig_20260712T195414_eager_red_tiger, _mig_20260725T184252_realtimeV3Umbrella, _mig_20260726T163042_queueTransactionalDispatch, _mig_20260730T182023_optimisticConcurrencyRevisions, _mig_20260731T000041_realtimeIdempotency1, _mig_20260731T084650_realtimeIdempotency1, _mig_20260805T165255_realtimeDrainCursorIndex, _mig_20260805T180812_realtimeSettlementRetention, _mig_20260806T151905_removeRealtimeHead],
 	seeds: [_seed_blogPosts, _seed_demoData, _seed_siteSettings],
 	fieldTypes: {
 		color: _ftype_color,

--- a/examples/tanstack-barbershop/src/questpie/server/.generated/app-factory.ts
+++ b/examples/tanstack-barbershop/src/questpie/server/.generated/app-factory.ts
@@ -63,6 +63,8 @@ import _mig_20260726T163042_queueTransactionalDispatch from "../migrations/20260
 import _mig_20260730T182023_optimisticConcurrencyRevisions from "../migrations/20260730T182023_optimistic-concurrency-revisions";
 import _mig_20260731T000041_realtimeIdempotency1 from "../migrations/20260731T000041_realtime-idempotency-1";
 import _mig_20260731T084650_realtimeIdempotency1 from "../migrations/20260731T084650_realtime-idempotency-1";
+import _mig_20260805T165255_realtimeDrainCursorIndex from "../migrations/20260805T165255_realtime-drain-cursor-index";
+import _mig_20260805T180812_realtimeSettlementRetention from "../migrations/20260805T180812_realtime-settlement-retention";
 
 // ── Seeds ──────────────────────────────────────────────────
 import _seed_blogPosts from "../seeds/blog-posts";
@@ -137,7 +139,7 @@ const _appDefinition = ({
 		appointmentConfirmation: _email_appointmentConfirmation,
 		newBlogPost: _email_newBlogPost,
 	},
-	migrations: [_mig_20260206T174642_gentle_azure_eagle, _mig_20260206T180920_fancy_green_tiger, _mig_20260211T100836_calm_blue_phoenix, _mig_20260218T195452_calm_blue_dragon, _mig_20260218T223923_fancy_blue_panda, _mig_20260218T235924_kind_crimson_falcon, _mig_20260307T122102_eager_red_eagle, _mig_20260307T135142_fancy_orange_tiger, _mig_20260424T221327_bold_yellow_phoenix, _mig_20260427T093217_eager_blue_phoenix, _mig_20260429T170546_kind_yellow_eagle, _mig_20260615T084209_swift_orange_eagle, _mig_20260712T094709_bold_red_griffin, _mig_20260712T195414_eager_red_tiger, _mig_20260725T184252_realtimeV3Umbrella, _mig_20260726T163042_queueTransactionalDispatch, _mig_20260730T182023_optimisticConcurrencyRevisions, _mig_20260731T000041_realtimeIdempotency1, _mig_20260731T084650_realtimeIdempotency1],
+	migrations: [_mig_20260206T174642_gentle_azure_eagle, _mig_20260206T180920_fancy_green_tiger, _mig_20260211T100836_calm_blue_phoenix, _mig_20260218T195452_calm_blue_dragon, _mig_20260218T223923_fancy_blue_panda, _mig_20260218T235924_kind_crimson_falcon, _mig_20260307T122102_eager_red_eagle, _mig_20260307T135142_fancy_orange_tiger, _mig_20260424T221327_bold_yellow_phoenix, _mig_20260427T093217_eager_blue_phoenix, _mig_20260429T170546_kind_yellow_eagle, _mig_20260615T084209_swift_orange_eagle, _mig_20260712T094709_bold_red_griffin, _mig_20260712T195414_eager_red_tiger, _mig_20260725T184252_realtimeV3Umbrella, _mig_20260726T163042_queueTransactionalDispatch, _mig_20260730T182023_optimisticConcurrencyRevisions, _mig_20260731T000041_realtimeIdempotency1, _mig_20260731T084650_realtimeIdempotency1, _mig_20260805T165255_realtimeDrainCursorIndex, _mig_20260805T180812_realtimeSettlementRetention],
 	seeds: [_seed_blogPosts, _seed_demoData, _seed_siteSettings],
 	fieldTypes: {
 		color: _ftype_color,

--- a/examples/tanstack-barbershop/src/questpie/server/.generated/context.gen.ts
+++ b/examples/tanstack-barbershop/src/questpie/server/.generated/context.gen.ts
@@ -62,6 +62,8 @@ import _mig_20260726T163042_queueTransactionalDispatch from "../migrations/20260
 import _mig_20260730T182023_optimisticConcurrencyRevisions from "../migrations/20260730T182023_optimistic-concurrency-revisions";
 import _mig_20260731T000041_realtimeIdempotency1 from "../migrations/20260731T000041_realtime-idempotency-1";
 import _mig_20260731T084650_realtimeIdempotency1 from "../migrations/20260731T084650_realtime-idempotency-1";
+import _mig_20260805T165255_realtimeDrainCursorIndex from "../migrations/20260805T165255_realtime-drain-cursor-index";
+import _mig_20260805T180812_realtimeSettlementRetention from "../migrations/20260805T180812_realtime-settlement-retention";
 
 // ── Seeds ──────────────────────────────────────────────────
 import _seed_blogPosts from "../seeds/blog-posts";

--- a/examples/tanstack-barbershop/src/questpie/server/.generated/context.gen.ts
+++ b/examples/tanstack-barbershop/src/questpie/server/.generated/context.gen.ts
@@ -64,6 +64,7 @@ import _mig_20260731T000041_realtimeIdempotency1 from "../migrations/20260731T00
 import _mig_20260731T084650_realtimeIdempotency1 from "../migrations/20260731T084650_realtime-idempotency-1";
 import _mig_20260805T165255_realtimeDrainCursorIndex from "../migrations/20260805T165255_realtime-drain-cursor-index";
 import _mig_20260805T180812_realtimeSettlementRetention from "../migrations/20260805T180812_realtime-settlement-retention";
+import _mig_20260806T151905_removeRealtimeHead from "../migrations/20260806T151905_remove-realtime-head";
 
 // ── Seeds ──────────────────────────────────────────────────
 import _seed_blogPosts from "../seeds/blog-posts";

--- a/examples/tanstack-barbershop/src/questpie/server/.generated/entities.gen.ts
+++ b/examples/tanstack-barbershop/src/questpie/server/.generated/entities.gen.ts
@@ -63,6 +63,8 @@ import _mig_20260726T163042_queueTransactionalDispatch from "../migrations/20260
 import _mig_20260730T182023_optimisticConcurrencyRevisions from "../migrations/20260730T182023_optimistic-concurrency-revisions";
 import _mig_20260731T000041_realtimeIdempotency1 from "../migrations/20260731T000041_realtime-idempotency-1";
 import _mig_20260731T084650_realtimeIdempotency1 from "../migrations/20260731T084650_realtime-idempotency-1";
+import _mig_20260805T165255_realtimeDrainCursorIndex from "../migrations/20260805T165255_realtime-drain-cursor-index";
+import _mig_20260805T180812_realtimeSettlementRetention from "../migrations/20260805T180812_realtime-settlement-retention";
 
 // ── Seeds ──────────────────────────────────────────────────
 import _seed_blogPosts from "../seeds/blog-posts";

--- a/examples/tanstack-barbershop/src/questpie/server/.generated/entities.gen.ts
+++ b/examples/tanstack-barbershop/src/questpie/server/.generated/entities.gen.ts
@@ -65,6 +65,7 @@ import _mig_20260731T000041_realtimeIdempotency1 from "../migrations/20260731T00
 import _mig_20260731T084650_realtimeIdempotency1 from "../migrations/20260731T084650_realtime-idempotency-1";
 import _mig_20260805T165255_realtimeDrainCursorIndex from "../migrations/20260805T165255_realtime-drain-cursor-index";
 import _mig_20260805T180812_realtimeSettlementRetention from "../migrations/20260805T180812_realtime-settlement-retention";
+import _mig_20260806T151905_removeRealtimeHead from "../migrations/20260806T151905_remove-realtime-head";
 
 // ── Seeds ──────────────────────────────────────────────────
 import _seed_blogPosts from "../seeds/blog-posts";

--- a/examples/tanstack-barbershop/src/questpie/server/.generated/index.ts
+++ b/examples/tanstack-barbershop/src/questpie/server/.generated/index.ts
@@ -72,6 +72,7 @@ import _mig_20260731T000041_realtimeIdempotency1 from "../migrations/20260731T00
 import _mig_20260731T084650_realtimeIdempotency1 from "../migrations/20260731T084650_realtime-idempotency-1";
 import _mig_20260805T165255_realtimeDrainCursorIndex from "../migrations/20260805T165255_realtime-drain-cursor-index";
 import _mig_20260805T180812_realtimeSettlementRetention from "../migrations/20260805T180812_realtime-settlement-retention";
+import _mig_20260806T151905_removeRealtimeHead from "../migrations/20260806T151905_remove-realtime-head";
 
 // ── Seeds ──────────────────────────────────────────────────
 import _seed_blogPosts from "../seeds/blog-posts";

--- a/examples/tanstack-barbershop/src/questpie/server/.generated/index.ts
+++ b/examples/tanstack-barbershop/src/questpie/server/.generated/index.ts
@@ -70,6 +70,8 @@ import _mig_20260726T163042_queueTransactionalDispatch from "../migrations/20260
 import _mig_20260730T182023_optimisticConcurrencyRevisions from "../migrations/20260730T182023_optimistic-concurrency-revisions";
 import _mig_20260731T000041_realtimeIdempotency1 from "../migrations/20260731T000041_realtime-idempotency-1";
 import _mig_20260731T084650_realtimeIdempotency1 from "../migrations/20260731T084650_realtime-idempotency-1";
+import _mig_20260805T165255_realtimeDrainCursorIndex from "../migrations/20260805T165255_realtime-drain-cursor-index";
+import _mig_20260805T180812_realtimeSettlementRetention from "../migrations/20260805T180812_realtime-settlement-retention";
 
 // ── Seeds ──────────────────────────────────────────────────
 import _seed_blogPosts from "../seeds/blog-posts";

--- a/examples/tanstack-barbershop/src/questpie/server/migrations/20260805T165255_realtime-drain-cursor-index.ts
+++ b/examples/tanstack-barbershop/src/questpie/server/migrations/20260805T165255_realtime-drain-cursor-index.ts
@@ -1,0 +1,17 @@
+import { migration } from "questpie/services"
+import type { OperationSnapshot } from "questpie/migration"
+import { sql } from "drizzle-orm"
+import snapshotJson from "./snapshots/20260805T165255_realtime-drain-cursor-index.json"
+
+const snapshot = snapshotJson as OperationSnapshot
+
+export default migration({
+	id: "realtimeDrainCursorIndex20260805T165255",
+	async up({ db }) {
+		await db.execute(sql`CREATE INDEX "idx_realtime_log_txid_seq" ON "questpie_realtime_log" ("txid","seq");`)
+	},
+	async down({ db }) {
+		await db.execute(sql`DROP INDEX "idx_realtime_log_txid_seq";`)
+	},
+	snapshot,
+})

--- a/examples/tanstack-barbershop/src/questpie/server/migrations/20260805T180812_realtime-settlement-retention.ts
+++ b/examples/tanstack-barbershop/src/questpie/server/migrations/20260805T180812_realtime-settlement-retention.ts
@@ -1,0 +1,19 @@
+import { migration } from "questpie/services"
+import type { OperationSnapshot } from "questpie/migration"
+import { sql } from "drizzle-orm"
+import snapshotJson from "./snapshots/20260805T180812_realtime-settlement-retention.json"
+
+const snapshot = snapshotJson as OperationSnapshot
+
+export default migration({
+	id: "realtimeSettlementRetention20260805T180812",
+	async up({ db }) {
+		await db.execute(sql`ALTER TABLE "questpie_realtime_log" ADD COLUMN "settled_at" timestamp(3);`)
+		await db.execute(sql`CREATE INDEX "idx_realtime_log_settled_at" ON "questpie_realtime_log" ("settled_at");`)
+	},
+	async down({ db }) {
+		await db.execute(sql`DROP INDEX "idx_realtime_log_settled_at";`)
+		await db.execute(sql`ALTER TABLE "questpie_realtime_log" DROP COLUMN "settled_at";`)
+	},
+	snapshot,
+})

--- a/examples/tanstack-barbershop/src/questpie/server/migrations/20260806T151905_remove-realtime-head.ts
+++ b/examples/tanstack-barbershop/src/questpie/server/migrations/20260806T151905_remove-realtime-head.ts
@@ -1,0 +1,21 @@
+import { migration } from "questpie/services"
+import type { OperationSnapshot } from "questpie/migration"
+import { sql } from "drizzle-orm"
+import snapshotJson from "./snapshots/20260806T151905_remove-realtime-head.json"
+
+const snapshot = snapshotJson as OperationSnapshot
+
+export default migration({
+	id: "removeRealtimeHead20260806T151905",
+	async up({ db }) {
+		await db.execute(sql`DROP TABLE "questpie_realtime_head";`)
+	},
+	async down({ db }) {
+		await db.execute(sql`CREATE TABLE "questpie_realtime_head" (
+	"id" text PRIMARY KEY,
+	"last_seq" bigint DEFAULT 0 NOT NULL,
+	"updated_at" timestamp(3) DEFAULT now() NOT NULL
+);`)
+	},
+	snapshot,
+})

--- a/examples/tanstack-barbershop/src/questpie/server/migrations/snapshots/20260805T165255_realtime-drain-cursor-index.json
+++ b/examples/tanstack-barbershop/src/questpie/server/migrations/snapshots/20260805T165255_realtime-drain-cursor-index.json
@@ -1,0 +1,43 @@
+{
+  "operations": [
+    {
+      "type": "set",
+      "path": "ddl.index__COLON__public__DOT__questpie_realtime_log__DOT__idx_realtime_log_txid_seq",
+      "value": {
+        "nameExplicit": true,
+        "columns": [
+          {
+            "value": "txid",
+            "isExpression": false,
+            "asc": true,
+            "nullsFirst": false,
+            "opclass": null
+          },
+          {
+            "value": "seq",
+            "isExpression": false,
+            "asc": true,
+            "nullsFirst": false,
+            "opclass": null
+          }
+        ],
+        "isUnique": false,
+        "where": null,
+        "with": "",
+        "method": "btree",
+        "concurrently": false,
+        "name": "idx_realtime_log_txid_seq",
+        "entityType": "indexes",
+        "schema": "public",
+        "table": "questpie_realtime_log"
+      },
+      "timestamp": "2026-08-05T16:52:57.722Z",
+      "migrationId": "realtimeDrainCursorIndex20260805T165255"
+    }
+  ],
+  "metadata": {
+    "migrationId": "realtimeDrainCursorIndex20260805T165255",
+    "timestamp": "2026-08-05T16:52:59.034Z",
+    "prevId": "00000000-0000-0000-0000-000000000000"
+  }
+}

--- a/examples/tanstack-barbershop/src/questpie/server/migrations/snapshots/20260805T180812_realtime-settlement-retention.json
+++ b/examples/tanstack-barbershop/src/questpie/server/migrations/snapshots/20260805T180812_realtime-settlement-retention.json
@@ -1,0 +1,55 @@
+{
+  "operations": [
+    {
+      "type": "set",
+      "path": "ddl.column__COLON__public__DOT__questpie_realtime_log__DOT__settled_at",
+      "value": {
+        "type": "timestamp(3)",
+        "typeSchema": null,
+        "notNull": false,
+        "dimensions": 0,
+        "default": null,
+        "generated": null,
+        "identity": null,
+        "name": "settled_at",
+        "entityType": "columns",
+        "schema": "public",
+        "table": "questpie_realtime_log"
+      },
+      "timestamp": "2026-08-05T18:08:12.311Z",
+      "migrationId": "realtimeSettlementRetention20260805T180812"
+    },
+    {
+      "type": "set",
+      "path": "ddl.index__COLON__public__DOT__questpie_realtime_log__DOT__idx_realtime_log_settled_at",
+      "value": {
+        "nameExplicit": true,
+        "columns": [
+          {
+            "value": "settled_at",
+            "isExpression": false,
+            "asc": true,
+            "nullsFirst": false,
+            "opclass": null
+          }
+        ],
+        "isUnique": false,
+        "where": null,
+        "with": "",
+        "method": "btree",
+        "concurrently": false,
+        "name": "idx_realtime_log_settled_at",
+        "entityType": "indexes",
+        "schema": "public",
+        "table": "questpie_realtime_log"
+      },
+      "timestamp": "2026-08-05T18:08:12.311Z",
+      "migrationId": "realtimeSettlementRetention20260805T180812"
+    }
+  ],
+  "metadata": {
+    "migrationId": "realtimeSettlementRetention20260805T180812",
+    "timestamp": "2026-08-05T18:08:12.487Z",
+    "prevId": "00000000-0000-0000-0000-000000000000"
+  }
+}

--- a/examples/tanstack-barbershop/src/questpie/server/migrations/snapshots/20260806T151905_remove-realtime-head.json
+++ b/examples/tanstack-barbershop/src/questpie/server/migrations/snapshots/20260806T151905_remove-realtime-head.json
@@ -1,0 +1,39 @@
+{
+  "operations": [
+    {
+      "type": "remove",
+      "path": "ddl.table__COLON__public__DOT__questpie_realtime_head",
+      "timestamp": "2026-08-06T15:19:05.326Z",
+      "migrationId": "removeRealtimeHead20260806T151905"
+    },
+    {
+      "type": "remove",
+      "path": "ddl.column__COLON__public__DOT__questpie_realtime_head__DOT__id",
+      "timestamp": "2026-08-06T15:19:05.326Z",
+      "migrationId": "removeRealtimeHead20260806T151905"
+    },
+    {
+      "type": "remove",
+      "path": "ddl.column__COLON__public__DOT__questpie_realtime_head__DOT__last_seq",
+      "timestamp": "2026-08-06T15:19:05.326Z",
+      "migrationId": "removeRealtimeHead20260806T151905"
+    },
+    {
+      "type": "remove",
+      "path": "ddl.column__COLON__public__DOT__questpie_realtime_head__DOT__updated_at",
+      "timestamp": "2026-08-06T15:19:05.326Z",
+      "migrationId": "removeRealtimeHead20260806T151905"
+    },
+    {
+      "type": "remove",
+      "path": "ddl.pk__COLON__public__DOT__questpie_realtime_head__DOT__questpie_realtime_head_pkey",
+      "timestamp": "2026-08-06T15:19:05.326Z",
+      "migrationId": "removeRealtimeHead20260806T151905"
+    }
+  ],
+  "metadata": {
+    "migrationId": "removeRealtimeHead20260806T151905",
+    "timestamp": "2026-08-06T15:19:05.507Z",
+    "prevId": "00000000-0000-0000-0000-000000000000"
+  }
+}

--- a/examples/tanstack-barbershop/test/openapi-spec.test.ts
+++ b/examples/tanstack-barbershop/test/openapi-spec.test.ts
@@ -53,6 +53,7 @@ describe("barbershop generated OpenAPI route snapshot", () => {
 			"/api/realtime/config",
 			"/api/realtime/crdt/exchange",
 			"/api/realtime/crdt/open",
+			"/api/transaction",
 			"/api/{collection}/{id}/purge",
 			"/api/create-booking",
 			"/api/get-active-barbers",
@@ -70,7 +71,7 @@ describe("barbershop generated OpenAPI route snapshot", () => {
 		};
 
 		expect(routeSnapshot).toEqual({
-			pathCount: 61,
+			pathCount: 62,
 			methods: {
 				"/api/channels/auth": ["options", "post"],
 				"/api/channels/config": ["get"],
@@ -84,6 +85,7 @@ describe("barbershop generated OpenAPI route snapshot", () => {
 				"/api/realtime/config": ["get"],
 				"/api/realtime/crdt/exchange": ["post"],
 				"/api/realtime/crdt/open": ["post"],
+				"/api/transaction": ["post"],
 				"/api/{collection}/{id}/purge": ["post"],
 			},
 		});

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
 		"brace-expansion": "5.0.9",
 		"fast-uri": "^3.1.5",
 		"hono": "^4.12.25",
-		"js-yaml": "^4.3.0",
+		"js-yaml": "^4.3.1",
 		"linkify-it": "^5.0.2",
 		"postcss": "^8.5.18",
 		"read-yaml-file": "^2.1.0",

--- a/packages/admin/src/client/builder/index.ts
+++ b/packages/admin/src/client/builder/index.ts
@@ -80,7 +80,7 @@ export type {
  * with a single, intentional definition that documents the trade-off and
  * provides a future narrowing point.
  */
-export type AnyQuestpieClient = QuestpieClient<any>;
+export type AnyQuestpieClient = Omit<QuestpieClient<any>, "transaction">;
 
 /**
  * Extract collection names from a QuestpieApp config

--- a/packages/admin/src/client/views/collection/form-view.tsx
+++ b/packages/admin/src/client/views/collection/form-view.tsx
@@ -1437,7 +1437,7 @@ export default function FormView({
 	// Create query options proxy for key building (same as use-collection hooks)
 	const queryOpts = React.useMemo(
 		() =>
-			createQuestpieQueryOptions(client, {
+			createQuestpieQueryOptions(client as any, {
 				keyPrefix: QUERY_KEY_PREFIX,
 				locale: contentLocale,
 			}),

--- a/packages/admin/src/exports/client.ts
+++ b/packages/admin/src/exports/client.ts
@@ -385,7 +385,7 @@ import type { QuestpieApp, QuestpieClient } from "questpie/client";
  * Unparameterised client type used throughout the admin library.
  * @see AnyQuestpieClient in builder/index.ts for rationale.
  */
-export type AnyQuestpieClient = QuestpieClient<any>;
+export type AnyQuestpieClient = Omit<QuestpieClient<any>, "transaction">;
 
 /**
  * Extract collection names from a QuestpieApp config

--- a/packages/admin/test/client/realtime-consumers.test.ts
+++ b/packages/admin/test/client/realtime-consumers.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, test } from "bun:test";
 
 import { QueryClient } from "@tanstack/react-query";
-import type { QuestpieApp, QuestpieClient } from "questpie/client";
+import {
+	deriveFindDeltas,
+	type QuestpieApp,
+	type QuestpieClient,
+} from "questpie/client";
 
 import { createQuestpieQueryOptions } from "@questpie/tanstack-query";
 
@@ -115,6 +119,84 @@ describe("admin realtime consumer regression", () => {
 			},
 			{ resourceType: "global", resource: "siteSettings", operation: "get" },
 		]);
+	});
+
+	test("a paged live list keeps the page counts the pager reads", async () => {
+		// list-view.tsx and table-view.tsx drive their pager off listData.totalPages
+		// and listData.totalDocs, and both subscribe with the page window.
+		const bootstrap = {
+			docs: [{ id: "post-41" }, { id: "post-42" }],
+			totalDocs: 138,
+			limit: 2,
+			totalPages: 69,
+			page: 21,
+			pagingCounter: 41,
+			hasPrevPage: true,
+			hasNextPage: true,
+			prevPage: 20,
+			nextPage: 22,
+		};
+		// A write on an earlier page slides this window along by one row. The
+		// server re-runs the windowed query, so the second frame is a whole
+		// snapshot and the client derives the keyed events itself.
+		const slid = {
+			...bootstrap,
+			docs: [{ id: "post-40" }, { id: "post-41" }],
+			totalDocs: 139,
+			totalPages: 70,
+		};
+		async function* snapshots() {
+			yield {
+				type: "snapshot" as const,
+				topicId: "collection:posts:find",
+				seq: 1,
+				data: bootstrap,
+			};
+			yield {
+				type: "snapshot" as const,
+				topicId: "collection:posts:find",
+				seq: 2,
+				data: slid,
+			};
+		}
+		const client = {
+			collections: new Proxy(
+				{},
+				{ get: () => ({ find: async () => ({ docs: [], totalDocs: 0 }) }) },
+			),
+			globals: {},
+			routes: {},
+			realtime: {
+				subscribe: () => () => {},
+				streamEvents: () => deriveFindDeltas(snapshots()),
+				destroy: () => {},
+				topicCount: 0,
+				subscriberCount: 0,
+			},
+		} as unknown as QuestpieClient<QuestpieApp>;
+		const queries = createQuestpieQueryOptions(client);
+
+		const listData = (await runQuery(
+			queries.collections.posts.find(
+				{ limit: 2, offset: 40 },
+				{ realtime: true },
+			),
+		)) as Record<string, unknown>;
+
+		expect(listData).toMatchObject({
+			totalDocs: 139,
+			limit: 2,
+			totalPages: 70,
+			page: 21,
+			pagingCounter: 41,
+			hasPrevPage: true,
+			hasNextPage: true,
+		});
+		expect(listData.docs).toEqual([{ id: "post-40" }, { id: "post-41" }]);
+		// The pager's next button is disabled on page >= totalPages.
+		expect((listData.page as number) >= (listData.totalPages as number)).toBe(
+			false,
+		);
 	});
 
 	test("direct invalidation treats one bulk event as one cache wake", () => {

--- a/packages/questpie/src/client/channels/pusher.ts
+++ b/packages/questpie/src/client/channels/pusher.ts
@@ -106,6 +106,8 @@ export class PusherChannelTransport implements ChannelClientTransport {
 			callback,
 			options.onReady,
 			() => this.failEntry(entry, channelSlowConsumerError()),
+			false,
+			options.onNotReady,
 		);
 		entry.subscribers.add(delivery.accept);
 		const errorCallback = options.onError
@@ -151,6 +153,7 @@ export class PusherChannelTransport implements ChannelClientTransport {
 			options.onReady,
 			() => this.failEntry(entry, channelSlowConsumerError()),
 			true,
+			options.onNotReady,
 		);
 		entry.presenceSubscribers.add(delivery.accept);
 		const errorCallback = options.onError
@@ -347,9 +350,6 @@ export class PusherChannelTransport implements ChannelClientTransport {
 			channel.bind("pusher:subscription_succeeded", (members) => {
 				try {
 					if (!subscription.isConnectionActive()) return;
-					if (entry.readiness.isReady) {
-						this.notify(entry, new Error("Channel subscription epoch ended"));
-					}
 					entry.readiness.end();
 					entry.providerEpochActive = true;
 					entry.pendingLive.clear();
@@ -501,7 +501,7 @@ export class PusherChannelTransport implements ChannelClientTransport {
 		entry.replayGeneration += 1;
 		entry.replaying = false;
 		entry.pendingLive.clear();
-		this.notify(entry, new Error("Channel connection epoch ended"));
+		entry.readiness.end();
 	}
 
 	private parseReplayMessage(value: unknown): ChannelTransportMessage {
@@ -554,8 +554,8 @@ export class PusherChannelTransport implements ChannelClientTransport {
 	}
 
 	private notify(entry: Entry, error: Error): void {
-		entry.readiness.end();
 		const errorCallbacks = Array.from(entry.errorCallbacks);
+		entry.readiness.end();
 		for (const callback of errorCallbacks) {
 			notifyChannelConsumer(callback, error);
 		}

--- a/packages/questpie/src/client/channels/readiness.ts
+++ b/packages/questpie/src/client/channels/readiness.ts
@@ -4,8 +4,10 @@ import { BoundedChannelQueue } from "./ordered-events.js";
 type ReadyRegistration = {
 	callback: () => void;
 	onEnd?: () => void;
+	onNotReady?: () => void;
 	active: boolean;
 	notifiedEpoch: number;
+	endedEpoch: number;
 };
 
 /** Per-logical-registration readiness over one shared channel transport entry. */
@@ -18,13 +20,19 @@ export class ChannelReadiness {
 		return this.admitted;
 	}
 
-	register(callback: (() => void) | undefined, onEnd?: () => void): () => void {
-		if (!callback && !onEnd) return () => {};
+	register(
+		callback: (() => void) | undefined,
+		onEnd?: () => void,
+		onNotReady?: () => void,
+	): () => void {
+		if (!callback && !onEnd && !onNotReady) return () => {};
 		const registration: ReadyRegistration = {
 			callback: callback ?? (() => {}),
 			onEnd,
+			onNotReady,
 			active: true,
 			notifiedEpoch: 0,
+			endedEpoch: 0,
 		};
 		this.registrations.add(registration);
 		if (this.admitted) {
@@ -48,13 +56,38 @@ export class ChannelReadiness {
 	}
 
 	end(): void {
+		const epoch = this.epoch;
+		const wasAdmitted = this.admitted;
+		const endCallbacks: Array<() => void> = [];
+		const notReadyCallbacks: Array<() => void> = [];
 		this.admitted = false;
-		for (const registration of this.registrations) {
+		for (const registration of Array.from(this.registrations)) {
 			if (!registration.active) continue;
+			if (registration.onEnd) endCallbacks.push(registration.onEnd);
+			if (
+				!wasAdmitted ||
+				registration.notifiedEpoch !== epoch ||
+				registration.endedEpoch === epoch
+			) {
+				continue;
+			}
+			registration.endedEpoch = epoch;
+			if (registration.onNotReady) {
+				notReadyCallbacks.push(registration.onNotReady);
+			}
+		}
+		for (const callback of endCallbacks) {
 			try {
-				registration.onEnd?.();
+				callback();
 			} catch {
 				// One subscriber cannot block epoch reset for its siblings.
+			}
+		}
+		for (const callback of notReadyCallbacks) {
+			try {
+				callback();
+			} catch {
+				// One subscriber cannot block lifecycle notification for its siblings.
 			}
 		}
 	}
@@ -115,6 +148,7 @@ export class ChannelReadyDelivery<T> {
 		onReady: (() => void) | undefined,
 		private readonly onOverflow: () => void,
 		private readonly waitForAdmission = false,
+		onNotReady?: () => void,
 	) {
 		this.awaitingReady = waitForAdmission || readiness.isReady;
 		this.releaseReady = readiness.register(
@@ -131,6 +165,7 @@ export class ChannelReadyDelivery<T> {
 					}
 				: undefined,
 			() => this.endEpoch(),
+			onNotReady,
 		);
 	}
 

--- a/packages/questpie/src/client/channels/sse.ts
+++ b/packages/questpie/src/client/channels/sse.ts
@@ -86,6 +86,8 @@ export class SseChannelTransport implements ChannelClientTransport {
 			callback,
 			options.onReady,
 			() => this.failEntry(entry, channelSlowConsumerError()),
+			false,
+			options.onNotReady,
 		);
 		entry.subscribers.add(delivery.accept);
 		const errorCallback = options.onError
@@ -131,6 +133,7 @@ export class SseChannelTransport implements ChannelClientTransport {
 			options.onReady,
 			() => this.failEntry(entry, channelSlowConsumerError()),
 			true,
+			options.onNotReady,
 		);
 		entry.presenceSubscribers.add(delivery.accept);
 		const errorCallback = options.onError
@@ -594,8 +597,8 @@ export class SseChannelTransport implements ChannelClientTransport {
 	}
 
 	private notifyEntry(entry: Entry, error: Error): void {
-		this.resetEntryEpoch(entry);
 		const errorCallbacks = Array.from(entry.errorCallbacks);
+		this.resetEntryEpoch(entry);
 		for (const callback of errorCallbacks) {
 			notifyChannelConsumer(callback, error);
 		}

--- a/packages/questpie/src/client/channels/types.ts
+++ b/packages/questpie/src/client/channels/types.ts
@@ -42,9 +42,14 @@ export type ChannelSubscribeOptions = {
 	onError?: (error: Error) => void;
 	/** Authorized and caught up for the current transport subscription epoch. */
 	onReady?: () => void;
+	/** The admitted epoch ended; a reconnect may later call `onReady` again. */
+	onNotReady?: () => void;
 };
 
-export type ChannelPresenceOptions = Omit<ChannelSubscribeOptions, "onReady">;
+export type ChannelPresenceOptions = Omit<
+	ChannelSubscribeOptions,
+	"onReady" | "onNotReady"
+>;
 
 type SubscribeMethod<TDefinition extends AnyChannelDefinition> =
 	keyof ChannelParamsOf<TDefinition> extends never

--- a/packages/questpie/src/client/index.ts
+++ b/packages/questpie/src/client/index.ts
@@ -755,6 +755,157 @@ type CollectionsAPI<T extends QuestpieApp> = {
 	>;
 };
 
+/**
+ * One mutation inside `client.transaction()`, for a single collection.
+ *
+ * The payload of each arm is the SAME params type the single-record client
+ * method takes — `UpdateParams` for update, `DeleteParams` for delete — so
+ * `expectedRevision` stays required at the type level exactly where
+ * `optimisticConcurrency` makes it required elsewhere, with no second
+ * definition to drift.
+ */
+type TransactionOperationFor<
+	TCollection extends AnyCollection,
+	TCollections extends Record<string, AnyCollectionOrBuilder>,
+	TName,
+	TDefinition = TCollection,
+> =
+	| {
+			collection: TName;
+			operation: "create";
+			data: CreateInputBase<
+				CollectionInsert<TCollection>,
+				ResolveRelationsDeep<CollectionRelations<TCollection>, TCollections>
+			>;
+	  }
+	| ({ collection: TName; operation: "update" } & UpdateParams<
+			CollectionUpdate<TCollection>,
+			ResolveRelationsDeep<CollectionRelations<TCollection>, TCollections>,
+			string,
+			ClientCollectionOptions<TDefinition>
+	  >)
+	| ({ collection: TName; operation: "delete" } & DeleteParams<
+			string,
+			ClientCollectionOptions<TDefinition>
+	  >);
+
+type UntypedTransactionOperation =
+	| {
+			collection: string;
+			operation: "create";
+			data: Record<string, unknown>;
+	  }
+	| {
+			collection: string;
+			operation: "update";
+			id: string;
+			data: Record<string, unknown>;
+			expectedRevision?: number;
+	  }
+	| {
+			collection: string;
+			operation: "delete";
+			id: string;
+			expectedRevision?: number;
+	  };
+
+type IsAny<T> = 0 extends 1 & T ? true : false;
+
+/**
+ * Every mutation any collection in the app accepts inside a transaction.
+ *
+ * `collection` and `operation` are both literal-typed, so a literal element
+ * narrows to one arm through TypeScript's discriminated-union fast path rather
+ * than a scan of the whole union.
+ */
+export type TransactionOperation<TApp extends QuestpieApp> =
+	IsAny<TApp> extends true
+		? UntypedTransactionOperation
+		: {
+				[K in keyof TApp["collections"]]: TransactionOperationFor<
+					GetCollection<TApp["collections"], K>,
+					TApp["collections"],
+					K,
+					TApp["collections"][K]
+				>;
+			}[keyof TApp["collections"]];
+
+/**
+ * Result of one operation, in the same shape the equivalent single-record
+ * method returns: the row for create/update, `{ success, data }` for delete.
+ */
+type TransactionOperationResult<TApp extends QuestpieApp, TOperation> =
+	IsAny<TApp> extends true
+		? unknown
+		: TOperation extends {
+					collection: infer TName extends keyof TApp["collections"];
+			  }
+			? TOperation extends { operation: "delete" }
+				? {
+						success: boolean;
+						data: ClientRow<
+							GetCollection<TApp["collections"], TName>,
+							TApp["collections"]
+						>;
+					}
+				: ClientRow<
+						GetCollection<TApp["collections"], TName>,
+						TApp["collections"]
+					>
+			: never;
+
+/**
+ * Results positionally typed against the operations that produced them.
+ *
+ * Per-position inference needs the `const` type parameter on `transaction()`
+ * and an array LITERAL at the call site; that combination infers a tuple. A
+ * pre-built `TransactionOperation<TApp>[]` variable is an array, not a tuple,
+ * so its result degrades to an array of the union of every row type the app
+ * can produce. That is the documented limit of this surface — the degraded
+ * form is still a real union, never `any`.
+ */
+export type TransactionResults<
+	TApp extends QuestpieApp,
+	TOperations extends readonly unknown[],
+> = {
+	-readonly [I in keyof TOperations]: TransactionOperationResult<
+		TApp,
+		TOperations[I]
+	>;
+};
+
+type ValidateTransactionOperation<
+	TApp extends QuestpieApp,
+	TOperation,
+> = TOperation extends {
+	collection: infer TName extends keyof TApp["collections"];
+}
+	? TOperation extends TransactionOperationFor<
+			GetCollection<TApp["collections"], TName>,
+			TApp["collections"],
+			TName,
+			TApp["collections"][TName]
+		>
+		? TOperation
+		: never
+	: never;
+
+type ValidateTransactionOperations<
+	TApp extends QuestpieApp,
+	TOperations extends readonly unknown[],
+> = {
+	[I in keyof TOperations]: ValidateTransactionOperation<TApp, TOperations[I]>;
+};
+
+type ClientTransaction<TApp extends QuestpieApp> =
+	IsAny<TApp> extends true
+		? (...args: any[]) => Promise<any>
+		: <const TOperations extends readonly UntypedTransactionOperation[]>(
+				operations: TOperations &
+					ValidateTransactionOperations<TApp, TOperations>,
+				options?: LocaleOptions,
+			) => Promise<TransactionResults<TApp, TOperations>>;
+
 type ClientGlobalOptions<TGlobal> =
 	GlobalState<TGlobal> extends {
 		options: infer TOptions extends
@@ -1050,6 +1201,35 @@ type RouteCallOptions = Omit<RequestInit, "method"> & {
  */
 export type QuestpieClient<in out TApp extends QuestpieApp> = {
 	collections: CollectionsAPI<TApp>;
+	/**
+	 * Apply an ordered list of mutations spanning any number of collections as
+	 * ONE server-side transaction. Every operation commits or none does — the
+	 * rows and the realtime change events roll back together.
+	 *
+	 * Each operation is authorized as the requesting principal against its own
+	 * collection; batching skips no access check. Operations run in the order
+	 * given and are never reordered, because order is semantic (create the post,
+	 * then its comment). Cross-table lock ordering is therefore the caller's:
+	 * two concurrent transactions touching the same rows in opposite order can
+	 * deadlock, so order operations consistently across call sites.
+	 *
+	 * Any thrown `QuestpieClientError` means NOTHING was applied. When an
+	 * operation is what failed, the error keeps that operation's own status and
+	 * code — a stale `expectedRevision` is still a 409 `CONFLICT`, a denied
+	 * write still a 403 — and `error.context.custom.transaction` says which
+	 * one: `{ index, collection, operation, applied: false }`. A malformed
+	 * request is rejected before anything runs and names the offending index in
+	 * its message instead.
+	 *
+	 * @example
+	 * ```ts
+	 * const [post, comment] = await client.transaction([
+	 *   { collection: "posts", operation: "create", data: { title: "Hello" } },
+	 *   { collection: "comments", operation: "update", id, data: { body: "Hi" } },
+	 * ]);
+	 * ```
+	 */
+	transaction: ClientTransaction<TApp>;
 	channels: ChannelsClient<AppChannelDefinitions<TApp>>;
 	globals: GlobalsAPI<TApp>;
 	routes: RoutesClient<TApp["routes"]>;
@@ -2006,8 +2186,28 @@ export function createClient<TApp extends QuestpieApp>(
 		},
 	});
 
+	/**
+	 * Cross-collection transaction — one request, one server transaction.
+	 *
+	 * The operations go over the wire as given; the server dispatches them in
+	 * that order. `mutationRequest` attaches the response's txid so realtime
+	 * echo suppression treats the whole batch as one of our own writes.
+	 */
+	const transaction = async (
+		operations: readonly unknown[],
+		options: LocaleOptions = {},
+	) => {
+		const queryString = stringifyQuery(options);
+		const path = `${apiBasePath}/transaction${queryString ? `?${queryString}` : ""}`;
+		return mutationRequest(path, {
+			method: "POST",
+			json: { operations },
+		});
+	};
+
 	return {
 		collections,
+		transaction,
 		channels: channelsApi,
 		[CRDT_CLIENT_HOST]: crdtHost,
 		globals,
@@ -2072,6 +2272,8 @@ export type { GlobalMeta } from "#questpie/shared/global-meta.js";
 // Re-export realtime types and helpers
 export type {
 	RealtimeAPI,
+	RealtimeDeltaDeleteReason,
+	RealtimeFindWindow,
 	RealtimeStreamEvent,
 	RealtimeTopicRejectedDetails,
 	RealtimeTopicRejectedPayload,

--- a/packages/questpie/src/client/realtime/index.ts
+++ b/packages/questpie/src/client/realtime/index.ts
@@ -21,6 +21,8 @@ export {
 	deriveFindDeltas,
 	envelopeMeta,
 	type RealtimeAPI,
+	type RealtimeDeltaDeleteReason,
+	type RealtimeFindWindow,
 	type RealtimeStreamEvent,
 	sseEventStream,
 	sseSnapshotStream,

--- a/packages/questpie/src/client/realtime/stream.ts
+++ b/packages/questpie/src/client/realtime/stream.ts
@@ -20,6 +20,17 @@ import { RealtimeTxidTracker } from "./txid.js";
 // Types
 // ============================================================================
 
+/**
+ * Why a keyed row left a topic's result. A store renders the two differently:
+ * a `deleted` row is gone, a row that only `left_predicate` still exists and
+ * may come back, or may already be held by another topic.
+ *
+ * - `deleted` — the row itself is gone: a hard delete, a soft delete, or a purge.
+ * - `left_predicate` — the row survives but no longer satisfies the topic's
+ *   `where` or the subscriber's access filter.
+ */
+export type RealtimeDeltaDeleteReason = "deleted" | "left_predicate";
+
 export type RealtimeStreamEvent<TData = unknown> =
 	| {
 			type: "snapshot";
@@ -44,6 +55,12 @@ export type RealtimeStreamEvent<TData = unknown> =
 			seq: number;
 			txid?: string;
 			key: string;
+			/**
+			 * Native delta frames always carry this. It is absent only when the
+			 * frame was diffed out of two snapshots ({@link deriveFindDeltas}),
+			 * which sees a row disappear and cannot tell the two apart.
+			 */
+			reason?: RealtimeDeltaDeleteReason;
 	  }
 	| {
 			type: "up-to-date";
@@ -142,23 +159,61 @@ export async function* deriveFindDeltas<
 
 type RealtimeFindEnvelope<TRow> = RealtimeFindData<TRow>;
 
-/** Metadata for an unwindowed realtime find result. */
-export function envelopeMeta<TRow>(
-	docs: readonly TRow[],
-	totalDocs = docs.length,
-) {
+/**
+ * The page window a find topic subscribed with.
+ *
+ * `limit` and `offset` are part of the topic, so the window is fixed for the
+ * subscription's lifetime and only the bootstrap frame can report it.
+ */
+export type RealtimeFindWindow = { limit?: number; page?: number };
+
+/** Read the window a previous frame established, ignoring absent fields. */
+function findWindow(
+	envelope: RealtimeFindEnvelope<unknown>,
+): RealtimeFindWindow {
+	const { limit, page } = envelope;
 	return {
-		totalDocs,
-		totalPages: 1,
-		page: 1,
-		hasNextPage: false,
-		hasPrevPage: false,
-		nextPage: null,
-		prevPage: null,
+		limit: typeof limit === "number" ? limit : undefined,
+		page: typeof page === "number" ? page : undefined,
 	};
 }
 
-/** Apply one snapshot or keyed row event to an unwindowed find result. */
+/**
+ * Rebuild find envelope metadata for a window.
+ *
+ * This mirrors the server paginator in `crud-generator.ts` field for field, so
+ * a live envelope and a re-fetched one agree. Only `totalDocs` moves between
+ * frames; `limit` and `page` are carried from the bootstrap frame because a
+ * later frame cannot know them.
+ *
+ * `limit` is widened to the row count when it would otherwise claim a page
+ * smaller than the rows on it: an unwindowed find reports `limit === totalDocs`,
+ * and that sentinel has to grow with the result.
+ */
+export function envelopeMeta<TRow>(
+	docs: readonly TRow[],
+	totalDocs = docs.length,
+	window?: RealtimeFindWindow,
+) {
+	const limit = Math.max(window?.limit ?? docs.length, docs.length);
+	const page = window?.page ?? 1;
+	const totalPages = limit > 0 ? Math.ceil(totalDocs / limit) : 1;
+	const hasPrevPage = page > 1;
+	const hasNextPage = page < totalPages;
+	return {
+		totalDocs,
+		limit,
+		totalPages,
+		page,
+		pagingCounter: (page - 1) * limit + 1,
+		hasPrevPage,
+		hasNextPage,
+		prevPage: hasPrevPage ? page - 1 : null,
+		nextPage: hasNextPage ? page + 1 : null,
+	};
+}
+
+/** Apply one snapshot or keyed row event to a find result, windowed or not. */
 export function applyRealtimeFindEvent<
 	TRow,
 	TData extends RealtimeFindEnvelope<TRow>,
@@ -172,12 +227,17 @@ export function applyRealtimeFindEvent<
 		throw new Error("Realtime find deltas require an initial snapshot");
 	}
 
+	const window = findWindow(current);
+
 	if (event.type === "up-to-date") {
+		// A heartbeat carries no meta. Falling back to the row count would shrink
+		// a windowed list's total to one page's worth of rows.
 		return {
 			...current,
 			...envelopeMeta(
 				current.docs,
-				event.meta?.totalDocs ?? current.docs.length,
+				event.meta?.totalDocs ?? current.totalDocs ?? current.docs.length,
+				window,
 			),
 		} as TData;
 	}
@@ -210,7 +270,18 @@ export function applyRealtimeFindEvent<
 		}
 	}
 
-	return { ...current, docs, ...envelopeMeta(docs) } as TData;
+	// A keyed event moves rows, not the window. It shifts the total by however
+	// many rows it actually added or removed; the `up-to-date` frame that closes
+	// the batch then replaces that estimate with the server's own count.
+	const totalDocs =
+		(current.totalDocs ?? current.docs.length) +
+		docs.length -
+		current.docs.length;
+	return {
+		...current,
+		docs,
+		...envelopeMeta(docs, totalDocs, window),
+	} as TData;
 }
 
 /** Apply snapshot/count metadata frames to a scalar realtime result. */

--- a/packages/questpie/src/exports/crdt.ts
+++ b/packages/questpie/src/exports/crdt.ts
@@ -1,5 +1,12 @@
 export * from "#questpie/shared/crdt-engine.js";
 export type * from "#questpie/server/modules/core/integrated/crdt/types.js";
+export type {
+	CrdtCanonicalProjectionValue,
+	CrdtProjectionAcknowledgementHook,
+	CrdtProjectionAcknowledgementInput,
+	CrdtProjectionAcknowledgementResult,
+	CrdtProjectionContributor,
+} from "#questpie/server/modules/core/integrated/crdt/config.js";
 export {
 	createCrdtClient,
 	type CreateCrdtClientOptions,

--- a/packages/questpie/src/server/adapters/routes/realtime.ts
+++ b/packages/questpie/src/server/adapters/routes/realtime.ts
@@ -7,7 +7,10 @@
 
 import { Buffer } from "node:buffer";
 
-import type { RealtimeTopicRejectedPayload } from "#questpie/shared/realtime-error.js";
+import type {
+	RealtimeTopicRejectedPayload,
+	RealtimeTopicRejectionReason,
+} from "#questpie/shared/realtime-error.js";
 
 import {
 	opaqueChannelAuthoritySubject,
@@ -24,8 +27,12 @@ import {
 	admitRealtimeTopic,
 	admitRealtimeTopicPolicy,
 	createConcurrencyLimiter,
+	DEFAULT_REALTIME_KEEP_ALIVE_INTERVAL_MS,
 	getRealtimeAdmissionRegistry,
+	type RealtimeAdmissionLease,
 	RealtimeTopicAdmissionError,
+	realtimeAdmissionBucket,
+	realtimeSlotTtlMs,
 	realtimeTopicRejectedPayload,
 	realtimePrincipalKey,
 	resolveRealtimeAdmissionConfig,
@@ -157,12 +164,13 @@ function collectionAccessCacheKey(definition: RealtimeDefinition | undefined) {
 	return realtime ? realtime.accessCacheKey : undefined;
 }
 
-function enforceRowLiveQueryPolicy(
+function enforceRealtimeTopicPolicy(
 	app: Questpie<any>,
 	topic: NormalizedTopicInput,
 	definition?: RealtimeDefinition,
 ): void {
 	const result = admitRealtimeTopicPolicy(topic, {
+		changeCapture: app.config?.realtime?.changeCapture,
 		rowLiveQueries: app.config?.realtime?.rowLiveQueries,
 		collectionRealtime:
 			topic.resourceType === "collection"
@@ -653,7 +661,7 @@ async function resolveIncrementalTopic(
 			topic.resource
 		];
 		if (!crud || !definition) throw new Error("Collection not found");
-		enforceRowLiveQueryPolicy(app, topic, definition);
+		enforceRealtimeTopicPolicy(app, topic, definition);
 		return evaluateTopicAccess(
 			app,
 			{
@@ -674,7 +682,7 @@ async function resolveIncrementalTopic(
 			topic.resource
 		];
 		if (!crud || !definition) throw new Error("Global not found");
-		enforceRowLiveQueryPolicy(app, topic, definition);
+		enforceRealtimeTopicPolicy(app, topic, definition);
 		return evaluateTopicAccess(
 			app,
 			{
@@ -800,19 +808,9 @@ export async function realtimeSubscribe(
 		return errorResponse(ApiError.notImplemented("Realtime"), request);
 	}
 	const observeAdmission = (
-		reason:
-			| "connection_limit"
-			| "subscription_limit"
-			| "query_limit"
-			| "relation_depth"
-			| "snapshot_bytes"
-			| "row_live_queries_disabled"
-			| "collection_realtime_disabled"
-			| "access"
-			| "not_found"
-			| "operation_shape"
-			| "since_seq_invalid"
-			| "activation_rejected",
+		// Spelling the union out again here let it drift from the one the server
+		// actually produces; a new reason has to reach the observer too.
+		reason: RealtimeTopicRejectionReason,
 		details: Partial<
 			Pick<RealtimeTopicRejectedPayload, "resource" | "operation"> & {
 				requestedLimit?: number;
@@ -1247,7 +1245,7 @@ export async function realtimeSubscribe(
 			collectionCruds.set(topic.resource, crud);
 			const definition = collectionDefinitions[topic.resource];
 			try {
-				enforceRowLiveQueryPolicy(app, topic, definition);
+				enforceRealtimeTopicPolicy(app, topic, definition);
 			} catch (error) {
 				if (!(error instanceof RealtimeTopicAdmissionError)) throw error;
 				observeTopicRejection(error);
@@ -1273,7 +1271,7 @@ export async function realtimeSubscribe(
 				if (!crud) throw new Error("Global not found");
 				globalCruds.set(topic.resource, crud);
 				const definition = globalDefinitions[topic.resource];
-				enforceRowLiveQueryPolicy(app, topic, definition);
+				enforceRealtimeTopicPolicy(app, topic, definition);
 				validatedTopics.push({
 					...topic,
 					type: "global",
@@ -1397,18 +1395,49 @@ export async function realtimeSubscribe(
 		);
 	}
 
-	const admissionRegistry = getRealtimeAdmissionRegistry(
-		app,
-		admission.maxConnectionsPerPrincipal,
+	const sharedProvider = body.transport === "shared-provider";
+	const keepAliveIntervalMs =
+		app.config?.realtime?.keepAliveIntervalMs ??
+		DEFAULT_REALTIME_KEEP_ALIVE_INTERVAL_MS;
+	const admissionRegistry = getRealtimeAdmissionRegistry(app);
+	const admissionBucket = realtimeAdmissionBucket(
+		resolved.appContext,
+		admission,
 	);
-	const releaseConnection = admissionRegistry.acquire(
-		realtimePrincipalKey(resolved.appContext),
-	);
-	if (!releaseConnection) {
-		observeAdmission("connection_limit");
+	const admissionDecision = admissionRegistry.acquire(admissionBucket.key, {
+		maximum: admissionBucket.maximum,
+		// The shared-provider session has its own client-liveness check — the
+		// topology client lease, renewed by the client's own re-probe — and its
+		// expiry already runs `close()`. Only the SSE path, where the framework
+		// owns no disconnect detector, needs the slot to expire on its own.
+		ttlMs: sharedProvider
+			? Number.POSITIVE_INFINITY
+			: realtimeSlotTtlMs(keepAliveIntervalMs),
+	});
+	if (!admissionDecision.admitted) {
+		const { observed, configuredLimit } = admissionDecision;
+		observeAdmission("connection_limit", { observed, configuredLimit });
+		// These two numbers are the whole diagnosis, and the reason this failure
+		// once went weeks without one. Emit them per topic in the typed shape the
+		// client parses, not as an opaque error string.
+		const scope = admissionBucket.anonymous
+			? "unauthenticated connections on this node"
+			: "connections for this principal";
+		const rejections = [...validatedTopicsById.values()].map((topic) =>
+			realtimeTopicRejectedPayload(topic, {
+				accepted: false,
+				reason: "connection_limit",
+				message: `Realtime connection limit reached: ${observed} of ${configuredLimit} ${scope} in use`,
+				configuredLimit,
+				observed,
+			}),
+		);
+		if (rejections.length > 0) {
+			return Response.json({ errors: rejections }, { status: 400 });
+		}
 		return errorResponse(
 			ApiError.badRequest(
-				"Realtime connection limit exceeded",
+				`Realtime connection limit exceeded (${observed} of ${configuredLimit} in use)`,
 				undefined,
 				"realtime.connectionLimitExceeded",
 			),
@@ -1416,13 +1445,14 @@ export async function realtimeSubscribe(
 			resolved.appContext.locale,
 		);
 	}
+	const admissionSlot: RealtimeAdmissionLease = admissionDecision.lease;
 
-	if (body.transport === "shared-provider") {
+	if (sharedProvider) {
 		if (
 			validatedChannelsById.size > 0 ||
 			(validatedTopicsById.size === 0 && !crdtHold)
 		) {
-			releaseConnection();
+			admissionSlot.release();
 			return errorResponse(
 				ApiError.badRequest(
 					"Shared-provider session bootstrap accepts live-query topics or an explicit CRDT hold",
@@ -1480,13 +1510,12 @@ export async function realtimeSubscribe(
 			const limitSnapshotConcurrency = createConcurrencyLimiter(
 				admission.initialSnapshotConcurrency,
 			);
-			const heartbeatIntervalMs =
-				app.config?.realtime?.keepAliveIntervalMs ?? 8000;
+			const heartbeatIntervalMs = keepAliveIntervalMs;
 			const originalIdentity = realtimeControlIdentity(resolved.appContext);
 			const close = () => {
 				if (closed) return;
 				closed = true;
-				releaseConnection();
+				admissionSlot.release();
 				unregisterControl();
 				void edge?.close().catch(() => {});
 				void activeSink.close("normal").catch(() => {});
@@ -1783,7 +1812,7 @@ export async function realtimeSubscribe(
 			if (sink) void sink.close("transport_error").catch(() => {});
 			return errorResponse(error, request, resolved.appContext.locale);
 		} finally {
-			if (!retainAdmission) releaseConnection();
+			if (!retainAdmission) admissionSlot.release();
 		}
 	}
 
@@ -1869,8 +1898,7 @@ export async function realtimeSubscribe(
 				const limitDeltaHydration = createConcurrencyLimiter(
 					admission.deltaHydrationConcurrency,
 				);
-				const heartbeatIntervalMs =
-					app.config?.realtime?.keepAliveIntervalMs ?? 8000;
+				const heartbeatIntervalMs = keepAliveIntervalMs;
 				const originalIdentity = realtimeControlIdentity(resolved.appContext);
 				const controlToken = globalThis.crypto.randomUUID();
 				let removeKeepAlive = () => {};
@@ -1882,7 +1910,7 @@ export async function realtimeSubscribe(
 				const close = () => {
 					if (closed) return;
 					closed = true;
-					releaseConnection();
+					admissionSlot.release();
 					removeKeepAlive();
 					unregisterControl();
 					flushPending = null;
@@ -1894,6 +1922,10 @@ export async function realtimeSubscribe(
 					void transport?.stop().catch(() => {});
 				};
 				closeStream = close;
+				// Let the registry tear this stream down if its lease lapses: the
+				// slot is only half the leak — the scheduler group, the topology
+				// heartbeat and the keepalive registration are the other half.
+				admissionSlot.setClose(close);
 				if (closeRequested || streamCancelled || request.signal.aborted) {
 					close();
 					return;
@@ -2491,11 +2523,29 @@ export async function realtimeSubscribe(
 
 				// Shared ping ticker keeps the connection alive. Default 8s — strictly under
 				// Bun's default 10s idleTimeout and typical proxy timeouts of 30-60s.
+				// It is also the connection's proof of life: the ping is the only
+				// traffic an idle-but-live stream generates, so it is the only thing
+				// that can renew the admission lease without depending on data.
 				removeKeepAlive = sharedSseKeepAliveTicker.register(
 					heartbeatIntervalMs,
 					(frame) => {
 						void sessionSink
 							.write(frame, "latest-snapshot")
+							.then((result) => {
+								// Renew only when the peer drained everything sent before
+								// this ping — `bufferedBytes` is measured after the enqueue,
+								// so "only this frame is queued" means the queue was empty.
+								// A peer that stopped reading, including one whose socket
+								// died without the runtime saying so, never clears it, and
+								// its lease lapses. `null` means the write was fenced and
+								// proves nothing.
+								if (
+									result.bufferedBytes !== null &&
+									result.bufferedBytes <= frame.byteLength
+								) {
+									admissionSlot.renew();
+								}
+							})
 							.catch(requestClose);
 					},
 				);
@@ -2513,7 +2563,7 @@ export async function realtimeSubscribe(
 					// The controller can already be errored by the runtime.
 				}
 				closeStream?.();
-				releaseConnection();
+				admissionSlot.release();
 				void transport?.stop().catch(() => {});
 			}
 		},
@@ -2522,7 +2572,7 @@ export async function realtimeSubscribe(
 		},
 		cancel: () => {
 			streamCancelled = true;
-			releaseConnection();
+			admissionSlot.release();
 			closeStream?.();
 		},
 	};

--- a/packages/questpie/src/server/adapters/routes/transaction.ts
+++ b/packages/questpie/src/server/adapters/routes/transaction.ts
@@ -1,0 +1,363 @@
+/**
+ * Cross-collection transaction route.
+ *
+ * One ordered list of mutations spanning any number of collections, applied
+ * inside a single Postgres transaction: every operation commits or none does.
+ * A client store that rolls its optimistic state back on failure needs exactly
+ * this — three separate HTTP calls leave the server holding two committed
+ * writes while the UI shows none.
+ *
+ * The engine already did all of this. `withTransaction` reuses an ambient
+ * transaction through AsyncLocalStorage
+ * (`collection/crud/shared/transaction.ts`), so every CRUD verb silently joins
+ * the transaction opened here, and the realtime outbox append does the same —
+ * a rollback takes the change events with it. What was missing was only the
+ * HTTP surface: every mutating route is scoped to one `params.collection`.
+ *
+ * ## Design decisions
+ *
+ * **Authorization.** Each operation is authorized as the requesting principal
+ * against its own collection. The transaction context is the request's own
+ * `appContext` with nothing but `db` replaced, so `accessMode`, `session` and
+ * `principal` are untouched and every verb runs its normal per-record access
+ * control and hooks. There is deliberately no elevated path here: batching is
+ * not a reason to skip a check, and one request buys one session resolution,
+ * not one authorization.
+ *
+ * **Ordering and locks.** Operations run strictly in the order given, and are
+ * never reordered. The order is semantic — operation N+1 routinely depends on
+ * N (create a post, then its comment; delete the child, then the parent) — so
+ * sorting by `(collection, id)` for deadlock avoidance would break referential
+ * correctness to buy a partial guarantee. Cross-table lock ordering therefore
+ * belongs to the caller, and it is a real hazard: two concurrent batches that
+ * touch the same rows in opposite order can deadlock, and Postgres will abort
+ * one of them (the loser gets a failure that, correctly, says nothing was
+ * applied). Callers who care should order operations consistently across call
+ * sites. Server-side code that needs to take locks explicitly ahead of its
+ * writes has `collection.lockMany()`, which locks in deterministic id order
+ * inside the active transaction.
+ *
+ * **The error contract.** A failure aborts the whole batch and the response
+ * carries `context.custom.transaction` naming the operation that failed and
+ * stating that nothing was applied. The underlying error's code, message,
+ * translation key and field errors are preserved verbatim, so a stale revision
+ * is still a 409 CONFLICT and a denied write is still a 403 — the descriptor
+ * tells the store *where*, the code tells it *what to do*.
+ *
+ * **Optimistic concurrency.** `expectedRevision` travels per operation. It is
+ * required at the type level on the client whenever the collection enables
+ * `optimisticConcurrency`, and enforced by the CRUD layer regardless. The
+ * `If-Match` header is rejected: one ETag cannot address many rows.
+ *
+ * POST /transaction
+ */
+
+import { attachTxid } from "#questpie/shared/txid.js";
+
+import {
+	getTransactionTxid,
+	withTransaction,
+} from "../../collection/crud/shared/transaction.js";
+import type { Questpie } from "../../config/questpie.js";
+import { ApiError, parseDatabaseError } from "../../errors/index.js";
+import type { AdapterConfig, AdapterContext } from "../types.js";
+import { resolveContext } from "../utils/context.js";
+import { parseRouteBody } from "../utils/request.js";
+import { handleError, smartResponse } from "../utils/response.js";
+import { txidHeaders } from "./optimistic-concurrency.js";
+
+/**
+ * One mutation in a transaction, as it arrives on the wire.
+ *
+ * The verb set is exactly what a client store produces — insert, update,
+ * delete. Bulk verbs (`updateMany`, `deleteMany`) are deliberately absent: a
+ * where-clause mutation inside an ordered batch has no stable meaning once
+ * earlier operations have already moved rows in or out of its predicate.
+ */
+export type TransactionOperationInput =
+	| {
+			collection: string;
+			operation: "create";
+			data: Record<string, unknown>;
+	  }
+	| {
+			collection: string;
+			operation: "update";
+			id: string | number;
+			data: Record<string, unknown>;
+			expectedRevision?: number;
+	  }
+	| {
+			collection: string;
+			operation: "delete";
+			id: string | number;
+			expectedRevision?: number;
+	  };
+
+/** Machine-readable descriptor attached to a failed transaction's error. */
+export type TransactionFailure = {
+	/** Zero-based index of the failing operation, in request order. */
+	index: number;
+	collection: string;
+	operation: TransactionOperationInput["operation"];
+	/** Always `false`: the transaction rolled back, including the outbox. */
+	applied: false;
+};
+
+/**
+ * Upper bound on one batch.
+ *
+ * A transaction is held open for the whole list, so an unbounded batch is an
+ * availability hazard — held row locks and a long-lived snapshot — rather than
+ * a correctness one. 100 matches the cap `lockMany` already enforces.
+ *
+ * Deliberately stricter than the per-collection `updateBatch`, which has no
+ * cap: that one takes a homogeneous update list for a single table, while this
+ * accepts arbitrary verbs across arbitrary tables from any authenticated
+ * caller.
+ */
+const MAX_TRANSACTION_OPERATIONS = 100;
+
+const MUTATION_OPERATIONS = new Set(["create", "update", "delete"]);
+
+/**
+ * Validate the wire body into operations that are safe to dispatch.
+ *
+ * `operation` is checked against a literal allowlist and `collection` against
+ * the app's own collections with `Object.hasOwn`, so neither a verb nor a
+ * collection name taken from the request body can reach anything but a real
+ * CRUD verb on a real collection.
+ */
+function parseOperations(
+	app: Questpie<any>,
+	body: unknown,
+): TransactionOperationInput[] {
+	if (body === null || typeof body !== "object") {
+		throw ApiError.badRequest(
+			"Invalid JSON body",
+			undefined,
+			"error.invalidJsonBody",
+		);
+	}
+
+	const { operations } = body as { operations?: unknown };
+	if (!Array.isArray(operations)) {
+		throw ApiError.badRequest("operations must be an array");
+	}
+	if (operations.length > MAX_TRANSACTION_OPERATIONS) {
+		throw ApiError.badRequest(
+			`A transaction accepts at most ${MAX_TRANSACTION_OPERATIONS} operations`,
+		);
+	}
+
+	return operations.map((raw, index) => {
+		const at = `operations[${index}]`;
+		if (raw === null || typeof raw !== "object") {
+			throw ApiError.badRequest(`${at} must be an object`);
+		}
+		const op = raw as Record<string, unknown>;
+
+		if (typeof op.collection !== "string") {
+			throw ApiError.badRequest(`${at}.collection must be a string`);
+		}
+		if (!Object.hasOwn(app.collections, op.collection)) {
+			throw ApiError.notFound("Collection", op.collection);
+		}
+		if (
+			typeof op.operation !== "string" ||
+			!MUTATION_OPERATIONS.has(op.operation)
+		) {
+			throw ApiError.badRequest(
+				`${at}.operation must be create, update or delete`,
+			);
+		}
+		if (
+			op.expectedRevision !== undefined &&
+			(typeof op.expectedRevision !== "number" ||
+				!Number.isFinite(op.expectedRevision))
+		) {
+			throw ApiError.badRequest(`${at}.expectedRevision must be a number`);
+		}
+
+		if (op.operation === "create") {
+			if (op.data === null || typeof op.data !== "object") {
+				throw ApiError.badRequest(`${at}.data must be an object`);
+			}
+			return {
+				collection: op.collection,
+				operation: "create",
+				data: op.data as Record<string, unknown>,
+			};
+		}
+
+		if (typeof op.id !== "string" && typeof op.id !== "number") {
+			throw ApiError.badRequest(`${at}.id must be a string or a number`);
+		}
+
+		if (op.operation === "update") {
+			if (op.data === null || typeof op.data !== "object") {
+				throw ApiError.badRequest(`${at}.data must be an object`);
+			}
+			return {
+				collection: op.collection,
+				operation: "update",
+				id: op.id,
+				data: op.data as Record<string, unknown>,
+				...(op.expectedRevision === undefined
+					? {}
+					: { expectedRevision: op.expectedRevision as number }),
+			};
+		}
+
+		return {
+			collection: op.collection,
+			operation: "delete",
+			id: op.id,
+			...(op.expectedRevision === undefined
+				? {}
+				: { expectedRevision: op.expectedRevision as number }),
+		};
+	});
+}
+
+/**
+ * Resolve a thrown value to an `ApiError` so decorating a failure never
+ * changes the status the caller would otherwise have received for that
+ * operation. Mirrors `handleError`'s ladder minus its `ZodError` rung: CRUD
+ * converts validation issues with `ApiError.fromZodError` before they leave
+ * the verb (`crud-generator.ts:1782`, `:2409`).
+ */
+function toApiError(error: unknown): ApiError {
+	if (error instanceof ApiError) return error;
+	const dbError = parseDatabaseError(error);
+	if (dbError) return dbError;
+	return ApiError.internal(
+		error instanceof Error ? error.message : "Unknown error",
+		error,
+	);
+}
+
+/**
+ * Re-throw an operation's failure with the transaction descriptor attached.
+ *
+ * Everything the client already keys on — code, message, `messageKey`, field
+ * errors — is carried through unchanged; only `context.custom.transaction` is
+ * added.
+ */
+function decorateFailure(
+	error: unknown,
+	index: number,
+	operation: TransactionOperationInput,
+): ApiError {
+	const resolved = toApiError(error);
+	const failure: TransactionFailure = {
+		index,
+		collection: operation.collection,
+		operation: operation.operation,
+		applied: false,
+	};
+
+	return new ApiError({
+		code: resolved.code,
+		message: resolved.message,
+		...(resolved.messageKey === undefined
+			? {}
+			: { messageKey: resolved.messageKey }),
+		...(resolved.messageParams === undefined
+			? {}
+			: { messageParams: resolved.messageParams }),
+		...(resolved.fieldErrors === undefined
+			? {}
+			: { fieldErrors: resolved.fieldErrors }),
+		context: {
+			...resolved.context,
+			custom: { ...resolved.context?.custom, transaction: failure },
+		},
+		cause: resolved.cause ?? error,
+	});
+}
+
+function applyOperation(
+	crud: any,
+	operation: TransactionOperationInput,
+	context: unknown,
+): Promise<unknown> {
+	// An explicit switch, not `crud[operation.operation]` — the verb reaching
+	// the collection must come from this file, never from the request body.
+	switch (operation.operation) {
+		case "create":
+			return crud.create(operation.data, context);
+		case "update":
+			return crud.updateById(
+				{
+					id: operation.id,
+					data: operation.data,
+					...(operation.expectedRevision === undefined
+						? {}
+						: { expectedRevision: operation.expectedRevision }),
+				},
+				context,
+			);
+		case "delete":
+			return crud.deleteById(
+				{
+					id: operation.id,
+					...(operation.expectedRevision === undefined
+						? {}
+						: { expectedRevision: operation.expectedRevision }),
+				},
+				context,
+			);
+	}
+}
+
+export async function collectionsTransaction(
+	app: Questpie<any>,
+	request: Request,
+	context?: AdapterContext,
+	config: AdapterConfig<any> = {},
+	input?: unknown,
+): Promise<Response> {
+	const resolved = await resolveContext(app, request, config, context);
+	const locale = resolved.appContext.locale;
+
+	try {
+		// One ETag cannot address many rows. Per-operation `expectedRevision` is
+		// the only conditional mechanism here.
+		if (request.headers.has("if-match")) {
+			throw ApiError.badRequest("If-Match is not supported on a transaction");
+		}
+
+		const body = input !== undefined ? input : await parseRouteBody(request);
+		const operations = parseOperations(app, body);
+		if (operations.length === 0) {
+			return smartResponse([], request, 200);
+		}
+
+		const results = await withTransaction(app.db, async (tx) => {
+			// The request's own context with the transaction swapped in. Reads and
+			// writes inside every verb then run on this connection and see each
+			// other's uncommitted rows; `session`, `principal` and `accessMode`
+			// are the caller's, unchanged.
+			const txContext = { ...resolved.appContext, db: tx };
+			const applied: unknown[] = [];
+
+			for (const [index, operation] of operations.entries()) {
+				const crud = app.collections[operation.collection as never] as any;
+				try {
+					applied.push(await applyOperation(crud, operation, txContext));
+				} catch (error) {
+					// Throwing out of `withTransaction` rolls the whole thing back —
+					// rows, realtime outbox entries and queued afterCommit callbacks.
+					throw decorateFailure(error, index, operation);
+				}
+			}
+
+			return attachTxid(applied, getTransactionTxid());
+		});
+
+		return smartResponse(results, request, 200, txidHeaders(results));
+	} catch (error) {
+		return handleError(error, { request, app, locale });
+	}
+}

--- a/packages/questpie/src/server/adapters/utils/parsers.ts
+++ b/packages/questpie/src/server/adapters/utils/parsers.ts
@@ -4,6 +4,8 @@
  * Utilities for parsing query parameters into CRUD options.
  */
 
+import { ApiError } from "#questpie/server/errors/base.js";
+
 import { getQueryParams, parseBoolean } from "./request.js";
 
 /**
@@ -17,6 +19,32 @@ function parseIntParam(value: unknown): number | undefined {
 	return Math.floor(num);
 }
 
+/**
+ * Parse a `columns` selection into the booleans the select builders compare by
+ * identity (`=== true` / `=== false`).
+ *
+ * A query string carries `columns[title]=false` as the *string* `"false"`, which
+ * is truthy, so forwarding the parsed query as-is is not the same fix as parsing
+ * it: a collection would fall back to selecting every column, and a global would
+ * select the very columns the caller asked it to drop.
+ *
+ * Returns undefined for anything that is not an object of flags, so junk widens
+ * to "no projection" rather than an empty one.
+ */
+function parseColumnsParam(
+	value: unknown,
+): Record<string, boolean> | undefined {
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		return undefined;
+	}
+
+	const columns: Record<string, boolean> = {};
+	for (const [key, flag] of Object.entries(value)) {
+		columns[key] = parseBoolean(flag);
+	}
+	return Object.keys(columns).length > 0 ? columns : undefined;
+}
+
 export const parseFindOptions = (url: URL) => {
 	const parsedQuery = getQueryParams(url);
 	const options: any = {};
@@ -27,13 +55,39 @@ export const parseFindOptions = (url: URL) => {
 	const offset = parseIntParam(parsedQuery.offset);
 	if (offset !== undefined) options.offset = offset;
 
+	// `page` is 1-based and is only meaningful against a page SIZE, so it is
+	// translated into the `offset` the CRUD layer actually reads. It used to be
+	// parsed onto an option nobody consumed, which made `?page=3` look supported
+	// while silently returning page 1. Anything that cannot be translated is
+	// refused rather than ignored.
 	const page = parseIntParam(parsedQuery.page);
-	if (page !== undefined) options.page = page;
+	if (page !== undefined) {
+		if (offset !== undefined) {
+			throw ApiError.badRequest(
+				"Pass either 'page' or 'offset', not both — they set the same position.",
+			);
+		}
+		if (page < 1) {
+			throw ApiError.badRequest(
+				"'page' is 1-based; the first page is 'page=1'.",
+			);
+		}
+		if (limit === undefined || limit < 1) {
+			throw ApiError.badRequest(
+				"'page' requires a 'limit' of at least 1 to size the page.",
+			);
+		}
+		options.offset = (page - 1) * limit;
+	}
 
 	if (parsedQuery.where) options.where = parsedQuery.where;
 	if (parsedQuery.orderBy) options.orderBy = parsedQuery.orderBy;
 	if (parsedQuery.groupBy) options.groupBy = parsedQuery.groupBy;
 	if (parsedQuery.with) options.with = parsedQuery.with;
+
+	const columns = parseColumnsParam(parsedQuery.columns);
+	if (columns) options.columns = columns;
+
 	if (parsedQuery.includeDeleted !== undefined) {
 		options.includeDeleted = parseBoolean(parsedQuery.includeDeleted);
 	}
@@ -53,6 +107,10 @@ export const parseFindOneOptions = (url: URL, id: string) => {
 	const options: any = { where: { id } };
 
 	if (parsedQuery.with) options.with = parsedQuery.with;
+
+	const columns = parseColumnsParam(parsedQuery.columns);
+	if (columns) options.columns = columns;
+
 	if (parsedQuery.includeDeleted !== undefined) {
 		options.includeDeleted = parseBoolean(parsedQuery.includeDeleted);
 	}
@@ -70,7 +128,10 @@ export const parseGlobalGetOptions = (url: URL) => {
 	const options: any = {};
 
 	if (parsedQuery.with) options.with = parsedQuery.with;
-	if (parsedQuery.columns) options.columns = parsedQuery.columns;
+
+	const columns = parseColumnsParam(parsedQuery.columns);
+	if (columns) options.columns = columns;
+
 	if (parsedQuery.locale) options.locale = parsedQuery.locale;
 	if (parsedQuery.stage) options.stage = parsedQuery.stage;
 	if (parsedQuery.localeFallback !== undefined) {

--- a/packages/questpie/src/server/channels/service.ts
+++ b/packages/questpie/src/server/channels/service.ts
@@ -2,10 +2,11 @@ import type { z } from "zod";
 
 import type { AppContext } from "#questpie/server/config/app-context.js";
 import type { Principal } from "#questpie/server/config/context.js";
-import type {
-	AppendChannelEventInput,
-	AppendChannelEventOptions,
-	ChannelEventReceipt,
+import {
+	type AppendChannelEventInput,
+	type AppendChannelEventOptions,
+	type ChannelEventReceipt,
+	hashResolvedChannel,
 } from "#questpie/server/modules/core/integrated/realtime/channel-event-ledger.js";
 
 import type { ChannelAuthoritySubject } from "./authority.js";
@@ -337,14 +338,43 @@ export class ChannelsService<
 		});
 	}
 
+	/**
+	 * Publish to several channels with a deterministic lock order.
+	 *
+	 * Each append takes a row lock on its channel's sequence head and holds it
+	 * until the caller's transaction commits. Two concurrent batches touching
+	 * the same channels in opposite orders therefore deadlock — a real
+	 * `40P01` from Postgres, not a theoretical one. Appending in resolved-hash
+	 * order gives every caller the same order, so they queue instead.
+	 *
+	 * Validation for the whole batch runs before the first append, so an
+	 * invalid request no longer leaves the earlier ones published.
+	 */
 	async publishBatch(
 		requests: readonly ChannelPublishRequest<TChannels>[],
 	): Promise<ChannelPublishReceipt[]> {
-		const receipts: ChannelPublishReceipt[] = [];
-		for (const request of requests) {
-			const { channel, ...input } =
-				request as ChannelPublishRequest<TChannels> & Record<string, unknown>;
-			receipts.push(await this.publish(channel as any, input as any));
+		const prepared = await Promise.all(
+			requests.map(async (request, index) => {
+				const { channel, ...input } =
+					request as ChannelPublishRequest<TChannels> & Record<string, unknown>;
+				const publish = await this.preparePublish(channel as any, input as any);
+				return {
+					index,
+					publish,
+					lockKey: hashResolvedChannel(publish.channel),
+				};
+			}),
+		);
+		// A stable sort keeps same-channel events in the order the caller wrote
+		// them, which is the only ordering the ledger promises.
+		const ordered = [...prepared].sort((a, b) =>
+			a.lockKey < b.lockKey ? -1 : a.lockKey > b.lockKey ? 1 : 0,
+		);
+		const receipts: ChannelPublishReceipt[] = Array.from({
+			length: requests.length,
+		});
+		for (const entry of ordered) {
+			receipts[entry.index] = await this.publishPrepared(entry.publish);
 		}
 		return receipts;
 	}

--- a/packages/questpie/src/server/collection/crud/query-builders/order-builder.ts
+++ b/packages/questpie/src/server/collection/crud/query-builders/order-builder.ts
@@ -9,6 +9,7 @@ import type { PgTable } from "drizzle-orm/pg-core";
 
 import type { CollectionBuilderState } from "#questpie/server/collection/builder/types.js";
 import type { OrderBy } from "#questpie/server/collection/crud/types.js";
+import { ApiError } from "#questpie/server/errors/base.js";
 
 /**
  * Options for building ORDER BY clauses
@@ -71,7 +72,12 @@ export function buildOrderByClauses(
 	// Object syntax
 	const clauses: SQL[] = [];
 	for (const [field, direction] of Object.entries(orderBy)) {
-		let column: SQL | any = (table as any)[field];
+		// A `virtual(sql)` field has no table column but does have an ordered SQL
+		// expression, and `buildWhereClause` already resolves it that way
+		// (`buildLocalizedFieldRef`). Resolving it here too means a field is
+		// orderable exactly when it is filterable, instead of silently sorting by
+		// nothing.
+		let column: SQL | any = state.virtuals?.[field] ?? (table as any)[field];
 
 		// For localized fields, use COALESCE with i18n tables
 		if (useI18n && i18nCurrentTable && state.localized.includes(field as any)) {
@@ -85,11 +91,22 @@ export function buildOrderByClauses(
 			}
 		}
 
-		if (column) {
-			clauses.push(
-				direction === "desc" ? sql`${column} DESC` : sql`${column} ASC`,
+		// An order term that resolves to nothing used to be dropped in silence, so
+		// the rows came back in an arbitrary order that merely LOOKED sorted. That
+		// is a typo you cannot see. It also breaks any caller that has to reproduce
+		// the sort — a keyset cursor compares against the terms it was told about,
+		// so a dropped term makes the ORDER BY and the cursor predicate disagree
+		// and pages then overlap or skip.
+		if (!column) {
+			throw ApiError.badRequest(
+				`Cannot order by '${field}': it is not a column of '${state.name}'. ` +
+					`Order by a stored field, a localized field, or a field declared with 'virtual: sql\`...\`'.`,
 			);
 		}
+
+		clauses.push(
+			direction === "desc" ? sql`${column} DESC` : sql`${column} ASC`,
+		);
 	}
 
 	return clauses;

--- a/packages/questpie/src/server/collection/crud/query-builders/where-builder.ts
+++ b/packages/questpie/src/server/collection/crud/query-builders/where-builder.ts
@@ -9,7 +9,12 @@ import {
 	and,
 	type Column,
 	eq,
+	gt,
+	gte,
 	inArray,
+	lt,
+	lte,
+	ne,
 	not,
 	or,
 	type SQL,
@@ -494,6 +499,41 @@ export function resolveFieldOperatorCondition(
 /**
  * Build operator condition for a field
  *
+ * Operators that compare a column against a value OF THAT COLUMN'S OWN TYPE
+ * (`eq`, `ne`, `not`, `gt`, `gte`, `lt`, `lte`, `in`, `notIn`) go through
+ * drizzle's helpers so the value is bound with the column's own
+ * `mapToDriverValue`. That encoder is the single definition of how a value of
+ * this column's type is represented on the wire — it is what INSERT and SELECT
+ * already use — so a comparison that bypasses it compares a value encoded one
+ * way against data that was written another way.
+ *
+ * Interpolating a value into a raw `sql` template instead binds it with the
+ * NOOP encoder, handing the raw JS value to the driver and leaving the wire
+ * format up to whichever driver happens to be installed. Measured consequences
+ * of the noop path:
+ *
+ *  - `node-postgres` renders a `Date` in LOCAL time with an offset
+ *    (`2026-08-05T08:00:00.000+02:00`). Postgres discards the offset for a
+ *    `timestamp` WITHOUT time zone column — which is what `createdAt` /
+ *    `updatedAt` / `deletedAt` are (`server/db/system-columns.ts`) — so the
+ *    boundary of a range filter moves by the client's UTC offset. Under
+ *    `TZ=America/Los_Angeles` a `gt` over `updatedAt` returns rows from BEFORE
+ *    the boundary; the column encoder's `toISOString()` is UTC and matches how
+ *    the value was written. Invisible on a UTC machine.
+ *  - a `numeric` column (`f.number({ mode: "decimal" })`) receives a JS number,
+ *    so Postgres compares in float8 and silently loses precision past 2^53;
+ *    the encoder sends text and the comparison stays in `numeric`.
+ *  - an array column receives a JS array, which drizzle splats into a SQL row
+ *    constructor (`col > ($1, $2)`) rather than an array literal.
+ *
+ * Pattern operators (`like`, `ilike`, `contains`, `startsWith`, ...) compare
+ * against a PATTERN rather than a value of the column's type, so they keep the
+ * raw template — encoding `%foo%` as the column's type would be wrong.
+ *
+ * When `column` is a bare SQL expression (a localized `COALESCE`, a
+ * `virtual(sql)`) there is no encoder to apply and drizzle's `bindIfParam`
+ * leaves the value untouched, exactly as before.
+ *
  * @param column - The column to apply the operator to
  * @param op - The operator name (eq, ne, gt, gte, lt, lte, in, etc.)
  * @param value - The value for the operator
@@ -508,21 +548,21 @@ export function buildOperatorCondition(
 		case "eq":
 			return eq(column, value);
 		case "ne":
-			return sql`${column} != ${value}`;
+			return ne(column, value);
 		case "not":
 			// Handle "not" operator: { field: { not: value } }
 			if (value === null) {
 				return sql`${column} IS NOT NULL`;
 			}
-			return sql`${column} != ${value}`;
+			return ne(column, value);
 		case "gt":
-			return sql`${column} > ${value}`;
+			return gt(column, value);
 		case "gte":
-			return sql`${column} >= ${value}`;
+			return gte(column, value);
 		case "lt":
-			return sql`${column} < ${value}`;
+			return lt(column, value);
 		case "lte":
-			return sql`${column} <= ${value}`;
+			return lte(column, value);
 		case "in":
 			return Array.isArray(value) ? inArray(column, value) : undefined;
 		case "notIn":

--- a/packages/questpie/src/server/collection/crud/query-builders/where-builder.ts
+++ b/packages/questpie/src/server/collection/crud/query-builders/where-builder.ts
@@ -269,9 +269,6 @@ export function buildWhereClause(
 				conditions.push(not(subClause));
 			}
 		} else if (key === "RAW" && typeof value === "function") {
-			if (failClosedAccess) {
-				throw accessCompilationError(state.name, key);
-			}
 			conditions.push(
 				value({
 					table,

--- a/packages/questpie/src/server/config/questpie.ts
+++ b/packages/questpie/src/server/config/questpie.ts
@@ -56,7 +56,6 @@ import {
 	questpieChannelEventTable,
 	questpieChannelHeadTable,
 	questpieChannelPresenceTable,
-	questpieRealtimeHeadTable,
 	questpieRealtimeLogTable,
 	questpieRealtimeTopologyTable,
 } from "#questpie/server/modules/core/integrated/realtime/collection.js";
@@ -1266,7 +1265,6 @@ export class Questpie<TConfig extends QuestpieConfig = QuestpieConfig> {
 
 		// 3. Always include realtime log table since realtime service is always initialized
 		schema.questpie_realtime_log = questpieRealtimeLogTable;
-		schema.questpie_realtime_head = questpieRealtimeHeadTable;
 		schema.questpie_channel_head = questpieChannelHeadTable;
 		schema.questpie_channel_event = questpieChannelEventTable;
 		schema.questpie_channel_dispatch = questpieChannelDispatchTable;

--- a/packages/questpie/src/server/modules/core/.generated/module.ts
+++ b/packages/questpie/src/server/modules/core/.generated/module.ts
@@ -56,6 +56,7 @@ import _route_realtime_crdt_exchange_POST from "../routes/realtime/crdt/exchange
 import _route_realtime_crdt_open_POST from "../routes/realtime/crdt/open.post";
 import _route_search from "../routes/search";
 import _route_search_reindex_collection from "../routes/search/reindex/[collection]";
+import _route_transaction from "../routes/transaction";
 
 // ── Services ────────────────────────────────────────────
 import _svc_auth from "../services/auth";
@@ -163,6 +164,7 @@ export type CoreRoutes = {
 	"realtime/crdt/open:POST": typeof _route_realtime_crdt_open_POST extends { __brand: "route" } ? RouteDefinition<unknown, unknown, RouteParamsFromKey<"realtime/crdt/open:POST">> : typeof _route_realtime_crdt_open_POST;
 	search: typeof _route_search extends { __brand: "route" } ? RouteDefinition<unknown, unknown, RouteParamsFromKey<"search">> : typeof _route_search;
 	"search/reindex/[collection]": typeof _route_search_reindex_collection extends { __brand: "route" } ? RouteDefinition<unknown, unknown, RouteParamsFromKey<"search/reindex/[collection]">> : typeof _route_search_reindex_collection;
+	transaction: typeof _route_transaction extends { __brand: "route" } ? RouteDefinition<unknown, unknown, RouteParamsFromKey<"transaction">> : typeof _route_transaction;
 };
 
 export type CoreFieldTypes = {
@@ -281,6 +283,7 @@ const _module: CoreModule = {
 		"realtime/crdt/open:POST": _route_realtime_crdt_open_POST,
 		search: _route_search,
 		"search/reindex/[collection]": _route_search_reindex_collection,
+		transaction: _route_transaction,
 	} as CoreRoutes,
 	services: {
 		auth: _svc_auth,

--- a/packages/questpie/src/server/modules/core/config/app.ts
+++ b/packages/questpie/src/server/modules/core/config/app.ts
@@ -137,6 +137,30 @@ function reportRealtimeCaptureError(
 	throw new FatalGlobalHookError(error);
 }
 
+/**
+ * Minimal structural slice of the app instance the realtime hooks reach for
+ * ({@link GlobalCollectionHookContext.app} is `unknown` pre-codegen).
+ */
+interface AppRealtimeSurface {
+	config?: { realtime?: { changeCapture?: boolean } };
+}
+
+/**
+ * Whether this application records mutations to the realtime outbox.
+ *
+ * Checked before `ctx.realtime` is touched so that an application that turned
+ * capture off issues no realtime SQL on a mutation at all — no outbox insert,
+ * and therefore no retention cleanup to schedule either. See
+ * `RealtimeConfig.changeCapture` for what that costs: no collection realtime,
+ * no resume, and no `txid` on the mutation result.
+ */
+function isRealtimeCaptureEnabled(app: unknown): boolean {
+	return (
+		(app as AppRealtimeSurface | undefined)?.config?.realtime?.changeCapture !==
+		false
+	);
+}
+
 function shouldCaptureRealtimeChange(
 	ctx: GlobalCollectionHookContext,
 ): boolean {
@@ -169,6 +193,7 @@ function publishRealtimeAfterCommit(
  */
 const realtimeHook = {
 	afterChange: async (ctx: GlobalCollectionHookContext) => {
+		if (!isRealtimeCaptureEnabled(ctx.app)) return;
 		const realtime = ctx.realtime;
 		if (!realtime) return;
 		if (!shouldCaptureRealtimeChange(ctx)) return;
@@ -193,6 +218,7 @@ const realtimeHook = {
 		}
 	},
 	afterDelete: async (ctx: GlobalCollectionHookContext) => {
+		if (!isRealtimeCaptureEnabled(ctx.app)) return;
 		const realtime = ctx.realtime;
 		if (!realtime) return;
 		if (!shouldCaptureRealtimeChange(ctx)) return;
@@ -217,6 +243,7 @@ const realtimeHook = {
 		}
 	},
 	afterPurge: async (ctx: GlobalCollectionHookContext) => {
+		if (!isRealtimeCaptureEnabled(ctx.app)) return;
 		const realtime = ctx.realtime;
 		if (!realtime) return;
 
@@ -416,6 +443,7 @@ const scheduledTransitionHook = {
  */
 const globalRealtimeHook = {
 	afterChange: async (ctx: GlobalGlobalHookContext) => {
+		if (!isRealtimeCaptureEnabled(ctx.app)) return;
 		const realtime = ctx.realtime;
 		if (!realtime) return;
 

--- a/packages/questpie/src/server/modules/core/integrated/crdt/config.ts
+++ b/packages/questpie/src/server/modules/core/integrated/crdt/config.ts
@@ -1,5 +1,52 @@
+import type { AnyDrizzleClient } from "#questpie/server/config/types.js";
 import type { VerifiedAgentCredential } from "#questpie/server/modules/core/integrated/crdt/authority.js";
 import type { CrdtFieldEngine } from "#questpie/shared/crdt-engine.js";
+
+export type CrdtCanonicalProjectionValue = string | readonly string[];
+
+export type CrdtProjectionContributor = Readonly<{
+	commitSeq: bigint;
+	sessionId: string | null;
+	actor:
+		| Readonly<{ kind: "human"; subjectId: string }>
+		| Readonly<{ kind: "agent"; issuer: string; subjectId: string }>;
+}>;
+
+export type CrdtProjectionAcknowledgementInput = Readonly<{
+	/** The framework-owned projection transaction. Writes join canonical acknowledgement. */
+	transaction: AnyDrizzleClient<any>;
+	owner: Readonly<{
+		kind: "collection" | "global";
+		key: string;
+		recordId: string | number | null;
+		current: Readonly<Record<string, unknown>>;
+	}>;
+	/** Complete authoritative aggregate cut, keyed by CRDT source path. */
+	values: ReadonlyMap<string, CrdtCanonicalProjectionValue>;
+	/** Source paths whose CRDT cursor advanced in this cut. */
+	changed: ReadonlySet<string>;
+	contributors: readonly CrdtProjectionContributor[];
+	resourceId: string;
+	resourceEpochId: string;
+	basisCommitSeq: bigint;
+	commitSeq: bigint;
+}>;
+
+export type CrdtProjectionAcknowledgementResult = void | Readonly<{
+	/**
+	 * Canonical aggregate values to persist. When present, the map must contain
+	 * exactly the same paths and value kinds as `input.values`.
+	 */
+	values?: ReadonlyMap<string, CrdtCanonicalProjectionValue>;
+	/** Non-CRDT columns on the locked canonical owner, written with the cut. */
+	ownerValues?: Readonly<Record<string, unknown>>;
+}>;
+
+export type CrdtProjectionAcknowledgementHook = (
+	input: CrdtProjectionAcknowledgementInput,
+) =>
+	| CrdtProjectionAcknowledgementResult
+	| Promise<CrdtProjectionAcknowledgementResult>;
 
 export type CrdtAgentAuthenticationInput = Readonly<{
 	request: Request;
@@ -17,4 +64,11 @@ export type CrdtRuntimeConfig = Readonly<{
 	authenticateAgent?: (
 		input: CrdtAgentAuthenticationInput,
 	) => VerifiedAgentCredential | null | Promise<VerifiedAgentCredential | null>;
+	projection?: Readonly<{
+		/**
+		 * Validate and canonically project one complete CRDT aggregate cut. Any
+		 * throw rolls back callback writes, canonical values, cursors and realtime.
+		 */
+		prepareAcknowledgement: CrdtProjectionAcknowledgementHook;
+	}>;
 }>;

--- a/packages/questpie/src/server/modules/core/integrated/crdt/projection-store.ts
+++ b/packages/questpie/src/server/modules/core/integrated/crdt/projection-store.ts
@@ -71,11 +71,16 @@ export type CrdtProjectionOwnerPort<TOwner> = Readonly<{
 		owner: TOwner,
 		input: {
 			values: ReadonlyMap<string, string | readonly string[]>;
+			changed: ReadonlySet<string>;
 			resourceId: string;
 			resourceEpochId: string;
+			basisCommitSeq: bigint;
 			commitSeq: bigint;
 		},
-	): Promise<void>;
+	): Promise<void | Readonly<{
+		values?: ReadonlyMap<string, string | readonly string[]>;
+		ownerChanged?: boolean;
+	}>>;
 	appendRealtimeChange(
 		transaction: CrdtDatabase,
 		owner: TOwner,
@@ -500,36 +505,75 @@ async function commitProjection<TOwner>(
 		};
 	}
 	const values = new Map<string, string | readonly string[]>();
+	const changed = new Set<string>();
 	for (const binding of bindings) {
 		const field = fields.get(binding.id)!;
+		values.set(binding.sourcePath, field.value);
 		if (
 			field.shouldWrite &&
 			field.targetFieldCursor > binding.projectedFieldCursor
 		) {
-			values.set(binding.sourcePath, field.value);
+			changed.add(binding.sourcePath);
 		}
 	}
-	if (values.size > 0 && ownerPort.prepareAcknowledgement) {
-		await ownerPort.prepareAcknowledgement(db, owner, {
-			values,
-			resourceId: claim.resourceId,
-			resourceEpochId: claim.resourceEpochId,
-			commitSeq: claim.targetCommitSeq,
-		});
+	let canonicalValues: ReadonlyMap<string, string | readonly string[]> = values;
+	let ownerChanged = false;
+	if (changed.size > 0 && ownerPort.prepareAcknowledgement) {
+		const preparedAcknowledgement = await ownerPort.prepareAcknowledgement(
+			db,
+			owner,
+			{
+				values,
+				changed,
+				resourceId: claim.resourceId,
+				resourceEpochId: claim.resourceEpochId,
+				basisCommitSeq: prepared.basisProjectedCommitSeq,
+				commitSeq: claim.targetCommitSeq,
+			},
+		);
+		if (preparedAcknowledgement?.values) {
+			canonicalValues = validateCanonicalValues(
+				preparedAcknowledgement.values,
+				bindings,
+			);
+		}
+		ownerChanged = preparedAcknowledgement?.ownerChanged === true;
 	}
-	const canonicalValues = values;
-	if (canonicalValues.size > 0) {
-		await ownerPort.writeCanonical(db, owner, canonicalValues);
+	const canonicalHashes = new Map<string, Uint8Array>();
+	const canonicalWrites = new Map<string, string | readonly string[]>();
+	for (const binding of bindings) {
+		const value = canonicalValues.get(binding.sourcePath)!;
+		const canonicalHash = await hashCrdtCanonicalValue(
+			binding.format === 1 ? "text" : "set",
+			value,
+		);
+		canonicalHashes.set(binding.id, canonicalHash);
+		const rawHash = rawHashes.get(binding.id)!;
+		if (!equalBytes(rawHash, canonicalHash)) {
+			canonicalWrites.set(binding.sourcePath, value);
+		}
+	}
+	if (canonicalWrites.size > 0 || ownerChanged) {
+		await ownerPort.writeCanonical(db, owner, canonicalWrites);
 	}
 	for (const binding of bindings) {
 		const field = fields.get(binding.id)!;
-		if (field.targetFieldCursor <= binding.projectedFieldCursor) continue;
+		const canonicalHash = canonicalHashes.get(binding.id)!;
+		const cursorAdvanced =
+			field.targetFieldCursor > binding.projectedFieldCursor;
+		const canonicalChanged = !equalBytes(
+			canonicalHash,
+			binding.projectedCanonicalHash,
+		);
+		if (!cursorAdvanced && !canonicalChanged) continue;
 		await db
 			.update(questpieCrdtBindingTable)
 			.set({
 				projectedFieldCursor: field.targetFieldCursor,
-				projectedCanonicalHash: Buffer.from(field.canonicalHash),
-				projectedCanonicalRevision: field.canonicalRevision,
+				projectedCanonicalHash: Buffer.from(canonicalHash),
+				projectedCanonicalRevision: cursorAdvanced
+					? field.canonicalRevision
+					: binding.projectedCanonicalRevision,
 				updatedAt: sql`now()`,
 			})
 			.where(eq(questpieCrdtBindingTable.id, binding.id));
@@ -541,7 +585,7 @@ async function commitProjection<TOwner>(
 			updatedAt: sql`now()`,
 		})
 		.where(eq(questpieCrdtResourceEpochTable.id, claim.resourceEpochId));
-	if (canonicalValues.size > 0) {
+	if (canonicalWrites.size > 0 || ownerChanged) {
 		const outboxChanges = await ownerPort.appendRealtimeChange(db, owner, {
 			origin: "crdt_projection",
 			resourceId: claim.resourceId,
@@ -570,6 +614,36 @@ async function commitProjection<TOwner>(
 		status: "applied" as const,
 		projectedCommitSeq: claim.targetCommitSeq,
 	});
+}
+
+function validateCanonicalValues(
+	values: ReadonlyMap<string, string | readonly string[]>,
+	bindings: readonly (typeof questpieCrdtBindingTable.$inferSelect)[],
+): ReadonlyMap<string, string | readonly string[]> {
+	if (!(values instanceof Map) || values.size !== bindings.length) {
+		throw new TypeError(
+			"CRDT projection acknowledgement must return the complete aggregate cut",
+		);
+	}
+	const result = new Map<string, string | readonly string[]>();
+	for (const binding of bindings) {
+		const value = values.get(binding.sourcePath);
+		if (
+			(binding.format === 1 && typeof value !== "string") ||
+			(binding.format === 2 &&
+				(!Array.isArray(value) ||
+					value.some((entry) => typeof entry !== "string")))
+		) {
+			throw new TypeError(
+				`CRDT projection acknowledgement returned an invalid value for '${binding.sourcePath}'`,
+			);
+		}
+		result.set(
+			binding.sourcePath,
+			Array.isArray(value) ? Object.freeze([...value]) : value,
+		);
+	}
+	return result;
 }
 
 async function suspendAggregate(

--- a/packages/questpie/src/server/modules/core/integrated/crdt/questpie-projection-owner.ts
+++ b/packages/questpie/src/server/modules/core/integrated/crdt/questpie-projection-owner.ts
@@ -1,14 +1,17 @@
-import { eq, getTableColumns } from "drizzle-orm";
+import { and, asc, eq, getTableColumns, gt, lte } from "drizzle-orm";
 
 import { mutateCanonicalRow } from "#questpie/server/collection/crud/shared/canonical-mutation.js";
 import { onAfterCommit } from "#questpie/server/collection/crud/shared/transaction.js";
 import type { Questpie } from "#questpie/server/config/questpie.js";
+import type { AnyDrizzleClient } from "#questpie/server/config/types.js";
 import { hashCrdtCanonicalValue } from "#questpie/shared/crdt-engine.js";
 
 import type { CrdtProjectionOwnerPort } from "./projection-store.js";
 import {
+	questpieCrdtCommitTable,
 	questpieCrdtDefinitionTable,
 	questpieCrdtResourceTable,
+	questpieCrdtSubjectTable,
 } from "./schema.js";
 
 type LockedOwner = {
@@ -24,6 +27,15 @@ type LockedOwner = {
 export function createQuestpieProjectionOwnerPort(
 	app: Questpie<any>,
 ): CrdtProjectionOwnerPort<LockedOwner> {
+	const prepareAcknowledgement =
+		app.config?.crdt?.projection?.prepareAcknowledgement;
+	const preparedOwnerValues = new WeakMap<
+		LockedOwner,
+		{
+			values: Readonly<Record<string, unknown>>;
+			crdtPaths: ReadonlySet<string>;
+		}
+	>();
 	return Object.freeze({
 		async lock(transaction, { resourceId }) {
 			const [identity] = await transaction
@@ -133,7 +145,23 @@ export function createQuestpieProjectionOwnerPort(
 			return result;
 		},
 		async writeCanonical(transaction, owner, values) {
-			const update: Record<string, string | readonly string[]> = {};
+			const prepared = preparedOwnerValues.get(owner);
+			preparedOwnerValues.delete(owner);
+			const update: Record<string, unknown> = {};
+			for (const [field, value] of Object.entries(prepared?.values ?? {})) {
+				if (
+					!owner.columns[field] ||
+					prepared?.crdtPaths.has(field) ||
+					["id", "revision", "createdAt", "updatedAt", "deletedAt"].includes(
+						field,
+					)
+				) {
+					throw new TypeError(
+						`CRDT projection acknowledgement cannot write owner field '${field}'`,
+					);
+				}
+				update[field] = value;
+			}
 			for (const [sourcePath, value] of values) {
 				if (!owner.columns[sourcePath]) {
 					throw new Error("CRDT canonical column is unavailable");
@@ -151,6 +179,95 @@ export function createQuestpieProjectionOwnerPort(
 				expectedRevision: "internal",
 			});
 		},
+		...(prepareAcknowledgement
+			? {
+					async prepareAcknowledgement(
+						transaction: AnyDrizzleClient<any>,
+						owner: LockedOwner,
+						input: {
+							values: ReadonlyMap<string, string | readonly string[]>;
+							changed: ReadonlySet<string>;
+							resourceId: string;
+							resourceEpochId: string;
+							basisCommitSeq: bigint;
+							commitSeq: bigint;
+						},
+					) {
+						const contributors = await transaction
+							.select({
+								commitSeq: questpieCrdtCommitTable.commitSeq,
+								sessionId: questpieCrdtCommitTable.sessionId,
+								kind: questpieCrdtSubjectTable.kind,
+								issuer: questpieCrdtSubjectTable.issuerKey,
+								subjectId: questpieCrdtSubjectTable.subjectKey,
+							})
+							.from(questpieCrdtCommitTable)
+							.innerJoin(
+								questpieCrdtSubjectTable,
+								eq(
+									questpieCrdtSubjectTable.id,
+									questpieCrdtCommitTable.subjectId,
+								),
+							)
+							.where(
+								and(
+									eq(questpieCrdtCommitTable.resourceId, input.resourceId),
+									eq(
+										questpieCrdtCommitTable.resourceEpochId,
+										input.resourceEpochId,
+									),
+									gt(questpieCrdtCommitTable.commitSeq, input.basisCommitSeq),
+									lte(questpieCrdtCommitTable.commitSeq, input.commitSeq),
+								),
+							)
+							.orderBy(asc(questpieCrdtCommitTable.commitSeq));
+						const result = await prepareAcknowledgement({
+							transaction,
+							owner: Object.freeze({
+								kind: owner.kind,
+								key: owner.key,
+								recordId: owner.recordId,
+								current: Object.freeze({ ...owner.row }),
+							}),
+							values: new Map(input.values),
+							changed: new Set(input.changed),
+							contributors: Object.freeze(
+								contributors.map((contributor) =>
+									Object.freeze({
+										commitSeq: contributor.commitSeq,
+										sessionId: contributor.sessionId,
+										actor:
+											contributor.kind === 1
+												? Object.freeze({
+														kind: "human" as const,
+														subjectId: contributor.subjectId,
+													})
+												: Object.freeze({
+														kind: "agent" as const,
+														issuer: contributor.issuer,
+														subjectId: contributor.subjectId,
+													}),
+									}),
+								),
+							),
+							resourceId: input.resourceId,
+							resourceEpochId: input.resourceEpochId,
+							basisCommitSeq: input.basisCommitSeq,
+							commitSeq: input.commitSeq,
+						});
+						if (result?.ownerValues) {
+							preparedOwnerValues.set(owner, {
+								values: Object.freeze({ ...result.ownerValues }),
+								crdtPaths: new Set(input.values.keys()),
+							});
+						}
+						return {
+							...(result?.values ? { values: result.values } : {}),
+							...(result?.ownerValues ? { ownerChanged: true } : {}),
+						};
+					},
+				}
+			: {}),
 		async appendRealtimeChange(_transaction, owner, input) {
 			const event = await app.realtime.appendChange({
 				resourceType: owner.kind,

--- a/packages/questpie/src/server/modules/core/integrated/realtime/TRANSPORT.md
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/TRANSPORT.md
@@ -86,14 +86,16 @@ the runtime immediately drains from its durable sequence cursor.
 
 The runtime also schedules unconditional slow reconciliation while a broker is
 active. It drains both durable sources: the live-query outbox and the channel
-delivery ledger. Every new writer locks the singleton outbox head inside the
-business transaction before inserting, so sequence order is commit order. An
-outbox drain reads strictly after its cursor and advances only after local
-dispatch. Native deltas have a two-phase rollout gate: deploy every writer with
-`nativeDeltas` disabled first, then enable it only after no legacy writer can
-append without the head lock. A channel drain follows the ordered-ledger rules
-below. These drains are the guarantee; broker delivery is only the latency
-optimization.
+delivery ledger. Writers take no shared lock, so sequence order is NOT commit
+order; an outbox drain instead reads only rows whose `txid` is below
+`pg_snapshot_xmin(pg_current_snapshot())`, ordered by `(txid, seq)`, and
+advances that composite cursor only after local dispatch. Every transaction
+below the watermark has ended, and newly eligible rows always sort after the
+cursor, so the delivered prefix is contiguous. Native deltas have a two-phase
+rollout gate: deploy every replica with `nativeDeltas` disabled first, then
+enable it only after no replica can still order the outbox by sequence alone. A
+channel drain follows the ordered-ledger rules below. These drains are the
+guarantee; broker delivery is only the latency optimization.
 
 Mutation capture and notification have different durability requirements:
 
@@ -375,6 +377,19 @@ On resume, the runtime compares `sinceSeq` with the retained outbox horizon:
 
 No code path treats an unavailable cursor as caught up. Resume never produces a
 silent gap.
+
+`sinceSeq` is a scalar compatibility hint, not the composite drain position, and
+only the service can decide whether it is still current. Every `seq` a client is
+stamped with comes from a settled row returned by `getLatestSeq()` — not
+`max(seq)`, because a visible row can still be waiting on an older open
+transaction. Resume answers `current` only when that settled row is exactly
+`sinceSeq` AND no retained row carries a higher transaction id. The second test
+is what catches a change with a LOWER sequence that committed after the client
+stopped, which comparing sequences cannot see. Retention preserves this proof by
+starting at `settled_at`, the first cleanup observation below PostgreSQL's
+settlement frontier; it never prunes a row merely because its transaction began
+long ago. Anything unverifiable recomputes once; an unchanged result is
+suppressed by the snapshot hash, so the wire stays quiet.
 
 ## Native-delta identity and queue ownership
 
@@ -916,23 +931,23 @@ verification, load-balancer affinity is removed.
 
 ## Fifteen-invariant gate
 
-| Invariant | Concrete mechanism                                                                                                                              | Required proof                                                                         |
-| --------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
-| H1        | Both seams start/stop with app lifecycle; no subscriber-gated broker start.                                                                     | Write-only instance wakes a separate subscriber instance.                              |
-| H2        | Lossy wake contract plus unconditional poll, reconnect drain, head-locked commit order, and the two-phase native-delta rollout gate.            | Drop/reorder wakes; prove commit-order capture and snapshot fallback during rollout.   |
-| H3        | Logical-operation batch guard; one in-tx append; caught post-commit publish.                                                                    | Exact event/insert/notify counts and response-path latency assertion.                  |
-| H4        | Scheduler keyed by topic and access equivalence; immutable byte fan-out; hash suppression; pre/post match.                                      | N equivalent sinks cause one query and unchanged results emit no frame.                |
-| H5        | Admission config, pre-registration access execution, bounded concurrency, finite limits.                                                        | Cap matrix and denied-topic teardown tests.                                            |
-| H6        | `ClientSink.write()` busy/throw contract, latest-wins replacement, bounded ordered queue, shared ticker, terminal cleanup.                      | Slow and failed sink tests prove bounded memory and zero listeners/timers after close. |
-| H7        | `sinceSeq`, revisioned complete desired topology, durable ownership/fencing, jittered reconnect, ping watchdog, forced reset outside retention. | Cross-replica topology, resume, reconciliation, and incremental mount tests.           |
-| H8        | Discriminated `find`/`count`/`get` topic union.                                                                                                 | Live count runs count and transfers O(1) data.                                         |
-| H9        | Notice-only broker and per-session private WS live-query channel with authorized refetch.                                                       | Cross-session WS test proves no ACL snapshot reaches a shared channel.                 |
-| H10       | Default time retention, no local watermark deletion, bounded replay infrastructure.                                                             | Cleanup with zero subscribers and multiple instances.                                  |
-| H11       | Caught async, isolated listeners, 42P01-only silence, client error/close, coarse session refresh.                                               | Failure-injection matrix produces no unhandled rejection or hanging client.            |
-| H12       | Non-throwing observer events for broker, drain, refresh, buffers, admission, resume, and failures.                                              | Observer contract tests plus sensitive-label audit.                                    |
-| H13       | Mutation and outbox append share the transaction; wake is post-commit.                                                                          | Crash-window rollback/commit/reconcile tests.                                          |
-| H14       | Separate `ChangeBroker` and `ClientTransport`; latest-snapshot and ordered-event QoS have different queue/replay rules.                         | Interface compile test and cross-driver QoS matrix.                                    |
-| H15       | Session-scoped default access key; cross-principal sharing only by explicit deterministic resolver.                                             | Adversarial row, field, and `afterRead` isolation tests.                               |
+| Invariant | Concrete mechanism                                                                                                                                              | Required proof                                                                                          |
+| --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| H1        | Both seams start/stop with app lifecycle; no subscriber-gated broker start.                                                                                     | Write-only instance wakes a separate subscriber instance.                                               |
+| H2        | Lossy wake contract plus unconditional poll, reconnect drain, `(txid, seq)` cursor below the visibility watermark, and the two-phase native-delta rollout gate. | Drop/reorder wakes; prove no row is skipped when txid and seq invert; snapshot fallback during rollout. |
+| H3        | Logical-operation batch guard; one in-tx append; caught post-commit publish.                                                                                    | Exact event/insert/notify counts and response-path latency assertion.                                   |
+| H4        | Scheduler keyed by topic and access equivalence; immutable byte fan-out; hash suppression; pre/post match.                                                      | N equivalent sinks cause one query and unchanged results emit no frame.                                 |
+| H5        | Admission config, pre-registration access execution, bounded concurrency, finite limits.                                                                        | Cap matrix and denied-topic teardown tests.                                                             |
+| H6        | `ClientSink.write()` busy/throw contract, latest-wins replacement, bounded ordered queue, shared ticker, terminal cleanup.                                      | Slow and failed sink tests prove bounded memory and zero listeners/timers after close.                  |
+| H7        | `sinceSeq`, revisioned complete desired topology, durable ownership/fencing, jittered reconnect, ping watchdog, forced reset outside retention.                 | Cross-replica topology, resume, reconciliation, and incremental mount tests.                            |
+| H8        | Discriminated `find`/`count`/`get` topic union.                                                                                                                 | Live count runs count and transfers O(1) data.                                                          |
+| H9        | Notice-only broker and per-session private WS live-query channel with authorized refetch.                                                                       | Cross-session WS test proves no ACL snapshot reaches a shared channel.                                  |
+| H10       | Default time retention, no local watermark deletion, bounded replay infrastructure.                                                                             | Cleanup with zero subscribers and multiple instances.                                                   |
+| H11       | Caught async, isolated listeners, 42P01-only silence, client error/close, coarse session refresh.                                                               | Failure-injection matrix produces no unhandled rejection or hanging client.                             |
+| H12       | Non-throwing observer events for broker, drain, refresh, buffers, admission, resume, and failures.                                                              | Observer contract tests plus sensitive-label audit.                                                     |
+| H13       | Mutation and outbox append share the transaction; wake is post-commit.                                                                                          | Crash-window rollback/commit/reconcile tests.                                                           |
+| H14       | Separate `ChangeBroker` and `ClientTransport`; latest-snapshot and ordered-event QoS have different queue/replay rules.                                         | Interface compile test and cross-driver QoS matrix.                                                     |
+| H15       | Session-scoped default access key; cross-principal sharing only by explicit deterministic resolver.                                                             | Adversarial row, field, and `afterRead` isolation tests.                                                |
 
 Dependent implementation tasks may start only after this table is reviewed
 15/15 and any blocker found by the grill is represented on the board.

--- a/packages/questpie/src/server/modules/core/integrated/realtime/admission.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/admission.ts
@@ -6,6 +6,13 @@ import type {
 export type RealtimeAdmissionConfig = {
 	maxTopicsPerConnection: number;
 	maxConnectionsPerPrincipal: number;
+	/**
+	 * Node-wide ceiling on connections that carry no principal at all. This is
+	 * one shared bucket, not a per-client one: an unauthenticated caller
+	 * supplies nothing the server can trust to tell it apart from the next
+	 * caller, so any per-client key would be a cap that never binds.
+	 */
+	maxAnonymousConnections: number;
 	maxFindLimit: number;
 	maxWithDepth: number;
 	initialSnapshotConcurrency: number;
@@ -21,6 +28,11 @@ export type RealtimeAdmissionConfig = {
 export const DEFAULT_REALTIME_ADMISSION: RealtimeAdmissionConfig = {
 	maxTopicsPerConnection: 20,
 	maxConnectionsPerPrincipal: 5,
+	// At the default 8s keepalive every admitted connection sustains roughly two
+	// scheduler queries per interval, so 200 anonymous streams is about 50
+	// standing queries/second — one node's worth of headroom, and 40x the
+	// authenticated per-principal cap so a public site only meets it under flood.
+	maxAnonymousConnections: 200,
 	maxFindLimit: 100,
 	maxWithDepth: 3,
 	initialSnapshotConcurrency: 4,
@@ -73,6 +85,10 @@ export function resolveRealtimeAdmissionConfig(
 		maxConnectionsPerPrincipal: positiveInteger(
 			config?.maxConnectionsPerPrincipal,
 			DEFAULT_REALTIME_ADMISSION.maxConnectionsPerPrincipal,
+		),
+		maxAnonymousConnections: positiveInteger(
+			config?.maxAnonymousConnections,
+			DEFAULT_REALTIME_ADMISSION.maxAnonymousConnections,
 		),
 		maxFindLimit: positiveInteger(
 			config?.maxFindLimit,
@@ -129,6 +145,8 @@ export type TopicAdmissionResult<TTopic extends AdmissionTopic> =
 			reason: RealtimeTopicRejectionReason;
 			requestedLimit?: number;
 			configuredLimit?: number;
+			/** What the server counted when it refused. */
+			observed?: number;
 	  };
 
 export class RealtimeTopicAdmissionError extends Error {
@@ -157,6 +175,9 @@ export function realtimeTopicRejectedPayload(
 				: {}),
 			...(rejection.configuredLimit !== undefined
 				? { configuredLimit: rejection.configuredLimit }
+				: {}),
+			...(rejection.observed !== undefined
+				? { observed: rejection.observed }
 				: {}),
 		},
 	};
@@ -210,14 +231,26 @@ export function admitRealtimeTopic<TTopic extends AdmissionTopic>(
 	return { accepted: true, topic: { ...topic, limit } };
 }
 
-/** Authoritative server policy, separate from durable change capture. */
+/** Authoritative server policy for one topic, checked strongest switch first. */
 export function admitRealtimeTopicPolicy<TTopic extends AdmissionTopic>(
 	topic: TTopic,
 	policy: {
+		changeCapture?: boolean;
 		rowLiveQueries?: boolean;
 		collectionRealtime?: boolean;
 	},
 ): TopicAdmissionResult<TTopic> {
+	// Capture off means there is no outbox to serve from, so it outranks the
+	// read-side switches — refusing here is the only alternative to a
+	// subscription that connects and then never emits.
+	if (policy.changeCapture === false) {
+		return {
+			accepted: false,
+			message:
+				"Realtime change capture is disabled by server policy; collection and global topics cannot be served",
+			reason: "change_capture_disabled",
+		};
+	}
 	if (policy.rowLiveQueries === false) {
 		return {
 			accepted: false,
@@ -238,24 +271,173 @@ export function admitRealtimeTopicPolicy<TTopic extends AdmissionTopic>(
 	return { accepted: true, topic: { ...topic } };
 }
 
+/** Keepalive default, shared with the route so the slot TTL tracks it. */
+export const DEFAULT_REALTIME_KEEP_ALIVE_INTERVAL_MS = 8000;
+
+/**
+ * How many keepalive beats a connection may fail to prove itself alive before
+ * its slot is reclaimable. The lease is renewed by evidence the peer drained
+ * the stream, so this only sets how long a peer that stopped reading — or one
+ * whose socket died without the runtime saying so — keeps holding a slot.
+ */
+export const REALTIME_SLOT_KEEPALIVE_BEATS = 4;
+
+/**
+ * Slot lease length. Derived from the keepalive rather than a constant of its
+ * own: the keepalive is the only traffic an idle-but-live stream generates, so
+ * it is what bounds "the longest legitimate idle stream". A TTL shorter than a
+ * few beats would evict live sessions.
+ */
+export function realtimeSlotTtlMs(keepAliveIntervalMs: number): number {
+	const interval =
+		Number.isFinite(keepAliveIntervalMs) && keepAliveIntervalMs >= 1
+			? keepAliveIntervalMs
+			: DEFAULT_REALTIME_KEEP_ALIVE_INTERVAL_MS;
+	return interval * REALTIME_SLOT_KEEPALIVE_BEATS;
+}
+
+type AdmissionSlot = {
+	expiresAt: number;
+	released: boolean;
+	close?: () => void;
+};
+
+export type RealtimeAdmissionLease = {
+	/** Hand the slot back. Idempotent, and safe after eviction. */
+	release: () => void;
+	/** Extend the lease. Callers must only call this on proof of life. */
+	renew: (now?: number) => void;
+	/** How the registry tears down a stream whose lease lapsed. */
+	setClose: (close: () => void) => void;
+};
+
+export type RealtimeAdmissionDecision =
+	| { admitted: true; lease: RealtimeAdmissionLease; observed: number }
+	| { admitted: false; observed: number; configuredLimit: number };
+
+export type RealtimeAdmissionOptions = {
+	maximum: number;
+	/**
+	 * Lease length in ms. `Number.POSITIVE_INFINITY` opts a transport out of TTL
+	 * reclamation — only valid when that transport owns another liveness check.
+	 */
+	ttlMs: number;
+	now?: number;
+};
+
+/**
+ * Per-process connection slots, held as leases rather than a bare count.
+ *
+ * A slot used to be released only by an explicit teardown, which made every
+ * release path a property of the runtime: if nothing propagated the client's
+ * disconnect, the count was immortal for the lifetime of the process and the
+ * principal was locked out until a restart. A lease expires on wall clock
+ * instead, so reclamation needs no cooperation from the runtime — and expiry
+ * closes the abandoned stream, so the scheduler groups, topology heartbeat and
+ * keepalive registration behind it go with it.
+ *
+ * Sweeping is lazy: it runs on admission, which is the only moment the count
+ * matters and the only moment the process is guaranteed to still be serving.
+ * A background timer here would keep the process alive and outlive the app.
+ */
 export class RealtimeAdmissionRegistry {
-	private readonly counts = new Map<string, number>();
+	private readonly buckets = new Map<string, Set<AdmissionSlot>>();
+	private nextFullSweepAt = Number.NEGATIVE_INFINITY;
 
-	constructor(private readonly maximum: number) {}
+	acquire(
+		key: string,
+		options: RealtimeAdmissionOptions,
+	): RealtimeAdmissionDecision {
+		const now = options.now ?? Date.now();
+		this.sweepAll(now, options.ttlMs);
+		const slots = this.sweepBucket(key, now);
 
-	acquire(principalKey: string | null): (() => void) | null {
-		if (principalKey === null) return () => {};
-		const count = this.counts.get(principalKey) ?? 0;
-		if (count >= this.maximum) return null;
-		this.counts.set(principalKey, count + 1);
-		let released = false;
-		return () => {
-			if (released) return;
-			released = true;
-			const next = (this.counts.get(principalKey) ?? 1) - 1;
-			if (next === 0) this.counts.delete(principalKey);
-			else this.counts.set(principalKey, next);
+		if (slots.size >= options.maximum) {
+			return {
+				admitted: false,
+				observed: slots.size,
+				configuredLimit: options.maximum,
+			};
+		}
+
+		const slot: AdmissionSlot = {
+			expiresAt: now + options.ttlMs,
+			released: false,
 		};
+		slots.add(slot);
+		return {
+			admitted: true,
+			observed: slots.size,
+			lease: {
+				release: () => {
+					if (slot.released) return;
+					slot.released = true;
+					const bucket = this.buckets.get(key);
+					if (!bucket) return;
+					bucket.delete(slot);
+					if (bucket.size === 0) this.buckets.delete(key);
+				},
+				renew: (renewedAt) => {
+					if (slot.released) return;
+					slot.expiresAt = (renewedAt ?? Date.now()) + options.ttlMs;
+				},
+				setClose: (close) => {
+					slot.close = close;
+				},
+			},
+		};
+	}
+
+	/** Live slots in one bucket. Diagnostics; expired slots are not counted. */
+	observed(key: string, now: number = Date.now()): number {
+		let live = 0;
+		for (const slot of this.buckets.get(key) ?? []) {
+			if (slot.expiresAt > now) live += 1;
+		}
+		return live;
+	}
+
+	private sweepBucket(key: string, now: number): Set<AdmissionSlot> {
+		let slots = this.buckets.get(key);
+		if (!slots) {
+			slots = new Set<AdmissionSlot>();
+			this.buckets.set(key, slots);
+			return slots;
+		}
+		evictExpired(slots, now);
+		return slots;
+	}
+
+	private sweepAll(now: number, ttlMs: number): void {
+		if (now < this.nextFullSweepAt) return;
+		// One pass per lease window is enough to keep abandoned streams from
+		// accumulating under principals that never reconnect.
+		this.nextFullSweepAt =
+			now + (Number.isFinite(ttlMs) ? Math.max(1000, ttlMs) : 60_000);
+		for (const [key, slots] of this.buckets) {
+			evictExpired(slots, now);
+			if (slots.size === 0) this.buckets.delete(key);
+		}
+	}
+}
+
+function evictExpired(slots: Set<AdmissionSlot>, now: number): void {
+	const expired: AdmissionSlot[] = [];
+	for (const slot of slots) {
+		if (slot.expiresAt <= now) expired.push(slot);
+	}
+	// Vacate first, then tear down: `close()` re-enters `release()`, and the
+	// slot must already be gone so that release cannot evict its replacement.
+	for (const slot of expired) {
+		slots.delete(slot);
+		slot.released = true;
+	}
+	for (const slot of expired) {
+		try {
+			slot.close?.();
+		} catch {
+			// One abandoned stream must not stop the sweep.
+		}
 	}
 }
 
@@ -263,11 +445,10 @@ const registries = new WeakMap<object, RealtimeAdmissionRegistry>();
 
 export function getRealtimeAdmissionRegistry(
 	owner: object,
-	maximum: number,
 ): RealtimeAdmissionRegistry {
 	let registry = registries.get(owner);
 	if (!registry) {
-		registry = new RealtimeAdmissionRegistry(maximum);
+		registry = new RealtimeAdmissionRegistry();
 		registries.set(owner, registry);
 	}
 	return registry;
@@ -289,6 +470,46 @@ export function realtimePrincipalKey(context: {
 	return typeof sessionId === "string" && sessionId
 		? `session:${sessionId}`
 		: null;
+}
+
+/**
+ * The bucket every unauthenticated connection shares.
+ *
+ * Deliberately *not* per connection. The obvious alternative — key on the
+ * server-issued edge session id, the way anonymous channel readers do — gives
+ * every connection its own bucket, which is a cap that can never bind: it is
+ * how these connections came to be unlimited in the first place. The other
+ * alternative, keying on the remote address, means trusting a forwarded-for
+ * header the framework does not own and a proxy can collapse or a client can
+ * forge. One shared bucket is the honest shape for what this registry actually
+ * is: a per-node resource guard. It bounds the node; it does not pretend to be
+ * a per-visitor quota.
+ */
+export const ANONYMOUS_ADMISSION_KEY = "anonymous";
+
+/**
+ * Pick the admission bucket and the cap that applies to it. One site, so an
+ * unauthenticated connection can never end up with no cap at all.
+ */
+export function realtimeAdmissionBucket(
+	context: Parameters<typeof realtimePrincipalKey>[0],
+	config: Pick<
+		RealtimeAdmissionConfig,
+		"maxConnectionsPerPrincipal" | "maxAnonymousConnections"
+	>,
+): { key: string; maximum: number; anonymous: boolean } {
+	const principalKey = realtimePrincipalKey(context);
+	return principalKey === null
+		? {
+				key: ANONYMOUS_ADMISSION_KEY,
+				maximum: config.maxAnonymousConnections,
+				anonymous: true,
+			}
+		: {
+				key: principalKey,
+				maximum: config.maxConnectionsPerPrincipal,
+				anonymous: false,
+			};
 }
 
 export function createConcurrencyLimiter(maximum: number) {

--- a/packages/questpie/src/server/modules/core/integrated/realtime/channel-event-ledger.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/channel-event-ledger.ts
@@ -9,6 +9,7 @@ import {
 import {
 	getCurrentTransaction,
 	onAfterCommit,
+	withTransaction,
 	withTransactionOrExisting,
 } from "#questpie/server/collection/crud/shared/transaction.js";
 import type { AnyDrizzleClient } from "#questpie/server/config/types.js";
@@ -277,6 +278,11 @@ export class ChannelEventLedger {
 		string,
 		Set<LocalSubscription>
 	>();
+	/** In-flight log page per channel, shared by every reader of that channel. */
+	private readonly channelReads = new Map<
+		string,
+		{ afterSeq: number; page: Promise<ChannelEventRow[]> }
+	>();
 	private sharedDrainPending = false;
 	private sharedDrainPromise: Promise<void> | null = null;
 	private cleanupInProgress = false;
@@ -320,21 +326,26 @@ export class ChannelEventLedger {
 		let eventId = "";
 
 		await withTransactionOrExisting(db, async (tx) => {
-			await tx
-				.insert(questpieChannelHeadTable)
-				.values({ channelHash, channel: input.channel })
-				.onConflictDoNothing();
-
 			// The UPDATE takes a row lock. Contending publishers cannot receive a
 			// sequence until the previous publisher commits, so seq order is commit order.
-			const [head] = await tx
-				.update(questpieChannelHeadTable)
-				.set({
-					lastSeq: sql`${questpieChannelHeadTable.lastSeq} + 1`,
-					updatedAt: new Date(),
-				})
-				.where(eq(questpieChannelHeadTable.channelHash, channelHash))
-				.returning({ seq: questpieChannelHeadTable.lastSeq });
+			//
+			// It is also attempted FIRST. The head, dispatch and coordinator-fence
+			// rows are created together by whichever append is first on a channel,
+			// so after that every append can reach its sequence in one statement
+			// instead of paying three upserts that can only ever be no-ops.
+			let head = await this.lockChannelSequence(tx, channelHash);
+			if (!head) {
+				await tx
+					.insert(questpieChannelHeadTable)
+					.values({ channelHash, channel: input.channel })
+					.onConflictDoNothing();
+				await tx
+					.insert(questpieChannelDispatchTable)
+					.values({ channelHash })
+					.onConflictDoNothing();
+				await this.authorityFences.ensureChannel(channelHash, tx);
+				head = await this.lockChannelSequence(tx, channelHash);
+			}
 			if (!head) throw new Error("Failed to lock channel sequence head");
 
 			const seq = Number(head.seq);
@@ -355,11 +366,6 @@ export class ChannelEventLedger {
 				wireJson: envelope.wireJson,
 				sizeBytes: envelope.sizeBytes,
 			});
-			await tx
-				.insert(questpieChannelDispatchTable)
-				.values({ channelHash })
-				.onConflictDoNothing();
-			await this.authorityFences.ensureChannel(channelHash, tx);
 
 			onAfterCommit(async () => {
 				void this.notifyAfterCommit(channelHash, eventId).catch((error) => {
@@ -372,6 +378,21 @@ export class ChannelEventLedger {
 		});
 
 		return Object.freeze({ eventId });
+	}
+
+	private async lockChannelSequence(
+		tx: AnyDrizzleClient<any>,
+		channelHash: string,
+	): Promise<{ seq: number } | undefined> {
+		const [head] = await tx
+			.update(questpieChannelHeadTable)
+			.set({
+				lastSeq: sql`${questpieChannelHeadTable.lastSeq} + 1`,
+				updatedAt: new Date(),
+			})
+			.where(eq(questpieChannelHeadTable.channelHash, channelHash))
+			.returning({ seq: questpieChannelHeadTable.lastSeq });
+		return head;
 	}
 
 	private async notifyAfterCommit(
@@ -837,49 +858,119 @@ export class ChannelEventLedger {
 		);
 	}
 
+	/**
+	 * Enforce the retention horizon in bounded SQL, on one node at a time.
+	 *
+	 * This used to `select *` the entire event table — payloads included — into
+	 * the heap and then issue one autocommit DELETE per row, hourly, on every
+	 * node at once. At the documented 24 h / 10 events per second that is
+	 * 864 000 rows and 864 000 transactions per node per pass.
+	 *
+	 * Both horizons are now single statements, and a transaction-scoped
+	 * advisory lock keeps concurrent nodes from repeating each other's work.
+	 */
 	async cleanup(): Promise<void> {
 		if (this.cleanupInProgress) return;
 		if (this.config.retentionMs <= 0 && this.config.retentionBytes <= 0) return;
 		this.cleanupInProgress = true;
 		try {
-			const rows = await this.db
-				.select()
-				.from(questpieChannelEventTable)
-				.orderBy(asc(questpieChannelEventTable.createdAt));
-			const dispatchRows =
-				this.clientTransport?.channelDeliveryScope === "shared-provider"
-					? await this.db.select().from(questpieChannelDispatchTable)
-					: [];
-			const publishedByChannel = new Map(
-				dispatchRows.map((row) => [row.channelHash, Number(row.publishedSeq)]),
-			);
-			const cutoff = Date.now() - this.config.retentionMs;
-			let retainedBytes = rows.reduce((sum, row) => sum + row.sizeBytes, 0);
-			for (const row of rows) {
-				const providerCursor = publishedByChannel.get(row.channelHash);
-				if (providerCursor !== undefined && Number(row.seq) > providerCursor) {
-					continue;
+			await withTransaction(this.db, async (tx) => {
+				if (!(await this.admitCleanup(tx))) return;
+				// Events the shared provider has not published yet are never
+				// eligible: the dispatch cursor is the only durable record of what
+				// has actually left this node.
+				const undispatched =
+					this.clientTransport?.channelDeliveryScope === "shared-provider"
+						? sql`and not exists (
+								select 1 from questpie_channel_dispatch d
+								where d.channel_hash = e.channel_hash
+									and e.seq > d.published_seq
+							)`
+						: sql``;
+
+				await this.reportRetentionHorizon(tx);
+				if (this.config.retentionMs > 0) {
+					const cutoff = new Date(Date.now() - this.config.retentionMs);
+					await tx.execute(sql`
+						delete from questpie_channel_event e
+						where e.created_at < ${cutoff} ${undispatched}
+					`);
 				}
-				const expired =
-					this.config.retentionMs > 0 && row.createdAt.getTime() < cutoff;
-				const overSize =
-					this.config.retentionBytes > 0 &&
-					retainedBytes > this.config.retentionBytes;
-				if (!expired && !overSize) continue;
-				await this.db
-					.delete(questpieChannelEventTable)
-					.where(
-						and(
-							eq(questpieChannelEventTable.channelHash, row.channelHash),
-							eq(questpieChannelEventTable.seq, row.seq),
-						),
-					);
-				retainedBytes -= row.sizeBytes;
-			}
+				if (this.config.retentionBytes > 0) {
+					// Keep the newest events up to the byte budget; everything the
+					// running total pushes past it goes in one statement.
+					await tx.execute(sql`
+						delete from questpie_channel_event e
+						using (
+							select channel_hash, seq,
+								sum(size_bytes) over (
+									order by created_at desc, channel_hash desc, seq desc
+									rows between unbounded preceding and current row
+								) as retained
+							from questpie_channel_event
+						) r
+						where e.channel_hash = r.channel_hash
+							and e.seq = r.seq
+							and r.retained > ${this.config.retentionBytes}
+							${undispatched}
+					`);
+				}
+			});
 		} catch (error) {
 			if (!hasPostgresErrorCode(error, "42P01")) throw error;
 		} finally {
 			this.cleanupInProgress = false;
+		}
+	}
+
+	/**
+	 * Say so when the byte cap, not the age cap, is the real retention horizon.
+	 *
+	 * `retentionBytes` defaults to 64 MB and `retentionMs` to 24 hours. At
+	 * ~500 bytes an event and 10 events per second the byte cap binds after
+	 * about 3.5 hours, so an operator who configured a day of replay silently
+	 * got a few hours of it — and every subscriber resuming past that horizon
+	 * gets a gap. Whichever cap wins, it is now named.
+	 */
+	private async reportRetentionHorizon(
+		tx: AnyDrizzleClient<any>,
+	): Promise<void> {
+		if (this.config.retentionBytes <= 0 || this.config.retentionMs <= 0) return;
+		const [totals] = await tx
+			.select({
+				retainedBytes: sql<number>`coalesce(sum(${questpieChannelEventTable.sizeBytes}), 0)::bigint`,
+				oldest: sql<Date | null>`min(${questpieChannelEventTable.createdAt})`,
+			})
+			.from(questpieChannelEventTable);
+		const retainedBytes = Number(totals?.retainedBytes ?? 0);
+		if (retainedBytes <= this.config.retentionBytes) return;
+		const oldest = totals?.oldest ? new Date(totals.oldest) : null;
+		const cutoff = Date.now() - this.config.retentionMs;
+		if (oldest && oldest.getTime() < cutoff) return;
+		this.logger?.warn(
+			`[Realtime] Channel retentionBytes (${this.config.retentionBytes}) is the binding retention horizon, not retentionMs (${this.config.retentionMs}). Retained ${retainedBytes} bytes of events, none of them old enough to expire. Subscribers resuming past the byte horizon will receive a channel gap.`,
+		);
+	}
+
+	/**
+	 * One node per cluster runs a retention pass.
+	 *
+	 * Unlike shared dispatch, cleanup had no lease of any kind, so every node
+	 * did the whole thing and the cost scaled with the fleet. The lock is
+	 * transaction-scoped so it cannot outlive a crashed pass.
+	 */
+	private async admitCleanup(tx: AnyDrizzleClient<any>): Promise<boolean> {
+		try {
+			const result = await tx.execute(
+				sql`select pg_try_advisory_xact_lock(hashtext('questpie_channel_event_cleanup')) as admitted`,
+			);
+			const [row] = Array.isArray(result) ? result : (result?.rows ?? []);
+			// A driver that cannot report the result is treated as admitted: an
+			// unnecessary pass is now cheap, a skipped one is unbounded growth.
+			if (typeof row?.admitted === "boolean") return row.admitted;
+			return true;
+		} catch {
+			return true;
 		}
 	}
 
@@ -907,7 +998,58 @@ export class ChannelEventLedger {
 		);
 	}
 
-	private async readEvents(
+	/**
+	 * Refuse to deliver across a hole in an already-connected subscriber's log.
+	 *
+	 * Gap detection used to exist only at subscribe and replay. On the live
+	 * drain path a subscriber whose unread rows were removed underneath it —
+	 * exactly what retention cleanup does on another node — simply received the
+	 * next surviving row: seq 1,2,3,6 with no gap frame, no close and no log.
+	 * The subscription is torn down here and the sink is left open, which is
+	 * the same shape the subscribe-time gap branch already hands the client.
+	 */
+	private async admitContiguous(
+		subscription: LocalSubscription,
+		row: ChannelEventRow,
+	): Promise<boolean> {
+		if (Number(row.seq) === subscription.readSeq + 1) return true;
+		this.observe({ type: "resume", outcome: "gap" });
+		this.logger?.warn(
+			`[Realtime] Channel "${subscription.channel}" delivery gap: expected seq ${
+				subscription.readSeq + 1
+			}, read seq ${Number(row.seq)}. Retained events no longer cover this subscriber.`,
+		);
+		const [oldest] = await this.db
+			.select({ eventId: questpieChannelEventTable.eventId })
+			.from(questpieChannelEventTable)
+			.where(
+				eq(questpieChannelEventTable.channelHash, subscription.channelHash),
+			)
+			.orderBy(asc(questpieChannelEventTable.seq))
+			.limit(1);
+		const frame: ChannelGapFrame = {
+			type: "channel_gap",
+			channel: subscription.channel,
+			requestedEventId: channelEventId(
+				subscription.channelHash,
+				subscription.readSeq,
+			),
+			oldestEventId: oldest?.eventId ?? null,
+		};
+		try {
+			await subscription.sink.write(
+				this.encodeLocalFrame(frame, subscription.encodeFrame),
+				"ordered-channel-event",
+			);
+		} finally {
+			// A sink that cannot take the gap frame must still stop receiving a
+			// stream it can no longer trust.
+			await this.releaseLocalSubscription(subscription);
+		}
+		return false;
+	}
+
+	private async selectEvents(
 		channelHash: string,
 		afterSeq: number,
 	): Promise<ChannelEventRow[]> {
@@ -922,6 +1064,44 @@ export class ChannelEventLedger {
 			)
 			.orderBy(asc(questpieChannelEventTable.seq))
 			.limit(this.config.batchSize);
+	}
+
+	/**
+	 * Read one page of a channel's log, keyed by TOPIC rather than by
+	 * subscriber.
+	 *
+	 * Every delivery path re-drains the ledger, so a fan-out wakes every
+	 * subscriber on a channel at once and each one used to issue its own
+	 * identical `seq > cursor` scan: 50 subscribers on one channel cost 50
+	 * index scans for one event. Concurrent readers of the same channel now
+	 * share the in-flight page instead.
+	 *
+	 * A page that hit `batchSize` is deliberately not shared with a reader at a
+	 * higher cursor: its length no longer answers "is there more after you",
+	 * which is what the drain loops test to decide whether to read again.
+	 */
+	private async readEvents(
+		channelHash: string,
+		afterSeq: number,
+	): Promise<ChannelEventRow[]> {
+		const inflight = this.channelReads.get(channelHash);
+		if (inflight && inflight.afterSeq <= afterSeq) {
+			const shared = await inflight.page;
+			if (shared.length < this.config.batchSize) {
+				return inflight.afterSeq === afterSeq
+					? shared
+					: shared.filter((row) => Number(row.seq) > afterSeq);
+			}
+		}
+		const page = this.selectEvents(channelHash, afterSeq);
+		this.channelReads.set(channelHash, { afterSeq, page });
+		try {
+			return await page;
+		} finally {
+			if (this.channelReads.get(channelHash)?.page === page) {
+				this.channelReads.delete(channelHash);
+			}
+		}
 	}
 
 	private async drainLocalSubscription(
@@ -962,6 +1142,7 @@ export class ChannelEventLedger {
 					);
 					if (rows.length === 0) break;
 					for (const row of rows) {
+						if (!(await this.admitContiguous(subscription, row))) return;
 						if (!this.enqueueLocal(subscription, row)) return;
 						subscription.readSeq = Number(row.seq);
 					}
@@ -1003,6 +1184,7 @@ export class ChannelEventLedger {
 			);
 			if (rows.length === 0) return;
 			for (const row of rows) {
+				if (!(await this.admitContiguous(subscription, row))) return;
 				if (!this.enqueueLocal(subscription, row)) return;
 				subscription.readSeq = Number(row.seq);
 			}
@@ -1263,19 +1445,44 @@ export class ChannelEventLedger {
 		let requestedChannelHash = channelHash;
 		do {
 			this.sharedDrainPending = false;
-			const heads = requestedChannelHash
-				? await this.db
-						.select()
-						.from(questpieChannelHeadTable)
-						.where(
-							eq(questpieChannelHeadTable.channelHash, requestedChannelHash),
-						)
-				: await this.db.select().from(questpieChannelHeadTable);
+			const heads = await this.pendingSharedChannels(requestedChannelHash);
 			for (const head of heads) await this.drainSharedChannel(head.channelHash);
 			// A wake racing this drain may target a different channel. The retry
 			// therefore reconciles all heads instead of trusting the first hint.
 			requestedChannelHash = undefined;
 		} while (this.sharedDrainPending);
+	}
+
+	/**
+	 * Channels whose head is ahead of the published cursor.
+	 *
+	 * The drain used to enumerate every head row that had ever existed and take
+	 * — then release — a coordinator lease on each one, so a fleet with a large
+	 * channel space paid two writes per idle channel on every pass, and a
+	 * single wake that raced an in-flight drain re-scanned the whole table.
+	 * Only channels with undelivered events are visited now.
+	 */
+	private async pendingSharedChannels(
+		channelHash?: string,
+	): Promise<Array<{ channelHash: string }>> {
+		return this.db
+			.select({ channelHash: questpieChannelHeadTable.channelHash })
+			.from(questpieChannelHeadTable)
+			.leftJoin(
+				questpieChannelDispatchTable,
+				eq(
+					questpieChannelDispatchTable.channelHash,
+					questpieChannelHeadTable.channelHash,
+				),
+			)
+			.where(
+				and(
+					sql`${questpieChannelHeadTable.lastSeq} > coalesce(${questpieChannelDispatchTable.publishedSeq}, 0)`,
+					...(channelHash
+						? [eq(questpieChannelHeadTable.channelHash, channelHash)]
+						: []),
+				),
+			);
 	}
 
 	private async drainSharedChannel(channelHash: string): Promise<void> {

--- a/packages/questpie/src/server/modules/core/integrated/realtime/collection.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/collection.ts
@@ -75,20 +75,6 @@ export const questpieRealtimeLogTable = pgTable(
 	],
 );
 
-/**
- * Global outbox sequence head.
- *
- * @deprecated Unused since the capture path stopped serializing on it. Kept so
- * upgrading applications do not need a DROP TABLE migration; no code reads or
- * writes it. `questpie_realtime_log.seq` is the sequence of record and
- * `(txid, seq)` is the drain cursor.
- */
-export const questpieRealtimeHeadTable = pgTable("questpie_realtime_head", {
-	id: text("id").primaryKey(),
-	lastSeq: bigint("last_seq", { mode: "number" }).default(0).notNull(),
-	updatedAt: systemTimestamp("updated_at").defaultNow().notNull(),
-});
-
 /** Per-resolved-channel sequence head. Updating this row serializes publishers. */
 export const questpieChannelHeadTable = pgTable("questpie_channel_head", {
 	channelHash: text("channel_hash").primaryKey(),

--- a/packages/questpie/src/server/modules/core/integrated/realtime/collection.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/collection.ts
@@ -63,11 +63,26 @@ export const questpieRealtimeLogTable = pgTable(
 		locale: text("locale"),
 		payload: jsonbSafe("payload").default({}),
 		createdAt: systemTimestamp("created_at").defaultNow().notNull(),
+		/** First cleanup observation after this transaction fell below snapshot xmin. */
+		settledAt: systemTimestamp("settled_at"),
 	},
-	(t) => [index("idx_realtime_log_created_at").on(t.createdAt)],
+	(t) => [
+		index("idx_realtime_log_created_at").on(t.createdAt),
+		index("idx_realtime_log_settled_at").on(t.settledAt),
+		// The drain cursor is `(txid, seq)`, not `seq` — see RealtimeService.
+		// Without this index every drain would sort the whole retained log.
+		index("idx_realtime_log_txid_seq").on(t.txid, t.seq),
+	],
 );
 
-/** Global outbox sequence head. Updating this row serializes commit cursors. */
+/**
+ * Global outbox sequence head.
+ *
+ * @deprecated Unused since the capture path stopped serializing on it. Kept so
+ * upgrading applications do not need a DROP TABLE migration; no code reads or
+ * writes it. `questpie_realtime_log.seq` is the sequence of record and
+ * `(txid, seq)` is the drain cursor.
+ */
 export const questpieRealtimeHeadTable = pgTable("questpie_realtime_head", {
 	id: text("id").primaryKey(),
 	lastSeq: bigint("last_seq", { mode: "number" }).default(0).notNull(),

--- a/packages/questpie/src/server/modules/core/integrated/realtime/delta.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/delta.ts
@@ -1,4 +1,7 @@
-import type { RealtimeStreamEvent } from "#questpie/client/realtime/stream.js";
+import type {
+	RealtimeDeltaDeleteReason,
+	RealtimeStreamEvent,
+} from "#questpie/client/realtime/stream.js";
 
 import type { RealtimeOperation } from "./types.js";
 
@@ -138,21 +141,50 @@ export function classifyRealtimeDelivery(
 
 export type RealtimeDeltaOp = "insert" | "update" | "delete" | "noop";
 
+/**
+ * A keyed operation plus, for a removal, why the row left.
+ *
+ * The reason needs no row image, so it is available for batch mutations too,
+ * whose payload carries only `{count, recordIds}`: the outbox already separates
+ * a predicate exit (`update`/`bulk_update`) from a removal (`delete`/
+ * `bulk_delete`, which covers hard deletes, soft deletes and purges alike).
+ */
+export type RealtimeDeltaDerivation =
+	| { op: Exclude<RealtimeDeltaOp, "delete"> }
+	| { op: "delete"; reason: RealtimeDeltaDeleteReason };
+
+function removesRow(operation: RealtimeOperation): boolean {
+	return operation === "delete" || operation === "bulk_delete";
+}
+
 /** Derive a keyed operation after the current row was authoritatively hydrated. */
 export function deriveDeltaOp(input: {
 	present: boolean;
 	operation: RealtimeOperation;
 	beforeMatch?: boolean | null;
-}): RealtimeDeltaOp {
+	/**
+	 * Another event in the same hydration batch removed this key. One batch is
+	 * hydrated once, so `present` already reflects every event in it: a row that
+	 * is updated out of the predicate and then deleted has to report `deleted`,
+	 * not the first event's `left_predicate`.
+	 */
+	deletedInBatch?: boolean;
+}): RealtimeDeltaDerivation {
 	if (input.present) {
 		if (input.operation === "create" || input.beforeMatch === false) {
-			return "insert";
+			return { op: "insert" };
 		}
-		return "update";
+		return { op: "update" };
 	}
 
 	if (input.operation === "create" || input.beforeMatch === false) {
-		return "noop";
+		return { op: "noop" };
 	}
-	return "delete";
+	return {
+		op: "delete",
+		reason:
+			input.deletedInBatch || removesRow(input.operation)
+				? "deleted"
+				: "left_predicate",
+	};
 }

--- a/packages/questpie/src/server/modules/core/integrated/realtime/refresh-scheduler.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/refresh-scheduler.ts
@@ -18,6 +18,12 @@ type RealtimeSource = {
 	getResumeState?(sinceSeq: number): Promise<{
 		latestSeq: number;
 		reset: boolean;
+		/**
+		 * Whether the resuming client is provably up to date. Only the service
+		 * can decide this: `latestSeq === sinceSeq` does not imply it, because a
+		 * lower sequence can settle after a higher one.
+		 */
+		current: boolean;
 	}>;
 	subscribe(
 		listener: (event: RealtimeChangeEvent) => void,
@@ -763,6 +769,18 @@ export class RealtimeRefreshScheduler {
 					group.resetQueued = true;
 					continue;
 				}
+				// One hydration answers for the whole batch, so a key deleted by any
+				// event in it is deleted, whatever an earlier event did to it.
+				const deletedIds = new Set<string>();
+				for (const event of events) {
+					if (
+						event.operation !== "delete" &&
+						event.operation !== "bulk_delete"
+					) {
+						continue;
+					}
+					for (const key of eventRecordIds(event)!) deletedIds.add(key);
+				}
 				const upToDate = await group.captureWatermark?.();
 				this.observe({
 					type: "routing.authoritative_db",
@@ -791,20 +809,21 @@ export class RealtimeRefreshScheduler {
 					for (const key of eventRecordIds(event)!) {
 						const row = rowsById.get(key);
 						const previousHash = group.rowHashes.get(key);
-						const operation = deriveDeltaOp({
+						const derived = deriveDeltaOp({
 							present: row !== undefined,
 							operation: event.operation,
 							beforeMatch: previousHash !== undefined,
+							deletedInBatch: deletedIds.has(key),
 						});
 						if (row !== undefined) {
 							const hash = await sha256(JSON.stringify(row));
 							group.rowHashes.set(key, hash);
-							if (operation !== "noop" && hash !== previousHash) {
+							if (derived.op !== "noop" && hash !== previousHash) {
 								this.deliverDeltaEvent(
 									group,
-									operation,
+									derived.op,
 									{
-										type: operation,
+										type: derived.op,
 										seq: event.seq,
 										...(event.txid ? { txid: event.txid } : {}),
 										key,
@@ -815,10 +834,10 @@ export class RealtimeRefreshScheduler {
 							} else {
 								this.observe({
 									type: "delta.suppressed",
-									reason: operation === "noop" ? "noop" : "unchanged",
+									reason: derived.op === "noop" ? "noop" : "unchanged",
 								});
 							}
-						} else if (operation === "delete") {
+						} else if (derived.op === "delete") {
 							group.rowHashes.delete(key);
 							this.deliverDeltaEvent(
 								group,
@@ -828,6 +847,7 @@ export class RealtimeRefreshScheduler {
 									seq: event.seq,
 									...(event.txid ? { txid: event.txid } : {}),
 									key,
+									reason: derived.reason,
 								},
 								"delta",
 							);
@@ -984,21 +1004,18 @@ export class RealtimeRefreshScheduler {
 
 	private async initialize(group: SchedulerGroup): Promise<void> {
 		try {
-			let resume: { latestSeq: number; reset: boolean };
+			let resume: { latestSeq: number; reset: boolean; current: boolean };
 			if (group.sinceSeq !== undefined && this.realtime.getResumeState) {
 				resume = await this.realtime.getResumeState(group.sinceSeq);
 			} else {
 				resume = {
 					latestSeq: await this.realtime.getLatestSeq(),
 					reset: false,
+					current: false,
 				};
 			}
 			const { latestSeq } = resume;
-			if (
-				group.sinceSeq !== undefined &&
-				latestSeq === group.sinceSeq &&
-				!resume.reset
-			) {
+			if (group.sinceSeq !== undefined && resume.current && !resume.reset) {
 				group.lastSeq = latestSeq;
 				this.observe({ type: "resume", outcome: "current" });
 				return;

--- a/packages/questpie/src/server/modules/core/integrated/realtime/service.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/service.ts
@@ -1,4 +1,4 @@
-import { asc, desc, eq, gt, lt } from "drizzle-orm";
+import { and, asc, desc, isNull, lt, sql } from "drizzle-orm";
 
 import {
 	opaqueChannelAuthoritySubject,
@@ -27,10 +27,7 @@ import {
 	hashResolvedChannel,
 	type LocalChannelSubscriptionInput,
 } from "./channel-event-ledger.js";
-import {
-	questpieRealtimeHeadTable,
-	questpieRealtimeLogTable,
-} from "./collection.js";
+import { questpieRealtimeLogTable } from "./collection.js";
 import {
 	RealtimeObservability,
 	type RealtimeMetricsSnapshot,
@@ -86,6 +83,36 @@ type AppendChangeInput = Omit<
 const DEFAULT_RETENTION_DAYS = 3;
 const DEFAULT_ADAPTER_RECONCILIATION_INTERVAL_MS = 15_000;
 
+/**
+ * Where one node has read to in the outbox, in the order changes settle.
+ *
+ * `seq` alone cannot express this: it is allocated when a row is inserted, not
+ * when its transaction commits, so a lower `seq` can settle after a higher one.
+ */
+type RealtimeDrainCursor = { txid: string; seq: number };
+
+/** Before any row: xid8 0 is below every assigned transaction id. */
+const EMPTY_DRAIN_CURSOR: RealtimeDrainCursor = { txid: "0", seq: 0 };
+
+/** How soon to look again when a committed change is not yet readable. */
+const SETTLEMENT_RETRY_MS = 250;
+
+/**
+ * Is this change strictly after the cursor in settled order?
+ *
+ * The read already says so in SQL; this keeps the same promise on the way out,
+ * so no driver quirk can turn "read from here" into a replay.
+ */
+function isAfterCursor(
+	event: Pick<RealtimeChangeEvent, "seq" | "txid">,
+	cursor: RealtimeDrainCursor,
+): boolean {
+	if (event.txid === undefined) return event.seq > cursor.seq;
+	const txid = BigInt(event.txid);
+	const from = BigInt(cursor.txid);
+	return txid > from || (txid === from && event.seq > cursor.seq);
+}
+
 type ListenerEntry = {
 	listener: RealtimeListener;
 	errorListener?: RealtimeErrorListener;
@@ -124,8 +151,9 @@ export class RealtimeService {
 	private startPromise: Promise<void> | null = null;
 	private publisherStartPromise: Promise<void> | null = null;
 	private publisherStarted = false;
-	private lastSeq = 0;
+	private cursor: RealtimeDrainCursor = EMPTY_DRAIN_CURSOR;
 	private pollTimer: ReturnType<typeof setInterval> | null = null;
+	private settlementRetryTimer: ReturnType<typeof setTimeout> | null = null;
 	private subscriptionContext?: RealtimeSubscriptionContext;
 	private retentionDays?: number;
 	private retentionCleanupIntervalMs: number;
@@ -342,25 +370,21 @@ export class RealtimeService {
 		input: AppendChangeInput,
 		db: DrizzleClientFromQuestpieConfig<any>,
 	): Promise<RealtimeChangeEvent> {
-		// The head-row lock must remain held until the outbox insert commits. This
-		// makes sequence order commit order for native delta cursors.
+		// Capture takes no fleet-wide lock. It used to UPDATE a single head row so
+		// that sequence order was commit order, and PostgreSQL holds that row lock
+		// until COMMIT — on the *caller's* business transaction. So exactly one
+		// capture in the whole cluster could be in flight at a time: measured
+		// throughput FELL as writers were added (57 -> 44 -> 35 captures/s at
+		// 4 -> 8 -> 16 writers, against 115 -> 145 -> 267 without it), one long
+		// transaction starved every other writer for its whole duration, and the
+		// head row was a mid-transaction lock-ordering point that turned ordinary
+		// row conflicts into deadlocks.
+		//
+		// Readers no longer need sequence order to be commit order: `readAfter`
+		// walks the log in `(txid, seq)` order below PostgreSQL's own visibility
+		// watermark. See `readAfter` for why that is gap-free.
 		let row: typeof questpieRealtimeLogTable.$inferSelect;
 		try {
-			// `last_seq` on this row is written and never read — the cursor of record
-			// is `questpie_realtime_log.seq`. Seeding it with `max(seq)` cost an
-			// InitPlan over the whole log on every capture, including the common
-			// case where the row already exists and the insert does nothing.
-			await db
-				.insert(questpieRealtimeHeadTable)
-				.values({ id: "global" })
-				.onConflictDoNothing();
-			const [head] = await db
-				.update(questpieRealtimeHeadTable)
-				.set({ updatedAt: new Date() })
-				.where(eq(questpieRealtimeHeadTable.id, "global"))
-				.returning({ id: questpieRealtimeHeadTable.id });
-			if (!head)
-				throw new Error("Realtime outbox sequence head is unavailable");
 			[row] = await db
 				.insert(questpieRealtimeLogTable)
 				.values({
@@ -1146,24 +1170,77 @@ export class RealtimeService {
 		};
 	}
 
+	/**
+	 * The highest sequence that is settled fleet-wide.
+	 *
+	 * Deliberately NOT `max(seq)`. Without the head lock a visible row can still
+	 * be un-settled — its transaction id may sit above the current watermark
+	 * while an older transaction is open — and a stamp taken from such a row is
+	 * not a value the scheduler may stamp. The returned row itself is settled;
+	 * lower sequence numbers may still belong to later transaction ids, so the
+	 * scalar remains a resume hint rather than the drain cursor.
+	 */
 	async getLatestSeq(): Promise<number> {
-		const rows = await this.db
-			.select({ seq: questpieRealtimeLogTable.seq })
-			.from(questpieRealtimeLogTable)
-			.orderBy(desc(questpieRealtimeLogTable.seq))
-			.limit(1);
-		return rows[0]?.seq ? Number(rows[0].seq) : 0;
+		const rows = await this.readSettledSeqHead();
+		return rows?.seq ?? 0;
 	}
 
-	async getResumeState(
-		sinceSeq: number,
-	): Promise<{ latestSeq: number; reset: boolean }> {
-		const latestSeq = await this.getLatestSeq();
-		if (sinceSeq === latestSeq) return { latestSeq, reset: false };
-		if (sinceSeq < 0 || sinceSeq > latestSeq) {
-			return { latestSeq, reset: true };
+	private async readSettledSeqHead(): Promise<{
+		seq: number;
+		txid: string;
+	} | null> {
+		const rows = await this.db
+			.select({
+				seq: questpieRealtimeLogTable.seq,
+				txid: questpieRealtimeLogTable.txid,
+			})
+			.from(questpieRealtimeLogTable)
+			.where(
+				sql`${questpieRealtimeLogTable.txid} < pg_snapshot_xmin(pg_current_snapshot())`,
+			)
+			.orderBy(desc(questpieRealtimeLogTable.seq))
+			.limit(1);
+		const row = rows[0];
+		if (!row?.txid) return null;
+		return { seq: Number(row.seq), txid: String(row.txid) };
+	}
+
+	/**
+	 * Decide what a resuming subscriber owes its client.
+	 *
+	 * `current` means "provably nothing happened that this client has not
+	 * already applied", which is what lets a deploy-restart storm reconnect
+	 * without every topic recomputing. It is only claimed when BOTH hold:
+	 *
+	 * - `sinceSeq` is the settled head, so the client's own data was computed
+	 *   from a snapshot at or after the moment that row settled, and
+	 * - no visible row has a transaction id above that row's, so nothing has
+	 *   committed since — including rows whose `seq` is *lower* than
+	 *   `sinceSeq`, which is exactly the case a `seq` comparison cannot see.
+	 *
+	 * Anything else falls back to one authoritative recompute, which is
+	 * suppressed on the wire when the result hashes the same.
+	 */
+	async getResumeState(sinceSeq: number): Promise<{
+		latestSeq: number;
+		reset: boolean;
+		current: boolean;
+	}> {
+		const settled = await this.readSettledSeqHead();
+		const latestSeq = settled?.seq ?? 0;
+		if (sinceSeq === latestSeq && settled) {
+			const newestTxid = await this.readNewestTxid();
+			// String compare would order "9" after "10"; xid8 is a 64-bit counter.
+			const current =
+				newestTxid !== null && BigInt(newestTxid) <= BigInt(settled.txid);
+			if (current) return { latestSeq, reset: false, current: true };
 		}
-		if (latestSeq === 0) return { latestSeq, reset: sinceSeq !== 0 };
+		if (sinceSeq < 0 || sinceSeq > latestSeq) {
+			return { latestSeq, reset: true, current: false };
+		}
+		if (latestSeq === 0) {
+			return { latestSeq, reset: sinceSeq !== 0, current: false };
+		}
 
 		const rows = await this.db
 			.select({ seq: questpieRealtimeLogTable.seq })
@@ -1171,10 +1248,55 @@ export class RealtimeService {
 			.orderBy(asc(questpieRealtimeLogTable.seq))
 			.limit(1);
 		const oldestSeq = rows[0]?.seq ? Number(rows[0].seq) : latestSeq;
-		return { latestSeq, reset: sinceSeq < oldestSeq - 1 };
+		return { latestSeq, reset: sinceSeq < oldestSeq - 1, current: false };
 	}
 
-	private async readSince(seq: number): Promise<RealtimeChangeEvent[]> {
+	/**
+	 * Newest transaction id in the visible log, settled or not.
+	 *
+	 * Rows written before `txid` existed (3.17) have none, and PostgreSQL sorts
+	 * those first under `DESC`, so a log still holding them answers `null` and
+	 * the resume fast path stays off until retention clears them.
+	 */
+	private async readNewestTxid(): Promise<string | null> {
+		const rows = await this.db
+			.select({ txid: questpieRealtimeLogTable.txid })
+			.from(questpieRealtimeLogTable)
+			.orderBy(desc(questpieRealtimeLogTable.txid))
+			.limit(1);
+		const txid = rows[0]?.txid;
+		return txid == null ? null : String(txid);
+	}
+
+	/**
+	 * Read the next batch of changes in the fleet-wide settled order.
+	 *
+	 * Two rules together make this gap-free without any lock:
+	 *
+	 * 1. Only rows whose `txid` is strictly below the reading snapshot's `xmin`
+	 *    are eligible. Every transaction with an id below `xmin` has already
+	 *    ended, so that set is stable and only ever grows.
+	 * 2. The cursor is the composite `(txid, seq)`, ordered by `txid` then `seq`.
+	 *    When `xmin` advances, every newly eligible row has `txid >=` the
+	 *    previous `xmin`, which is strictly greater than the cursor's `txid`
+	 *    (rule 1 keeps the cursor below the watermark it was read at). So new
+	 *    rows always sort after everything already read, and the visible prefix
+	 *    stays contiguous.
+	 *
+	 * The `seq` half of the cursor alone is NOT enough. Transaction ids and
+	 * `seq` are assigned independently and can invert: a transaction that took
+	 * its xid early but appended late gets a low `txid` with a high `seq`, so a
+	 * `WHERE seq > cursor` reader advances past a lower `seq` that is still
+	 * uncommitted and skips it forever once it commits. That is measured, not
+	 * theoretical — see `.private/realtime-research-2026-08-05/probes/
+	 * xid-seq-inversion.ts`, which fails against the seq-only cursor.
+	 *
+	 * Aborted transactions need no handling: their rows are never visible, and
+	 * a row is only eligible once its transaction has ended.
+	 */
+	private async readAfter(
+		cursor: RealtimeDrainCursor,
+	): Promise<RealtimeChangeEvent[]> {
 		const rows = await this.db
 			.select({
 				seq: questpieRealtimeLogTable.seq,
@@ -1188,8 +1310,16 @@ export class RealtimeService {
 				createdAt: questpieRealtimeLogTable.createdAt,
 			})
 			.from(questpieRealtimeLogTable)
-			.where(gt(questpieRealtimeLogTable.seq, seq))
-			.orderBy(asc(questpieRealtimeLogTable.seq))
+			.where(
+				and(
+					sql`${questpieRealtimeLogTable.txid} < pg_snapshot_xmin(pg_current_snapshot())`,
+					sql`(${questpieRealtimeLogTable.txid}, ${questpieRealtimeLogTable.seq}) > (${cursor.txid}::text::xid8, ${cursor.seq}::bigint)`,
+				),
+			)
+			.orderBy(
+				asc(questpieRealtimeLogTable.txid),
+				asc(questpieRealtimeLogTable.seq),
+			)
 			.limit(this.batchSize);
 
 		return rows
@@ -1204,7 +1334,33 @@ export class RealtimeService {
 				payload: (row.payload ?? {}) as RealtimeChangePayload,
 				createdAt: row.createdAt,
 			}))
-			.filter((event) => event.seq > seq);
+			.filter((event) => isAfterCursor(event, cursor));
+	}
+
+	/**
+	 * The newest settled position: the log's composite head below the visibility
+	 * watermark. A booting node adopts it so it delivers what happens next
+	 * instead of replaying the retained log, and never adopts a position that
+	 * could still be overtaken by an open transaction.
+	 */
+	private async readSettledHead(): Promise<RealtimeDrainCursor> {
+		const rows = await this.db
+			.select({
+				seq: questpieRealtimeLogTable.seq,
+				txid: questpieRealtimeLogTable.txid,
+			})
+			.from(questpieRealtimeLogTable)
+			.where(
+				sql`${questpieRealtimeLogTable.txid} < pg_snapshot_xmin(pg_current_snapshot())`,
+			)
+			.orderBy(
+				desc(questpieRealtimeLogTable.txid),
+				desc(questpieRealtimeLogTable.seq),
+			)
+			.limit(1);
+		const row = rows[0];
+		if (!row?.txid) return EMPTY_DRAIN_CURSOR;
+		return { txid: String(row.txid), seq: Number(row.seq) };
 	}
 
 	private async ensureStarted(): Promise<void> {
@@ -1216,8 +1372,7 @@ export class RealtimeService {
 
 		this.startPromise = (async () => {
 			const signalGeneration = this.drainSignalGeneration;
-			const latestSeq = await this.getLatestSeq();
-			this.lastSeq = latestSeq;
+			this.cursor = await this.readSettledHead();
 			this.started = true;
 			await this.initialize();
 
@@ -1297,6 +1452,10 @@ export class RealtimeService {
 			clearInterval(this.pollTimer);
 			this.pollTimer = null;
 		}
+		if (this.settlementRetryTimer) {
+			clearTimeout(this.settlementRetryTimer);
+			this.settlementRetryTimer = null;
+		}
 		if (this.channelPollTimer) {
 			clearInterval(this.channelPollTimer);
 			this.channelPollTimer = null;
@@ -1321,18 +1480,21 @@ export class RealtimeService {
 		}
 		this.draining = true;
 		const startedAt = performance.now();
-		const initialSeq = this.lastSeq;
+		const initialSeq = this.cursor.seq;
 		let rows = 0;
 		let newestCreatedAt: Date | undefined;
 
 		try {
 			while (true) {
-				const events = await this.readSince(this.lastSeq);
+				const events = await this.readAfter(this.cursor);
 				if (events.length === 0) break;
 				rows += events.length;
 				newestCreatedAt = events.at(-1)?.createdAt;
 
-				this.lastSeq = events[events.length - 1].seq;
+				const last = events[events.length - 1];
+				// `readAfter` filters on `txid`, so a row reaching here without one
+				// only happens behind a test double; keep the cursor's own id then.
+				this.cursor = { txid: last.txid ?? this.cursor.txid, seq: last.seq };
 				for (const event of events) {
 					this.emit(event);
 				}
@@ -1343,7 +1505,7 @@ export class RealtimeService {
 				type: "drain.completed",
 				reason,
 				rows,
-				seqDelta: Math.max(0, this.lastSeq - initialSeq),
+				seqDelta: Math.max(0, this.cursor.seq - initialSeq),
 				lagMs: newestCreatedAt
 					? Math.max(0, Date.now() - newestCreatedAt.getTime())
 					: 0,
@@ -1360,8 +1522,51 @@ export class RealtimeService {
 
 			if (shouldDrainAgain) {
 				this.drainSafely(reason);
+			} else {
+				this.scheduleSettlementRetry();
 			}
 		}
+	}
+
+	/**
+	 * Come back for changes that are committed but not yet readable.
+	 *
+	 * A change is only drained once its transaction id falls below the reading
+	 * snapshot's `xmin`, which an OLDER open write transaction holds back. The
+	 * publisher's own wake-up already fired by then, so without this the change
+	 * would wait for the next reconciliation poll — 15 seconds by default —
+	 * every time any long write transaction overlaps it.
+	 *
+	 * The probe asks for any row after the cursor, not only one currently above
+	 * `xmin`: the blocker can end between the empty drain statement and this
+	 * statement. In that race the row is already readable, but still needs the
+	 * retry because its original broker wake has passed.
+	 */
+	private scheduleSettlementRetry(): void {
+		if (!this.started || this.settlementRetryTimer) return;
+		void this.hasPendingChange()
+			.then((pending) => {
+				if (!pending || !this.started || this.settlementRetryTimer) return;
+				this.settlementRetryTimer = setTimeout(() => {
+					this.settlementRetryTimer = null;
+					this.drainSafely("poll");
+				}, SETTLEMENT_RETRY_MS);
+			})
+			.catch((error) => {
+				this.logger?.warn("[Realtime] Settlement probe failed", error);
+			});
+	}
+
+	/** Is any visible change still beyond this node's composite cursor? */
+	private async hasPendingChange(): Promise<boolean> {
+		const rows = await this.db
+			.select({ seq: questpieRealtimeLogTable.seq })
+			.from(questpieRealtimeLogTable)
+			.where(
+				sql`(${questpieRealtimeLogTable.txid}, ${questpieRealtimeLogTable.seq}) > (${this.cursor.txid}::text::xid8, ${this.cursor.seq}::bigint)`,
+			)
+			.limit(1);
+		return rows.length > 0;
 	}
 
 	private emit(event: RealtimeChangeEvent): void {
@@ -1446,9 +1651,25 @@ export class RealtimeService {
 			const cutoff = new Date(
 				now - (this.retentionDays as number) * 24 * 60 * 60 * 1000,
 			);
+			// Retention starts when a row is first OBSERVED as settled, not when its
+			// transaction inserted it. `created_at` is the transaction start time, so
+			// an old transaction can commit a row that is already beyond the retention
+			// window while an even older xid still keeps it above the drain frontier.
+			// Deleting by `created_at` would erase that row before any node was allowed
+			// to read it. Marking only rows below the same xmin gate as `readAfter`
+			// gives every newly drainable prefix a full retention window.
+			await this.db
+				.update(questpieRealtimeLogTable)
+				.set({ settledAt: new Date(now) })
+				.where(
+					and(
+						isNull(questpieRealtimeLogTable.settledAt),
+						sql`${questpieRealtimeLogTable.txid} < pg_snapshot_xmin(pg_current_snapshot())`,
+					),
+				);
 			await this.db
 				.delete(questpieRealtimeLogTable)
-				.where(lt(questpieRealtimeLogTable.createdAt, cutoff));
+				.where(lt(questpieRealtimeLogTable.settledAt, cutoff));
 		} catch (error) {
 			// Best-effort cleanup; keep realtime delivery resilient to cleanup failures.
 			this.logger?.warn("[Realtime] Outbox cleanup failed", error);

--- a/packages/questpie/src/server/modules/core/integrated/realtime/types.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/types.ts
@@ -109,16 +109,57 @@ export type RealtimeSubscriptionScopeResolver = (
 
 export interface RealtimeConfig {
 	/**
-	 * Enables native row-delta emission after every writer replica has been
-	 * upgraded to the commit-order outbox protocol. Keep disabled during the
-	 * first phase of a rolling deployment; snapshot realtime remains available.
+	 * Enables native row-delta emission once every replica reads the outbox in
+	 * settled `(txid, seq)` order. Keep disabled during the first phase of a
+	 * rolling deployment: a replica still ordering by sequence alone can skip a
+	 * row. Snapshot realtime remains available throughout.
 	 *
 	 * @default false
 	 */
 	nativeDeltas?: boolean;
 	/**
-	 * Authoritative server switch for collection/global row live queries.
-	 * Change capture, dependency watches, typed channels, and CRDT stay enabled.
+	 * Records collection and global mutations to the realtime outbox — the
+	 * write side of collection realtime, and the only source row live queries
+	 * can be served from.
+	 *
+	 * While enabled (the default), every collection and global mutation writes a
+	 * before/after scalar image to `questpie_realtime_log`, retained
+	 * {@link retentionDays} days. That is one insert, taking no shared lock, so
+	 * concurrent writers do not queue behind each other — but the cost is paid on
+	 * every write whether or not anything is subscribed.
+	 *
+	 * Turn it off when the application uses typed channels only, or no realtime
+	 * at all. Capture then issues no SQL at all: no outbox insert, no drain, no
+	 * retention cleanup.
+	 *
+	 * What is given up, in full:
+	 * - **Collection and global realtime.** Every `collection`/`global` topic is
+	 *   refused at admission with `change_capture_disabled`, including topics
+	 *   that only watch a resource as a relation dependency.
+	 * - **Resume.** With no outbox there is nothing for `sinceSeq` to replay, so
+	 *   a reconnecting client cannot catch up on what it missed.
+	 * - **`txid` correlation.** Mutations stop returning a transaction id, so
+	 *   `getTxid()` is `undefined` and optimistic clients (`@questpie/tanstack-db`)
+	 *   cannot match a local write against a server frame.
+	 *
+	 * What still works: typed channels and their ordered ledger, channel
+	 * presence, CRDT document sync, and every ordinary read and write. CRDT
+	 * canonical projection is the single exception that keeps writing outbox
+	 * rows — its commit protocol requires exactly one row per commit.
+	 *
+	 * @see {@link rowLiveQueries} — the narrower, read-side sibling.
+	 * @default true
+	 */
+	changeCapture?: boolean;
+	/**
+	 * Serves collection/global row live queries. Refusing them here leaves
+	 * change capture, dependency watches, typed channels, and CRDT enabled: the
+	 * outbox is still written, so `txid` correlation and resume keep working and
+	 * row topics can be re-enabled without a gap in the log.
+	 *
+	 * This is the read side of the pair; {@link changeCapture} is the write
+	 * side. Capture off already implies no live queries, so this flag only
+	 * matters while capture is on.
 	 *
 	 * @default true
 	 */

--- a/packages/questpie/src/server/modules/core/routes/transaction.ts
+++ b/packages/questpie/src/server/modules/core/routes/transaction.ts
@@ -1,0 +1,25 @@
+/**
+ * Cross-collection transaction route — an ordered list of mutations spanning
+ * several collections, applied as one server-side transaction.
+ *
+ * `transaction` joins `health`, `search`, `jwks`, `realtime`, `channels` and
+ * `globals` as a literal sibling of `[collection]`. Literal segments beat
+ * parameterized ones in the router, so a collection actually named
+ * `transaction` would have its root routes shadowed — the same reservation
+ * those existing literals already carry.
+ *
+ * POST /transaction
+ */
+
+import { collectionsTransaction } from "#questpie/server/adapters/routes/transaction.js";
+import { route } from "#questpie/server/routes/define-route.js";
+import { routeApp } from "#questpie/server/routes/route-app.js";
+
+export default route()
+	.post()
+	.raw()
+	.handler(async (ctx) => {
+		const { request } = ctx;
+		const app = routeApp(ctx);
+		return collectionsTransaction(app, request);
+	});

--- a/packages/questpie/src/server/modules/starter/jobs/realtime-cleanup.ts
+++ b/packages/questpie/src/server/modules/starter/jobs/realtime-cleanup.ts
@@ -13,6 +13,9 @@ export default job({
 		cron: "0 * * * *",
 	},
 	handler: async (ctx) => {
+		// With `realtime.changeCapture: false` nothing ever writes the outbox, so
+		// the hourly DELETE would only be a scan the application did not ask for.
+		if ((ctx as any).app?.config?.realtime?.changeCapture === false) return;
 		await (ctx as any).realtime.cleanupOutbox(true);
 	},
 });

--- a/packages/questpie/src/shared/realtime-error.ts
+++ b/packages/questpie/src/shared/realtime-error.ts
@@ -10,6 +10,14 @@ export type RealtimeTopicRejectionReason =
 	| "query_limit"
 	| "relation_depth"
 	| "snapshot_bytes"
+	/**
+	 * The application turned collection change capture off
+	 * (`realtime.changeCapture: false`). Distinct from
+	 * `row_live_queries_disabled` because the consequences differ: there is no
+	 * outbox at all, so `sinceSeq` resume and `txid` correlation are gone too,
+	 * and no server setting short of re-enabling capture will serve this topic.
+	 */
+	| "change_capture_disabled"
 	| "row_live_queries_disabled"
 	| "collection_realtime_disabled"
 	| "connection_limit"
@@ -24,6 +32,7 @@ const REALTIME_TOPIC_REJECTION_REASONS = new Set<string>([
 	"query_limit",
 	"relation_depth",
 	"snapshot_bytes",
+	"change_capture_disabled",
 	"row_live_queries_disabled",
 	"collection_realtime_disabled",
 	"connection_limit",

--- a/packages/questpie/test/client/client-channels.test.ts
+++ b/packages/questpie/test/client/client-channels.test.ts
@@ -198,6 +198,112 @@ describe("channels client", () => {
 		delivery.stop();
 	});
 
+	test("notifies every admitted logical SSE subscriber exactly once when its epoch ends", async () => {
+		let resource:
+			| {
+					onEvent(event: { type: string; data: string }): void;
+					onError(error: Error): void;
+					onEpochEnd?(error: Error): void;
+			  }
+			| undefined;
+		const connection = {
+			registerChannel(options: typeof resource): () => void {
+				resource = options;
+				return () => {};
+			},
+		};
+		const transport = new SseChannelTransport({
+			baseUrl: "http://localhost:3000",
+			withCredentials: false,
+			fetcher: async () => {
+				throw new Error("The shared connection owns SSE fetching");
+			},
+			connection: connection as any,
+		});
+		const input = {
+			registryKey: "news",
+			params: {},
+			resolvedName: "news",
+			visibility: "public" as const,
+		};
+		const lifecycle: string[] = [];
+		let stopDuringEpochEnd = false;
+		let stopFirst: () => void;
+		let stopSecond: () => void;
+		stopFirst = transport.subscribe(input, () => {}, {
+			onReady: () => lifecycle.push("first:ready"),
+			onNotReady: () => {
+				lifecycle.push("first:not-ready");
+				if (stopDuringEpochEnd) {
+					stopFirst();
+					stopSecond();
+				}
+				throw new Error("consumer lifecycle callback failed");
+			},
+			onError: (error) => lifecycle.push(`first:error:${error.message}`),
+		});
+		stopSecond = transport.subscribe(input, () => {}, {
+			onReady: () => lifecycle.push("second:ready"),
+			onNotReady: () => lifecycle.push("second:not-ready"),
+			onError: (error) => lifecycle.push(`second:error:${error.message}`),
+		});
+		const preAdmissionLifecycle: string[] = [];
+		const stopBeforeReady = transport.subscribe(input, () => {}, {
+			onReady: () => preAdmissionLifecycle.push("ready"),
+			onNotReady: () => preAdmissionLifecycle.push("not-ready"),
+		});
+
+		resource!.onEpochEnd?.(new Error("initial transport unavailable"));
+		expect(lifecycle).toEqual([]);
+		expect(preAdmissionLifecycle).toEqual([]);
+		stopBeforeReady();
+		resource!.onEvent({
+			type: "channel_ready",
+			data: JSON.stringify({ channelSubscriptionId: "channel:news" }),
+		});
+		expect(lifecycle).toEqual(["first:ready", "second:ready"]);
+
+		const stopAborted = transport.subscribe(input, () => {}, {
+			onReady: () => lifecycle.push("aborted:ready"),
+			onNotReady: () => lifecycle.push("aborted:not-ready"),
+		});
+		await Promise.resolve();
+		stopAborted();
+		resource!.onEpochEnd?.(new Error("ordinary reconnect"));
+		resource!.onEpochEnd?.(new Error("duplicate reconnect signal"));
+		expect(lifecycle).toEqual([
+			"first:ready",
+			"second:ready",
+			"aborted:ready",
+			"first:not-ready",
+			"second:not-ready",
+		]);
+
+		resource!.onEvent({
+			type: "channel_ready",
+			data: JSON.stringify({ channelSubscriptionId: "channel:news" }),
+		});
+		stopDuringEpochEnd = true;
+		resource!.onError(new Error("terminal channel failure"));
+		expect(lifecycle).toEqual([
+			"first:ready",
+			"second:ready",
+			"aborted:ready",
+			"first:not-ready",
+			"second:not-ready",
+			"first:ready",
+			"second:ready",
+			"first:not-ready",
+			"second:not-ready",
+			"first:error:terminal channel failure",
+			"second:error:terminal channel failure",
+		]);
+
+		stopSecond();
+		stopFirst();
+		transport.destroy();
+	});
+
 	test("keeps explicit plain JSON channel publishing interoperable", async () => {
 		const instant = new Date("2026-03-29T00:30:00.000Z");
 		let publishRequest: RequestInit | undefined;
@@ -2049,6 +2155,7 @@ describe("channels client", () => {
 			},
 			{
 				onReady: () => lifecycle.push("ready"),
+				onNotReady: () => lifecycle.push("not-ready"),
 				onError: (error: Error) => {
 					errors.push(error);
 					lifecycle.push(`error:${error.message}`);
@@ -2118,13 +2225,11 @@ describe("channels client", () => {
 			replayedInstant.getTime(),
 		);
 		expect(messages[1]?.data.isoLookingString).not.toBeInstanceOf(Date);
-		expect(errors.map((error) => error.message)).toEqual([
-			"Channel subscription epoch ended",
-		]);
+		expect(errors).toEqual([]);
 		expect(lifecycle).toEqual([
 			"ready",
 			`event:${channelHash}:1`,
-			"error:Channel subscription epoch ended",
+			"not-ready",
 			`event:${channelHash}:2`,
 			"ready",
 			`event:${channelHash}:3`,
@@ -2168,6 +2273,7 @@ describe("channels client", () => {
 				lifecycle.push(`event:${message.eventId}`),
 			{
 				onReady: () => lifecycle.push("ready"),
+				onNotReady: () => lifecycle.push("not-ready"),
 				onError: (error: Error) => lifecycle.push(`error:${error.message}`),
 			},
 		);
@@ -2188,10 +2294,7 @@ describe("channels client", () => {
 		provider.connection.transition("disconnected");
 		provider.connection.transition("connecting");
 		await waitFor(
-			() =>
-				lifecycle.filter(
-					(value) => value === "error:Channel connection epoch ended",
-				).length === 1,
+			() => lifecycle.filter((value) => value === "not-ready").length === 1,
 		);
 		provider.channel.emit("pusher:subscription_succeeded", {});
 		await new Promise((resolve) => setTimeout(resolve, 0));
@@ -2201,12 +2304,7 @@ describe("channels client", () => {
 			new Error("stale subscription error"),
 		);
 		await new Promise((resolve) => setTimeout(resolve, 0));
-		expect(lifecycle).toEqual([
-			"ready",
-			`event:${channelHash}:1`,
-			"error:Channel subscription epoch ended",
-			"error:Channel connection epoch ended",
-		]);
+		expect(lifecycle).toEqual(["ready", `event:${channelHash}:1`, "not-ready"]);
 		provider.channel.emit("questpie:channel", {
 			eventId: `${channelHash}:3`,
 			event: "updated",
@@ -2226,12 +2324,7 @@ describe("channels client", () => {
 			}),
 		);
 		await new Promise((resolve) => setTimeout(resolve, 10));
-		expect(lifecycle).toEqual([
-			"ready",
-			`event:${channelHash}:1`,
-			"error:Channel subscription epoch ended",
-			"error:Channel connection epoch ended",
-		]);
+		expect(lifecycle).toEqual(["ready", `event:${channelHash}:1`, "not-ready"]);
 
 		provider.connection.transition("connected");
 		provider.channel.emit("pusher:subscription_succeeded", {});
@@ -2255,8 +2348,7 @@ describe("channels client", () => {
 		expect(lifecycle).toEqual([
 			"ready",
 			`event:${channelHash}:1`,
-			"error:Channel subscription epoch ended",
-			"error:Channel connection epoch ended",
+			"not-ready",
 			`event:${channelHash}:2`,
 			"ready",
 		]);
@@ -2400,10 +2492,7 @@ describe("channels client", () => {
 		);
 		await new Promise((resolve) => setTimeout(resolve, 10));
 
-		expect(errors).toEqual([
-			"Channel subscription epoch ended",
-			"Channel client slow consumer",
-		]);
+		expect(errors).toEqual(["Channel client slow consumer"]);
 		expect(messages).toEqual([`${channelHash}:1`]);
 		expect(client.channels.channelCount).toBe(0);
 		client.channels.destroy();
@@ -2484,10 +2573,7 @@ describe("channels client", () => {
 		);
 		await new Promise((resolve) => setTimeout(resolve, 20));
 
-		expect(errors).toEqual([
-			"Channel subscription epoch ended",
-			"Provider rejected subscription",
-		]);
+		expect(errors).toEqual(["Provider rejected subscription"]);
 		expect(ready).toBe(1);
 		expect(messages).toEqual([`${channelHash}:1`]);
 		expect(client.channels.channelCount).toBe(0);
@@ -2545,7 +2631,6 @@ describe("channels client", () => {
 			errors.some((error) => error.message === "Channel event replay gap"),
 		);
 		expect(errors.map((error) => error.message)).toEqual([
-			"Channel subscription epoch ended",
 			"Channel event replay gap",
 		]);
 		expect(ready).toBe(1);
@@ -2714,7 +2799,6 @@ describe("channels client", () => {
 		);
 		expect(replay).toBe(1);
 		expect(errors.map((error) => error.message)).toEqual([
-			"Channel subscription epoch ended",
 			expect.stringContaining("Unsupported QUESTPIE typed event wire version"),
 		]);
 		expect(client.channels.channelCount).toBe(0);

--- a/packages/questpie/test/client/realtime-stream-events.test.ts
+++ b/packages/questpie/test/client/realtime-stream-events.test.ts
@@ -213,13 +213,170 @@ describe("realtime stream events", () => {
 				{ id: "third", title: "Third" },
 			],
 			totalDocs: 2,
+			limit: 3,
 			totalPages: 1,
 			page: 1,
+			pagingCounter: 1,
 			hasNextPage: false,
 			hasPrevPage: false,
 			nextPage: null,
 			prevPage: null,
 		});
+	});
+
+	it("keeps the bootstrap page window across row events and totals frames", () => {
+		// Page 21 of 69, the envelope a windowed live list bootstraps with.
+		const bootstrap = {
+			docs: [
+				{ id: "a", title: "A" },
+				{ id: "b", title: "B" },
+			],
+			totalDocs: 138,
+			limit: 2,
+			totalPages: 69,
+			page: 21,
+			pagingCounter: 41,
+			hasPrevPage: true,
+			hasNextPage: true,
+			prevPage: 20,
+			nextPage: 22,
+		};
+
+		let result = applyRealtimeFindEvent(undefined, {
+			type: "snapshot",
+			topicId: "posts",
+			seq: 1,
+			data: bootstrap,
+		});
+
+		// A write elsewhere slides the window: one row leaves, one arrives.
+		result = applyRealtimeFindEvent(result, {
+			type: "delete",
+			topicId: "posts",
+			seq: 2,
+			key: "a",
+		});
+		result = applyRealtimeFindEvent(result, {
+			type: "insert",
+			topicId: "posts",
+			seq: 2,
+			key: "c",
+			row: { id: "c", title: "C" },
+			index: 1,
+		});
+
+		expect(result).toEqual({
+			docs: [
+				{ id: "b", title: "B" },
+				{ id: "c", title: "C" },
+			],
+			totalDocs: 138,
+			limit: 2,
+			totalPages: 69,
+			page: 21,
+			pagingCounter: 41,
+			hasPrevPage: true,
+			hasNextPage: true,
+			prevPage: 20,
+			nextPage: 22,
+		});
+
+		// The totals frame carries the server's own count; the window stays put
+		// and only the derived page counts move with it.
+		result = applyRealtimeFindEvent(result, {
+			type: "up-to-date",
+			topicId: "posts",
+			seq: 2,
+			meta: { totalDocs: 139 },
+		});
+
+		expect(result).toMatchObject({
+			totalDocs: 139,
+			limit: 2,
+			totalPages: 70,
+			page: 21,
+			pagingCounter: 41,
+			hasPrevPage: true,
+			hasNextPage: true,
+		});
+		expect(result.docs).toHaveLength(2);
+	});
+
+	it("keeps the total across a heartbeat that carries no meta", () => {
+		const bootstrap = {
+			docs: [{ id: "a", title: "A" }],
+			totalDocs: 5000,
+			limit: 100,
+			totalPages: 50,
+			page: 1,
+			pagingCounter: 1,
+			hasPrevPage: false,
+			hasNextPage: true,
+			prevPage: null,
+			nextPage: 2,
+		};
+
+		const result = applyRealtimeFindEvent(
+			applyRealtimeFindEvent(undefined, {
+				type: "snapshot",
+				topicId: "posts",
+				seq: 1,
+				data: bootstrap,
+			}),
+			{ type: "up-to-date", topicId: "posts", seq: 2, upToDate: "42" },
+		);
+
+		expect(result).toMatchObject({
+			totalDocs: 5000,
+			limit: 100,
+			totalPages: 50,
+			hasNextPage: true,
+		});
+	});
+
+	it("keeps an unwindowed result on one page as its rows grow", () => {
+		// Native row deltas only ever serve unwindowed topics, so the server's
+		// synthesized `limit === totalDocs` has to grow with the result.
+		let result = applyRealtimeFindEvent(undefined, {
+			type: "snapshot",
+			topicId: "posts",
+			seq: 1,
+			data: {
+				docs: [{ id: "a", title: "A" }],
+				totalDocs: 1,
+				limit: 1,
+				totalPages: 1,
+				page: 1,
+				pagingCounter: 1,
+				hasPrevPage: false,
+				hasNextPage: false,
+				prevPage: null,
+				nextPage: null,
+			},
+		});
+		result = applyRealtimeFindEvent(result, {
+			type: "insert",
+			topicId: "posts",
+			seq: 2,
+			key: "b",
+			row: { id: "b", title: "B" },
+		});
+		result = applyRealtimeFindEvent(result, {
+			type: "up-to-date",
+			topicId: "posts",
+			seq: 2,
+			meta: { totalDocs: 2 },
+		});
+
+		expect(result).toMatchObject({
+			totalDocs: 2,
+			limit: 2,
+			totalPages: 1,
+			page: 1,
+			hasNextPage: false,
+			nextPage: null,
+		});
+		expect(result.docs).toHaveLength(2);
 	});
 
 	it("treats a reset snapshot as an authoritative replacement", () => {

--- a/packages/questpie/test/collection/access-where-compilation.test.ts
+++ b/packages/questpie/test/collection/access-where-compilation.test.ts
@@ -1,8 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 
+import { sql } from "drizzle-orm";
 import { integer, pgTable, text } from "drizzle-orm/pg-core";
 
 import { collection } from "../../src/exports/index.js";
+import { realtimeSubscribe } from "../../src/server/adapters/routes/realtime.js";
 import type { CollectionBuilderState } from "../../src/server/collection/builder/types.js";
 import { buildWhereClause } from "../../src/server/collection/crud/query-builders/where-builder.js";
 import { mergeWhereWithAccess } from "../../src/server/collection/crud/shared/access-control.js";
@@ -98,10 +100,13 @@ describe("access WHERE compilation", () => {
 		);
 	});
 
-	it("rejects an untyped RAW access escape hatch", () => {
-		expect(() => compile({ RAW: () => ({}) })).toThrow(
-			"Cannot compile access predicate 'accessCompileParents.RAW'",
-		);
+	it("allows RAW under the access marker", () => {
+		expect(
+			compile({
+				RAW: ({ table }: { table: typeof parents }) =>
+					sql`${table.tenantId} = ${"tenant-a"}`,
+			}),
+		).toBeDefined();
 	});
 
 	it("does not apply strict access compilation to an ordinary user where", () => {
@@ -169,6 +174,60 @@ const validSecuredChildren = collection("valid_secured_access_children")
 	}))
 	.access({ create: true, read: true });
 
+const rawSecuredParents = collection("raw_secured_access_parents")
+	.fields(({ f }) => ({
+		name: f.text().required(),
+		tenantId: f.text().required(),
+	}))
+	.access({
+		create: true,
+		read: ({ session }) => ({
+			RAW: ({ table }) => sql`${table.tenantId} = ${session?.user.id}`,
+		}),
+	});
+
+async function readSseSnapshot(
+	response: Response,
+): Promise<Record<string, any>> {
+	const reader = response.body!.getReader();
+	const decoder = new TextDecoder();
+	let buffer = "";
+	try {
+		for (;;) {
+			const separator = buffer.indexOf("\n\n");
+			if (separator !== -1) {
+				const frame = buffer.slice(0, separator);
+				buffer = buffer.slice(separator + 2);
+				const event = frame
+					.split("\n")
+					.find((line) => line.startsWith("event:"))
+					?.slice(6)
+					.trim();
+				if (event === "session") continue;
+				const data = frame
+					.split("\n")
+					.filter((line) => line.startsWith("data:"))
+					.map((line) => line.slice(5).trim())
+					.join("");
+				return { event, data: JSON.parse(data) };
+			}
+			const next = await Promise.race([
+				reader.read(),
+				new Promise<never>((_, reject) =>
+					setTimeout(
+						() => reject(new Error("Timed out waiting for snapshot")),
+						2_000,
+					),
+				),
+			]);
+			if (next.done) throw new Error("SSE stream closed before snapshot");
+			buffer += decoder.decode(next.value, { stream: true });
+		}
+	} finally {
+		await reader.cancel().catch(() => {});
+	}
+}
+
 describe("access WHERE CRUD integration", () => {
 	let setup: Awaited<ReturnType<typeof buildMockApp>>;
 
@@ -179,6 +238,7 @@ describe("access WHERE CRUD integration", () => {
 				secured_access_compile_children: securedChildren,
 				valid_secured_access_parents: validSecuredParents,
 				valid_secured_access_children: validSecuredChildren,
+				raw_secured_access_parents: rawSecuredParents,
 			},
 		});
 		await runTestDbMigrations(setup.app);
@@ -234,5 +294,49 @@ describe("access WHERE CRUD integration", () => {
 		);
 
 		expect(result.docs.map((row: { name: string }) => row.name)).toEqual(["A"]);
+	});
+
+	it("allows RAW under the access marker for a realtime find subscription", async () => {
+		const crud = setup.app.collections.raw_secured_access_parents;
+		await crud.create(
+			{ name: "Allowed", tenantId: "tenant-a" },
+			createTestContext(),
+		);
+		await crud.create(
+			{ name: "Hidden", tenantId: "tenant-b" },
+			createTestContext(),
+		);
+
+		const response = await realtimeSubscribe(
+			setup.app,
+			new Request("http://localhost/realtime", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({
+					topics: [
+						{
+							id: "raw-access",
+							resourceType: "collection",
+							resource: "raw_secured_access_parents",
+							operation: "find",
+						},
+					],
+				}),
+			}),
+			{},
+			undefined,
+			{
+				accessMode: "user",
+				getSession: async () => createMockSession({ id: "tenant-a" }),
+			},
+		);
+
+		expect(response.status).toBe(200);
+		const snapshot = await readSseSnapshot(response);
+		expect({
+			event: snapshot.event,
+			error: snapshot.data.message,
+			names: snapshot.data.data?.docs?.map((row: { name: string }) => row.name),
+		}).toEqual({ event: "snapshot", error: undefined, names: ["Allowed"] });
 	});
 });

--- a/packages/questpie/test/collection/find-versions-access.test.ts
+++ b/packages/questpie/test/collection/find-versions-access.test.ts
@@ -167,7 +167,9 @@ describe("findVersions access predicates", () => {
 		).rejects.toMatchObject({ code: "FORBIDDEN" });
 		await expect(
 			documents.findVersions({ id: document.id }, userContext("raw-access")),
-		).rejects.toThrow("Cannot compile access predicate 'va_docs.RAW'");
+		).rejects.toThrow(
+			"Cannot compile version-history access predicate 'va_docs.RAW'",
+		);
 		await expect(
 			documents.findVersions({ id: document.id }, system),
 		).resolves.toHaveLength(1);

--- a/packages/questpie/test/crdt/append/append-store.test.ts
+++ b/packages/questpie/test/crdt/append/append-store.test.ts
@@ -276,7 +276,7 @@ describe("CRDT atomic append store", () => {
 						targetFieldCursor: field.targetFieldCursor,
 						canonicalHash: current.canonicalHash,
 						canonicalRevision: current.canonicalRevision,
-						value: current.sourcePath === "title" ? "projected" : "",
+						value: current.sourcePath === "title" ? "projected" : "Body",
 						shouldWrite: field.shouldWrite,
 					};
 				});
@@ -330,6 +330,36 @@ describe("CRDT atomic append store", () => {
 		let realtimeChanges = 0;
 		const projectionOwner = createQuestpieProjectionOwnerPort({
 			db,
+			config: {
+				crdt: {
+					namespace: "test",
+					projection: {
+						prepareAcknowledgement: async (input) => {
+							expect(input.commitSeq).toBe(1n);
+							expect(input.basisCommitSeq).toBe(0n);
+							expect(input.owner).toMatchObject({
+								kind: "collection",
+								key: "articles",
+								recordId: "article-1",
+							});
+							expect(input.changed).toEqual(new Set(["title"]));
+							expect(input.values.get("title")).toBe("rejected");
+							expect(input.contributors).toEqual([
+								{
+									commitSeq: 1n,
+									sessionId: SESSION_ID,
+									actor: { kind: "human", subjectId: "user-1" },
+								},
+							]);
+							await input.transaction
+								.update(articlesTable)
+								.set({ status: "derived" })
+								.where(eq(articlesTable.id, "article-1"));
+							throw new Error("consumer rejected aggregate cut");
+						},
+					},
+				},
+			},
 			collections: {
 				articles: {
 					"~internalState": {
@@ -367,17 +397,7 @@ describe("CRDT atomic append store", () => {
 					};
 				});
 			},
-			owner: {
-				...projectionOwner,
-				prepareAcknowledgement: async (transaction, _owner, input) => {
-					await transaction
-						.update(articlesTable)
-						.set({ status: "derived" })
-						.where(eq(articlesTable.id, "article-1"));
-					expect(input.commitSeq).toBe(1n);
-					throw new Error("consumer rejected aggregate cut");
-				},
-			},
+			owner: projectionOwner,
 		});
 
 		await expect(projector.runOnce()).rejects.toThrow(
@@ -406,6 +426,123 @@ describe("CRDT atomic append store", () => {
 			1,
 		);
 		expect(realtimeChanges).toBe(0);
+	});
+
+	it("commits canonical values, owner projections, and derived writes under one acknowledgement", async () => {
+		await db.execute(sql`
+			CREATE TABLE article_references (
+				article_id text NOT NULL,
+				target text NOT NULL,
+				PRIMARY KEY (article_id, target)
+			)
+		`);
+		await createCrdtAppendStore(db, { lockOwnerRow }).append(
+			await appendInput(fixture),
+		);
+		await db.update(questpieCrdtProjectionTable).set({ dueAt: new Date(0) });
+		let realtimeChanges = 0;
+		const projectionOwner = createQuestpieProjectionOwnerPort({
+			db,
+			config: {
+				crdt: {
+					namespace: "test",
+					projection: {
+						prepareAcknowledgement: async (input) => {
+							await input.transaction.execute(sql`
+								INSERT INTO article_references (article_id, target)
+								VALUES ('article-1', 'task-1')
+								ON CONFLICT DO NOTHING
+							`);
+							return {
+								values: new Map(input.values).set("title", "canonical"),
+								ownerValues: { status: "canonical" },
+							};
+						},
+					},
+				},
+			},
+			collections: {
+				articles: {
+					"~internalState": {
+						name: "articles",
+						options: { optimisticConcurrency: true },
+					},
+					"~internalRelatedTable": articlesTable,
+				},
+			},
+			globals: {},
+			realtime: {
+				appendChange: async () => ({
+					seq: ++realtimeChanges,
+					resourceType: "collection",
+					resource: "articles",
+					operation: "update",
+					recordId: "article-1",
+					payload: { origin: "crdt_projection" },
+					createdAt: new Date(),
+				}),
+				notify: async () => {},
+			},
+		} as any);
+		const projector = createCrdtProjectionStore(db, {
+			materializeExactCut: async (database, _claim, scheduled) => {
+				const bindings = await database.select().from(questpieCrdtBindingTable);
+				return scheduled.map((field) => {
+					const binding = bindings.find(
+						(candidate) => candidate.id === field.bindingId,
+					)!;
+					return {
+						bindingId: binding.id,
+						stableFieldId: binding.stableFieldId,
+						fieldEpoch: binding.fieldEpoch,
+						targetFieldCursor: field.targetFieldCursor,
+						canonicalHash: binding.canonicalHash,
+						canonicalRevision: binding.canonicalRevision,
+						value: binding.sourcePath === "title" ? "  canonical  " : "Body",
+						shouldWrite: field.shouldWrite,
+					};
+				});
+			},
+			owner: projectionOwner,
+		});
+
+		await expect(projector.runOnce()).resolves.toEqual({
+			status: "applied",
+			projectedCommitSeq: 1n,
+		});
+		const [owner] = await db.select().from(articlesTable);
+		expect(owner).toMatchObject({
+			title: "canonical",
+			status: "canonical",
+			revision: 2,
+		});
+		const references = await db.execute(sql`
+			SELECT article_id, target FROM article_references
+		`);
+		expect(references.rows).toEqual([
+			{ article_id: "article-1", target: "task-1" },
+		]);
+		expect(realtimeChanges).toBe(1);
+
+		await createCrdtAppendStore(db, { lockOwnerRow }).append(
+			await appendInput(
+				fixture,
+				"00000000-0000-4000-8000-000000000399",
+				encodeDeterministicTextUpdate([
+					{ type: "insert", index: 7, value: " again" },
+				]),
+			),
+		);
+		await db.update(questpieCrdtProjectionTable).set({ dueAt: new Date(0) });
+		await expect(projector.runOnce()).resolves.toEqual({
+			status: "applied",
+			projectedCommitSeq: 2n,
+		});
+		const [activeResource] = await db
+			.select()
+			.from(questpieCrdtResourceTable)
+			.where(eq(questpieCrdtResourceTable.id, RESOURCE_ID));
+		expect(activeResource?.status).toBe(1);
 	});
 
 	it("writes the owner and realtime outbox through one managed transaction", async () => {

--- a/packages/questpie/test/integration/adapter-route-config.test.ts
+++ b/packages/questpie/test/integration/adapter-route-config.test.ts
@@ -2,12 +2,13 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 
 import { z } from "zod";
 
-import { collection, route } from "../../src/exports/index.js";
+import { collection, global, route } from "../../src/exports/index.js";
 import { createFetchHandler } from "../../src/server/adapters/http.js";
 import type { AdapterContext } from "../../src/server/adapters/types.js";
 import { tryGetContext } from "../../src/server/config/context.js";
 import type { SearchAdapter } from "../../src/server/modules/core/integrated/search/types.js";
 import { buildMockApp } from "../utils/mocks/mock-app-builder";
+import { runTestDbMigrations } from "../utils/test-db";
 
 function createSearchAdapterMock(): {
 	adapter: SearchAdapter;
@@ -457,6 +458,91 @@ describe("adapter route config", () => {
 			expect(
 				setup.app.mocks.logger.getLogsContaining("HTTP request completed"),
 			).toEqual([]);
+		});
+	});
+
+	describe("read projection over http", () => {
+		const posts = collection("posts").fields(({ f }) => ({
+			title: f.text().required(),
+			body: f.textarea().required(),
+		}));
+		const settings = global("settings").fields(({ f }) => ({
+			siteName: f.text().required(),
+			tagline: f.text().required(),
+		}));
+
+		let setup: Awaited<ReturnType<typeof buildMockApp>>;
+		let created: { id: string };
+
+		beforeEach(async () => {
+			setup = await buildMockApp({
+				collections: { posts },
+				globals: { settings },
+				defaultAccess: { read: true, create: true, update: true },
+			});
+			await runTestDbMigrations(setup.app);
+			const handler = createFetchHandler(setup.app);
+			created = (await (
+				await handler(
+					new Request("http://localhost/posts", {
+						method: "POST",
+						body: JSON.stringify({ title: "Narrow", body: "Wide" }),
+					}),
+				)
+			)?.json()) as { id: string };
+		});
+
+		afterEach(async () => {
+			await setup.cleanup();
+		});
+
+		it("narrows a collection read to the requested columns", async () => {
+			const handler = createFetchHandler(setup.app);
+
+			const included = await handler(
+				new Request("http://localhost/posts?columns[title]=true"),
+			);
+			expect(included?.status).toBe(200);
+			const listed = (await included?.json())?.docs?.[0];
+			expect(listed).toMatchObject({ id: created.id, title: "Narrow" });
+			expect(listed).not.toHaveProperty("body");
+
+			// Omission mode: `false` has to survive the query string as a boolean,
+			// not as the truthy string "false".
+			const omitted = await handler(
+				new Request("http://localhost/posts?columns[body]=false"),
+			);
+			const remaining = (await omitted?.json())?.docs?.[0];
+			expect(remaining).toMatchObject({ title: "Narrow" });
+			expect(remaining).not.toHaveProperty("body");
+
+			const one = await handler(
+				new Request(`http://localhost/posts/${created.id}?columns[title]=true`),
+			);
+			expect(one?.status).toBe(200);
+			const record = await one?.json();
+			expect(record).toMatchObject({ id: created.id, title: "Narrow" });
+			expect(record).not.toHaveProperty("body");
+		});
+
+		it("narrows a global read to the requested columns", async () => {
+			const handler = createFetchHandler(setup.app);
+			await handler(
+				new Request("http://localhost/globals/settings", {
+					method: "PATCH",
+					body: JSON.stringify({ siteName: "QUESTPIE", tagline: "Wide" }),
+				}),
+			);
+
+			const response = await handler(
+				new Request(
+					"http://localhost/globals/settings?columns[siteName]=true&columns[tagline]=false",
+				),
+			);
+			expect(response?.status).toBe(200);
+			const record = await response?.json();
+			expect(record).toMatchObject({ siteName: "QUESTPIE" });
+			expect(record).not.toHaveProperty("tagline");
 		});
 	});
 

--- a/packages/questpie/test/integration/cross-collection-transaction.test.ts
+++ b/packages/questpie/test/integration/cross-collection-transaction.test.ts
@@ -1,0 +1,319 @@
+/**
+ * POST /transaction — an ordered list of mutations across several collections,
+ * applied as ONE server-side transaction.
+ *
+ * The engine (`withTransaction` + the ambient-transaction outbox append) was
+ * already atomic across collections; these tests pin the HTTP surface built on
+ * top of it: all-or-nothing including the realtime outbox, per-operation
+ * authorization as the requesting principal, and a failure that says which
+ * operation failed.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+
+import { createClient, QuestpieClientError } from "../../src/client/index.js";
+import {
+	collection,
+	questpieRealtimeLogTable,
+} from "../../src/exports/index.js";
+import { createFetchHandler } from "../../src/server/adapters/http.js";
+import { buildMockApp } from "../utils/mocks/mock-app-builder";
+import { createMockSession, createTestContext } from "../utils/test-context";
+import { runTestDbMigrations } from "../utils/test-db";
+
+const posts = collection("posts").fields(({ f }) => ({
+	title: f.text().required(),
+}));
+
+const comments = collection("comments").fields(({ f }) => ({
+	body: f.text().required(),
+}));
+
+const tags = collection("tags").fields(({ f }) => ({
+	label: f.text().required(),
+}));
+
+/** Only an admin may create one of these — the per-operation access probe. */
+const auditEntries = collection("audit_entries")
+	.fields(({ f }) => ({ note: f.text().required() }))
+	.access({
+		create: ({ session }) => (session?.user as any)?.role === "admin",
+	});
+
+const versionedDocs = collection("versioned_docs")
+	.fields(({ f }) => ({ title: f.text().required() }))
+	.options({ optimisticConcurrency: true });
+
+type TransactionOp = Record<string, unknown>;
+
+describe("cross-collection transaction route", () => {
+	let setup: Awaited<ReturnType<typeof buildMockApp>>;
+	let ctx: ReturnType<typeof createTestContext>;
+
+	beforeEach(async () => {
+		setup = await buildMockApp(
+			{
+				collections: { posts, comments, tags, auditEntries, versionedDocs },
+			},
+			{ realtime: { pollIntervalMs: 10 } },
+		);
+		await runTestDbMigrations(setup.app);
+		ctx = createTestContext(setup.app);
+	});
+
+	afterEach(async () => {
+		await setup.cleanup();
+	});
+
+	const transact = (
+		operations: TransactionOp[],
+		session: ReturnType<typeof createMockSession> | null = createMockSession({
+			role: "admin",
+		}),
+	) => {
+		const handler = createFetchHandler(setup.app, {
+			getSession: async () => session,
+		});
+		return handler(
+			new Request("http://localhost/transaction", {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({ operations }),
+			}),
+		);
+	};
+
+	const counts = async () => ({
+		posts: await setup.app.collections.posts.count({}, ctx),
+		comments: await setup.app.collections.comments.count({}, ctx),
+		tags: await setup.app.collections.tags.count({}, ctx),
+		auditEntries: await setup.app.collections.auditEntries.count({}, ctx),
+	});
+
+	const outbox = () =>
+		setup.app.db.select().from(questpieRealtimeLogTable) as Promise<
+			Array<{ resource: string; operation: string; txid: string | null }>
+		>;
+
+	it("commits three collections atomically, under one transaction id", async () => {
+		const response = await transact([
+			{ collection: "posts", operation: "create", data: { title: "Post" } },
+			{ collection: "comments", operation: "create", data: { body: "Body" } },
+			{ collection: "tags", operation: "create", data: { label: "Label" } },
+		]);
+
+		expect(response?.status).toBe(200);
+		const results = (await response?.json()) as Array<Record<string, unknown>>;
+		expect(results).toHaveLength(3);
+		expect(results[0]?.title).toBe("Post");
+		expect(results[1]?.body).toBe("Body");
+		expect(results[2]?.label).toBe("Label");
+
+		expect(await counts()).toMatchObject({ posts: 1, comments: 1, tags: 1 });
+
+		// One transaction means one txid — on the response and on every change
+		// event the batch produced.
+		const headerTxid = response?.headers.get("X-Questpie-Txid");
+		expect(headerTxid).toBeString();
+
+		const rows = await outbox();
+		expect(rows).toHaveLength(3);
+		expect(rows.map((row) => row.resource).sort()).toEqual([
+			"comments",
+			"posts",
+			"tags",
+		]);
+		expect(new Set(rows.map((row) => row.txid)).size).toBe(1);
+		expect(rows[0]?.txid).toBe(headerTxid);
+	});
+
+	it("rolls the first two operations back — and the outbox with them — when the third fails", async () => {
+		const response = await transact([
+			{ collection: "posts", operation: "create", data: { title: "Post" } },
+			{ collection: "comments", operation: "create", data: { body: "Body" } },
+			// `label` is required; this operation cannot be applied.
+			{ collection: "tags", operation: "create", data: {} },
+		]);
+
+		expect(response?.status).toBeGreaterThanOrEqual(400);
+		const body = (await response?.json()) as { error: Record<string, any> };
+		expect(body.error.context.custom.transaction).toEqual({
+			index: 2,
+			collection: "tags",
+			operation: "create",
+			applied: false,
+		});
+
+		expect(await counts()).toMatchObject({ posts: 0, comments: 0, tags: 0 });
+		expect(await outbox()).toHaveLength(0);
+	});
+
+	it("authorizes every operation as the requesting principal, not as the system", async () => {
+		const restricted = [
+			{ collection: "posts", operation: "create", data: { title: "Post" } },
+			{
+				collection: "auditEntries",
+				operation: "create",
+				data: { note: "Sensitive" },
+			},
+		];
+
+		const denied = await transact(
+			restricted,
+			createMockSession({ role: "editor" }),
+		);
+
+		expect(denied?.status).toBe(403);
+		const body = (await denied?.json()) as { error: Record<string, any> };
+		expect(body.error.code).toBe("FORBIDDEN");
+		// The batch says WHICH operation was refused; the allowed one before it
+		// was still rolled back.
+		expect(body.error.context.custom.transaction).toMatchObject({
+			index: 1,
+			collection: "auditEntries",
+			applied: false,
+		});
+		expect(await counts()).toMatchObject({ posts: 0, auditEntries: 0 });
+
+		// Positive control: the identical batch as an admin commits, so the
+		// refusal above came from the access rule and nothing else.
+		const allowed = await transact(
+			restricted,
+			createMockSession({ role: "admin" }),
+		);
+		expect(allowed?.status).toBe(200);
+		expect(await counts()).toMatchObject({ posts: 1, auditEntries: 1 });
+	});
+
+	it("aborts the whole batch on a revision conflict", async () => {
+		const doc = await setup.app.collections.versionedDocs.create(
+			{ title: "Original" },
+			ctx,
+		);
+		expect(doc.revision).toBe(1);
+
+		const response = await transact([
+			{ collection: "posts", operation: "create", data: { title: "Post" } },
+			{
+				collection: "versionedDocs",
+				operation: "update",
+				id: doc.id,
+				expectedRevision: 99,
+				data: { title: "Stale write" },
+			},
+		]);
+
+		expect(response?.status).toBe(409);
+		const body = (await response?.json()) as { error: Record<string, any> };
+		expect(body.error.code).toBe("CONFLICT");
+		expect(body.error.context.custom.transaction).toMatchObject({
+			index: 1,
+			collection: "versionedDocs",
+			operation: "update",
+			applied: false,
+		});
+
+		expect(await counts()).toMatchObject({ posts: 0 });
+		const unchanged = await setup.app.collections.versionedDocs.findOne(
+			{ where: { id: doc.id } },
+			ctx,
+		);
+		expect(unchanged?.title).toBe("Original");
+		expect(unchanged?.revision).toBe(1);
+
+		// Positive control: the correct revision commits both operations.
+		const fresh = await transact([
+			{ collection: "posts", operation: "create", data: { title: "Post" } },
+			{
+				collection: "versionedDocs",
+				operation: "update",
+				id: doc.id,
+				expectedRevision: 1,
+				data: { title: "Fresh write" },
+			},
+		]);
+		expect(fresh?.status).toBe(200);
+		expect(await counts()).toMatchObject({ posts: 1 });
+	});
+
+	it("applies operations in the order given, so later ones see earlier ones", async () => {
+		const created = await setup.app.collections.posts.create(
+			{ title: "First" },
+			ctx,
+		);
+
+		const response = await transact([
+			{
+				collection: "posts",
+				operation: "update",
+				id: created.id,
+				data: { title: "Renamed" },
+			},
+			{ collection: "posts", operation: "delete", id: created.id },
+		]);
+
+		expect(response?.status).toBe(200);
+		const results = (await response?.json()) as Array<Record<string, any>>;
+		expect(results[0]?.title).toBe("Renamed");
+		// The delete is served the row the update in the same transaction wrote.
+		expect(results[1]?.success).toBe(true);
+		expect(results[1]?.data?.title).toBe("Renamed");
+		expect(await counts()).toMatchObject({ posts: 0 });
+	});
+
+	it("is reachable through the typed client, error contract included", async () => {
+		const handler = createFetchHandler(setup.app, {
+			getSession: async () => createMockSession({ role: "admin" }),
+		});
+		const client = createClient<any>({
+			baseURL: "http://localhost",
+			fetch: ((input: any, init: any) =>
+				handler(new Request(input, init))) as typeof fetch,
+		});
+
+		const [post, comment] = await client.transaction([
+			{ collection: "posts", operation: "create", data: { title: "Post" } },
+			{ collection: "comments", operation: "create", data: { body: "Body" } },
+		]);
+		expect(post.title).toBe("Post");
+		expect(comment.body).toBe("Body");
+		expect(await counts()).toMatchObject({ posts: 1, comments: 1 });
+
+		const failure = await client
+			.transaction([
+				{ collection: "posts", operation: "create", data: { title: "Second" } },
+				{ collection: "tags", operation: "create", data: {} },
+			])
+			.then(
+				() => null,
+				(error: unknown) => error,
+			);
+
+		expect(failure).toBeInstanceOf(QuestpieClientError);
+		expect((failure as QuestpieClientError).context?.custom).toMatchObject({
+			transaction: { index: 1, collection: "tags", applied: false },
+		});
+		// The successful batch above is still there; the failed one added nothing.
+		expect(await counts()).toMatchObject({ posts: 1, tags: 0 });
+	});
+
+	it("refuses a verb or a collection it does not own", async () => {
+		const unknownVerb = await transact([
+			{ collection: "posts", operation: "updateMany", where: {}, data: {} },
+		]);
+		expect(unknownVerb?.status).toBe(400);
+
+		const unknownCollection = await transact([
+			{ collection: "ghosts", operation: "create", data: {} },
+		]);
+		expect(unknownCollection?.status).toBe(404);
+
+		// A prototype key is not a collection.
+		const prototypeKey = await transact([
+			{ collection: "constructor", operation: "create", data: {} },
+		]);
+		expect(prototypeKey?.status).toBe(404);
+
+		expect(await outbox()).toHaveLength(0);
+	});
+});

--- a/packages/questpie/test/integration/ordered-channel-ledger-postgres.test.ts
+++ b/packages/questpie/test/integration/ordered-channel-ledger-postgres.test.ts
@@ -1,0 +1,401 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+
+import { and, asc, eq, sql } from "drizzle-orm";
+import pg from "pg";
+import { z } from "zod";
+
+import { channel } from "../../src/server/channels/channel-builder.js";
+import { ChannelsService } from "../../src/server/channels/service.js";
+import { withTransaction } from "../../src/server/collection/crud/shared/transaction.js";
+import {
+	ChannelEventLedger,
+	hashResolvedChannel,
+} from "../../src/server/modules/core/integrated/realtime/channel-event-ledger.js";
+import {
+	questpieChannelAuthorityFenceTable,
+	questpieChannelAuthorityRevocationTable,
+	questpieChannelDispatchTable,
+	questpieChannelEventTable,
+	questpieChannelHeadTable,
+} from "../../src/server/modules/core/integrated/realtime/collection.js";
+import type {
+	ClientCloseReason,
+	ClientSink,
+	DeliveryClass,
+} from "../../src/server/modules/core/integrated/realtime/transport.js";
+import { buildMockApp } from "../utils/mocks/mock-app-builder.js";
+import { runTestDbMigrations } from "../utils/test-db.js";
+
+/**
+ * The channel ledger's guarantees are about LOCKS: sequence order equals commit
+ * order because the head row is locked, retention runs on one node because of an
+ * advisory lock, and multi-channel publishes deadlock unless they agree on an
+ * order. None of that is observable on PGlite, which is a single embedded
+ * backend where a "second transaction" runs inside the first without blocking —
+ * the existing PGlite ordering test passes with the head lock deleted.
+ *
+ * These are the same claims, against a real server with a real connection pool.
+ */
+const databaseUrl =
+	process.env.QUESTPIE_CHANNEL_LEDGER_DATABASE_URL ??
+	process.env.QUESTPIE_TRANSACTION_LOCK_DATABASE_URL;
+
+type TestSink = ClientSink & {
+	frames: Array<Record<string, any>>;
+	closeReasons: ClientCloseReason[];
+};
+
+function createSink(sessionId: string): TestSink {
+	const decoder = new TextDecoder();
+	return {
+		sessionId,
+		frames: [],
+		closeReasons: [],
+		async write(frame: Uint8Array, _delivery: DeliveryClass) {
+			this.frames.push(JSON.parse(decoder.decode(frame)));
+			return { status: "accepted", bufferedBytes: 0 };
+		},
+		async close(reason: ClientCloseReason) {
+			this.closeReasons.push(reason);
+		},
+	};
+}
+
+const settle = () => new Promise((resolve) => setTimeout(resolve, 60));
+
+describe.skipIf(!databaseUrl)("ordered channel ledger on PostgreSQL", () => {
+	const channels = {
+		room: channel("room-[roomId]")
+			.events({ message: z.object({ order: z.string() }) })
+			.authorize(true),
+	};
+	let setup: Awaited<ReturnType<typeof buildMockApp>>;
+	const ledgers = new Set<ChannelEventLedger>();
+
+	beforeAll(async () => {
+		const pool = new pg.Pool({ connectionString: databaseUrl, max: 1 });
+		try {
+			await pool.query("create extension if not exists pg_trgm");
+		} finally {
+			await pool.end();
+		}
+		setup = await buildMockApp(
+			{ channels },
+			{ db: { url: databaseUrl!, pool: { max: 8 } } },
+		);
+		await runTestDbMigrations(setup.app);
+	});
+
+	afterAll(async () => {
+		for (const value of ledgers) await value.destroy();
+		await setup.cleanup();
+	});
+
+	async function reset() {
+		await setup.app.db.delete(questpieChannelEventTable);
+		await setup.app.db.delete(questpieChannelDispatchTable);
+		await setup.app.db.delete(questpieChannelAuthorityRevocationTable);
+		await setup.app.db.delete(questpieChannelAuthorityFenceTable);
+		await setup.app.db.delete(questpieChannelHeadTable);
+	}
+
+	function ledger(
+		config: ConstructorParameters<typeof ChannelEventLedger>[3] = {},
+		logger?: ConstructorParameters<typeof ChannelEventLedger>[4],
+	): ChannelEventLedger {
+		const value = new ChannelEventLedger(
+			setup.app.db,
+			undefined,
+			undefined,
+			config,
+			logger,
+		);
+		ledgers.add(value);
+		return value;
+	}
+
+	test("a second publisher cannot take a sequence until the first commits", async () => {
+		await reset();
+		const events = ledger();
+		let markFirstAppended = () => {};
+		const firstAppended = new Promise<void>((resolve) => {
+			markFirstAppended = resolve;
+		});
+		let releaseFirst = () => {};
+		const holdFirst = new Promise<void>((resolve) => {
+			releaseFirst = resolve;
+		});
+
+		const first = withTransaction(setup.app.db, async (tx) => {
+			const receipt = await events.append(
+				{
+					channel: "room-lock",
+					event: "message",
+					schemaIdentity: "room:message",
+					data: { order: "first" },
+				},
+				{ db: tx },
+			);
+			markFirstAppended();
+			await holdFirst;
+			return receipt;
+		});
+		await firstAppended;
+
+		let secondSettled = false;
+		const second = withTransaction(setup.app.db, (tx) =>
+			events.append(
+				{
+					channel: "room-lock",
+					event: "message",
+					schemaIdentity: "room:message",
+					data: { order: "second" },
+				},
+				{ db: tx },
+			),
+		).then((receipt) => {
+			secondSettled = true;
+			return receipt;
+		});
+		await new Promise((resolve) => setTimeout(resolve, 200));
+
+		// This is the whole point of the head row, and the assertion PGlite
+		// cannot make: the second publisher is blocked on a real row lock.
+		expect(secondSettled).toBe(false);
+		releaseFirst();
+		const [firstReceipt, secondReceipt] = await Promise.all([first, second]);
+
+		const rows = await setup.app.db
+			.select()
+			.from(questpieChannelEventTable)
+			.orderBy(asc(questpieChannelEventTable.seq));
+		expect(rows.map((row: any) => row.payload.order)).toEqual([
+			"first",
+			"second",
+		]);
+		expect(firstReceipt.eventId).toEndWith(":1");
+		expect(secondReceipt.eventId).toEndWith(":2");
+	});
+
+	test("60 concurrent publishers on one channel produce a contiguous sequence", async () => {
+		await reset();
+		const events = ledger();
+		await Promise.all(
+			Array.from({ length: 60 }, (_, index) =>
+				events.append({
+					channel: "room-parallel",
+					event: "message",
+					schemaIdentity: "room:message",
+					data: { index },
+				}),
+			),
+		);
+		const rows = await setup.app.db
+			.select({ seq: questpieChannelEventTable.seq })
+			.from(questpieChannelEventTable)
+			.orderBy(asc(questpieChannelEventTable.seq));
+		expect(rows.map((row: any) => Number(row.seq))).toEqual(
+			Array.from({ length: 60 }, (_, index) => index + 1),
+		);
+	});
+
+	test("publishBatch locks channels in hash order, not caller order", async () => {
+		await reset();
+		// Deadlock-freedom is exactly "every caller agrees on an order". Assert
+		// the order directly: hold the lock on the channel that sorts FIRST, and
+		// hand publishBatch the two channels in the opposite order. A batch that
+		// respects hash order blocks before writing anything.
+		const service = new ChannelsService(channels, setup.app.realtime!, {
+			accessMode: "system",
+		} as any);
+		const resolve = (roomId: string) =>
+			service.resolveName("room", { roomId } as any);
+		const rooms = ["alpha", "beta"].sort((a, b) => {
+			const left = hashResolvedChannel(resolve(a));
+			const right = hashResolvedChannel(resolve(b));
+			return left < right ? -1 : left > right ? 1 : 0;
+		});
+		const [firstByHash, secondByHash] = rooms;
+
+		// Seed both heads so the batch takes the fast single-statement path.
+		const seed = ledger();
+		for (const room of rooms) {
+			await seed.append({
+				channel: resolve(room),
+				event: "message",
+				schemaIdentity: "room:message",
+				data: { order: "seed" },
+			});
+		}
+
+		const blocker = new pg.Client({ connectionString: databaseUrl });
+		await blocker.connect();
+		let batchSettled = false;
+		try {
+			await blocker.query("begin");
+			const locked = await blocker.query(
+				"update questpie_channel_head set updated_at = now() where channel_hash = $1",
+				[hashResolvedChannel(resolve(firstByHash))],
+			);
+			expect(locked.rowCount).toBe(1);
+
+			const batch = service
+				.publishBatch([
+					{
+						channel: "room",
+						params: { roomId: secondByHash },
+						event: "message",
+						data: { order: "caller-first" },
+					},
+					{
+						channel: "room",
+						params: { roomId: firstByHash },
+						event: "message",
+						data: { order: "caller-second" },
+					},
+				] as any)
+				.then((receipts) => {
+					batchSettled = true;
+					return receipts;
+				});
+			await new Promise((resolve) => setTimeout(resolve, 250));
+
+			expect(batchSettled).toBe(false);
+			// Nothing was written to the channel the caller listed FIRST: the
+			// batch reordered and is parked on the hash-first channel's lock.
+			// In caller order this row exists, which is the deadlock cycle.
+			const written = await setup.app.db
+				.select()
+				.from(questpieChannelEventTable)
+				.where(
+					and(
+						eq(
+							questpieChannelEventTable.channelHash,
+							hashResolvedChannel(resolve(secondByHash)),
+						),
+						eq(questpieChannelEventTable.seq, 2),
+					),
+				);
+			expect(written).toEqual([]);
+
+			await blocker.query("commit");
+			const receipts = await batch;
+			expect(receipts).toHaveLength(2);
+			// Receipts still come back in the caller's order.
+			expect(receipts[0].eventId).toStartWith(
+				hashResolvedChannel(resolve(secondByHash)),
+			);
+			expect(receipts[1].eventId).toStartWith(
+				hashResolvedChannel(resolve(firstByHash)),
+			);
+		} finally {
+			await blocker.query("rollback").catch(() => {});
+			await blocker.end();
+		}
+	});
+
+	test("concurrent nodes do not repeat a retention pass", async () => {
+		await reset();
+		const seedLedger = ledger({ retentionMs: 0, retentionBytes: 0 });
+		for (let index = 0; index < 60; index++) {
+			await seedLedger.append({
+				channel: "room-retention",
+				event: "message",
+				schemaIdentity: "room:message",
+				data: { index },
+			});
+		}
+		// Age the rows on the SERVER clock so the assertion does not depend on
+		// skew between this process and the database.
+		await setup.app.db.execute(
+			sql`update questpie_channel_event set created_at = now() - interval '1 day'`,
+		);
+
+		const nodes = [
+			ledger({ retentionMs: 60_000, retentionBytes: 0 }),
+			ledger({ retentionMs: 60_000, retentionBytes: 0 }),
+			ledger({ retentionMs: 60_000, retentionBytes: 0 }),
+		];
+		let statements = 0;
+		const db = setup.app.db as Record<string, any>;
+		const original = {
+			execute: db.execute.bind(setup.app.db),
+			delete: db.delete.bind(setup.app.db),
+			transaction: db.transaction.bind(setup.app.db),
+		};
+		const count = <T>(value: T): T => {
+			statements += 1;
+			return value;
+		};
+		db.execute = (...args: any[]) => count(original.execute(...args));
+		db.delete = (...args: any[]) => count(original.delete(...args));
+		db.transaction = (callback: (tx: any) => any, ...rest: any[]) =>
+			original.transaction(
+				(tx: any) =>
+					callback(
+						new Proxy(tx, {
+							get(target, property, receiver) {
+								const value = Reflect.get(target, property, receiver);
+								if (property !== "execute" && property !== "delete") {
+									return value;
+								}
+								return (...args: any[]) => count(value.apply(target, args));
+							},
+						}),
+					),
+				...rest,
+			);
+		try {
+			await Promise.all(nodes.map((node) => node.cleanup()));
+		} finally {
+			Object.assign(db, original);
+		}
+
+		expect(await setup.app.db.select().from(questpieChannelEventTable)).toEqual(
+			[],
+		);
+		// One node deletes; the other two see the advisory lock is taken and
+		// stop after probing it. Never 60 deletes, and never 3x anything.
+		expect(statements).toBeLessThanOrEqual(8);
+	});
+
+	test("fan-out reads the log once per channel across a real connection pool", async () => {
+		await reset();
+		const events = ledger();
+		const reads: number[] = [];
+		const store = events as unknown as {
+			selectEvents: (channelHash: string, afterSeq: number) => Promise<unknown>;
+		};
+		const selectEvents = store.selectEvents.bind(events);
+		store.selectEvents = (channelHash: string, afterSeq: number) => {
+			reads.push(afterSeq);
+			return selectEvents(channelHash, afterSeq);
+		};
+
+		const sinks: TestSink[] = [];
+		for (let index = 0; index < 50; index++) {
+			const sink = createSink(`fanout-${index}`);
+			sinks.push(sink);
+			await events.subscribeLocal({
+				subscriptionId: `fanout-${index}`,
+				channel: "room-fanout",
+				sink,
+			});
+		}
+		await settle();
+		reads.length = 0;
+
+		await events.append({
+			channel: "room-fanout",
+			event: "message",
+			schemaIdentity: "room:message",
+			data: { id: 1 },
+		});
+		await events.drain();
+
+		expect(sinks.every((sink) => sink.frames.length === 1)).toBe(true);
+		// SQL for one event is a function of the channel, not of how many
+		// subscribers are attached to it.
+		expect(reads.length).toBeLessThanOrEqual(2);
+	});
+});

--- a/packages/questpie/test/integration/ordered-channel-ledger-postgres.test.ts
+++ b/packages/questpie/test/integration/ordered-channel-ledger-postgres.test.ts
@@ -88,6 +88,7 @@ describe.skipIf(!databaseUrl)("ordered channel ledger on PostgreSQL", () => {
 
 	afterAll(async () => {
 		for (const value of ledgers) await value.destroy();
+		await setup.app.migrations.down();
 		await setup.cleanup();
 	});
 

--- a/packages/questpie/test/integration/ordered-channel-ledger.test.ts
+++ b/packages/questpie/test/integration/ordered-channel-ledger.test.ts
@@ -7,7 +7,7 @@ import {
 	test,
 } from "bun:test";
 
-import { and, asc, eq } from "drizzle-orm";
+import { and, asc, eq, inArray, sql } from "drizzle-orm";
 
 import { channel } from "../../src/server/channels/channel-builder.js";
 import { ChannelsService } from "../../src/server/channels/service.js";
@@ -739,6 +739,209 @@ describe("ordered channel event ledger", () => {
 		await events.drain();
 		expect(sink.frames).toHaveLength(1);
 		expect(sink.closeReasons).toEqual([]);
+	});
+
+	test("a connected subscriber whose unread events are removed gets a gap, not the next surviving event", async () => {
+		// Retention cleanup on another node deletes rows a live subscriber has
+		// not read yet. Delivery used to jump the hole in silence: the sink saw
+		// 1, 2, 3, 6 with no gap frame, no close and nothing logged.
+		const events = ledger(undefined, { retentionMs: 0, retentionBytes: 0 });
+		// A second instance stands in for the node that owns the publish and the
+		// retention pass; it never touches this subscriber's sink.
+		const publisher = ledger(undefined, { retentionMs: 0, retentionBytes: 0 });
+		const sink = createSink("live-gap");
+		await events.subscribeLocal({
+			subscriptionId: "live-gap-room",
+			channel: "private-room-1",
+			sink,
+		});
+		for (const id of [1, 2, 3]) {
+			await publisher.append({
+				channel: "private-room-1",
+				event: "message",
+				schemaIdentity: "room:message",
+				data: { id },
+			});
+		}
+		await events.drain();
+		expect(sink.frames.map((frame) => frame.data.id)).toEqual([1, 2, 3]);
+
+		for (const id of [4, 5, 6]) {
+			await publisher.append({
+				channel: "private-room-1",
+				event: "message",
+				schemaIdentity: "room:message",
+				data: { id },
+			});
+		}
+		await setup.app.db
+			.delete(questpieChannelEventTable)
+			.where(
+				and(
+					eq(
+						questpieChannelEventTable.channelHash,
+						hashResolvedChannel("private-room-1"),
+					),
+					inArray(questpieChannelEventTable.seq, [4, 5]),
+				),
+			);
+		await events.drain();
+
+		expect(sink.frames.at(-1)).toEqual(
+			expect.objectContaining({
+				type: "channel_gap",
+				channel: "private-room-1",
+			}),
+		);
+		expect(
+			sink.frames
+				.filter((frame) => frame.type === "channel_event")
+				.map((frame) => frame.data.id),
+		).toEqual([1, 2, 3]);
+		expect(events.hasLocalSubscription("live-gap-room")).toBe(false);
+
+		// The torn-down subscription receives nothing further.
+		await publisher.append({
+			channel: "private-room-1",
+			event: "message",
+			schemaIdentity: "room:message",
+			data: { id: 7 },
+		});
+		await events.drain();
+		expect(
+			sink.frames.filter((frame) => frame.type === "channel_event"),
+		).toHaveLength(3);
+	});
+
+	test("one log read serves every subscriber on a channel", async () => {
+		// Reads were issued per subscriber: 50 subscribers on one channel cost
+		// 50 identical `seq > cursor` scans for a single event.
+		const events = ledger();
+		const reads: number[] = [];
+		const store = events as unknown as {
+			selectEvents: (channelHash: string, afterSeq: number) => Promise<unknown>;
+		};
+		const selectEvents = store.selectEvents.bind(events);
+		store.selectEvents = (channelHash: string, afterSeq: number) => {
+			reads.push(afterSeq);
+			return selectEvents(channelHash, afterSeq);
+		};
+
+		const sinks = [] as ReturnType<typeof createSink>[];
+		for (let index = 0; index < 20; index++) {
+			const sink = createSink(`shared-read-${index}`);
+			sinks.push(sink);
+			await events.subscribeLocal({
+				subscriptionId: `shared-read-${index}`,
+				channel: "private-room-1",
+				sink,
+			});
+		}
+		reads.length = 0;
+		await events.append({
+			channel: "private-room-1",
+			event: "message",
+			schemaIdentity: "room:message",
+			data: { id: 1 },
+		});
+		await events.drain();
+
+		expect(sinks.every((sink) => sink.frames.length === 1)).toBe(true);
+		// Two drain passes (the append's own, and the explicit one), one read each.
+		expect(reads.length).toBeLessThanOrEqual(2);
+	});
+
+	test("cleanup names the retention cap that actually bound", async () => {
+		// retentionBytes defaults to 64 MB and retentionMs to 24 h. The byte cap
+		// wins long before the day is up and used to do it silently.
+		const warnings: string[] = [];
+		const events = new ChannelEventLedger(
+			setup.app.db,
+			undefined,
+			undefined,
+			{ retentionMs: 24 * 60 * 60 * 1000, retentionBytes: 200 },
+			{ warn: (message: string) => warnings.push(message), error: () => {} },
+		);
+		ledgers.add(events);
+		for (const id of [1, 2, 3, 4]) {
+			await events.append({
+				channel: "private-room-1",
+				event: "message",
+				schemaIdentity: "room:message",
+				data: { id, filler: "z".repeat(120) },
+			});
+		}
+		await events.cleanup();
+
+		expect(warnings).toHaveLength(1);
+		expect(warnings[0]).toContain("retentionBytes");
+		expect(warnings[0]).toContain("retentionMs");
+		const remaining = await setup.app.db
+			.select()
+			.from(questpieChannelEventTable);
+		expect(remaining.length).toBeLessThan(4);
+	});
+
+	test("cleanup deletes in bounded statements instead of one transaction per row", async () => {
+		const events = ledger(undefined, {
+			retentionMs: 60_000,
+			retentionBytes: 0,
+		});
+		for (let id = 0; id < 40; id++) {
+			await events.append({
+				channel: "private-room-1",
+				event: "message",
+				schemaIdentity: "room:message",
+				data: { id },
+			});
+		}
+		await setup.app.db.execute(
+			sql`update questpie_channel_event set created_at = now() - interval '1 day'`,
+		);
+		// Count every write statement cleanup issues, whether it goes through the
+		// query builder or raw SQL, and whether it runs on the connection or
+		// inside a transaction.
+		let statements = 0;
+		const db = setup.app.db as Record<string, any>;
+		const original = {
+			execute: db.execute.bind(setup.app.db),
+			delete: db.delete.bind(setup.app.db),
+			transaction: db.transaction.bind(setup.app.db),
+		};
+		const count = <T>(value: T): T => {
+			statements += 1;
+			return value;
+		};
+		db.execute = (...args: any[]) => count(original.execute(...args));
+		db.delete = (...args: any[]) => count(original.delete(...args));
+		db.transaction = (callback: (tx: any) => any, ...rest: any[]) =>
+			original.transaction(
+				(tx: any) =>
+					callback(
+						new Proxy(tx, {
+							get(target, property, receiver) {
+								const value = Reflect.get(target, property, receiver);
+								if (property !== "execute" && property !== "delete") {
+									return value;
+								}
+								return (...args: any[]) => count(value.apply(target, args));
+							},
+						}),
+					),
+				...rest,
+			);
+		try {
+			await events.cleanup();
+		} finally {
+			Object.assign(db, original);
+		}
+
+		expect(await setup.app.db.select().from(questpieChannelEventTable)).toEqual(
+			[],
+		);
+		// Advisory lock, retention report and the deletes. Never proportional to
+		// the row count.
+		expect(statements).toBeLessThanOrEqual(4);
 	});
 
 	test("slow local sink closes instead of dropping and continuing", async () => {

--- a/packages/questpie/test/integration/read-path-query-compilation.test.ts
+++ b/packages/questpie/test/integration/read-path-query-compilation.test.ts
@@ -1,0 +1,341 @@
+/**
+ * How the collection read path COMPILES a query — the three ways it used to
+ * disagree with itself.
+ *
+ * 1. Range operators bound their value with the noop encoder while `eq` bound
+ *    the same value with the column's own encoder, so one predicate could put
+ *    two different wire values on the same column in one query.
+ * 2. An `orderBy` term that resolved to nothing was dropped in silence, so the
+ *    rows came back in an arbitrary order that merely looked sorted.
+ * 3. `?page=N` was parsed onto an option nobody read, so it always returned
+ *    page 1.
+ */
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+
+import { sql } from "drizzle-orm";
+import {
+	boolean,
+	integer,
+	jsonb,
+	numeric,
+	PgDialect,
+	pgTable,
+	text,
+	timestamp,
+	varchar,
+} from "drizzle-orm/pg-core";
+
+import { collection } from "../../src/exports/index.js";
+import { createFetchHandler } from "../../src/server/adapters/http.js";
+import { buildOperatorCondition } from "../../src/server/collection/crud/query-builders/where-builder.js";
+import { buildMockApp } from "../utils/mocks/mock-app-builder.js";
+import { createTestContext } from "../utils/test-context";
+import { runTestDbMigrations } from "../utils/test-db.js";
+
+// ---------------------------------------------------------------------------
+// 1 · Range operators must bind exactly like equality
+// ---------------------------------------------------------------------------
+
+const dialect = new PgDialect();
+const render = (condition: ReturnType<typeof buildOperatorCondition>) =>
+	dialect.sqlToQuery(condition as never).params;
+
+/** Columns standing in for the field factories that produce each of them. */
+const probe = pgTable("probe", {
+	// f.text() / f.email() / f.url() / f.select()
+	vc: varchar("vc", { length: 255 }),
+	// f.boolean()
+	flag: boolean("flag"),
+	// f.number()
+	count: integer("count"),
+	// f.number({ mode: "decimal" }) — the encoder sends text so Postgres keeps
+	// `numeric` semantics instead of comparing in float8.
+	price: numeric("price", { precision: 20, scale: 0, mode: "number" }),
+	// f.datetime() — timestamptz
+	startsAt: timestamp("starts_at", {
+		precision: 3,
+		withTimezone: true,
+		mode: "date",
+	}),
+	// createdAt / updatedAt / deletedAt — timestamp WITHOUT time zone
+	updatedAt: timestamp("updated_at", { precision: 3, mode: "date" }),
+	// f.json() / f.object()
+	meta: jsonb("meta"),
+	// .array()
+	tags: text("tags").array(),
+});
+
+const instant = new Date("2026-08-05T06:00:00.000Z");
+
+const bindingCases: Array<{ label: string; column: unknown; value: unknown }> =
+	[
+		{ label: "varchar (f.text)", column: probe.vc, value: "abc" },
+		{ label: "boolean (f.boolean)", column: probe.flag, value: true },
+		{ label: "integer (f.number)", column: probe.count, value: 42 },
+		{
+			label: "numeric (f.number({mode:'decimal'}))",
+			column: probe.price,
+			value: 10000000000000000,
+		},
+		{
+			label: "timestamptz (f.datetime)",
+			column: probe.startsAt,
+			value: instant,
+		},
+		{
+			label: "timestamp without tz (createdAt/updatedAt)",
+			column: probe.updatedAt,
+			value: instant,
+		},
+		{ label: "jsonb (f.json)", column: probe.meta, value: { a: 1 } },
+		{ label: "text[] (.array())", column: probe.tags, value: ["a", "b"] },
+	];
+
+describe("range operators bind like equality", () => {
+	for (const { label, column, value } of bindingCases) {
+		it(`binds gt/gte/lt/lte/ne the same as eq — ${label}`, () => {
+			const expected = render(buildOperatorCondition(column, "eq", value));
+
+			for (const op of ["gt", "gte", "lt", "lte", "ne"]) {
+				expect(
+					render(buildOperatorCondition(column, op, value)),
+					`operator '${op}' on ${label} must bind the value the same way 'eq' does`,
+				).toEqual(expected);
+			}
+		});
+	}
+
+	it("keeps the value untouched when the column is a bare SQL expression", () => {
+		// A localized COALESCE or a virtual(sql) carries no encoder, so there is
+		// nothing to apply and the value must pass through exactly as before.
+		const expr = sql`COALESCE(a, b)`;
+		expect(render(buildOperatorCondition(expr, "gt", instant))).toEqual([
+			instant,
+		]);
+	});
+});
+
+describe("a range boundary does not move with the server timezone", () => {
+	/**
+	 * `createdAt`/`updatedAt` are `timestamp` WITHOUT time zone. node-postgres
+	 * serializes a raw `Date` in LOCAL time with an offset, and Postgres discards
+	 * the offset for such a column — so binding a `Date` instead of the column's
+	 * own encoding moves the boundary by the process's UTC offset. That is
+	 * invisible on a UTC machine, which is why it survived CI.
+	 *
+	 * Rendering through node-postgres's own `prepareValue` is what the Node
+	 * runtime actually puts on the wire (`services/db.ts` picks `pg` off Bun).
+	 */
+	const script = `
+		import { PgDialect, pgTable, timestamp } from "drizzle-orm/pg-core";
+		import pgUtils from "pg/lib/utils.js";
+		import { buildOperatorCondition } from "./src/server/collection/crud/query-builders/where-builder.ts";
+
+		const t = pgTable("t", {
+			updatedAt: timestamp("updated_at", { precision: 3, mode: "date" }),
+		});
+		const dialect = new PgDialect();
+		const instant = new Date("2026-08-05T06:00:00.000Z");
+		const wire = (op) =>
+			pgUtils.prepareValue(
+				dialect.sqlToQuery(buildOperatorCondition(t.updatedAt, op, instant)).params[0],
+			);
+
+		console.log(JSON.stringify({ eq: wire("eq"), gt: wire("gt"), lte: wire("lte") }));
+	`;
+
+	const timezones = ["UTC", "Europe/Bratislava", "America/Los_Angeles"];
+	const packageRoot = new URL("../..", import.meta.url).pathname;
+
+	it("renders the same wire value in every timezone, and the same one eq renders", async () => {
+		const rendered: Array<Record<string, string>> = [];
+
+		for (const timezone of timezones) {
+			const child = Bun.spawn([process.execPath, "-e", script], {
+				cwd: packageRoot,
+				env: { ...Bun.env, TZ: timezone },
+				stdout: "pipe",
+				stderr: "pipe",
+			});
+			const [exitCode, stdout, stderr] = await Promise.all([
+				child.exited,
+				new Response(child.stdout).text(),
+				new Response(child.stderr).text(),
+			]);
+			expect(exitCode, stderr).toBe(0);
+			rendered.push(JSON.parse(stdout));
+		}
+
+		// The boundary is the same instant no matter where the server runs.
+		for (const [index, timezone] of timezones.entries()) {
+			expect(
+				rendered[index]?.gt,
+				`gt boundary under TZ=${timezone} must not depend on the timezone`,
+			).toBe(rendered[0]?.gt);
+		}
+
+		// ...and it is the same instant equality would have compared against, so a
+		// predicate mixing `eq` and `gt` on one column compares like with like.
+		for (const [index, timezone] of timezones.entries()) {
+			const row = rendered[index];
+			expect(row?.gt, `gt must bind like eq under TZ=${timezone}`).toBe(
+				row?.eq,
+			);
+			expect(row?.lte, `lte must bind like eq under TZ=${timezone}`).toBe(
+				row?.eq,
+			);
+		}
+
+		// The value written to the column is its UTC rendering, so the boundary
+		// compared against it must be too.
+		expect(rendered[0]?.gt).toBe("2026-08-05T06:00:00.000Z");
+	}, 30_000);
+});
+
+// ---------------------------------------------------------------------------
+// 2 · orderBy must not drop terms it cannot resolve
+// ---------------------------------------------------------------------------
+
+const widgets = collection("widgets")
+	.fields(({ f }) => ({
+		name: f.text().required(),
+		priceCents: f.number().required(),
+		// Filterable through `where` before this change, but not orderable.
+		priceDoubled: f.number().virtual(sql<number>`(widgets."priceCents" * 2)`),
+	}))
+	.access({ create: true, read: true, update: true });
+
+describe("orderBy refuses terms it cannot resolve", () => {
+	let setup: Awaited<ReturnType<typeof buildMockApp>>;
+	let ctx: ReturnType<typeof createTestContext>;
+
+	beforeAll(async () => {
+		setup = await buildMockApp({ collections: { widgets } });
+		await runTestDbMigrations(setup.app);
+		ctx = createTestContext();
+
+		// Inserted in an order that is NOT the sorted order, so a dropped ORDER BY
+		// term shows up as the insertion order rather than accidentally passing.
+		for (const [name, priceCents] of [
+			["beta", 300],
+			["alpha", 100],
+			["delta", 400],
+			["gamma", 200],
+		] as const) {
+			await setup.app.collections.widgets.create(
+				{ id: crypto.randomUUID(), name, priceCents },
+				ctx,
+			);
+		}
+	}, 60_000);
+
+	afterAll(async () => {
+		await setup?.cleanup();
+	});
+
+	it("throws on an order term that is not a column", async () => {
+		await expect(
+			setup.app.collections.widgets.find(
+				{ orderBy: { pricecents: "asc" } as never },
+				ctx,
+			),
+		).rejects.toThrow(/Cannot order by 'pricecents'/);
+	});
+
+	it("still sorts by a real column", async () => {
+		const result = await setup.app.collections.widgets.find(
+			{ orderBy: { name: "asc" } },
+			ctx,
+		);
+		expect(result.docs.map((d: any) => d.name)).toEqual([
+			"alpha",
+			"beta",
+			"delta",
+			"gamma",
+		]);
+	});
+
+	it("sorts by a virtual(sql) column instead of ignoring it", async () => {
+		const result = await setup.app.collections.widgets.find(
+			{ orderBy: { priceDoubled: "desc" } as never },
+			ctx,
+		);
+		expect(result.docs.map((d: any) => d.priceCents)).toEqual([
+			400, 300, 200, 100,
+		]);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// 3 · ?page=N
+// ---------------------------------------------------------------------------
+
+const notes = collection("notes")
+	.fields(({ f }) => ({ title: f.text().required() }))
+	.access({ create: true, read: true, update: true });
+
+describe("?page=N", () => {
+	let setup: Awaited<ReturnType<typeof buildMockApp>>;
+	let handler: ReturnType<typeof createFetchHandler>;
+
+	beforeAll(async () => {
+		setup = await buildMockApp({ collections: { notes } });
+		await runTestDbMigrations(setup.app);
+		handler = createFetchHandler(setup.app, { accessMode: "system" });
+
+		const ctx = createTestContext();
+		for (const title of ["n1", "n2", "n3", "n4", "n5", "n6"]) {
+			await setup.app.collections.notes.create(
+				{ id: crypto.randomUUID(), title },
+				ctx,
+			);
+		}
+	}, 60_000);
+
+	afterAll(async () => {
+		await setup?.cleanup();
+	});
+
+	const get = (query: string) =>
+		handler(new Request(`http://localhost/notes?${query}`));
+
+	it("returns the requested page, not page 1", async () => {
+		const paged = await get("page=2&limit=2&orderBy[title]=asc");
+		expect(paged.status).toBe(200);
+		const body = (await paged.json()) as { docs: any[]; page: number };
+
+		expect(body.docs.map((d) => d.title)).toEqual(["n3", "n4"]);
+		expect(body.page).toBe(2);
+	});
+
+	it("agrees with the equivalent offset", async () => {
+		const byPage = (await (
+			await get("page=3&limit=2&orderBy[title]=asc")
+		).json()) as { docs: any[] };
+		const byOffset = (await (
+			await get("offset=4&limit=2&orderBy[title]=asc")
+		).json()) as { docs: any[] };
+
+		expect(byPage.docs.map((d) => d.title)).toEqual(["n5", "n6"]);
+		expect(byPage.docs.map((d) => d.title)).toEqual(
+			byOffset.docs.map((d) => d.title),
+		);
+	});
+
+	it("refuses a page it cannot honor rather than ignoring it", async () => {
+		// No page size to multiply by.
+		expect((await get("page=2")).status).toBe(400);
+		// Pages are 1-based.
+		expect((await get("page=0&limit=2")).status).toBe(400);
+		// Two ways of saying where to start.
+		expect((await get("page=2&limit=2&offset=0")).status).toBe(400);
+	});
+
+	it("leaves plain offset paging alone", async () => {
+		const body = (await (
+			await get("offset=2&limit=2&orderBy[title]=asc")
+		).json()) as { docs: any[]; page: number };
+		expect(body.docs.map((d) => d.title)).toEqual(["n3", "n4"]);
+		expect(body.page).toBe(2);
+	});
+});

--- a/packages/questpie/test/integration/realtime-admission-slots.test.ts
+++ b/packages/questpie/test/integration/realtime-admission-slots.test.ts
@@ -1,0 +1,320 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { collection } from "../../src/exports/index.js";
+import { createFetchHandler } from "../../src/server/adapters/http.js";
+import { isRealtimeTopicRejectedPayload } from "../../src/shared/realtime-error.js";
+import { buildMockApp } from "../utils/mocks/mock-app-builder";
+import { runTestDbMigrations } from "../utils/test-db";
+
+/**
+ * Connection slots, end to end through the real SSE route.
+ *
+ * The outage these cover: a slot was released only by an explicit teardown, so
+ * when nothing propagated the client's disconnect the count was immortal and
+ * the principal was locked out until the process restarted. Before this suite
+ * there was no test anywhere asserting that an SSE slot is ever released.
+ */
+
+type Setup = Awaited<ReturnType<typeof buildMockApp>>;
+
+let setup: Setup | undefined;
+
+afterEach(async () => {
+	await setup?.cleanup?.();
+	setup = undefined;
+});
+
+const SESSION = {
+	user: { id: "slot-user" },
+	session: { id: "slot-session" },
+};
+
+async function build(realtime: Record<string, unknown>) {
+	const built = await buildMockApp(
+		{
+			collections: {
+				posts: collection("posts")
+					.fields(({ f }) => ({ title: f.text().required() }))
+					.access({ read: true }),
+			},
+		},
+		{ realtime: { retentionDays: 0, ...realtime } as never },
+	);
+	await runTestDbMigrations(built.app);
+	setup = built;
+	return built;
+}
+
+function handlerFor(app: Setup["app"], authenticated: boolean) {
+	return createFetchHandler(app, {
+		getSession: async () => (authenticated ? SESSION : null),
+	});
+}
+
+function subscribeRequest(signal?: AbortSignal) {
+	return new Request("http://localhost/realtime", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({
+			topics: [
+				{
+					id: "posts-all",
+					resourceType: "collection",
+					resource: "posts",
+					operation: "find",
+					limit: 10,
+				},
+			],
+		}),
+		...(signal ? { signal } : {}),
+	});
+}
+
+/** A client that never reads its stream — the shape of an abandoned peer. */
+async function subscribe(
+	handler: (request: Request) => Promise<Response>,
+	signal?: AbortSignal,
+): Promise<Response> {
+	const response = await handler(subscribeRequest(signal));
+	if (response.status !== 200) await response.text().catch(() => {});
+	return response;
+}
+
+/** A client that keeps reading, the way a live browser does. */
+function liveReader(body: ReadableStream<Uint8Array>) {
+	const reader = body.getReader();
+	const pump = (async () => {
+		try {
+			// `close()` cancels the reader, which resolves the pending read as done.
+			for (;;) {
+				const chunk = await reader.read();
+				if (chunk.done) return;
+			}
+		} catch {
+			// Cancelled by the test.
+		}
+	})();
+	return {
+		close: async () => {
+			await reader.cancel().catch(() => {});
+			await pump;
+		},
+	};
+}
+
+/**
+ * Read until the named SSE event arrives, so a test can be sure the stream is
+ * fully established. Without this, tearing a connection down mid-`start()`
+ * releases the slot through the start-catch and proves nothing about the
+ * disconnect paths.
+ */
+async function awaitEvent(
+	body: ReadableStream<Uint8Array>,
+	event: string,
+	timeoutMs: number,
+): Promise<void> {
+	const reader = body.getReader();
+	const decoder = new TextDecoder();
+	let seen = "";
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	const expired = new Promise<"timeout">((resolve) => {
+		timer = setTimeout(() => resolve("timeout"), timeoutMs);
+	});
+	try {
+		for (;;) {
+			const outcome = await Promise.race([reader.read(), expired]);
+			if (outcome === "timeout") {
+				throw new Error(`Timed out waiting for SSE event "${event}"`);
+			}
+			if (outcome.done) {
+				throw new Error(`Stream ended before SSE event "${event}"`);
+			}
+			seen += decoder.decode(outcome.value, { stream: true });
+			if (seen.includes(`event: ${event}`)) return;
+		}
+	} finally {
+		if (timer) clearTimeout(timer);
+		reader.releaseLock();
+	}
+}
+
+async function readsToCompletion(
+	body: ReadableStream<Uint8Array>,
+	timeoutMs: number,
+): Promise<boolean> {
+	const reader = body.getReader();
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	const expired = new Promise<"timeout">((resolve) => {
+		timer = setTimeout(() => resolve("timeout"), timeoutMs);
+	});
+	try {
+		for (;;) {
+			const outcome = await Promise.race([reader.read(), expired]);
+			if (outcome === "timeout") return false;
+			if (outcome.done) return true;
+		}
+	} finally {
+		if (timer) clearTimeout(timer);
+		reader.releaseLock();
+	}
+}
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+describe("realtime admission slots", () => {
+	// TTL is 4 keepalive beats, so 60ms of keepalive is a 240ms lease.
+	const FAST_LEASE = { keepAliveIntervalMs: 60 };
+	const LEASE_MS = 60 * 4;
+
+	test("a leaked slot self-heals after the TTL, and its stream is torn down", async () => {
+		const built = await build({
+			...FAST_LEASE,
+			admission: { maxConnectionsPerPrincipal: 2 },
+		});
+		const handler = handlerFor(built.app, true);
+
+		const first = await subscribe(handler);
+		const second = await subscribe(handler);
+		const refused = await subscribe(handler);
+		expect([first.status, second.status, refused.status]).toEqual([
+			200, 200, 400,
+		]);
+
+		// Nobody read either stream and nothing aborted them: exactly the state
+		// the runtime leaves behind when it never reports the disconnect.
+		await sleep(LEASE_MS + 200);
+
+		const readmitted = await subscribe(handler);
+		expect(readmitted.status).toBe(200);
+
+		// Reclaiming the slot must also close the stream holding it — otherwise
+		// the scheduler group and topology heartbeat behind it leak on.
+		expect(await readsToCompletion(first.body!, 2000)).toBe(true);
+
+		await readmitted.body?.cancel().catch(() => {});
+		await second.body?.cancel().catch(() => {});
+	}, 30_000);
+
+	test("a live client renews its lease, so the TTL never evicts it", async () => {
+		const built = await build({
+			...FAST_LEASE,
+			admission: { maxConnectionsPerPrincipal: 1 },
+		});
+		const handler = handlerFor(built.app, true);
+
+		const live = await subscribe(handler);
+		expect(live.status).toBe(200);
+		const reader = liveReader(live.body!);
+
+		// Three lease windows of an idle-but-read stream. Only the keepalive
+		// flows, which is the point: the TTL has to outlast a silent connection.
+		await sleep(LEASE_MS * 3);
+
+		const refused = await subscribe(handler);
+		expect(refused.status).toBe(400);
+
+		await reader.close();
+	}, 30_000);
+
+	test("an unauthenticated client is subject to a cap", async () => {
+		const built = await build({
+			...FAST_LEASE,
+			admission: {
+				maxConnectionsPerPrincipal: 5,
+				maxAnonymousConnections: 2,
+			},
+		});
+		const handler = handlerFor(built.app, false);
+
+		const statuses: number[] = [];
+		const bodies: ReadableStream<Uint8Array>[] = [];
+		let lastRefusal: Response | undefined;
+		for (let index = 0; index < 4; index += 1) {
+			const response = await handler(subscribeRequest());
+			statuses.push(response.status);
+			if (response.status === 200 && response.body) bodies.push(response.body);
+			else lastRefusal = response;
+		}
+		// Every anonymous connection shares one bucket, so the cap binds.
+		expect(statuses).toEqual([200, 200, 400, 400]);
+
+		const payload = (await lastRefusal!.json()) as {
+			errors: unknown[];
+		};
+		expect(payload.errors).toHaveLength(1);
+		expect(isRealtimeTopicRejectedPayload(payload.errors[0])).toBe(true);
+		expect(payload.errors[0]).toMatchObject({
+			details: { reason: "connection_limit", configuredLimit: 2, observed: 2 },
+		});
+
+		for (const body of bodies) await body.cancel().catch(() => {});
+	}, 30_000);
+
+	test("a connection_limit rejection reaches the client typed, with both numbers", async () => {
+		const built = await build({
+			...FAST_LEASE,
+			admission: { maxConnectionsPerPrincipal: 1 },
+		});
+		const handler = handlerFor(built.app, true);
+
+		const held = await subscribe(handler);
+		expect(held.status).toBe(200);
+
+		const refused = await handler(subscribeRequest());
+		expect(refused.status).toBe(400);
+		const payload = (await refused.json()) as { errors: unknown[] };
+		const rejection = payload.errors[0];
+		expect(isRealtimeTopicRejectedPayload(rejection)).toBe(true);
+		expect(rejection).toMatchObject({
+			code: "REALTIME_TOPIC_REJECTED",
+			topicId: "posts-all",
+			resource: "posts",
+			operation: "find",
+			retryable: false,
+			details: {
+				reason: "connection_limit",
+				// The configured cap and what the server actually counted. These
+				// two numbers are the entire diagnosis.
+				configuredLimit: 1,
+				observed: 1,
+			},
+		});
+		expect((rejection as { message: string }).message).toContain("1 of 1");
+
+		await held.body?.cancel().catch(() => {});
+	}, 30_000);
+
+	test("an SSE slot is released when the client disconnects", async () => {
+		// A lease far longer than the test, so only a real release path can free
+		// the slot here — the TTL cannot stand in for it.
+		const built = await build({
+			keepAliveIntervalMs: 30_000,
+			admission: { maxConnectionsPerPrincipal: 1 },
+		});
+		const handler = handlerFor(built.app, true);
+
+		// 1. The client aborts the request (browser navigation, watchdog reconnect).
+		const aborter = new AbortController();
+		const aborted = await subscribe(handler, aborter.signal);
+		expect(aborted.status).toBe(200);
+		await awaitEvent(aborted.body!, "snapshot", 5000);
+		await sleep(100);
+		expect((await subscribe(handler)).status).toBe(400);
+
+		aborter.abort();
+		await sleep(100);
+		const afterAbort = await subscribe(handler);
+		expect(afterAbort.status).toBe(200);
+
+		// 2. The consumer cancels the response body.
+		await awaitEvent(afterAbort.body!, "snapshot", 5000);
+		await sleep(100);
+		expect((await subscribe(handler)).status).toBe(400);
+
+		await afterAbort.body!.cancel();
+		await sleep(100);
+		const afterCancel = await subscribe(handler);
+		expect(afterCancel.status).toBe(200);
+		await afterCancel.body?.cancel().catch(() => {});
+	}, 30_000);
+});

--- a/packages/questpie/test/integration/realtime-change-capture.test.ts
+++ b/packages/questpie/test/integration/realtime-change-capture.test.ts
@@ -1,0 +1,288 @@
+import { afterEach, describe, expect, it } from "bun:test";
+
+import { PGlite } from "@electric-sql/pglite";
+import { pg_trgm } from "@electric-sql/pglite/contrib/pg_trgm";
+
+import {
+	collection,
+	getTxid,
+	global,
+	questpieRealtimeLogTable,
+} from "../../src/exports/index.js";
+import { realtimeSubscribe } from "../../src/server/adapters/routes/realtime.js";
+import { buildMockApp } from "../utils/mocks/mock-app-builder";
+import { createTestContext } from "../utils/test-context";
+import { runTestDbMigrations } from "../utils/test-db";
+
+/**
+ * Records every statement the driver executes, including the ones issued inside
+ * a managed transaction — which is where change capture writes the outbox.
+ * Counting statements is the only way to tell "the outbox ended up empty" apart
+ * from "the outbox was never touched": a `DELETE`d row and a row that was never
+ * inserted look identical from a `SELECT`.
+ */
+type SqlProbe = {
+	statements: string[];
+	reset: () => void;
+	realtime: () => string[];
+};
+
+const REALTIME_CAPTURE_SQL = /questpie_realtime_(log|head)/i;
+
+function instrumentPglite(client: PGlite): SqlProbe {
+	const statements: string[] = [];
+	const record = (statement: unknown) => {
+		if (typeof statement === "string") statements.push(statement);
+	};
+
+	const wrapExecutor = <T extends object>(target: T): T => {
+		const executor = target as unknown as {
+			query?: (...args: unknown[]) => unknown;
+			exec?: (...args: unknown[]) => unknown;
+		};
+		const query = executor.query?.bind(executor);
+		if (query) {
+			executor.query = (...args: unknown[]) => {
+				record(args[0]);
+				return query(...args);
+			};
+		}
+		const exec = executor.exec?.bind(executor);
+		if (exec) {
+			executor.exec = (...args: unknown[]) => {
+				record(args[0]);
+				return exec(...args);
+			};
+		}
+		return target;
+	};
+
+	wrapExecutor(client);
+	const transaction = client.transaction.bind(client);
+	(client as unknown as { transaction: unknown }).transaction = (
+		callback: (tx: object) => unknown,
+		...rest: unknown[]
+	) =>
+		(transaction as (...args: unknown[]) => unknown)(
+			(tx: object) => callback(wrapExecutor(tx)),
+			...rest,
+		);
+
+	return {
+		statements,
+		reset: () => {
+			statements.length = 0;
+		},
+		realtime: () =>
+			statements.filter((statement) => REALTIME_CAPTURE_SQL.test(statement)),
+	};
+}
+
+async function flushEventLoopTurns(turns = 20): Promise<void> {
+	for (let turn = 0; turn < turns; turn += 1) {
+		await new Promise<void>((resolve) => setImmediate(resolve));
+	}
+}
+
+const posts = () =>
+	collection("posts")
+		.fields(({ f }) => ({ title: f.text().required() }))
+		.access({ read: true });
+
+const siteSettings = () =>
+	global("site_settings").fields(({ f }) => ({ title: f.text().required() }));
+
+async function buildApp(changeCapture: boolean) {
+	const client = await PGlite.create({ extensions: { pg_trgm } });
+	await client.exec("CREATE EXTENSION IF NOT EXISTS pg_trgm");
+	const probe = instrumentPglite(client);
+
+	const setup = await buildMockApp(
+		{
+			collections: { posts: posts() },
+			globals: { siteSettings: siteSettings() },
+		},
+		{ db: { pglite: client }, realtime: { changeCapture } },
+	);
+	await runTestDbMigrations(setup.app);
+
+	return {
+		app: setup.app,
+		probe,
+		ctx: createTestContext(setup.app),
+		cleanup: async () => {
+			await setup.cleanup();
+			await client.close();
+		},
+	};
+}
+
+const collectionTopic = {
+	id: "col-posts",
+	resourceType: "collection" as const,
+	resource: "posts",
+};
+
+const globalTopic = {
+	id: "global-siteSettings",
+	resourceType: "global" as const,
+	resource: "siteSettings",
+};
+
+const subscribeRequest = (topics: unknown[]) =>
+	new Request("http://localhost/realtime", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ topics }),
+	});
+
+describe("realtime change capture switch", () => {
+	let active: Awaited<ReturnType<typeof buildApp>> | undefined;
+
+	afterEach(async () => {
+		await active?.cleanup();
+		active = undefined;
+	}, 30_000);
+
+	describe("changeCapture: false", () => {
+		it("issues no realtime SQL for a collection mutation", async () => {
+			active = await buildApp(false);
+			active.probe.reset();
+
+			const created = await active.app.collections.posts.create(
+				{ title: "Uncaptured" },
+				active.ctx,
+			);
+			await active.app.collections.posts.update(
+				{ where: { id: created.id }, data: { title: "Still uncaptured" } },
+				active.ctx,
+			);
+			await active.app.collections.posts.delete(
+				{ where: { id: created.id } },
+				active.ctx,
+			);
+			await flushEventLoopTurns();
+
+			expect(active.probe.realtime()).toEqual([]);
+			// The mutations really ran — an empty probe from a no-op app would prove
+			// nothing.
+			expect(active.probe.statements.length).toBeGreaterThan(0);
+			expect(
+				await active.app.db.select().from(questpieRealtimeLogTable),
+			).toHaveLength(0);
+		}, 30_000);
+
+		it("issues no realtime SQL for a global mutation", async () => {
+			active = await buildApp(false);
+			active.probe.reset();
+
+			await active.app.globals.siteSettings.update(
+				{ title: "Uncaptured" },
+				active.ctx,
+			);
+			await flushEventLoopTurns();
+
+			expect(active.probe.realtime()).toEqual([]);
+			expect(
+				await active.app.db.select().from(questpieRealtimeLogTable),
+			).toHaveLength(0);
+		}, 30_000);
+
+		it("refuses a collection subscription with change_capture_disabled", async () => {
+			active = await buildApp(false);
+
+			const response = await realtimeSubscribe(
+				active.app,
+				subscribeRequest([collectionTopic]),
+				{},
+				undefined,
+				{ accessMode: "user" },
+			);
+
+			expect(response.status).toBe(400);
+			expect(await response.json()).toMatchObject({
+				errors: [
+					{
+						code: "REALTIME_TOPIC_REJECTED",
+						topicId: "col-posts",
+						resource: "posts",
+						retryable: false,
+						details: { reason: "change_capture_disabled" },
+					},
+				],
+			});
+			expect(active.app.realtime.listeners.size).toBe(0);
+		}, 30_000);
+
+		it("refuses a global subscription with change_capture_disabled", async () => {
+			active = await buildApp(false);
+
+			const response = await realtimeSubscribe(
+				active.app,
+				subscribeRequest([globalTopic]),
+				{},
+				undefined,
+				{ accessMode: "user" },
+			);
+
+			expect(response.status).toBe(400);
+			expect(await response.json()).toMatchObject({
+				errors: [
+					{
+						code: "REALTIME_TOPIC_REJECTED",
+						details: { reason: "change_capture_disabled" },
+					},
+				],
+			});
+		}, 30_000);
+
+		it("returns no txid, so optimistic clients cannot silently mismatch", async () => {
+			active = await buildApp(false);
+
+			const created = await active.app.collections.posts.create(
+				{ title: "No txid" },
+				active.ctx,
+			);
+
+			expect(getTxid(created)).toBeUndefined();
+		}, 30_000);
+	});
+
+	describe("changeCapture on (default)", () => {
+		it("still writes the outbox and correlates the txid", async () => {
+			active = await buildApp(true);
+			active.probe.reset();
+
+			const created = await active.app.collections.posts.create(
+				{ title: "Captured" },
+				active.ctx,
+			);
+
+			const realtimeSql = active.probe.realtime();
+			expect(
+				realtimeSql.filter((statement) =>
+					/insert into "questpie_realtime_log"/i.test(statement),
+				),
+			).toHaveLength(1);
+
+			const rows = await active.app.db.select().from(questpieRealtimeLogTable);
+			expect(rows).toHaveLength(1);
+			expect(getTxid(created)).toBe(rows[0]?.txid as string);
+		}, 30_000);
+
+		it("admits a collection subscription", async () => {
+			active = await buildApp(true);
+
+			const response = await realtimeSubscribe(
+				active.app,
+				subscribeRequest([collectionTopic]),
+				{},
+				undefined,
+				{ accessMode: "user" },
+			);
+
+			expect(response.status).toBe(200);
+			await response.body?.cancel();
+		}, 30_000);
+	});
+});

--- a/packages/questpie/test/integration/realtime-drain-cursor-postgres.test.ts
+++ b/packages/questpie/test/integration/realtime-drain-cursor-postgres.test.ts
@@ -1,0 +1,517 @@
+/**
+ * The outbox drain against a real PostgreSQL server, with real concurrency.
+ *
+ * These cover the properties that used to be bought with a fleet-wide lock on
+ * `questpie_realtime_head` and are now bought with the `(txid, seq)` cursor:
+ * nothing is skipped when transaction ids and sequences invert, one
+ * transaction's appends stay together and in order, aborted work never
+ * surfaces, a resuming client is only told "current" when that is provable, a
+ * booting node does not replay the retained log, and retention pruning does not
+ * drag the cursor backwards.
+ *
+ * PGlite cannot host them: every one needs two connections whose transactions
+ * overlap. Point the suite at a throwaway server:
+ *
+ *   QUESTPIE_REALTIME_TXID_DATABASE_URL=postgresql://probe:probe@127.0.0.1:55450/qp_rt_test \
+ *     bun test packages/questpie/test/integration/realtime-drain-cursor-postgres.test.ts
+ */
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+
+import { eq, sql } from "drizzle-orm";
+import pg from "pg";
+
+import { withTransaction } from "../../src/exports/index.js";
+import { questpieRealtimeLogTable } from "../../src/server/modules/core/integrated/realtime/collection.js";
+import { RealtimeService } from "../../src/server/modules/core/integrated/realtime/service.js";
+import type { ChangeBroker } from "../../src/server/modules/core/integrated/realtime/transport.js";
+import type { RealtimeChangeEvent } from "../../src/server/modules/core/integrated/realtime/types.js";
+import { buildMockApp } from "../utils/mocks/mock-app-builder.js";
+import { runTestDbMigrations } from "../utils/test-db.js";
+
+const databaseUrl =
+	process.env.QUESTPIE_REALTIME_TXID_DATABASE_URL ??
+	process.env.QUESTPIE_TRANSACTION_LOCK_DATABASE_URL;
+
+/** A broker that accepts and drops every notice, so drains are driven here. */
+const silentBroker: ChangeBroker = {
+	start: async () => {},
+	stop: async () => {},
+	publish: async () => {},
+};
+
+let app: any;
+let cleanup: (() => Promise<void>) | undefined;
+
+/**
+ * Run drains until the service is quiet.
+ *
+ * `drain()` collapses concurrent calls, so a single call can return without
+ * having read anything when the startup drain is still in flight.
+ */
+async function drainFully(): Promise<void> {
+	const realtime = app.realtime as any;
+	for (let attempt = 0; attempt < 200; attempt++) {
+		await realtime.drain("poll");
+		if (!realtime.draining && !realtime.drainPending) return;
+		await new Promise((resolve) => setTimeout(resolve, 5));
+	}
+	throw new Error("realtime drain never settled");
+}
+
+const append = (
+	recordId: string,
+	operation = "update",
+): Promise<RealtimeChangeEvent> =>
+	app.realtime.appendChange({
+		resourceType: "collection",
+		resource: "posts",
+		operation,
+		recordId,
+	});
+
+/** Assign a transaction id without appending — what an ordinary write does. */
+const takeXid = (tx: any): Promise<unknown> =>
+	tx.execute(sql`select pg_current_xact_id()`);
+
+async function collect(): Promise<{
+	seen: RealtimeChangeEvent[];
+	stop: () => void;
+}> {
+	const seen: RealtimeChangeEvent[] = [];
+	const stop = app.realtime.subscribe((event: RealtimeChangeEvent) => {
+		seen.push(event);
+	});
+	// subscribe() starts the service in the background; the cursor is only
+	// seeded once that resolves.
+	await (app.realtime as any).ensureStarted();
+	await drainFully();
+	seen.length = 0;
+	return { seen, stop };
+}
+
+const recordIds = (events: RealtimeChangeEvent[]): (string | null)[] =>
+	events.map((event) => event.recordId);
+
+describe.skipIf(!databaseUrl)("realtime drain cursor on PostgreSQL", () => {
+	beforeAll(async () => {
+		const pool = new pg.Pool({ connectionString: databaseUrl, max: 1 });
+		try {
+			await pool.query("create extension if not exists pg_trgm");
+		} finally {
+			await pool.end();
+		}
+		const setup = await buildMockApp(
+			{},
+			{
+				db: { url: databaseUrl!, pool: { max: 16 } },
+				realtime: { changeBroker: silentBroker, pollIntervalMs: 0 },
+			},
+		);
+		await runTestDbMigrations(setup.app);
+		app = setup.app;
+		cleanup = async () => {
+			await setup.app.migrations.down();
+			await setup.cleanup();
+		};
+	}, 120_000);
+
+	afterAll(async () => {
+		await cleanup?.();
+	}, 120_000);
+
+	it("delivers a change whose transaction id inverts against its sequence", async () => {
+		const { seen, stop } = await collect();
+
+		let firstHasXid = () => {};
+		const firstXid = new Promise<void>((resolve) => {
+			firstHasXid = resolve;
+		});
+		let releaseFirst = () => {};
+		const holdFirst = new Promise<void>((resolve) => {
+			releaseFirst = resolve;
+		});
+		let secondAppended = () => {};
+		const appended = new Promise<void>((resolve) => {
+			secondAppended = resolve;
+		});
+		let releaseSecond = () => {};
+		const holdSecond = new Promise<void>((resolve) => {
+			releaseSecond = resolve;
+		});
+
+		try {
+			// T1 takes the LOWER transaction id first and appends nothing yet.
+			const first = withTransaction(app.db, async (tx: any) => {
+				await takeXid(tx);
+				firstHasXid();
+				await holdFirst;
+				return append("low-txid-high-seq");
+			});
+			await firstXid;
+
+			// T2 takes a HIGHER transaction id and appends the LOWER sequence.
+			const second = withTransaction(app.db, async (tx: any) => {
+				await takeXid(tx);
+				const event = await append("high-txid-low-seq");
+				secondAppended();
+				await holdSecond;
+				return event;
+			});
+			await appended;
+
+			releaseFirst();
+			const firstEvent = await first;
+
+			// While T2 is open only T1's row is settled — and its sequence is the
+			// HIGHER one. A seq-only cursor advances past T2's row here and never
+			// comes back for it.
+			await drainFully();
+			expect(recordIds(seen)).toEqual(["low-txid-high-seq"]);
+
+			releaseSecond();
+			const secondEvent = await second;
+			expect(secondEvent.seq).toBeLessThan(firstEvent.seq);
+			expect(BigInt(secondEvent.txid!)).toBeGreaterThan(
+				BigInt(firstEvent.txid!),
+			);
+
+			await drainFully();
+			expect(recordIds(seen)).toEqual([
+				"low-txid-high-seq",
+				"high-txid-low-seq",
+			]);
+		} finally {
+			releaseFirst();
+			releaseSecond();
+			stop();
+		}
+	}, 60_000);
+
+	it("delivers every append of one transaction, in insertion order", async () => {
+		const { seen, stop } = await collect();
+		try {
+			const events = await withTransaction(app.db, async () => [
+				await append("one"),
+				await append("two"),
+				await append("three"),
+			]);
+			expect(new Set(events.map((event) => event.txid)).size).toBe(1);
+
+			await drainFully();
+			expect(recordIds(seen)).toEqual(["one", "two", "three"]);
+		} finally {
+			stop();
+		}
+	}, 60_000);
+
+	it("never delivers an aborted transaction's appends", async () => {
+		const { seen, stop } = await collect();
+		try {
+			await expect(
+				withTransaction(app.db, async () => {
+					await append("rolled-back");
+					throw new Error("business failure");
+				}),
+			).rejects.toThrow("business failure");
+
+			await append("committed");
+			await drainFully();
+			expect(recordIds(seen)).toEqual(["committed"]);
+
+			// The aborted row consumed a sequence number; the cursor must not stall
+			// on the hole it left behind.
+			await append("after-the-hole");
+			await drainFully();
+			expect(recordIds(seen)).toEqual(["committed", "after-the-hole"]);
+		} finally {
+			stop();
+		}
+	}, 60_000);
+
+	it("resumes from a stored cursor without replaying or skipping", async () => {
+		const { seen, stop } = await collect();
+		try {
+			await append("before-disconnect");
+			await drainFully();
+			expect(recordIds(seen)).toEqual(["before-disconnect"]);
+			const storedCursor = await app.realtime.getLatestSeq();
+			stop();
+
+			// Nothing happened while the client was away.
+			expect(await app.realtime.getResumeState(storedCursor)).toEqual({
+				latestSeq: storedCursor,
+				reset: false,
+				current: true,
+			});
+
+			// Something did.
+			await append("while-away");
+			const afterWrite = await app.realtime.getResumeState(storedCursor);
+			expect(afterWrite.current).toBe(false);
+			expect(afterWrite.reset).toBe(false);
+			expect(afterWrite.latestSeq).toBeGreaterThan(storedCursor);
+		} finally {
+			stop();
+		}
+	}, 60_000);
+
+	it("refuses to call a resuming client current while an unsettled change is already committed", async () => {
+		const { stop } = await collect();
+		let hasXid = () => {};
+		const blocker = new Promise<void>((resolve) => {
+			hasXid = resolve;
+		});
+		let release = () => {};
+		const hold = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+
+		try {
+			await append("stored");
+			await drainFully();
+			const storedCursor = await app.realtime.getLatestSeq();
+			expect((await app.realtime.getResumeState(storedCursor)).current).toBe(
+				true,
+			);
+
+			// An unrelated transaction holds a LOW id open...
+			const blocking = withTransaction(app.db, async (tx: any) => {
+				await takeXid(tx);
+				hasXid();
+				await hold;
+			});
+			await blocker;
+
+			// ...so this append commits, is visible, and is still not settled. The
+			// settled head therefore still equals the client's stored cursor, and a
+			// sequence comparison alone would wrongly report "current".
+			await append("committed-but-unsettled");
+			const whileBlocked = await app.realtime.getResumeState(storedCursor);
+			expect(whileBlocked.latestSeq).toBe(storedCursor);
+			expect(whileBlocked.current).toBe(false);
+
+			release();
+			await blocking;
+			const afterRelease = await app.realtime.getResumeState(storedCursor);
+			expect(afterRelease.current).toBe(false);
+			expect(afterRelease.latestSeq).toBeGreaterThan(storedCursor);
+		} finally {
+			release();
+			stop();
+		}
+	}, 60_000);
+
+	it("does not replay the retained log when a node boots with no subscribers", async () => {
+		for (const id of ["old-1", "old-2", "old-3"]) await append(id);
+
+		// A second node, booting after those writes with an empty listener set.
+		// It must adopt the settled head, so its first subscriber sees what
+		// happens next rather than the whole retained log — three days of it by
+		// default, on every deploy.
+		const booting = new RealtimeService(app.db, {
+			changeBroker: silentBroker,
+			pollIntervalMs: 0,
+		});
+		const seen: RealtimeChangeEvent[] = [];
+		const stop = booting.subscribe((event: RealtimeChangeEvent) => {
+			seen.push(event);
+		});
+		const drainBooting = async () => {
+			for (let attempt = 0; attempt < 200; attempt++) {
+				await (booting as any).drain("poll");
+				if (!(booting as any).draining && !(booting as any).drainPending)
+					return;
+				await new Promise((resolve) => setTimeout(resolve, 5));
+			}
+			throw new Error("booting node drain never settled");
+		};
+
+		try {
+			await (booting as any).ensureStarted();
+			await drainBooting();
+			expect(seen).toEqual([]);
+
+			await append("after-boot");
+			await drainBooting();
+			expect(recordIds(seen)).toEqual(["after-boot"]);
+		} finally {
+			stop();
+			await booting.destroy();
+		}
+	}, 60_000);
+
+	it("keeps the cursor and the resume horizon consistent after retention pruning", async () => {
+		const { seen, stop } = await collect();
+		try {
+			await append("kept-1");
+			await drainFully();
+			const cursorAfterFirst = await app.realtime.getLatestSeq();
+
+			await append("kept-2");
+			await drainFully();
+			expect(recordIds(seen)).toEqual(["kept-1", "kept-2"]);
+
+			// Age every row past the retention window and prune, exactly as
+			// scheduleRetentionCleanup does.
+			await app.db.execute(
+				sql`update questpie_realtime_log set created_at = now() - interval '30 days', settled_at = now() - interval '30 days'`,
+			);
+			await app.realtime.cleanupOutbox(true);
+
+			// A drained node keeps its position: pruning resurrects nothing.
+			await drainFully();
+			expect(seen).toHaveLength(2);
+
+			// A client resuming from a pruned position is told to reset.
+			const pruned = await app.realtime.getResumeState(cursorAfterFirst);
+			expect(pruned.reset).toBe(true);
+			expect(pruned.current).toBe(false);
+
+			// New changes still flow through the same cursor.
+			await append("after-prune");
+			await drainFully();
+			expect(recordIds(seen)).toEqual(["kept-1", "kept-2", "after-prune"]);
+		} finally {
+			stop();
+		}
+	}, 60_000);
+
+	it("never prunes a committed row before the settlement frontier lets a node drain it", async () => {
+		const { seen, stop } = await collect();
+		await append("stored-before-blocker");
+		await drainFully();
+		const storedCursor = await app.realtime.getLatestSeq();
+		seen.length = 0;
+		let hasXid = () => {};
+		const blocker = new Promise<void>((resolve) => {
+			hasXid = resolve;
+		});
+		let release = () => {};
+		const hold = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+
+		try {
+			const blocking = withTransaction(app.db, async (tx: any) => {
+				await takeXid(tx);
+				hasXid();
+				await hold;
+			});
+			await blocker;
+
+			const event = await append("old-but-unsettled");
+			await app.db.execute(
+				sql`update questpie_realtime_log set created_at = now() - interval '30 days' where seq = ${event.seq}`,
+			);
+			await app.realtime.cleanupOutbox(true);
+
+			const whileBlocked = await app.db
+				.select({ settledAt: questpieRealtimeLogTable.settledAt })
+				.from(questpieRealtimeLogTable)
+				.where(eq(questpieRealtimeLogTable.seq, event.seq));
+			expect(whileBlocked).toEqual([{ settledAt: null }]);
+			expect((await app.realtime.getResumeState(storedCursor)).current).toBe(
+				false,
+			);
+			await drainFully();
+			expect(seen).toEqual([]);
+
+			release();
+			await blocking;
+			await app.realtime.cleanupOutbox(true);
+
+			const afterSettlement = await app.db
+				.select({ settledAt: questpieRealtimeLogTable.settledAt })
+				.from(questpieRealtimeLogTable)
+				.where(eq(questpieRealtimeLogTable.seq, event.seq));
+			expect(afterSettlement).toHaveLength(1);
+			expect(afterSettlement[0]?.settledAt).not.toBeNull();
+			expect((await app.realtime.getResumeState(storedCursor)).current).toBe(
+				false,
+			);
+
+			await drainFully();
+			expect(recordIds(seen)).toEqual(["old-but-unsettled"]);
+		} finally {
+			release();
+			stop();
+		}
+	}, 60_000);
+
+	it("delivers a change held back by an older transaction without waiting for a poll", async () => {
+		// pollIntervalMs is 0 here, so nothing but the settlement retry can
+		// deliver this: the publisher's wake-up fires at commit, when the change
+		// is still unreadable.
+		const { seen, stop } = await collect();
+		let hasXid = () => {};
+		const blocker = new Promise<void>((resolve) => {
+			hasXid = resolve;
+		});
+		let release = () => {};
+		const hold = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+
+		try {
+			const blocking = withTransaction(app.db, async (tx: any) => {
+				await takeXid(tx);
+				hasXid();
+				await hold;
+			});
+			await blocker;
+
+			await append("behind-a-blocker");
+			await drainFully();
+			expect(seen).toEqual([]);
+
+			release();
+			await blocking;
+
+			for (let attempt = 0; attempt < 100; attempt++) {
+				if (seen.length > 0) break;
+				await new Promise((resolve) => setTimeout(resolve, 50));
+			}
+			expect(recordIds(seen)).toEqual(["behind-a-blocker"]);
+		} finally {
+			release();
+			stop();
+		}
+	}, 60_000);
+
+	it("captures concurrently instead of serializing on a global row", async () => {
+		const { seen, stop } = await collect();
+		let holderAppended = () => {};
+		const captured = new Promise<void>((resolve) => {
+			holderAppended = resolve;
+		});
+		let release = () => {};
+		const hold = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+
+		try {
+			// One transaction captures and then keeps working, the way a bulk import
+			// inside a single withTransaction does. Under the head-row lock this
+			// blocked every other capture in the fleet until it committed.
+			const holder = withTransaction(app.db, async () => {
+				await append("long-transaction");
+				holderAppended();
+				await hold;
+			});
+			await captured;
+
+			const others = await Promise.all(
+				Array.from({ length: 6 }, (_, index) => append(`concurrent-${index}`)),
+			);
+			expect(others).toHaveLength(6);
+
+			release();
+			await holder;
+			await drainFully();
+			expect(seen).toHaveLength(7);
+		} finally {
+			release();
+			stop();
+		}
+	}, 60_000);
+});

--- a/packages/questpie/test/integration/realtime-outbox-cursor.test.ts
+++ b/packages/questpie/test/integration/realtime-outbox-cursor.test.ts
@@ -1,0 +1,175 @@
+/**
+ * The outbox cursor, with the concurrency simulated instead of real.
+ *
+ * `realtime-drain-cursor-postgres.test.ts` proves the same properties against a
+ * real server with overlapping transactions, but that needs a PostgreSQL URL and
+ * only runs in the realtime matrix job. These write the `txid` column directly,
+ * relative to the current visibility watermark, so the ordering rules are
+ * covered on PGlite in the ordinary test run too.
+ *
+ * A row whose `txid` sits above `pg_snapshot_xmin(pg_current_snapshot())` is
+ * exactly what an open transaction's row looks like to a reader: present in the
+ * table, not yet drainable. Lowering it afterwards is that transaction ending.
+ */
+import { afterEach, describe, expect, it } from "bun:test";
+
+import { sql } from "drizzle-orm";
+
+import { rowsOf } from "../../src/server/db/driver-result.js";
+import type { ChangeBroker } from "../../src/server/modules/core/integrated/realtime/transport.js";
+import type { RealtimeChangeEvent } from "../../src/server/modules/core/integrated/realtime/types.js";
+import { buildMockApp } from "../utils/mocks/mock-app-builder.js";
+import { runTestDbMigrations } from "../utils/test-db.js";
+
+const silentBroker: ChangeBroker = {
+	start: async () => {},
+	stop: async () => {},
+	publish: async () => {},
+};
+
+let teardown: (() => Promise<void>) | undefined;
+
+async function buildApp(): Promise<any> {
+	const setup = await buildMockApp(
+		{},
+		{ realtime: { changeBroker: silentBroker, pollIntervalMs: 0 } },
+	);
+	await runTestDbMigrations(setup.app);
+	teardown = setup.cleanup;
+	return setup.app;
+}
+
+/** The lowest transaction id still open — everything below it has ended. */
+async function watermark(app: any): Promise<bigint> {
+	const rows = rowsOf<{ xmin: string }>(
+		await app.db.execute(
+			sql`select pg_snapshot_xmin(pg_current_snapshot())::text as "xmin"`,
+		),
+	);
+	return BigInt(rows[0]!.xmin);
+}
+
+/** Append one outbox row with a chosen transaction id. */
+async function appendWithTxid(
+	app: any,
+	txid: bigint,
+	recordId: string,
+): Promise<number> {
+	const rows = rowsOf<{ seq: string | number }>(
+		await app.db.execute(sql`
+			insert into questpie_realtime_log
+				(txid, resource_type, resource, operation, record_id, payload)
+			values (${txid.toString()}::text::xid8, 'collection', 'posts', 'update', ${recordId}, '{}'::jsonb)
+			returning seq
+		`),
+	);
+	return Number(rows[0]!.seq);
+}
+
+async function collect(app: any): Promise<{
+	seen: RealtimeChangeEvent[];
+	stop: () => void;
+}> {
+	const seen: RealtimeChangeEvent[] = [];
+	const stop = app.realtime.subscribe((event: RealtimeChangeEvent) => {
+		seen.push(event);
+	});
+	await (app.realtime as any).ensureStarted();
+	await (app.realtime as any).drain("poll");
+	seen.length = 0;
+	return { seen, stop };
+}
+
+const drain = (app: any): Promise<void> => (app.realtime as any).drain("poll");
+
+describe("realtime outbox cursor", () => {
+	afterEach(async () => {
+		await teardown?.();
+		teardown = undefined;
+	});
+
+	it("delivers a lower sequence that becomes readable after a higher one", async () => {
+		const app = await buildApp();
+		const { seen, stop } = await collect(app);
+		try {
+			const open = await watermark(app);
+			// Still open: a higher transaction id, appended first, so a LOWER seq.
+			const pendingSeq = await appendWithTxid(app, open + 1000n, "still-open");
+			// Committed: a lower transaction id, appended second, so a HIGHER seq.
+			const settledSeq = await appendWithTxid(
+				app,
+				open - 1n,
+				"already-settled",
+			);
+			expect(pendingSeq).toBeLessThan(settledSeq);
+
+			await drain(app);
+			expect(seen.map((event) => event.recordId)).toEqual(["already-settled"]);
+
+			// The open transaction ends: its row becomes readable, still carrying a
+			// transaction id above the one already delivered. A seq-only cursor sits
+			// at the higher sequence and never comes back for this row.
+			const now = await watermark(app);
+			await app.db.execute(sql`
+				update questpie_realtime_log
+				   set txid = ${(now - 1n).toString()}::text::xid8
+				 where seq = ${pendingSeq}
+			`);
+
+			await drain(app);
+			expect(seen.map((event) => event.recordId)).toEqual([
+				"already-settled",
+				"still-open",
+			]);
+		} finally {
+			stop();
+		}
+	});
+
+	it("never re-delivers a change the cursor has passed", async () => {
+		const app = await buildApp();
+		const { seen, stop } = await collect(app);
+		try {
+			const open = await watermark(app);
+			await appendWithTxid(app, open - 1n, "one");
+			await appendWithTxid(app, open - 1n, "two");
+
+			await drain(app);
+			await drain(app);
+			await drain(app);
+			expect(seen.map((event) => event.recordId)).toEqual(["one", "two"]);
+		} finally {
+			stop();
+		}
+	});
+
+	it("reports the settled head, not the newest row", async () => {
+		const app = await buildApp();
+		const open = await watermark(app);
+		const settledSeq = await appendWithTxid(app, open - 1n, "settled");
+		const pendingSeq = await appendWithTxid(app, open + 1000n, "pending");
+		expect(pendingSeq).toBeGreaterThan(settledSeq);
+
+		expect(await app.realtime.getLatestSeq()).toBe(settledSeq);
+	});
+
+	it("refuses to resume as current while a newer change is unreadable", async () => {
+		const app = await buildApp();
+		const open = await watermark(app);
+		const settledSeq = await appendWithTxid(app, open - 1n, "settled");
+
+		expect(await app.realtime.getResumeState(settledSeq)).toEqual({
+			latestSeq: settledSeq,
+			reset: false,
+			current: true,
+		});
+
+		await appendWithTxid(app, open + 1000n, "pending");
+		const blocked = await app.realtime.getResumeState(settledSeq);
+		// The settled head has not moved, so a sequence comparison alone would
+		// call this client current. It is not: a change it never saw is committed.
+		expect(blocked.latestSeq).toBe(settledSeq);
+		expect(blocked.current).toBe(false);
+		expect(blocked.reset).toBe(false);
+	});
+});

--- a/packages/questpie/test/integration/realtime-transactional-capture.test.ts
+++ b/packages/questpie/test/integration/realtime-transactional-capture.test.ts
@@ -118,7 +118,11 @@ describe("realtime matrix transactional change capture", () => {
 		expect(getTxid(result)).toBe(rows[0]?.txid);
 	});
 
-	it("assigns outbox cursors in commit order without dropping a late commit", async () => {
+	// PGlite is one connection, so these two transactions cannot overlap and the
+	// sequences come out in commit order for that reason alone. What real
+	// concurrency does to the cursor is in
+	// `realtime-drain-cursor-postgres.test.ts`, which needs a real server.
+	it("keeps both appends when one transaction commits late", async () => {
 		let firstAppended = () => {};
 		const appended = new Promise<void>((resolve) => {
 			firstAppended = resolve;
@@ -162,7 +166,7 @@ describe("realtime matrix transactional change capture", () => {
 		expect(rows.map((row) => row.recordId)).toEqual(["first", "second"]);
 	});
 
-	it("wraps public appendChange calls in the commit-order transaction", async () => {
+	it("wraps public appendChange calls in their own transaction", async () => {
 		const originalTransaction = setup.app.db.transaction.bind(setup.app.db);
 		const transactionSpy = spyOn(
 			setup.app.db,

--- a/packages/questpie/test/integration/realtime-txid-postgres.test.ts
+++ b/packages/questpie/test/integration/realtime-txid-postgres.test.ts
@@ -26,7 +26,7 @@ describe.skipIf(!databaseUrl)("realtime txid PostgreSQL ordering", () => {
 		}
 	});
 
-	it("serializes outbox sequence allocation across real connections", async () => {
+	it("captures from two open transactions without serializing them", async () => {
 		const broker: ChangeBroker = {
 			start: async () => {},
 			stop: async () => {},
@@ -40,6 +40,7 @@ describe.skipIf(!databaseUrl)("realtime txid PostgreSQL ordering", () => {
 			},
 		);
 		await runTestDbMigrations(setup.app);
+		const baseCursor = await (setup.app.realtime as any).readSettledHead();
 		const baseSeq = await setup.app.realtime.getLatestSeq();
 		let markFirstAppended = () => {};
 		const firstAppended = new Promise<void>((resolve) => {
@@ -76,8 +77,11 @@ describe.skipIf(!databaseUrl)("realtime txid PostgreSQL ordering", () => {
 				secondSettled = true;
 				return event;
 			});
+			// Capture used to take an exclusive lock on one head row and hold it to
+			// COMMIT, so this second capture could not finish until the first
+			// transaction ended — the whole fleet's write ceiling.
 			await new Promise((resolve) => setTimeout(resolve, 100));
-			expect(secondSettled).toBe(false);
+			expect(secondSettled).toBe(true);
 
 			releaseFirst();
 			const [firstEvent, secondEvent] = await Promise.all([first, second]);
@@ -85,7 +89,7 @@ describe.skipIf(!databaseUrl)("realtime txid PostgreSQL ordering", () => {
 				baseSeq + 1,
 				baseSeq + 2,
 			]);
-			const delivered = await setup.app.realtime.readSince(baseSeq);
+			const delivered = await (setup.app.realtime as any).readAfter(baseCursor);
 			expect(
 				delivered.map((event) => ({
 					seq: event.seq,

--- a/packages/questpie/test/integration/realtime.test.ts
+++ b/packages/questpie/test/integration/realtime.test.ts
@@ -455,6 +455,64 @@ describe("realtime matrix", () => {
 			await reader.close();
 		});
 
+		it("says whether a delete frame is a removal or a predicate exit", async () => {
+			const adapter = new MockChangeBroker();
+			const posts = collection("posts")
+				.fields(({ f }) => ({
+					title: f.textarea().required(),
+					archived: f.boolean().default(false),
+				}))
+				.access({ read: true, create: true, update: true, delete: true });
+			setup = await buildMockApp(
+				{ collections: { posts } },
+				{ realtime: { changeBroker: adapter, nativeDeltas: true } },
+			);
+			await runTestDbMigrations(setup.app);
+			const context = createTestContext();
+			const archivedLater = await setup.app.collections.posts.create(
+				{ title: "Archived later", archived: false },
+				context,
+			);
+			const deletedLater = await setup.app.collections.posts.create(
+				{ title: "Deleted later", archived: false },
+				context,
+			);
+			const subscribe = (...a: [Request, Record<string, string>, any?]) =>
+				realtimeSubscribe(setup.app, a[0], a[1], a[2], { accessMode: "user" });
+			const response = await subscribe(
+				createRealtimeRequest([
+					collectionTopic("posts", {
+						mode: "delta",
+						where: { archived: false },
+					}),
+				]),
+				{},
+				undefined,
+			);
+			const reader = createSSEReader(response.body!);
+			expect((await reader.readSnapshot()).data.data.docs).toHaveLength(2);
+
+			await setup.app.collections.posts.update(
+				{ id: archivedLater.id, data: { archived: true } },
+				context,
+			);
+			expect(await reader.readSnapshot()).toMatchObject({
+				event: "delete",
+				data: { key: archivedLater.id, reason: "left_predicate" },
+			});
+			expect((await reader.readSnapshot()).event).toBe("up-to-date");
+
+			await setup.app.collections.posts.delete(
+				{ id: deletedLater.id },
+				context,
+			);
+			expect(await reader.readSnapshot()).toMatchObject({
+				event: "delete",
+				data: { key: deletedLater.id, reason: "deleted" },
+			});
+			await reader.close();
+		});
+
 		it("rebootstraps when a relational access dependency changes", async () => {
 			const adapter = new MockChangeBroker();
 			const documents = collection("documents")
@@ -2343,6 +2401,7 @@ describe("realtime matrix", () => {
 				locale: null,
 				payload: { name: "old" },
 				createdAt: oldCreatedAt,
+				settledAt: oldCreatedAt,
 			});
 
 			const ctx = createTestContext();
@@ -2379,6 +2438,7 @@ describe("realtime matrix", () => {
 				operation: "create",
 				recordId: "expired-headless-row",
 				createdAt: new Date(Date.now() - 4 * 24 * 60 * 60 * 1000),
+				settledAt: new Date(Date.now() - 4 * 24 * 60 * 60 * 1000),
 			});
 
 			await setup.app.realtime.cleanupOutbox(true);
@@ -3725,7 +3785,7 @@ describe("realtime matrix", () => {
 			expect((await reader.readSnapshot()).event).toBe("snapshot");
 			await new Promise((resolve) => setTimeout(resolve, 20));
 
-			const readSpy = spyOn(setup.app.realtime, "readSince").mockRejectedValue(
+			const readSpy = spyOn(setup.app.realtime, "readAfter").mockRejectedValue(
 				new Error("drain failed"),
 			);
 			try {

--- a/packages/questpie/test/migration/migrations.test.ts
+++ b/packages/questpie/test/migration/migrations.test.ts
@@ -12,7 +12,14 @@ import { pathToFileURL } from "node:url";
 
 import type { PGlite } from "@electric-sql/pglite";
 import { sql } from "drizzle-orm";
-import { bigserial, index, jsonb, pgTable, text } from "drizzle-orm/pg-core";
+import {
+	bigserial,
+	customType,
+	index,
+	jsonb,
+	pgTable,
+	text,
+} from "drizzle-orm/pg-core";
 
 import { createApp, module } from "../../src/exports/index.js";
 import { collection } from "../../src/exports/index.js";
@@ -480,10 +487,14 @@ describe("Migration System - DrizzleMigrationGenerator", () => {
 		const { DrizzleMigrationGenerator } =
 			await import("../../src/server/migration/generator.js");
 		const generator = new DrizzleMigrationGenerator();
+		const xid8 = customType<{ data: string }>({
+			dataType: () => "xid8",
+		});
 		const oldRealtimeLogTable = pgTable(
 			"questpie_realtime_log",
 			{
 				seq: bigserial("seq", { mode: "number" }).primaryKey(),
+				txid: xid8("txid").default(sql`pg_current_xact_id()`),
 				resourceType: text("resource_type").notNull(),
 				resource: text("resource").notNull(),
 				operation: text("operation").notNull(),
@@ -491,6 +502,7 @@ describe("Migration System - DrizzleMigrationGenerator", () => {
 				locale: text("locale"),
 				payload: jsonb("payload").default({}),
 				createdAt: systemTimestamp("created_at").defaultNow().notNull(),
+				settledAt: systemTimestamp("settled_at"),
 			},
 			(table) => [
 				index("idx_realtime_log_seq").on(table.seq),
@@ -499,6 +511,8 @@ describe("Migration System - DrizzleMigrationGenerator", () => {
 					table.resource,
 				),
 				index("idx_realtime_log_created_at").on(table.createdAt),
+				index("idx_realtime_log_settled_at").on(table.settledAt),
+				index("idx_realtime_log_txid_seq").on(table.txid, table.seq),
 			],
 		);
 

--- a/packages/questpie/test/search/search-adapter.test.ts
+++ b/packages/questpie/test/search/search-adapter.test.ts
@@ -164,6 +164,7 @@ describe("PostgresSearchAdapter", () => {
 
 			// Realtime table (always included)
 			expect(schema.questpie_realtime_log).toBeDefined();
+			expect(schema.questpie_realtime_head).toBeUndefined();
 		});
 	});
 

--- a/packages/questpie/test/types/client-transaction.test-d.ts
+++ b/packages/questpie/test/types/client-transaction.test-d.ts
@@ -1,0 +1,148 @@
+/**
+ * `client.transaction()` — the cross-collection write surface.
+ *
+ * What is guaranteed here: operations are constrained per collection, results
+ * are typed per POSITION (a tuple, not an array of a union), and
+ * `expectedRevision` is required exactly where `optimisticConcurrency` makes it
+ * required on the single-record methods.
+ */
+
+import type { QuestpieClient } from "#questpie/client/index.js";
+import { collection } from "#questpie/server/collection/builder/collection-builder.js";
+
+import type { Equal, Expect, NoAny } from "./_assert.js";
+
+const posts = collection("posts").fields(({ f }) => ({
+	title: f.text().required(),
+}));
+
+const comments = collection("comments").fields(({ f }) => ({
+	body: f.text().required(),
+	upvotes: f.number(),
+}));
+
+const versionedDocs = collection("versioned_docs")
+	.fields(({ f }) => ({ title: f.text().required() }))
+	.options({ optimisticConcurrency: true });
+
+type App = {
+	collections: {
+		posts: typeof posts;
+		comments: typeof comments;
+		versionedDocs: typeof versionedDocs;
+	};
+};
+
+declare const client: QuestpieClient<App>;
+
+// ── Results are typed per position ──────────────────────────────────────────
+
+declare const results: Awaited<
+	ReturnType<
+		typeof client.transaction<
+			[
+				{ collection: "posts"; operation: "create"; data: { title: string } },
+				{
+					collection: "comments";
+					operation: "update";
+					id: string;
+					data: { body: string };
+				},
+				{ collection: "posts"; operation: "delete"; id: string },
+			]
+		>
+	>
+>;
+
+// A fixed length is what distinguishes a tuple from an array of a union.
+type _ResultsAreATuple = Expect<Equal<(typeof results)["length"], 3>>;
+type _CreateReturnsTheRow = Expect<Equal<(typeof results)[0]["title"], string>>;
+type _UpdateReturnsTheOtherRow = Expect<
+	Equal<(typeof results)[1]["body"], string>
+>;
+type _DeleteReturnsSuccessAndRow = Expect<
+	Equal<(typeof results)[2]["success"], boolean>
+>;
+type _DeletePayloadIsTheRow = Expect<
+	Equal<(typeof results)[2]["data"]["title"], string>
+>;
+type _NoAnyLeakedIn = NoAny<(typeof results)[0]>;
+
+// A literal call site infers the same tuple without an explicit type argument.
+const inferred = client.transaction([
+	{ collection: "posts", operation: "create", data: { title: "Hello" } },
+	{ collection: "posts", operation: "delete", id: "post-1" },
+]);
+type _InferredCreateRow = Expect<
+	Equal<Awaited<typeof inferred>[0]["title"], string>
+>;
+type _InferredDeleteResult = Expect<
+	Equal<Awaited<typeof inferred>[1]["success"], boolean>
+>;
+
+// ── Operations are constrained per collection ───────────────────────────────
+
+client.transaction([
+	{ collection: "posts", operation: "create", data: { title: "Hello" } },
+	{ collection: "comments", operation: "create", data: { body: "Hi" } },
+	{ collection: "comments", operation: "delete", id: "comment-1" },
+]);
+
+client.transaction([
+	// @ts-expect-error `body` is a comments field, not a posts field
+	{ collection: "posts", operation: "create", data: { body: "Hello" } },
+]);
+
+client.transaction([
+	// @ts-expect-error there is no such collection
+	{ collection: "ghosts", operation: "create", data: { title: "Hello" } },
+]);
+
+client.transaction([
+	// @ts-expect-error bulk verbs have no meaning inside an ordered batch
+	{ collection: "posts", operation: "updateMany", where: {}, data: {} },
+]);
+
+// ── expectedRevision follows optimisticConcurrency ──────────────────────────
+
+client.transaction([
+	{
+		collection: "versionedDocs",
+		operation: "update",
+		id: "doc-1",
+		expectedRevision: 3,
+		data: { title: "Renamed" },
+	},
+	{
+		collection: "versionedDocs",
+		operation: "delete",
+		id: "doc-2",
+		expectedRevision: 1,
+	},
+]);
+
+client.transaction([
+	// @ts-expect-error an optimistically-concurrent update needs its revision
+	{
+		collection: "versionedDocs",
+		operation: "update",
+		id: "doc-1",
+		data: { title: "Unsafe" },
+	},
+]);
+
+client.transaction([
+	// @ts-expect-error an optimistically-concurrent delete needs its revision
+	{ collection: "versionedDocs", operation: "delete", id: "doc-1" },
+]);
+
+// A collection without the option still accepts the plain form.
+client.transaction([
+	{
+		collection: "posts",
+		operation: "update",
+		id: "post-1",
+		data: { title: "x" },
+	},
+	{ collection: "posts", operation: "delete", id: "post-2" },
+]);

--- a/packages/questpie/test/types/realtime-transport.test-d.ts
+++ b/packages/questpie/test/types/realtime-transport.test-d.ts
@@ -43,8 +43,16 @@ type _channelReadinessIsOptionalAndPayloadFree = Expect<
 	Equal<NonNullable<ChannelSubscribeOptions["onReady"]>, () => void>
 >;
 
+type _channelNotReadinessIsOptionalAndPayloadFree = Expect<
+	Equal<NonNullable<ChannelSubscribeOptions["onNotReady"]>, () => void>
+>;
+
 type _oneShotPresenceDoesNotExposeContinuingAdmission = Expect<
 	Equal<"onReady" extends keyof ChannelPresenceOptions ? true : false, false>
+>;
+
+type _oneShotPresenceDoesNotExposeContinuingEpochEnd = Expect<
+	Equal<"onNotReady" extends keyof ChannelPresenceOptions ? true : false, false>
 >;
 
 declare const sink: ClientSink;

--- a/packages/questpie/test/units/realtime-admission.test.ts
+++ b/packages/questpie/test/units/realtime-admission.test.ts
@@ -1,12 +1,27 @@
 import { describe, expect, it } from "bun:test";
 
 import {
+	ANONYMOUS_ADMISSION_KEY,
 	DEFAULT_REALTIME_ADMISSION,
+	REALTIME_SLOT_KEEPALIVE_BEATS,
 	RealtimeAdmissionRegistry,
 	admitRealtimeTopic,
 	admitRealtimeTopicPolicy,
+	realtimeAdmissionBucket,
+	realtimeSlotTtlMs,
 	resolveRealtimeAdmissionConfig,
 } from "../../src/server/modules/core/integrated/realtime/admission.js";
+
+const HOUR = 3_600_000;
+
+/** Non-expiring slots, for the assertions that are only about counting. */
+function slot(
+	registry: RealtimeAdmissionRegistry,
+	key: string,
+	maximum: number,
+) {
+	return registry.acquire(key, { maximum, ttlMs: HOUR });
+}
 
 describe("realtime admission", () => {
 	it("applies the finite default limit and rejects query caps", () => {
@@ -75,17 +90,113 @@ describe("realtime admission", () => {
 		});
 	});
 
-	it("releases per-principal counters idempotently", () => {
-		const registry = new RealtimeAdmissionRegistry(2);
-		const first = registry.acquire("user-1");
-		const second = registry.acquire("user-1");
-		expect(first).not.toBeNull();
-		expect(second).not.toBeNull();
-		expect(registry.acquire("user-1")).toBeNull();
+	it("releases per-principal slots idempotently", () => {
+		const registry = new RealtimeAdmissionRegistry();
+		const first = slot(registry, "user-1", 2);
+		const second = slot(registry, "user-1", 2);
+		expect(first.admitted).toBe(true);
+		expect(second.admitted).toBe(true);
+		expect(slot(registry, "user-1", 2)).toMatchObject({
+			admitted: false,
+			observed: 2,
+			configuredLimit: 2,
+		});
 
-		first!();
-		first!();
-		expect(registry.acquire("user-1")).not.toBeNull();
+		expect(first.admitted).toBe(true);
+		if (!first.admitted) return;
+		first.lease.release();
+		first.lease.release();
+		expect(registry.observed("user-1")).toBe(1);
+		expect(slot(registry, "user-1", 2).admitted).toBe(true);
+	});
+
+	it("reclaims a slot whose lease lapsed, and closes the stream behind it", () => {
+		const registry = new RealtimeAdmissionRegistry();
+		const closed: string[] = [];
+		const leaked = registry.acquire("user-1", {
+			maximum: 1,
+			ttlMs: 1000,
+			now: 0,
+		});
+		expect(leaked.admitted).toBe(true);
+		if (!leaked.admitted) return;
+		leaked.lease.setClose(() => closed.push("leaked"));
+
+		// Nothing released it and nothing renewed it — the runtime never told us.
+		expect(
+			registry.acquire("user-1", { maximum: 1, ttlMs: 1000, now: 999 }),
+		).toMatchObject({ admitted: false, observed: 1, configuredLimit: 1 });
+		expect(closed).toEqual([]);
+
+		const readmitted = registry.acquire("user-1", {
+			maximum: 1,
+			ttlMs: 1000,
+			now: 1001,
+		});
+		expect(readmitted.admitted).toBe(true);
+		expect(closed).toEqual(["leaked"]);
+		// The evicted lease must not vacate its successor's cell.
+		leaked.lease.release();
+		expect(registry.observed("user-1", 1001)).toBe(1);
+	});
+
+	it("keeps a renewed slot forever, so a live idle stream is never evicted", () => {
+		const registry = new RealtimeAdmissionRegistry();
+		const live = registry.acquire("user-1", { maximum: 1, ttlMs: 100, now: 0 });
+		expect(live.admitted).toBe(true);
+		if (!live.admitted) return;
+		live.lease.setClose(() => {
+			throw new Error("a renewed slot must never be evicted");
+		});
+
+		// One renewal per keepalive beat, well past many TTL windows.
+		for (let beat = 1; beat <= 100; beat += 1) {
+			live.lease.renew(beat * 25);
+			expect(
+				registry.acquire("user-1", {
+					maximum: 1,
+					ttlMs: 100,
+					now: beat * 25,
+				}),
+			).toMatchObject({ admitted: false, observed: 1 });
+		}
+	});
+
+	it("ties the slot TTL to the keepalive interval", () => {
+		expect(realtimeSlotTtlMs(8000)).toBe(8000 * REALTIME_SLOT_KEEPALIVE_BEATS);
+		expect(realtimeSlotTtlMs(250)).toBe(250 * REALTIME_SLOT_KEEPALIVE_BEATS);
+		// Longer than the longest legitimate idle stream: an idle stream still
+		// gets a ping every interval, so it renews every interval.
+		expect(realtimeSlotTtlMs(8000)).toBeGreaterThan(8000);
+		expect(realtimeSlotTtlMs(Number.NaN)).toBe(
+			8000 * REALTIME_SLOT_KEEPALIVE_BEATS,
+		);
+	});
+
+	it("caps unauthenticated connections in one shared bucket", () => {
+		const config = resolveRealtimeAdmissionConfig({
+			maxConnectionsPerPrincipal: 5,
+			maxAnonymousConnections: 2,
+		});
+		expect(realtimeAdmissionBucket({ session: null }, config)).toEqual({
+			key: ANONYMOUS_ADMISSION_KEY,
+			maximum: 2,
+			anonymous: true,
+		});
+		expect(
+			realtimeAdmissionBucket({ session: { user: { id: "u1" } } }, config),
+		).toEqual({ key: "user:u1", maximum: 5, anonymous: false });
+
+		// Two anonymous callers share the bucket, so the cap actually binds.
+		const registry = new RealtimeAdmissionRegistry();
+		const bucket = realtimeAdmissionBucket({ session: null }, config);
+		expect(slot(registry, bucket.key, bucket.maximum).admitted).toBe(true);
+		expect(slot(registry, bucket.key, bucket.maximum).admitted).toBe(true);
+		expect(slot(registry, bucket.key, bucket.maximum)).toMatchObject({
+			admitted: false,
+			observed: 2,
+			configuredLimit: 2,
+		});
 	});
 
 	it("keeps configured admission limits finite", () => {
@@ -160,11 +271,11 @@ describe("realtime admission", () => {
 	});
 
 	it("DoS matrix bounds connection, limit, and relation-depth floods", () => {
-		const registry = new RealtimeAdmissionRegistry(5);
-		const releases = Array.from({ length: 500 }, () =>
-			registry.acquire("one-principal"),
+		const registry = new RealtimeAdmissionRegistry();
+		const decisions = Array.from({ length: 500 }, () =>
+			slot(registry, "one-principal", 5),
 		);
-		expect(releases.filter(Boolean)).toHaveLength(5);
+		expect(decisions.filter((decision) => decision.admitted)).toHaveLength(5);
 		expect(
 			admitRealtimeTopic(
 				{
@@ -189,20 +300,23 @@ describe("realtime admission", () => {
 				DEFAULT_REALTIME_ADMISSION,
 			),
 		).toMatchObject({ accepted: false });
-		for (const release of releases) release?.();
+		for (const decision of decisions) {
+			if (decision.admitted) decision.lease.release();
+		}
 	});
 
 	it("counts every live stream as a distinct server-owned admission slot", () => {
-		const registry = new RealtimeAdmissionRegistry(2);
+		const registry = new RealtimeAdmissionRegistry();
 
-		const first = registry.acquire("user-1");
-		const second = registry.acquire("user-1");
-		expect(first).not.toBeNull();
-		expect(second).not.toBeNull();
-		expect(registry.acquire("user-1")).toBeNull();
+		const first = slot(registry, "user-1", 2);
+		const second = slot(registry, "user-1", 2);
+		expect(first.admitted).toBe(true);
+		expect(second.admitted).toBe(true);
+		expect(slot(registry, "user-1", 2).admitted).toBe(false);
 
-		first!();
-		expect(registry.acquire("user-1")).not.toBeNull();
+		if (!first.admitted) return;
+		first.lease.release();
+		expect(slot(registry, "user-1", 2).admitted).toBe(true);
 	});
 
 	it("keeps row-topic policy distinct from collection change capture", () => {
@@ -241,5 +355,41 @@ describe("realtime admission", () => {
 			accepted: false,
 			reason: "row_live_queries_disabled",
 		});
+	});
+
+	it("reports change capture ahead of the read-side switches", () => {
+		// A reader has to be able to tell "the server stopped serving row topics"
+		// from "there is no outbox to serve", because only the second one also
+		// costs resume and txid correlation. Capture is the stronger switch, so it
+		// is the reason reported when both are off.
+		for (const topic of [
+			{ id: "posts", resourceType: "collection" as const, resource: "posts" },
+			{
+				id: "settings",
+				resourceType: "global" as const,
+				resource: "settings",
+				operation: "get" as const,
+			},
+		]) {
+			expect(
+				admitRealtimeTopicPolicy(topic, { changeCapture: false }),
+			).toMatchObject({
+				accepted: false,
+				reason: "change_capture_disabled",
+			});
+			expect(
+				admitRealtimeTopicPolicy(topic, {
+					changeCapture: false,
+					rowLiveQueries: false,
+					collectionRealtime: false,
+				}),
+			).toMatchObject({
+				accepted: false,
+				reason: "change_capture_disabled",
+			});
+			expect(
+				admitRealtimeTopicPolicy(topic, { changeCapture: true }),
+			).toMatchObject({ accepted: true });
+		}
 	});
 });

--- a/packages/questpie/test/units/realtime-delta.test.ts
+++ b/packages/questpie/test/units/realtime-delta.test.ts
@@ -100,22 +100,45 @@ describe("realtime delta delivery", () => {
 	it("derives idempotent keyed operations from authoritative hydration", () => {
 		expect(
 			deriveDeltaOp({ present: true, operation: "create", beforeMatch: false }),
-		).toBe("insert");
+		).toEqual({ op: "insert" });
 		expect(
 			deriveDeltaOp({ present: true, operation: "update", beforeMatch: true }),
-		).toBe("update");
+		).toEqual({ op: "update" });
 		expect(
 			deriveDeltaOp({ present: true, operation: "update", beforeMatch: false }),
-		).toBe("insert");
+		).toEqual({ op: "insert" });
 		expect(
 			deriveDeltaOp({ present: false, operation: "update", beforeMatch: true }),
-		).toBe("delete");
+		).toMatchObject({ op: "delete" });
 		expect(
 			deriveDeltaOp({
 				present: false,
 				operation: "create",
 				beforeMatch: false,
 			}),
-		).toBe("noop");
+		).toEqual({ op: "noop" });
+	});
+
+	it("separates a removed row from one that only left the predicate", () => {
+		const removed = { present: false, beforeMatch: true } as const;
+
+		for (const operation of ["delete", "bulk_delete"] as const) {
+			expect(deriveDeltaOp({ ...removed, operation })).toEqual({
+				op: "delete",
+				reason: "deleted",
+			});
+		}
+		for (const operation of ["update", "bulk_update"] as const) {
+			expect(deriveDeltaOp({ ...removed, operation })).toEqual({
+				op: "delete",
+				reason: "left_predicate",
+			});
+		}
+
+		// One hydration answers for the whole batch, so a delete anywhere in it
+		// outranks an earlier predicate exit for the same key.
+		expect(
+			deriveDeltaOp({ ...removed, operation: "update", deletedInBatch: true }),
+		).toEqual({ op: "delete", reason: "deleted" });
 	});
 });

--- a/packages/questpie/test/units/realtime-refresh-scheduler.test.ts
+++ b/packages/questpie/test/units/realtime-refresh-scheduler.test.ts
@@ -19,6 +19,20 @@ class FakeRealtimeSource {
 		return this.latestSeq;
 	}
 
+	/**
+	 * Mirrors RealtimeService: only the source can decide "current", because
+	 * `latestSeq === sinceSeq` alone does not prove it once a lower sequence can
+	 * settle after a higher one. This fake has no concurrency, so the settled
+	 * head is the latest sequence.
+	 */
+	async getResumeState(sinceSeq: number) {
+		return {
+			latestSeq: this.latestSeq,
+			reset: false,
+			current: sinceSeq === this.latestSeq,
+		};
+	}
+
 	subscribe(
 		listener: (event: RealtimeChangeEvent) => void,
 		_topics: RealtimeTopics,

--- a/packages/tanstack-db/README.md
+++ b/packages/tanstack-db/README.md
@@ -36,6 +36,16 @@ pagination, locale, stage, and soft-delete controls. Projections (`columns`),
 relation expansion (`with`), extras, and grouping are rejected because every
 TanStack DB row must retain the base collection shape and its canonical `id`.
 
+Snapshot mode narrows that set further, to what a live subscription can carry:
+`where`, `orderBy`, `limit`, `offset` and `locale`. `search`, `stage`,
+`includeDeleted` and `localeFallback` are rejected there, because the live
+snapshot would ignore them while the post-mutation repair read applied them —
+one collection describing two different row sets.
+
+A mutation that loses an optimistic-concurrency race rejects with
+`QuestpieDbConflictError`. The optimistic state is already rolled back, so
+refetch before retrying: the row still on screen carries the revision that lost.
+
 The package currently supports refetch and full-snapshot synchronization. Native
 row-delta synchronization is added independently without changing the collection
 factory API.

--- a/packages/tanstack-db/src/collection.ts
+++ b/packages/tanstack-db/src/collection.ts
@@ -27,9 +27,91 @@ type MutationCollectionClient<TRow extends MutableRow> = {
 		opts?: { onError?: (error: Error) => void },
 	) => () => void;
 	create: (data: TRow) => Promise<unknown>;
-	update: (params: { id: string; data: Partial<TRow> }) => Promise<unknown>;
-	delete: (params: { id: string }) => Promise<unknown>;
+	updateBatch: (params: {
+		updates: Array<{
+			id: string;
+			data: Partial<TRow>;
+			expectedRevision?: number;
+		}>;
+	}) => Promise<unknown>;
+	deleteMany: (params: {
+		where: { id: { in: string[] } };
+		expectedRevisions?: Array<{ id: string; expectedRevision: number }>;
+	}) => Promise<unknown>;
 };
+
+/**
+ * A mutation lost an optimistic-concurrency race: QUESTPIE answered `409`
+ * (`CONFLICT`), or `412` when the request carried `If-Match`. TanStack DB has
+ * already rolled the optimistic state back, so the row on screen is the stale
+ * one that lost — refetch the collection before retrying, otherwise the retry
+ * carries the same stale revision and conflicts again.
+ *
+ * `ids` lists every row in the failed transaction. QUESTPIE validates all
+ * revisions before writing any row, so a conflict fails the whole batch without
+ * naming the individual loser.
+ */
+export class QuestpieDbConflictError extends Error {
+	readonly collection: string;
+	readonly operation: "update" | "delete";
+	readonly ids: string[];
+
+	constructor(options: {
+		collection: string;
+		operation: "update" | "delete";
+		ids: string[];
+		cause: unknown;
+	}) {
+		super(
+			`QUESTPIE rejected a ${options.operation} on "${options.collection}" as a conflict: ${options.ids.join(", ")}`,
+			{ cause: options.cause },
+		);
+		this.name = "QuestpieDbConflictError";
+		this.collection = options.collection;
+		this.operation = options.operation;
+		this.ids = options.ids;
+	}
+}
+
+function isConflict(error: unknown): boolean {
+	if (!error || typeof error !== "object") return false;
+	const { code, status } = error as { code?: unknown; status?: unknown };
+	return status === 409 || status === 412 || code === "CONFLICT";
+}
+
+async function asConflict<TResult>(
+	options: {
+		collection: string;
+		operation: "update" | "delete";
+		ids: string[];
+	},
+	run: () => Promise<TResult>,
+): Promise<TResult> {
+	try {
+		return await run();
+	} catch (error) {
+		if (!isConflict(error)) throw error;
+		throw new QuestpieDbConflictError({ ...options, cause: error });
+	}
+}
+
+/**
+ * QUESTPIE owns the `revision` column and only adds it when the collection
+ * enables `optimisticConcurrency`, so its presence on the row TanStack DB read
+ * is the feature detection. Collections without the feature must not send the
+ * key at all: the server ignores it there, which would read as a precondition
+ * that was checked when it never was.
+ */
+function revisionOf(original: unknown): number | undefined {
+	const revision = (original as { revision?: unknown } | undefined)?.revision;
+	return typeof revision === "number" ? revision : undefined;
+}
+
+/** Spreadable form of {@link revisionOf}, so the key is absent when unset. */
+function expectedRevisionOf(original: unknown): { expectedRevision?: number } {
+	const revision = revisionOf(original);
+	return revision === undefined ? {} : { expectedRevision: revision };
+}
 
 function rowId(row: MutableRow): string {
 	if (typeof row.id !== "string" || row.id.length === 0) {
@@ -45,6 +127,19 @@ function persistedRow<TRow extends MutableRow>(
 	return result && typeof result === "object" && "id" in result
 		? (result as TRow)
 		: fallback;
+}
+
+function persistedRowsById<TRow extends MutableRow>(
+	result: unknown,
+): Map<string, TRow> {
+	const rows = new Map<string, TRow>();
+	if (!Array.isArray(result)) return rows;
+	for (const row of result) {
+		if (row && typeof row === "object" && typeof row.id === "string") {
+			rows.set(row.id, row as TRow);
+		}
+	}
+	return rows;
 }
 
 export function createQuestpieCollection<TRow extends MutableRow>(options: {
@@ -75,6 +170,11 @@ export function createQuestpieCollection<TRow extends MutableRow>(options: {
 	});
 	const skipRefetch = syncMode === "snapshot" ? { refetch: false } : undefined;
 
+	// TanStack DB calls these handlers once per collection, so every mutation
+	// here targets `name` and becomes exactly one QUESTPIE request. A TanStack DB
+	// transaction that spans two collections still becomes one request per
+	// collection, and nothing here can make those two commit together — apps that
+	// need cross-collection atomicity must drive it themselves.
 	return createCollection(
 		queryCollectionOptions({
 			id: `questpie:${name}`,
@@ -84,6 +184,10 @@ export function createQuestpieCollection<TRow extends MutableRow>(options: {
 			getKey: rowId,
 			onInsert: async ({ transaction }) => {
 				const snapshotRevision = getSnapshotRevision();
+				// FRAMEWORK GAP: QUESTPIE has no batch create — `updateBatch` and
+				// `deleteMany` have no `createMany` counterpart — so inserts stay N
+				// independent requests. Order is not preserved, and a partial failure
+				// leaves rows on the server while the client rolls all of them back.
 				const persisted = await Promise.all(
 					transaction.mutations.map((mutation) =>
 						client.create(mutation.modified),
@@ -116,43 +220,48 @@ export function createQuestpieCollection<TRow extends MutableRow>(options: {
 			},
 			onUpdate: async ({ transaction }) => {
 				const snapshotRevision = getSnapshotRevision();
-				const persisted = await Promise.all(
-					transaction.mutations.map((mutation) =>
-						client.update({
-							id: String(mutation.key),
-							data: mutation.changes,
-						}),
-					),
+				const ids = transaction.mutations.map((mutation) =>
+					String(mutation.key),
 				);
+				// One request, one server transaction: QUESTPIE locks the ids in
+				// deterministic order and validates every revision before writing any
+				// row, so the batch either lands whole or leaves nothing behind.
+				const result = await asConflict(
+					{ collection: name, operation: "update", ids },
+					() =>
+						client.updateBatch({
+							updates: transaction.mutations.map((mutation) => ({
+								id: String(mutation.key),
+								data: mutation.changes,
+								...expectedRevisionOf(mutation.original),
+							})),
+						}),
+				);
+				const persisted = persistedRowsById<TRow>(result);
 				await reconcileMutation(
 					snapshotRevision,
 					(rows) => {
 						const byId = new Map(rows.map((row) => [row.id, row]));
-						for (let index = 0; index < transaction.mutations.length; index++) {
-							const mutation = transaction.mutations[index]!;
+						for (const mutation of transaction.mutations) {
 							const current = byId.get(String(mutation.key));
 							if (!current) continue;
 							byId.set(
 								String(mutation.key),
-								persistedRow(persisted[index], {
-									...current,
-									...mutation.changes,
-								} as TRow),
+								persisted.get(String(mutation.key)) ??
+									({ ...current, ...mutation.changes } as TRow),
 							);
 						}
 						return rows.map((row) => byId.get(row.id) ?? row);
 					},
 					(rows) => {
 						const byId = new Map(rows.map((row) => [row.id, row]));
-						for (let index = 0; index < transaction.mutations.length; index++) {
-							const mutation = transaction.mutations[index]!;
+						for (const mutation of transaction.mutations) {
 							const current = byId.get(String(mutation.key));
 							if (!current) continue;
 							const original = mutation.original as TRow;
-							const result = persistedRow(persisted[index], {
-								...original,
-								...mutation.changes,
-							} as TRow);
+							const result =
+								persisted.get(String(mutation.key)) ??
+								({ ...original, ...mutation.changes } as TRow);
 							const merged = { ...current };
 							for (const key of Object.keys(result) as Array<keyof TRow>) {
 								if (deepEquals(current[key], original[key])) {
@@ -168,14 +277,28 @@ export function createQuestpieCollection<TRow extends MutableRow>(options: {
 			},
 			onDelete: async ({ transaction }) => {
 				const snapshotRevision = getSnapshotRevision();
-				await Promise.all(
-					transaction.mutations.map((mutation) =>
-						client.delete({ id: String(mutation.key) }),
-					),
+				const ids = transaction.mutations.map((mutation) =>
+					String(mutation.key),
 				);
-				const deleted = new Set(
-					transaction.mutations.map((mutation) => String(mutation.key)),
+				const expectedRevisions = transaction.mutations.flatMap((mutation) => {
+					const revision = revisionOf(mutation.original);
+					return revision === undefined
+						? []
+						: [{ id: String(mutation.key), expectedRevision: revision }];
+				});
+				await asConflict({ collection: name, operation: "delete", ids }, () =>
+					client.deleteMany({
+						where: { id: { in: ids } },
+						// QUESTPIE requires one entry per matched row, so a partially
+						// revisioned batch would be rejected as a conflict rather than
+						// checked. Rows carry a revision only with optimistic
+						// concurrency on, where every row has one.
+						...(expectedRevisions.length === ids.length
+							? { expectedRevisions }
+							: {}),
+					}),
 				);
+				const deleted = new Set(ids);
 				await reconcileMutation(
 					snapshotRevision,
 					(rows) => rows.filter((row) => !deleted.has(row.id)),

--- a/packages/tanstack-db/src/exports/index.ts
+++ b/packages/tanstack-db/src/exports/index.ts
@@ -1,4 +1,13 @@
-export { and, eq, gt, inArray, lt, or, useLiveQuery } from "../collection.js";
+export {
+	and,
+	eq,
+	gt,
+	inArray,
+	lt,
+	or,
+	QuestpieDbConflictError,
+	useLiveQuery,
+} from "../collection.js";
 export {
 	createQuestpieCollections,
 	type CreateQuestpieCollectionsOptions,
@@ -14,4 +23,5 @@ export type {
 	IdOf,
 	QuestpieCollections,
 	QuestpieDb,
+	SnapshotFindOptionsOf,
 } from "../types.js";

--- a/packages/tanstack-db/src/factory.test.ts
+++ b/packages/tanstack-db/src/factory.test.ts
@@ -4,10 +4,23 @@ import { QueryClient } from "@tanstack/react-query";
 import { collection } from "questpie";
 import type { QuestpieClient } from "questpie/client";
 
+import { QuestpieDbConflictError } from "./collection.js";
 import { createQuestpieCollections } from "./factory.js";
 import { resolveSync } from "./sync.js";
 
-type Row = { id: string; title: string };
+/**
+ * `revision` is only present on collections that enable optimistic concurrency,
+ * so the fake seeds it per test rather than always.
+ */
+type Row = { id: string; title: string; revision?: number };
+
+/** Shaped like a `QuestpieClientError` raised by a lost revision race. */
+function conflictError(): Error {
+	return Object.assign(new Error("Optimistic concurrency conflict"), {
+		status: 409,
+		code: "CONFLICT",
+	});
+}
 
 const posts = collection("posts").fields(({ f }) => ({
 	title: f.text(255).required(),
@@ -32,6 +45,8 @@ function createFakeClient(initial: Row[]) {
 	let rows = initial;
 	let failFind = false;
 	let failUpdate = false;
+	let conflictUpdate = false;
+	let conflictDelete = false;
 	let heldCreate:
 		| {
 				started: () => void;
@@ -51,7 +66,16 @@ function createFakeClient(initial: Row[]) {
 		  }
 		| undefined;
 	let liveListener: ((value: ReturnType<typeof envelope>) => void) | undefined;
-	const calls = { find: 0, create: 0, update: 0, delete: 0 };
+	const calls = { find: 0, create: 0, updateBatch: 0, deleteMany: 0 };
+	const requests = {
+		updateBatch: [] as Array<
+			Array<{ id: string; data: Partial<Row>; expectedRevision?: number }>
+		>,
+		deleteMany: [] as Array<{
+			where: { id: { in: string[] } };
+			expectedRevisions?: Array<{ id: string; expectedRevision: number }>;
+		}>,
+	};
 
 	const api = {
 		find: async () => {
@@ -71,25 +95,45 @@ function createFakeClient(initial: Row[]) {
 			await held?.wait;
 			return row;
 		},
-		update: async ({ id, data }: { id: string; data: Partial<Row> }) => {
-			calls.update += 1;
+		updateBatch: async ({
+			updates,
+		}: {
+			updates: Array<{
+				id: string;
+				data: Partial<Row>;
+				expectedRevision?: number;
+			}>;
+		}) => {
+			calls.updateBatch += 1;
+			requests.updateBatch.push(updates);
 			if (failUpdate) throw new Error("update rejected");
-			rows = rows.map((row) => (row.id === id ? { ...row, ...data } : row));
-			const result = rows.find((row) => row.id === id)!;
+			if (conflictUpdate) throw conflictError();
+			const updated: Row[] = [];
+			for (const { id, data } of updates) {
+				rows = rows.map((row) => (row.id === id ? { ...row, ...data } : row));
+				updated.push(rows.find((row) => row.id === id)!);
+			}
 			const held = heldUpdate;
 			heldUpdate = undefined;
 			held?.started();
 			await held?.wait;
-			return result;
+			return updated;
 		},
-		delete: async ({ id }: { id: string }) => {
-			calls.delete += 1;
-			rows = rows.filter((row) => row.id !== id);
+		deleteMany: async (params: {
+			where: { id: { in: string[] } };
+			expectedRevisions?: Array<{ id: string; expectedRevision: number }>;
+		}) => {
+			calls.deleteMany += 1;
+			requests.deleteMany.push(params);
+			if (conflictDelete) throw conflictError();
+			const deleted = new Set(params.where.id.in);
+			const count = rows.filter((row) => deleted.has(row.id)).length;
+			rows = rows.filter((row) => !deleted.has(row.id));
 			const held = heldDelete;
 			heldDelete = undefined;
 			held?.started();
 			await held?.wait;
-			return { success: true };
+			return { success: true, count };
 		},
 		live: (
 			_options: unknown,
@@ -106,11 +150,18 @@ function createFakeClient(initial: Row[]) {
 	return {
 		client: { collections: { posts: api } } as unknown as QuestpieClient<App>,
 		calls,
+		requests,
 		failNextFind() {
 			failFind = true;
 		},
 		failNextUpdate() {
 			failUpdate = true;
+		},
+		conflictUpdates() {
+			conflictUpdate = true;
+		},
+		conflictDeletes() {
+			conflictDelete = true;
 		},
 		holdNextCreate() {
 			let markStarted = () => {};
@@ -270,9 +321,118 @@ describe("createQuestpieCollections", () => {
 		expect(db.collections.posts.get("one")?.title).toBe("After");
 		await transaction.isPersisted.promise;
 
-		expect(fake.calls.update).toBe(1);
+		expect(fake.calls.updateBatch).toBe(1);
 		expect(fake.calls.find).toBeGreaterThanOrEqual(2);
 		expect(db.collections.posts.get("one")?.title).toBe("After");
+		db.destroy();
+	});
+
+	it("sends one ordered batch request per mutation transaction", async () => {
+		const fake = createFakeClient([
+			{ id: "one", title: "One" },
+			{ id: "two", title: "Two" },
+		]);
+		const db = createQuestpieCollections(fake.client, {
+			queryClient: new QueryClient(),
+		});
+		await db.collections.posts.preload();
+
+		const updated = db.collections.posts.update(["one", "two"], (drafts) => {
+			drafts[0]!.title = "First";
+			drafts[1]!.title = "Second";
+		});
+		await updated.isPersisted.promise;
+
+		expect(fake.calls.updateBatch).toBe(1);
+		expect(fake.requests.updateBatch[0]).toEqual([
+			{ id: "one", data: { title: "First" } },
+			{ id: "two", data: { title: "Second" } },
+		]);
+		expect(db.collections.posts.get("two")?.title).toBe("Second");
+
+		const removed = db.collections.posts.delete(["one", "two"]);
+		await removed.isPersisted.promise;
+
+		expect(fake.calls.deleteMany).toBe(1);
+		expect(fake.requests.deleteMany[0]?.where).toEqual({
+			id: { in: ["one", "two"] },
+		});
+		expect(db.collections.posts.size).toBe(0);
+		db.destroy();
+	});
+
+	it("sends the read revision with every optimistic-concurrency mutation", async () => {
+		const fake = createFakeClient([
+			{ id: "one", title: "Before", revision: 7 },
+			{ id: "two", title: "Before", revision: 3 },
+		]);
+		const db = createQuestpieCollections(fake.client, {
+			queryClient: new QueryClient(),
+		});
+		await db.collections.posts.preload();
+
+		const updated = db.collections.posts.update("one", (draft) => {
+			draft.title = "After";
+		});
+		await updated.isPersisted.promise;
+		expect(fake.requests.updateBatch[0]?.[0]?.expectedRevision).toBe(7);
+
+		const removed = db.collections.posts.delete("two");
+		await removed.isPersisted.promise;
+		expect(fake.requests.deleteMany[0]?.expectedRevisions).toEqual([
+			{ id: "two", expectedRevision: 3 },
+		]);
+		db.destroy();
+	});
+
+	it("omits the revision when the collection has no optimistic concurrency", async () => {
+		const fake = createFakeClient([
+			{ id: "one", title: "Before" },
+			{ id: "two", title: "Before" },
+		]);
+		const db = createQuestpieCollections(fake.client, {
+			queryClient: new QueryClient(),
+		});
+		await db.collections.posts.preload();
+
+		const updated = db.collections.posts.update("one", (draft) => {
+			draft.title = "After";
+		});
+		await updated.isPersisted.promise;
+		expect(
+			Object.hasOwn(fake.requests.updateBatch[0]![0]!, "expectedRevision"),
+		).toBe(false);
+
+		const removed = db.collections.posts.delete("two");
+		await removed.isPersisted.promise;
+		expect(
+			Object.hasOwn(fake.requests.deleteMany[0]!, "expectedRevisions"),
+		).toBe(false);
+		db.destroy();
+	});
+
+	it("surfaces a lost revision race as a conflict the store can act on", async () => {
+		const fake = createFakeClient([
+			{ id: "one", title: "Before", revision: 7 },
+		]);
+		const db = createQuestpieCollections(fake.client, {
+			queryClient: new QueryClient(),
+		});
+		await db.collections.posts.preload();
+		fake.conflictUpdates();
+
+		const transaction = db.collections.posts.update("one", (draft) => {
+			draft.title = "Loser";
+		});
+		const error = await transaction.isPersisted.promise.catch(
+			(rejection: unknown) => rejection,
+		);
+
+		expect(error).toBeInstanceOf(QuestpieDbConflictError);
+		expect((error as QuestpieDbConflictError).operation).toBe("update");
+		expect((error as QuestpieDbConflictError).collection).toBe("posts");
+		expect((error as QuestpieDbConflictError).ids).toEqual(["one"]);
+		expect(db.collections.posts.get("one")?.title).toBe("Before");
 		db.destroy();
 	});
 
@@ -469,6 +629,33 @@ describe("createQuestpieCollections", () => {
 		});
 
 		expect(() => db.collections.posts).toThrow("find.columns is not supported");
+		db.destroy();
+	});
+
+	it("rejects snapshot find options that live subscriptions cannot carry", () => {
+		const fake = createFakeClient([{ id: "one", title: "Before" }]);
+		const db = createQuestpieCollections(fake.client, {
+			queryClient: new QueryClient(),
+			syncMode: "snapshot",
+			find: { posts: { search: "questpie" } } as never,
+		});
+
+		expect(() => db.collections.posts).toThrow(
+			"find.search is not supported in snapshot sync mode",
+		);
+		db.destroy();
+	});
+
+	it("keeps find-only options in refetch mode, where find drives both reads", async () => {
+		const fake = createFakeClient([{ id: "one", title: "Before" }]);
+		const db = createQuestpieCollections(fake.client, {
+			queryClient: new QueryClient(),
+			find: { posts: { includeDeleted: true, stage: "draft" } },
+		});
+
+		await db.collections.posts.preload();
+
+		expect(db.collections.posts.get("one")?.title).toBe("Before");
 		db.destroy();
 	});
 

--- a/packages/tanstack-db/src/factory.ts
+++ b/packages/tanstack-db/src/factory.ts
@@ -4,16 +4,29 @@ import type { QuestpieApp, QuestpieClient } from "questpie/client";
 
 import { createQuestpieCollection } from "./collection.js";
 import type { QuestpieDbSyncMode } from "./sync.js";
-import type { CollectionKeys, FindOptionsOf, QuestpieDb } from "./types.js";
+import type {
+	CollectionKeys,
+	FindOptionsOf,
+	QuestpieDb,
+	SnapshotFindOptionsOf,
+} from "./types.js";
 
-export type QuestpieFindOptions<TApp extends QuestpieApp> = Partial<{
-	[K in CollectionKeys<TApp>]: FindOptionsOf<TApp, K>;
+export type QuestpieFindOptions<
+	TApp extends QuestpieApp,
+	TMode extends QuestpieDbSyncMode = QuestpieDbSyncMode,
+> = Partial<{
+	[K in CollectionKeys<TApp>]: TMode extends "snapshot"
+		? SnapshotFindOptionsOf<TApp, K>
+		: FindOptionsOf<TApp, K>;
 }>;
 
-export type CreateQuestpieCollectionsOptions<TApp extends QuestpieApp> = {
+export type CreateQuestpieCollectionsOptions<
+	TApp extends QuestpieApp,
+	TMode extends QuestpieDbSyncMode = QuestpieDbSyncMode,
+> = {
 	queryClient: QueryClient;
-	syncMode?: QuestpieDbSyncMode;
-	find?: QuestpieFindOptions<TApp>;
+	syncMode?: TMode;
+	find?: QuestpieFindOptions<TApp, TMode>;
 	keyPrefix?: QueryKey;
 };
 
@@ -28,6 +41,19 @@ const SHAPE_CHANGING_FIND_OPTIONS = [
 	"groupBy",
 ] as const;
 
+/**
+ * Find options `find()` honours that the realtime topic cannot carry — the
+ * complement of `SnapshotFindOptionsOf`. In snapshot mode the live subscription
+ * would silently ignore them while the post-mutation repair read applied them,
+ * so the two would describe different row sets.
+ */
+export const SNAPSHOT_UNSUPPORTED_FIND_OPTIONS = [
+	"search",
+	"localeFallback",
+	"includeDeleted",
+	"stage",
+] as const;
+
 function assertBaseRowFindOptions(options: unknown): void {
 	if (!options || typeof options !== "object" || Array.isArray(options)) return;
 	for (const key of SHAPE_CHANGING_FIND_OPTIONS) {
@@ -39,9 +65,23 @@ function assertBaseRowFindOptions(options: unknown): void {
 	}
 }
 
-export function createQuestpieCollections<TApp extends QuestpieApp>(
+function assertSnapshotFindOptions(options: unknown): void {
+	if (!options || typeof options !== "object" || Array.isArray(options)) return;
+	for (const key of SNAPSHOT_UNSUPPORTED_FIND_OPTIONS) {
+		if (key in options) {
+			throw new Error(
+				`QUESTPIE TanStack DB find.${key} is not supported in snapshot sync mode because live subscriptions cannot carry it, so snapshots and repair reads would describe different rows`,
+			);
+		}
+	}
+}
+
+export function createQuestpieCollections<
+	TApp extends QuestpieApp,
+	TMode extends QuestpieDbSyncMode = QuestpieDbSyncMode,
+>(
 	client: QuestpieClient<TApp>,
-	options: CreateQuestpieCollectionsOptions<TApp>,
+	options: CreateQuestpieCollectionsOptions<TApp, TMode>,
 ): QuestpieDb<TApp> {
 	const cache = new Map<string, Collection<{ id: string }, string>>();
 	const disposers = new Set<() => void>();
@@ -63,6 +103,7 @@ export function createQuestpieCollections<TApp extends QuestpieApp>(
 				if (!collectionClient) return undefined;
 				const findOptions = options.find?.[property as CollectionKeys<TApp>];
 				assertBaseRowFindOptions(findOptions);
+				if (syncMode === "snapshot") assertSnapshotFindOptions(findOptions);
 				const created = createQuestpieCollection({
 					client: collectionClient as unknown as RuntimeCollectionClient,
 					name: property,

--- a/packages/tanstack-db/src/types.test.ts
+++ b/packages/tanstack-db/src/types.test.ts
@@ -1,15 +1,21 @@
 import { describe, expect, it } from "bun:test";
 
 import type { Collection } from "@tanstack/db";
+import type { QueryClient } from "@tanstack/react-query";
 import { collection } from "questpie";
 import type { QuestpieClient } from "questpie/client";
 
 import { eq, useLiveQuery } from "./exports/index.js";
+import {
+	createQuestpieCollections,
+	SNAPSHOT_UNSUPPORTED_FIND_OPTIONS,
+} from "./factory.js";
 import type {
 	CollectionRowOf,
 	FindOptionsOf,
 	IdOf,
 	QuestpieDb,
+	SnapshotFindOptionsOf,
 } from "./types.js";
 
 type Equal<A, B> =
@@ -65,6 +71,39 @@ describe("tanstack-db types", () => {
 		checkFindOptions({ with: { author: true } });
 
 		expect(checkTypes).toBeInstanceOf(Function);
+	});
+
+	it("narrows snapshot find options to what the realtime topic carries", () => {
+		type SnapshotKeys = keyof SnapshotFindOptionsOf<App, "posts">;
+		type _topicFields = Expect<
+			Equal<SnapshotKeys, "where" | "orderBy" | "limit" | "offset" | "locale">
+		>;
+		// The runtime guard and the type must name the same options.
+		type _guardMatchesType = Expect<
+			Equal<
+				Exclude<keyof FindOptionsOf<App, "posts">, SnapshotKeys>,
+				(typeof SNAPSHOT_UNSUPPORTED_FIND_OPTIONS)[number]
+			>
+		>;
+
+		const checkSnapshotFindOptions = (
+			options: SnapshotFindOptionsOf<App, "posts">,
+		) => options;
+		// @ts-expect-error a live subscription cannot carry search
+		checkSnapshotFindOptions({ search: "questpie" });
+
+		const checkSnapshotRegistry = (
+			client: QuestpieClient<App>,
+			queryClient: QueryClient,
+		) =>
+			createQuestpieCollections(client, {
+				queryClient,
+				syncMode: "snapshot",
+				// @ts-expect-error a live subscription cannot carry includeDeleted
+				find: { posts: { includeDeleted: true } },
+			});
+
+		expect(checkSnapshotRegistry).toBeInstanceOf(Function);
 	});
 
 	it("keeps live-query where and join fields typed", () => {

--- a/packages/tanstack-db/src/types.ts
+++ b/packages/tanstack-db/src/types.ts
@@ -5,6 +5,7 @@ import type {
 	CollectionSelectFromApp,
 	FindManyOptions,
 	GetCollection,
+	LiveQueryOptions,
 	QuestpieApp,
 	QuestpieClient,
 	ResolveRelationsDeep,
@@ -45,6 +46,27 @@ export type FindOptionsOf<
 	| "localeFallback"
 	| "includeDeleted"
 	| "stage"
+>;
+
+/**
+ * The find options a `syncMode: "snapshot"` collection may use: the ones the
+ * realtime topic carries. `live()` re-runs the query server-side from those
+ * topic fields alone, so anything it drops would make the live snapshot and the
+ * `find()` repair describe different rows. Derived from `LiveQueryOptions` so
+ * the two cannot drift.
+ */
+export type SnapshotFindOptionsOf<
+	TApp extends QuestpieApp,
+	K extends CollectionKeys<TApp>,
+> = Pick<
+	FindOptionsOf<TApp, K>,
+	Extract<
+		keyof FindOptionsOf<TApp, K>,
+		keyof LiveQueryOptions<
+			CollectionSelectOf<TApp, K>,
+			CollectionRelationsOf<TApp, K>
+		>
+	>
 >;
 
 export type CollectionRowOf<

--- a/scripts/any-census.json
+++ b/scripts/any-census.json
@@ -3,7 +3,7 @@
 	"packages": {
 		"admin": {
 			": any": 453,
-			"as any": 458,
+			"as any": 459,
 			"as unknown as": 27,
 			"@ts-expect-error": 0
 		},
@@ -56,8 +56,8 @@
 			"@ts-expect-error": 0
 		},
 		"questpie": {
-			": any": 542,
-			"as any": 462,
+			": any": 544,
+			"as any": 464,
 			"as unknown as": 50,
 			"@ts-expect-error": 0
 		},

--- a/scripts/size-budget.json
+++ b/scripts/size-budget.json
@@ -2,55 +2,55 @@
 	"$comment": "Published package-size budget (npm pack --dry-run unpackedSize, so `files`/.npmignore are respected). Packages are DISCOVERED from packages/* — never hand-edit the list. Regenerate with `bun run scripts/size-budget.ts --update` after a build, and review the diff. Gate: unpackedSize >5% over budget fails CI. entryCount is informational only.",
 	"targets": {
 		"admin": {
-			"unpackedSize": 2705603,
-			"entryCount": 624
+			"unpackedSize": 2718995,
+			"entryCount": 622
 		},
 		"crdt-yjs": {
-			"unpackedSize": 27114,
+			"unpackedSize": 27188,
 			"entryCount": 10
 		},
 		"create-questpie": {
-			"unpackedSize": 257991,
-			"entryCount": 149
+			"unpackedSize": 260876,
+			"entryCount": 150
 		},
 		"elysia": {
-			"unpackedSize": 10437,
+			"unpackedSize": 10323,
 			"entryCount": 6
 		},
 		"hono": {
-			"unpackedSize": 9862,
+			"unpackedSize": 9917,
 			"entryCount": 6
 		},
 		"mcp": {
-			"unpackedSize": 151661,
+			"unpackedSize": 151778,
 			"entryCount": 17
 		},
 		"next": {
-			"unpackedSize": 5969,
+			"unpackedSize": 6028,
 			"entryCount": 4
 		},
 		"observability": {
-			"unpackedSize": 11581,
+			"unpackedSize": 11868,
 			"entryCount": 3
 		},
 		"openapi": {
-			"unpackedSize": 66865,
+			"unpackedSize": 66306,
 			"entryCount": 13
 		},
 		"questpie": {
-			"unpackedSize": 3767904,
-			"entryCount": 770
+			"unpackedSize": 3995718,
+			"entryCount": 782
 		},
 		"sandbox": {
-			"unpackedSize": 245337,
+			"unpackedSize": 245345,
 			"entryCount": 23
 		},
 		"tanstack-db": {
-			"unpackedSize": 13564,
+			"unpackedSize": 19696,
 			"entryCount": 4
 		},
 		"tanstack-query": {
-			"unpackedSize": 35854,
+			"unpackedSize": 36876,
 			"entryCount": 4
 		},
 		"testing": {
@@ -58,11 +58,11 @@
 			"entryCount": 5
 		},
 		"vite-plugin-iconify": {
-			"unpackedSize": 18832,
+			"unpackedSize": 18831,
 			"entryCount": 6
 		},
 		"workflows": {
-			"unpackedSize": 203746,
+			"unpackedSize": 208407,
 			"entryCount": 30
 		}
 	}

--- a/scripts/type-budget.json
+++ b/scripts/type-budget.json
@@ -1,22 +1,22 @@
 {
-	"$comment": "Type-perf budget (deterministic tsc metrics). Regenerate with `bun run scripts/type-budget.ts --update` and review the diff \u2014 never hand-edit. Gate: instantiations >3% over budget fails CI. NOTE: a package target measures its OWN tsconfig, which includes its type tests \u2014 packages/questpie jumped +7.9% on 2026-07-29 purely from adding test/types/field-inference.test-d.ts (286,129 instantiations for that one file; removing it returns the number to baseline exactly). Test cost is not framework cost and users never typecheck our tests, so when this target moves, check whether a test file was added before hunting a regression. The three example targets are the user-facing signal.",
+	"$comment": "Type-perf budget (deterministic tsc metrics). Regenerate with `bun run scripts/type-budget.ts --update` and review the diff — never hand-edit. Gate: instantiations >3% over budget fails CI. NOTE: a package target measures its OWN tsconfig, which includes its type tests — packages/questpie jumped +7.9% on 2026-07-29 purely from adding test/types/field-inference.test-d.ts (286,129 instantiations for that one file; removing it returns the number to baseline exactly). Test cost is not framework cost and users never typecheck our tests, so when this target moves, check whether a test file was added before hunting a regression. The three example targets are the user-facing signal.",
 	"tsVersion": "5.9.2",
 	"targets": {
 		"packages/questpie": {
-			"types": 491764,
-			"instantiations": 1754033
+			"types": 504920,
+			"instantiations": 1831510
 		},
 		"examples/toy-factory-backend": {
-			"types": 771500,
-			"instantiations": 2792488
+			"types": 781255,
+			"instantiations": 2826959
 		},
 		"examples/tanstack-barbershop": {
-			"types": 1016832,
-			"instantiations": 3580243
+			"types": 1027947,
+			"instantiations": 3618124
 		},
 		"examples/city-portal": {
-			"types": 853126,
-			"instantiations": 2943876
+			"types": 863138,
+			"instantiations": 2980539
 		}
 	}
 }

--- a/skills/questpie/AGENTS.md
+++ b/skills/questpie/AGENTS.md
@@ -10420,6 +10420,25 @@ TanStack DB and TanStack React DB unchanged. They are here so a component import
 from one place; their semantics and their documentation are upstream's. Only
 `createQuestpieCollections` is QUESTPIE's own.
 
+Optimistic-concurrency failures are normalized to
+`QuestpieDbConflictError`. Catch it when a mutation should refetch stale rows
+before offering a retry; its `collection`, `operation`, and `ids` properties
+identify the failed atomic batch.
+
+```ts
+import { QuestpieDbConflictError } from "@questpie/tanstack-db";
+
+try {
+	await db.posts.update(id, (draft) => {
+		draft.title = "Canonical title";
+	});
+} catch (error) {
+	if (error instanceof QuestpieDbConflictError) {
+		await queryClient.invalidateQueries();
+	}
+}
+```
+
 ## Types
 
 `QuestpieDb` is the collection map, and the rest describe one collection:

--- a/skills/questpie/AGENTS.md
+++ b/skills/questpie/AGENTS.md
@@ -6566,9 +6566,17 @@ cut; reconnect and replay reauthorize against current application state.
 ## Client, presence, and TanStack Query
 
 ```ts
-const stop = client.channels.chatRoom.subscribe({ roomId }, (message) => {
-	if (message.event === "message") console.log(message.data.text);
-});
+const stop = client.channels.chatRoom.subscribe(
+	{ roomId },
+	(message) => {
+		if (message.event === "message") console.log(message.data.text);
+	},
+	{
+		onReady: () => setMutationEnabled(true),
+		onNotReady: () => setMutationEnabled(false),
+		onError: console.error,
+	},
+);
 
 await client.channels.chatRoom.publish({
 	params: { roomId },
@@ -6584,6 +6592,15 @@ const stopPresence = client.channels.chatRoom.subscribePresence(
 stop();
 stopPresence();
 ```
+
+`onReady` begins an admitted logical subscription epoch after authorization and
+replay catch-up. `onNotReady` runs exactly once when that admitted epoch ends;
+successful reconnect calls `onReady` again for the next epoch. It is not called
+before the subscriber's first `onReady`, or when the subscriber explicitly
+stops or aborts. Ordinary reconnects use `onNotReady` without manufacturing an
+`onError`; a terminal failure after admission calls `onNotReady` before
+`onError`. Lifecycle callback exceptions are isolated from sibling subscribers,
+cleanup, and later reconnects.
 
 `presence()` returns one typed snapshot. `subscribePresence()` emits the initial and later rosters, and `presenceIter(params, { signal })` provides the async-generator form. Pusher/Soketi uses native membership; SSE uses Postgres leases across instances and deduplicates multiple connections by authenticated principal. Crash leave converges after the lease TTL.
 

--- a/skills/questpie/AGENTS.md
+++ b/skills/questpie/AGENTS.md
@@ -6419,6 +6419,15 @@ invalidation stay enabled. Raw topics receive the same
 `collection_realtime_disabled` or `row_live_queries_disabled` rejection as
 typed clients, before scheduler allocation or bootstrap.
 
+`realtime: { changeCapture: false }` is the write-side switch, and the stronger
+one. Mutations stop writing the outbox: no insert, no drain, no retention
+cleanup, so an application built on typed channels alone pays nothing for the
+collection lane. It costs collection and global realtime: every such topic is
+refused with `change_capture_disabled`, plus `sinceSeq` resume and the `txid`
+that `@questpie/tanstack-db` matches optimistic writes against. Typed channels,
+channel presence, and CRDT document sync are unaffected; CRDT canonical
+projection still writes its own outbox row per commit.
+
 A personalized relation query for 100,000 principals in one shared scope can
 cause 100,000 authoritative recomputations. Snapshot fallback is correct but
 expensive. Prefer materialized inbox rows with direct `recipientId`, a shared
@@ -6682,9 +6691,20 @@ Missed hints reconcile from PostgreSQL.
 The server Yjs engine uses bounded in-process worker threads for untrusted CPU
 work. That is private runtime machinery, not another deployable worker service.
 
+When canonical text and application-owned projections must advance atomically,
+configure `crdt.projection.prepareAcknowledgement`. It receives the complete
+authoritative aggregate cut, changed field paths, exact Human/Agent
+contributors, the locked owner and the framework projection transaction. It
+may write exact relation rows through that transaction and return canonical
+field values plus ordinary owner-column projections. Throwing rolls back those
+writes together with canonical fields, projection cursors and the realtime
+outbox event. The callback may retry and grants no authority of its own, so
+consumer validation and derived writes must be deterministic, idempotent and
+must recheck product authorization.
+
 ## Generated client
 
-Build the CRDT API from an existing client with `createCrdtClient` — it reuses
+Build the CRDT API from an existing client with `createCrdtClient`. It reuses
 that client's realtime session (still one connection), and keeps the CRDT
 implementation out of the bundle of every app that never calls it.
 

--- a/skills/questpie/coverage.json
+++ b/skills/questpie/coverage.json
@@ -260,7 +260,6 @@
 		"questpieChannelEventTable": "ordered channel infrastructure table managed by realtime migrations",
 		"questpieChannelHeadTable": "ordered channel infrastructure table managed by realtime migrations",
 		"questpieChannelPresenceTable": "channel presence infrastructure table managed by realtime migrations",
-		"questpieRealtimeHeadTable": "durable realtime commit-order cursor infrastructure table",
 		"questpieRealtimeLogTable": "realtime outbox table (managed by adapter migrations)",
 		"questpieRealtimeTopologyTable": "durable realtime infrastructure table managed by realtime migrations",
 		"questpieSearchFacetsTable": "search infrastructure table",

--- a/skills/questpie/references/channels.md
+++ b/skills/questpie/references/channels.md
@@ -124,9 +124,17 @@ cut; reconnect and replay reauthorize against current application state.
 ## Client, presence, and TanStack Query
 
 ```ts
-const stop = client.channels.chatRoom.subscribe({ roomId }, (message) => {
-	if (message.event === "message") console.log(message.data.text);
-});
+const stop = client.channels.chatRoom.subscribe(
+	{ roomId },
+	(message) => {
+		if (message.event === "message") console.log(message.data.text);
+	},
+	{
+		onReady: () => setMutationEnabled(true),
+		onNotReady: () => setMutationEnabled(false),
+		onError: console.error,
+	},
+);
 
 await client.channels.chatRoom.publish({
 	params: { roomId },
@@ -142,6 +150,15 @@ const stopPresence = client.channels.chatRoom.subscribePresence(
 stop();
 stopPresence();
 ```
+
+`onReady` begins an admitted logical subscription epoch after authorization and
+replay catch-up. `onNotReady` runs exactly once when that admitted epoch ends;
+successful reconnect calls `onReady` again for the next epoch. It is not called
+before the subscriber's first `onReady`, or when the subscriber explicitly
+stops or aborts. Ordinary reconnects use `onNotReady` without manufacturing an
+`onError`; a terminal failure after admission calls `onNotReady` before
+`onError`. Lifecycle callback exceptions are isolated from sibling subscribers,
+cleanup, and later reconnects.
 
 `presence()` returns one typed snapshot. `subscribePresence()` emits the initial and later rosters, and `presenceIter(params, { signal })` provides the async-generator form. Pusher/Soketi uses native membership; SSE uses Postgres leases across instances and deduplicates multiple connections by authenticated principal. Crash leave converges after the lease TTL.
 

--- a/skills/questpie/references/collaborative-documents.md
+++ b/skills/questpie/references/collaborative-documents.md
@@ -77,9 +77,20 @@ Missed hints reconcile from PostgreSQL.
 The server Yjs engine uses bounded in-process worker threads for untrusted CPU
 work. That is private runtime machinery, not another deployable worker service.
 
+When canonical text and application-owned projections must advance atomically,
+configure `crdt.projection.prepareAcknowledgement`. It receives the complete
+authoritative aggregate cut, changed field paths, exact Human/Agent
+contributors, the locked owner and the framework projection transaction. It
+may write exact relation rows through that transaction and return canonical
+field values plus ordinary owner-column projections. Throwing rolls back those
+writes together with canonical fields, projection cursors and the realtime
+outbox event. The callback may retry and grants no authority of its own, so
+consumer validation and derived writes must be deterministic, idempotent and
+must recheck product authorization.
+
 ## Generated client
 
-Build the CRDT API from an existing client with `createCrdtClient` — it reuses
+Build the CRDT API from an existing client with `createCrdtClient`. It reuses
 that client's realtime session (still one connection), and keeps the CRDT
 implementation out of the bundle of every app that never calls it.
 

--- a/skills/questpie/references/realtime.md
+++ b/skills/questpie/references/realtime.md
@@ -192,6 +192,15 @@ invalidation stay enabled. Raw topics receive the same
 `collection_realtime_disabled` or `row_live_queries_disabled` rejection as
 typed clients, before scheduler allocation or bootstrap.
 
+`realtime: { changeCapture: false }` is the write-side switch, and the stronger
+one. Mutations stop writing the outbox: no insert, no drain, no retention
+cleanup, so an application built on typed channels alone pays nothing for the
+collection lane. It costs collection and global realtime: every such topic is
+refused with `change_capture_disabled`, plus `sinceSeq` resume and the `txid`
+that `@questpie/tanstack-db` matches optimistic writes against. Typed channels,
+channel presence, and CRDT document sync are unaffected; CRDT canonical
+projection still writes its own outbox row per commit.
+
 A personalized relation query for 100,000 principals in one shared scope can
 cause 100,000 authoritative recomputations. Snapshot fallback is correct but
 expensive. Prefer materialized inbox rows with direct `recipientId`, a shared

--- a/skills/questpie/references/tanstack-db.md
+++ b/skills/questpie/references/tanstack-db.md
@@ -73,6 +73,25 @@ TanStack DB and TanStack React DB unchanged. They are here so a component import
 from one place; their semantics and their documentation are upstream's. Only
 `createQuestpieCollections` is QUESTPIE's own.
 
+Optimistic-concurrency failures are normalized to
+`QuestpieDbConflictError`. Catch it when a mutation should refetch stale rows
+before offering a retry; its `collection`, `operation`, and `ids` properties
+identify the failed atomic batch.
+
+```ts
+import { QuestpieDbConflictError } from "@questpie/tanstack-db";
+
+try {
+	await db.posts.update(id, (draft) => {
+		draft.title = "Canonical title";
+	});
+} catch (error) {
+	if (error instanceof QuestpieDbConflictError) {
+		await queryClient.invalidateQueries();
+	}
+}
+```
+
 ## Types
 
 `QuestpieDb` is the collection map, and the rest describe one collection:


### PR DESCRIPTION
## What changed

Ships the next QUESTPIE realtime release train as one changeset:

- lock-free transactional realtime capture with settlement-aware `(txid, seq)` draining and retention migrations
- bounded realtime admission, ordered channel delivery, native deltas and honest stream failures
- cross-collection atomic transactions plus read-path ordering, range and paging fixes
- TanStack DB batched optimistic mutations and reconciliation
- public `crdt.projection.prepareAcknowledgement` hook for atomic validation, canonicalization, derived writes and owner projections
- compiled `RAW` predicates in collection read access, including realtime subscriptions
- typed channel `onNotReady` lifecycle across SSE and Pusher/Soketi reconnect epochs
- production docs, generated examples, PostgreSQL CI gates and migration snapshots

## Why

The release makes realtime writes horizontally scalable without skipping committed changes, and gives CRDT consumers one framework-owned transaction in which canonical content, derived application state, projection cursors and the realtime outbox either all commit or all roll back.

## Validation

- `bun run check-types`: 27/27 tasks
- CRDT: 339 passed, 3 PostgreSQL-only skipped, 0 failed
- realtime focused suite: 120 passed, 0 failed
- read path + cross-collection transaction + TanStack DB: 45 passed, 0 failed
- observability isolated suite: 6 passed, 0 failed
- OpenAPI route snapshot: passed
- `bun run verify:realtime-migrations`: both examples clean and idempotent
- `bun run validate:docs`: 312 files, 0 errors
- `bun run format:check`: passed
- `bun run lint`: passed with pre-existing warnings
- consolidated channel lifecycle suite: 52 passed, 0 failed
- RAW access compiler + realtime subscription regression: passed
- full `packages/questpie` suite: 3046 passed; one migration-test prompt exposed and repaired, isolated rerun 16/16 passed

The included minor changeset advances the fixed QUESTPIE package train after merge.