### PR TITLE
fix(migrations): reconcile framework schema upgrades

### DIFF
--- a/.changeset/calm-pies-settle.md
+++ b/.changeset/calm-pies-settle.md
@@ -1,0 +1,7 @@
+---
+"questpie": patch
+---
+
+Ship the framework-owned realtime `settled_at` compatibility migration and an
+explicit migration baseline command for databases previously created by
+development schema push.

--- a/apps/docs/content/docs/ship/migrations/commands.mdx
+++ b/apps/docs/content/docs/ship/migrations/commands.mdx
@@ -5,7 +5,7 @@ kind: reference
 package: questpie
 ---
 
-Seven commands deal with the database schema. Each one takes
+Eight commands deal with the database schema. Each one takes
 `-c, --config <path>`, which defaults to `questpie.config.ts`.
 
 | Command                   | Also accepts       | What it does                                                |
@@ -14,6 +14,7 @@ Seven commands deal with the database schema. Each one takes
 | `questpie migrate`        | `migrate:up`       | Runs pending migrations, then the search index migrations   |
 | `questpie migrate:down`   |                    | Rolls back the last batch                                   |
 | `questpie migrate:status` |                    | Prints executed and pending migrations                      |
+| `questpie migrate:baseline` |                  | Records an existing pushed schema in the migration ledger   |
 | `questpie migrate:reset`  |                    | Rolls back every executed migration                         |
 | `questpie migrate:fresh`  |                    | Reset, then up, then reset seed tracking                    |
 | `questpie push`           |                    | Applies the schema straight to a development database       |
@@ -89,6 +90,29 @@ column rolls back to that column, empty.
 
 Creates the ledger table if it is missing. Then prints the current batch, the
 executed migrations with their batch and time, and the pending ones.
+
+## `migrate:baseline`
+
+Use this only when a development database was previously created with
+`questpie push` and therefore has schema objects but no matching migration
+ledger rows. It records every migration through an inclusive target without
+running their `up()` functions:
+
+```bash
+questpie migrate:baseline --target <last-existing-migration-id> --force
+questpie migrate
+```
+
+Inspect the live schema and `questpie migrate:status` before choosing the
+target. `--target` is required and must name a registered migration. `--force`
+is also required because choosing a migration not represented by the live
+schema can make later deploys fail or silently miss required DDL. `--dry-run`
+prints the intended target without writing the ledger and does not require
+`--force`.
+
+The same operation is available to controlled deployment tooling as
+`app.migrations.baseline({ targetMigration })`. It has no confirmation prompt;
+the caller owns the same schema verification required by the CLI.
 
 ## `migrate:reset` and `migrate:fresh`
 

--- a/packages/questpie/src/cli/commands/run.ts
+++ b/packages/questpie/src/cli/commands/run.ts
@@ -6,7 +6,13 @@ import { SeedRunner } from "../../server/seed/runner.js";
 import { loadQuestpieConfig } from "../config.js";
 import { resolveCliPath } from "../utils.js";
 
-export type RunMigrationAction = "up" | "down" | "status" | "reset" | "fresh";
+export type RunMigrationAction =
+	| "up"
+	| "down"
+	| "status"
+	| "reset"
+	| "fresh"
+	| "baseline";
 
 export type RunMigrationOptions = {
 	action: RunMigrationAction;
@@ -14,6 +20,7 @@ export type RunMigrationOptions = {
 	targetMigration?: string;
 	batch?: number;
 	dryRun?: boolean;
+	force?: boolean;
 };
 
 /**
@@ -39,6 +46,14 @@ export async function runMigrationCommand(
 		(!Number.isSafeInteger(options.batch) || options.batch < 1)
 	) {
 		throw new Error("--batch must be a positive integer");
+	}
+	if (options.action === "baseline" && !options.targetMigration) {
+		throw new Error("migrate:baseline requires --target <migration>");
+	}
+	if (options.action === "baseline" && !options.force && !options.dryRun) {
+		throw new Error(
+			"migrate:baseline records migrations without running them; pass --force after verifying the target schema",
+		);
 	}
 
 	// Load config
@@ -110,6 +125,12 @@ export async function runMigrationCommand(
 
 			case "status":
 				await runner.status(migrations);
+				break;
+
+			case "baseline":
+				await app.migrations.baseline({
+					targetMigration: options.targetMigration!,
+				});
 				break;
 
 			default:

--- a/packages/questpie/src/cli/index.ts
+++ b/packages/questpie/src/cli/index.ts
@@ -223,6 +223,38 @@ program
 		}
 	});
 
+// Baseline migrations represented by an existing schema
+program
+	.command("migrate:baseline")
+	.description(
+		"Record existing migrations without running them (schema-push reconciliation)",
+	)
+	.option(
+		"-c, --config <path>",
+		"Path to app config file",
+		"questpie.config.ts",
+	)
+	.requiredOption(
+		"-t, --target <migration>",
+		"Last migration already represented by the database schema",
+	)
+	.option("--force", "Confirm that the target schema was verified")
+	.option("--dry-run", "Show what would be recorded without executing")
+	.action(async (options) => {
+		try {
+			await runMigrationCommand({
+				action: "baseline",
+				configPath: options.config,
+				targetMigration: options.target,
+				force: options.force,
+				dryRun: options.dryRun,
+			});
+		} catch (error) {
+			console.error("❌ Failed to baseline migrations:", error);
+			process.exit(1);
+		}
+	});
+
 // Reset migrations
 program
 	.command("migrate:reset")

--- a/packages/questpie/src/server/config/create-app.ts
+++ b/packages/questpie/src/server/config/create-app.ts
@@ -24,6 +24,7 @@ import {
 	mergeMessagesIntoConfig,
 	mergeTranslationsConfig,
 } from "#questpie/server/i18n/translator.js";
+import { frameworkMigrations } from "#questpie/server/migration/framework-migrations.js";
 import coreModule from "#questpie/server/modules/core/.generated/module.js";
 import { mergeAuthOptions } from "#questpie/server/modules/core/integrated/auth/merge.js";
 import { createCrdtRuntimeManifests } from "#questpie/server/modules/core/integrated/crdt/manifest-runtime.js";
@@ -763,7 +764,10 @@ async function createAppFromDefinition(
 		observability: runtime.observability,
 		executor: runtime.executor,
 		migrations: {
-			migrations: [...merged.migrations],
+			// Application migrations must run first. This lets a historical app
+			// migration create an older framework table before a forward-only
+			// framework compatibility migration repairs it.
+			migrations: [...merged.migrations, ...frameworkMigrations],
 		},
 		seeds: {
 			seeds: [...merged.seeds],

--- a/packages/questpie/src/server/config/integrated/migrations-api.ts
+++ b/packages/questpie/src/server/config/integrated/migrations-api.ts
@@ -9,6 +9,7 @@ import {
 } from "#questpie/server/migration/generator.js";
 import { MigrationRunner } from "#questpie/server/migration/runner.js";
 import type {
+	BaselineMigrationsOptions,
 	GenerateMigrationResult,
 	Migration,
 	MigrationStatus,
@@ -126,6 +127,15 @@ export class QuestpieMigrationsAPI<
 	async fresh(): Promise<void> {
 		await this.reset();
 		await this.up();
+	}
+
+	/**
+	 * Mark migrations through an inclusive target as applied without executing
+	 * them. Use this only to reconcile a database whose schema was previously
+	 * created with development-only `questpie push`.
+	 */
+	async baseline(options: BaselineMigrationsOptions): Promise<void> {
+		await this.runner.baseline(this.getMigrations(), options);
 	}
 
 	/**

--- a/packages/questpie/src/server/migration/framework-migrations.ts
+++ b/packages/questpie/src/server/migration/framework-migrations.ts
@@ -1,0 +1,34 @@
+import { sql } from "drizzle-orm";
+
+import type { Migration } from "./types.js";
+
+/**
+ * Framework-owned compatibility migrations run after application migrations.
+ *
+ * They intentionally have no snapshots: application schema generation already
+ * includes framework tables, while these migrations repair databases created
+ * by an older migration or by development-only schema push.
+ */
+export const frameworkMigrations: readonly Migration[] = [
+	{
+		id: "questpieRealtimeSettledAt20260808T000000",
+		async up({ db }) {
+			await db.execute(sql`
+				DO $$
+				BEGIN
+					IF to_regclass('questpie_realtime_log') IS NOT NULL THEN
+						ALTER TABLE "questpie_realtime_log"
+						ADD COLUMN IF NOT EXISTS "settled_at" timestamp(3);
+						CREATE INDEX IF NOT EXISTS "idx_realtime_log_settled_at"
+						ON "questpie_realtime_log" ("settled_at");
+					END IF;
+				END $$
+			`);
+		},
+		async down() {
+			// Compatibility migrations are deliberately forward-only. The column may
+			// have been created by an application migration or schema push, so removing
+			// it during rollback would destroy schema owned by another migration path.
+		},
+	},
+];

--- a/packages/questpie/src/server/migration/runner.ts
+++ b/packages/questpie/src/server/migration/runner.ts
@@ -5,6 +5,7 @@ import { assertSupportedPostgresVersion } from "#questpie/server/db/postgres-ver
 import { getEnv, getNodeEnv } from "#questpie/server/utils/env.js";
 
 import type {
+	BaselineMigrationsOptions,
 	Migration,
 	MigrationDb,
 	MigrationRecord,
@@ -346,6 +347,45 @@ export class MigrationRunner {
 	}
 
 	/**
+	 * Record existing schema migrations without executing their `up` functions.
+	 *
+	 * This is an explicit reconciliation operation for a database previously
+	 * created with development-only schema push. The target is inclusive so the
+	 * caller must identify the last migration already represented by the schema.
+	 */
+	async baseline(
+		migrations: Migration[],
+		options: BaselineMigrationsOptions,
+	): Promise<void> {
+		await assertSupportedPostgresVersion(this.db);
+		await this.ensureMigrationsTable();
+
+		const targetIndex = migrations.findIndex(
+			(migration) => migration.id === options.targetMigration,
+		);
+		if (targetIndex < 0) {
+			throw new Error(`Migration not found: ${options.targetMigration}`);
+		}
+
+		const candidates = migrations.slice(0, targetIndex + 1);
+		await this.db.transaction(async (tx) => {
+			await tx.execute(
+				sql`SELECT pg_advisory_xact_lock(hashtext(${this.tableName}))`,
+			);
+			const currentBatch = await this.getCurrentBatch(tx);
+			const batch = currentBatch + 1;
+
+			for (const migration of candidates) {
+				await tx.execute(sql`
+					INSERT INTO ${sql.identifier(this.tableName)} (id, name, batch)
+					VALUES (${migration.id}, ${migration.id}, ${batch})
+					ON CONFLICT (id) DO NOTHING
+				`);
+			}
+		});
+	}
+
+	/**
 	 * Get migration status
 	 */
 	async status(migrations: Migration[]): Promise<MigrationStatus> {
@@ -427,8 +467,8 @@ export class MigrationRunner {
 	/**
 	 * Get current batch number
 	 */
-	private async getCurrentBatch(): Promise<number> {
-		const result: any = await this.db.execute(
+	private async getCurrentBatch(db: MigrationDb = this.db): Promise<number> {
+		const result: any = await db.execute(
 			sql`SELECT MAX(batch) as max_batch FROM ${sql.identifier(this.tableName)}`,
 		);
 

--- a/packages/questpie/src/server/migration/types.ts
+++ b/packages/questpie/src/server/migration/types.ts
@@ -141,6 +141,11 @@ export type RunMigrationsOptions = {
 	targetMigration?: string;
 };
 
+export type BaselineMigrationsOptions = {
+	/** Mark pending migrations through this migration ID as already applied. */
+	targetMigration: string;
+};
+
 /**
  * Migration status information
  */

--- a/packages/questpie/test/cli/run-migration-command.test.ts
+++ b/packages/questpie/test/cli/run-migration-command.test.ts
@@ -53,16 +53,16 @@ describe("runMigrationCommand", () => {
 
 		await runMigrationCommand({ action: "up", configPath });
 		expect(destroy).toHaveBeenCalledTimes(1);
-		expect(up).not.toHaveBeenCalled();
+		expect(up).toHaveBeenCalledTimes(1);
 
 		setup.app.config.migrations = [migration];
 		await runMigrationCommand({ action: "up", configPath, dryRun: true });
 		expect(destroy).toHaveBeenCalledTimes(2);
-		expect(up).not.toHaveBeenCalled();
+		expect(up).toHaveBeenCalledTimes(1);
 
 		await runMigrationCommand({ action: "up", configPath });
 		expect(destroy).toHaveBeenCalledTimes(3);
-		expect(up).toHaveBeenCalledTimes(1);
+		expect(up).toHaveBeenCalledTimes(2);
 
 		log.mockRestore();
 		up.mockRestore();
@@ -85,5 +85,39 @@ describe("runMigrationCommand", () => {
 		log.mockRestore();
 		up.mockRestore();
 		destroy.mockRestore();
+	});
+
+	it("requires explicit force before baselining a pushed schema", async () => {
+		setup.app.config.migrations = [migration];
+		const baseline = spyOn(setup.app.migrations, "baseline").mockResolvedValue(
+			undefined,
+		);
+		const destroy = spyOn(setup.app, "destroy").mockResolvedValue(undefined);
+		const log = spyOn(console, "log").mockImplementation(() => {});
+
+		await expect(
+			runMigrationCommand({
+				action: "baseline",
+				configPath,
+				targetMigration: migration.id,
+			}),
+		).rejects.toThrow("pass --force");
+		expect(baseline).not.toHaveBeenCalled();
+		expect(destroy).not.toHaveBeenCalled();
+
+		await runMigrationCommand({
+			action: "baseline",
+			configPath,
+			targetMigration: migration.id,
+			force: true,
+		});
+		expect(baseline).toHaveBeenCalledWith({
+			targetMigration: migration.id,
+		});
+		expect(destroy).toHaveBeenCalledTimes(1);
+
+		log.mockRestore();
+		destroy.mockRestore();
+		baseline.mockRestore();
 	});
 });

--- a/packages/questpie/test/migration/migrations.test.ts
+++ b/packages/questpie/test/migration/migrations.test.ts
@@ -24,6 +24,7 @@ import {
 import { createApp, module } from "../../src/exports/index.js";
 import { collection } from "../../src/exports/index.js";
 import { systemTimestamp } from "../../src/server/db/system-columns.js";
+import { frameworkMigrations } from "../../src/server/migration/framework-migrations.js";
 import { MigrationRunner } from "../../src/server/migration/runner.js";
 import type {
 	Migration,
@@ -321,6 +322,66 @@ AND table_name IN ('posts', 'comments')
 				"third",
 			]);
 		} finally {
+			await targetDb.close();
+		}
+	});
+
+	test("baselines a pushed schema before applying framework compatibility migrations", async () => {
+		const targetDb = await createTestDb();
+		const targetApp = await createApp(module({ name: "baseline-test" }), {
+			app: { url: "http://localhost:3000" },
+			db: { pglite: targetDb },
+			email: { adapter: new MockMailAdapter() },
+			queue: { adapter: new MockQueueAdapter() },
+			kv: { adapter: new MockKVAdapter() },
+			logger: { adapter: new MockLogger() },
+		});
+		const runner = new MigrationRunner(targetApp.db, { silent: true });
+		const historicalMigration: Migration = {
+			id: "historicalRealtimeTable",
+			async up() {
+				throw new Error("the baselined migration must not run");
+			},
+			async down() {},
+		};
+		const migrations = [historicalMigration, ...frameworkMigrations];
+
+		try {
+			await targetDb.exec(`
+				CREATE TABLE questpie_realtime_log (
+					seq BIGSERIAL PRIMARY KEY,
+					created_at timestamp(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
+				)
+			`);
+
+			await runner.baseline(migrations, {
+				targetMigration: historicalMigration.id,
+			});
+			await runner.runMigrationsUp(migrations);
+
+			const columns = await targetDb.query(`
+				SELECT column_name
+				FROM information_schema.columns
+				WHERE table_name = 'questpie_realtime_log'
+					AND column_name = 'settled_at'
+			`);
+			const indexes = await targetDb.query(`
+				SELECT indexname
+				FROM pg_indexes
+				WHERE tablename = 'questpie_realtime_log'
+					AND indexname = 'idx_realtime_log_settled_at'
+			`);
+			const status = await runner.status(migrations);
+
+			expect(columns.rows).toHaveLength(1);
+			expect(indexes.rows).toHaveLength(1);
+			expect(status.pending).toHaveLength(0);
+			expect(status.executed.map((migration) => migration.id)).toEqual([
+				historicalMigration.id,
+				frameworkMigrations[0]!.id,
+			]);
+		} finally {
+			await targetApp.destroy();
 			await targetDb.close();
 		}
 	});


### PR DESCRIPTION
## What changed

- ship a framework-owned, forward-only compatibility migration for `questpie_realtime_log.settled_at` and its cleanup index
- append framework compatibility migrations after application migrations
- add `questpie migrate:baseline --target <id> --force` for explicit reconciliation of databases previously created with development-only schema push
- expose and document the equivalent controlled API, `app.migrations.baseline({ targetMigration })`

## Root cause

QUESTPIE 3.25 realtime capture writes and cleanup use `settled_at`, but the released framework only included the column in its current Drizzle schema. Existing databases therefore did not receive an upgrade migration. Databases originally created through `questpie push` also had framework tables without matching migration-ledger rows, so ordinary migration execution failed on historical `CREATE TABLE` statements before it could apply a repair.

## Impact

Existing applications can explicitly baseline the already-present historical schema, then run pending migrations. The framework compatibility migration safely repairs the realtime table without an application-owned `questpie_*` workaround.

## Validation

- `bun run --filter questpie check-types`
- `bun test packages/questpie/test/migration/migrations.test.ts packages/questpie/test/cli/run-migration-command.test.ts` — 20 passed
- focused Oxlint — only two pre-existing warnings in legacy touched files
