### PR TITLE
fix(realtime): reopen query-only edges for CRDT

### DIFF
--- a/.changeset/calm-lions-reconnect.md
+++ b/.changeset/calm-lions-reconnect.md
@@ -1,0 +1,7 @@
+---
+"questpie": patch
+---
+
+Reconnect an existing query-only realtime edge before a late collaborative
+document acquire so SSE and shared-provider sessions gain CRDT authority without
+hanging in the authorizing state.

--- a/apps/docs/content/docs/client/collaborative-documents.mdx
+++ b/apps/docs/content/docs/client/collaborative-documents.mdx
@@ -19,6 +19,9 @@ export const crdt = createCrdtClient(client);
 
 `createCrdtClient` takes the client you already built and reuses its realtime
 session. A collaborative app still holds exactly one connection.
+If that connection started for a live query without CRDT authority, the first
+document connection replaces the edge once and carries its query subscriptions
+onto the CRDT-capable session.
 `createClient()` does not build this API for you. There is no `client.crdt`
 either, and reading that property throws a message pointing you back here.
 

--- a/packages/questpie/src/client/realtime/pusher.ts
+++ b/packages/questpie/src/client/realtime/pusher.ts
@@ -103,6 +103,7 @@ export class PusherRealtimeTransport implements RealtimeClientTransport {
 	private readonly topics = new Map<string, TopicEntry>();
 	private readonly crdt = new Map<string, CrdtEntry>();
 	private session: SessionResponse | null = null;
+	private sessionCrdtHold = false;
 	private readonly connection: PusherConnectionManager;
 	private subscription: ManagedPusherSubscription | null = null;
 	private sessionPromise: Promise<void> | null = null;
@@ -199,7 +200,7 @@ export class PusherRealtimeTransport implements RealtimeClientTransport {
 			this.closeIfIdle();
 		};
 		try {
-			await this.ensureSession();
+			await this.ensureCrdtSession();
 			if (signal?.aborted) throw new DOMException("Aborted", "AbortError");
 			const session = this.session;
 			if (!session) throw new Error("Realtime edge session is unavailable");
@@ -225,6 +226,14 @@ export class PusherRealtimeTransport implements RealtimeClientTransport {
 		} catch (error) {
 			release();
 			throw error;
+		}
+	}
+
+	private async ensureCrdtSession(): Promise<void> {
+		while (!this.destroyed) {
+			await this.ensureSession();
+			if (!this.session || this.sessionCrdtHold) return;
+			this.disconnect();
 		}
 	}
 
@@ -293,6 +302,7 @@ export class PusherRealtimeTransport implements RealtimeClientTransport {
 	private async openSession(): Promise<void> {
 		const initial = [...this.topics.entries()];
 		if (!this.hasDemand() || this.destroyed) return;
+		const crdtHold = this.holdCount > 0 || this.crdt.size > 0;
 		const authHeaders = await this.options.getAuthHeaders?.();
 		const response = await this.options.fetcher(
 			`${this.options.baseUrl}/realtime`,
@@ -304,9 +314,7 @@ export class PusherRealtimeTransport implements RealtimeClientTransport {
 					topics: initial.map(([topicId, entry]) =>
 						topicPayload(topicId, entry.topic),
 					),
-					...(this.holdCount > 0 || this.crdt.size > 0
-						? { crdtHold: true }
-						: {}),
+					...(crdtHold ? { crdtHold: true } : {}),
 				}),
 				credentials: "include",
 			},
@@ -326,6 +334,7 @@ export class PusherRealtimeTransport implements RealtimeClientTransport {
 			throw new Error("Invalid shared-provider realtime session");
 		}
 		this.session = session;
+		this.sessionCrdtHold = crdtHold;
 		if (this.destroyed) {
 			await this.sendDesiredTopology().catch(() => {});
 			this.disconnect();
@@ -783,6 +792,7 @@ export class PusherRealtimeTransport implements RealtimeClientTransport {
 		this.subscription?.release();
 		this.subscription = null;
 		this.session = null;
+		this.sessionCrdtHold = false;
 		this.controlOperation = Promise.resolve();
 		this.desiredRevision = 0;
 		this.desiredTopologyGeneration = 0;

--- a/packages/questpie/src/client/realtime/sse-connection.ts
+++ b/packages/questpie/src/client/realtime/sse-connection.ts
@@ -51,10 +51,12 @@ export class SseConnectionManager {
 	private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 	private watchdogTimer: ReturnType<typeof setTimeout> | null = null;
 	private connecting = false;
+	private connectingCrdtHold = false;
 	private reconnectPending = false;
 	private watchdogTriggered = false;
 	private retryAttempt = 0;
 	private controlSession: ControlSession | null = null;
+	private controlSessionCrdtHold = false;
 	private controlOperation: Promise<void> = Promise.resolve();
 	private topologyGeneration = 0;
 	private flushedGeneration = 0;
@@ -113,8 +115,7 @@ export class SseConnectionManager {
 			this.applyTopologyChange();
 		};
 		try {
-			const controlSession =
-				this.controlSession ?? (await this.waitForSession(signal));
+			const controlSession = await this.acquireCrdtSession(signal);
 			return {
 				sessionId: controlSession.sessionId,
 				token: controlSession.token,
@@ -137,6 +138,31 @@ export class SseConnectionManager {
 		} catch (error) {
 			release();
 			throw error;
+		}
+	}
+
+	private async acquireCrdtSession(
+		signal?: AbortSignal,
+	): Promise<ControlSession> {
+		while (true) {
+			if (signal?.aborted) throw new DOMException("Aborted", "AbortError");
+			if (this.controlSession && this.controlSessionCrdtHold) {
+				return this.controlSession;
+			}
+			if (
+				this.controlSession ||
+				(this.connecting && !this.connectingCrdtHold)
+			) {
+				this.reconnectPending = true;
+				this.controlSession = null;
+				this.controlSessionCrdtHold = false;
+				this.abortController?.abort();
+			}
+			this.applyTopologyChange();
+			const candidate = await this.waitForSession(signal);
+			if (candidate === this.controlSession && this.controlSessionCrdtHold) {
+				return candidate;
+			}
 		}
 	}
 
@@ -282,12 +308,14 @@ export class SseConnectionManager {
 		this.abortController = new AbortController();
 		try {
 			const authHeaders = await this.options.getAuthHeaders?.();
+			const topology = this.openTopology();
+			this.connectingCrdtHold = topology.crdtHold === true;
 			const response = await this.options.fetcher(
 				`${this.options.baseUrl}/realtime`,
 				{
 					method: "POST",
 					headers: { "Content-Type": "application/json", ...authHeaders },
-					body: JSON.stringify(this.openTopology()),
+					body: JSON.stringify(topology),
 					credentials: this.options.withCredentials ? "include" : "omit",
 					signal: this.abortController.signal,
 				},
@@ -346,7 +374,9 @@ export class SseConnectionManager {
 		} finally {
 			this.clearWatchdog();
 			this.connecting = false;
+			this.connectingCrdtHold = false;
 			this.controlSession = null;
+			this.controlSessionCrdtHold = false;
 			if (this.reconnectPending) {
 				this.reconnectPending = false;
 				this.scheduleConnect(0);
@@ -521,6 +551,7 @@ export class SseConnectionManager {
 					sessionId: session.sessionId,
 					token: session.token,
 				};
+				this.controlSessionCrdtHold = this.connectingCrdtHold;
 				for (const waiter of this.sessionWaiters) {
 					waiter.resolve(this.controlSession);
 				}

--- a/packages/questpie/test/client/crdt-realtime-session.test.ts
+++ b/packages/questpie/test/client/crdt-realtime-session.test.ts
@@ -622,6 +622,82 @@ describe("internal CRDT realtime session", () => {
 		session.destroy();
 	});
 
+	test("reopens a query-only SSE edge before a late CRDT acquire", async () => {
+		const opens: Record<string, unknown>[] = [];
+		const streamControllers: ReadableStreamDefaultController<Uint8Array>[] = [];
+		const fetcher: typeof fetch = async (input, init) => {
+			const url = String(input);
+			if (url.endsWith("/realtime/config")) {
+				return Response.json({ transport: "sse" });
+			}
+			if (!url.endsWith("/realtime")) {
+				throw new Error(`Unexpected request: ${url}`);
+			}
+			const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+			if (body.sessionId) {
+				return Response.json({ status: "accepted" }, { status: 202 });
+			}
+			opens.push(body);
+			const index = opens.length - 1;
+			const stream = new ReadableStream<Uint8Array>({
+				start(controller) {
+					streamControllers[index] = controller;
+					controller.enqueue(
+						encoder.encode(
+							`event: session\ndata: ${JSON.stringify({
+								sessionId: `edge-${index + 1}`,
+								token: `control-${index + 1}`,
+								control: {
+									protocol: "questpie-realtime-topology",
+									versions: [2],
+								},
+							})}\n\n`,
+						),
+					);
+				},
+			});
+			init?.signal?.addEventListener("abort", () => {
+				try {
+					streamControllers[index]?.close();
+				} catch {
+					// The replacement may already have closed the old stream.
+				}
+			});
+			return new Response(stream, {
+				headers: { "content-type": "text/event-stream" },
+			});
+		};
+		const session = createRealtimeClientSession({
+			baseUrl: "http://localhost:3000",
+			withCredentials: true,
+			debounceMs: 0,
+			fetcher,
+		});
+		const stopQuery = session.subscribe(
+			{
+				resourceType: "collection",
+				resource: "articles",
+				operation: "find",
+			},
+			() => {},
+		);
+		await waitFor(() => opens.length === 1);
+
+		const capability = await session.acquireEdgeCapability();
+
+		expect(capability.sessionId).toBe("edge-2");
+		expect(opens).toHaveLength(2);
+		expect(opens[0]).not.toHaveProperty("crdtHold");
+		expect(opens[1]).toMatchObject({ crdtHold: true });
+		expect(opens[1]?.topics).toEqual([
+			expect.objectContaining({ resource: "articles" }),
+		]);
+
+		capability.release();
+		stopQuery();
+		session.destroy();
+	});
+
 	test("replays exact CRDT topology after an SSE edge reconnect", async () => {
 		const opens: Record<string, unknown>[] = [];
 		const controls: Record<string, unknown>[] = [];
@@ -992,6 +1068,71 @@ describe("internal CRDT realtime session", () => {
 		session.destroy();
 	});
 
+	test("reopens a query-only Pusher edge before a late CRDT acquire", async () => {
+		FakePusher.instances = [];
+		const opens: Record<string, unknown>[] = [];
+		const fetcher: typeof fetch = async (input, init) => {
+			const url = String(input);
+			if (url.endsWith("/realtime/auth")) {
+				return Response.json({ auth: "signed" });
+			}
+			if (url.endsWith("/realtime") && init?.method === "POST") {
+				const body = JSON.parse(String(init.body)) as Record<string, unknown>;
+				if (body.transport !== "shared-provider") {
+					return Response.json({ status: "accepted" }, { status: 202 });
+				}
+				opens.push(body);
+				const index = opens.length;
+				return Response.json({
+					transport: "shared-provider",
+					sessionId: `pusher-edge-${index}`,
+					token: `pusher-control-${index}`,
+					channel: `private-questpie-rt-pusher-edge-${index}`,
+					control: {
+						protocol: "questpie-realtime-topology",
+						versions: [2],
+					},
+				});
+			}
+			throw new Error(`Unexpected request: ${url}`);
+		};
+		const transport = new PusherRealtimeTransport({
+			baseUrl: "http://localhost:3000",
+			fetcher,
+			config: { provider: "pusher", key: "public-key" },
+			refetchTopic: async () => ({}),
+			connection: new PusherConnectionManager({
+				loadPusher: async () =>
+					({ default: FakePusher }) as unknown as PusherModule,
+			}),
+		});
+		const stopQuery = transport.subscribe(
+			{
+				resourceType: "collection",
+				resource: "articles",
+				operation: "find",
+			},
+			() => {},
+			undefined,
+			"query:articles",
+		);
+		await waitFor(() => opens.length === 1);
+
+		const capability = await transport.acquire();
+
+		expect(capability.sessionId).toBe("pusher-edge-2");
+		expect(opens).toHaveLength(2);
+		expect(opens[0]).not.toHaveProperty("crdtHold");
+		expect(opens[1]).toMatchObject({ crdtHold: true });
+		expect(opens[1]?.topics).toEqual([
+			expect.objectContaining({ id: "query:articles", resource: "articles" }),
+		]);
+
+		capability.release();
+		stopQuery();
+		transport.destroy();
+	});
+
 	test("refetches only the opaque Pusher query targets in an invalidation", async () => {
 		FakePusher.instances = [];
 		const refetches = new Map<string, number>();
@@ -1168,12 +1309,12 @@ describe("internal CRDT realtime session", () => {
 
 		await waitFor(() => errors.length > 0);
 		await replacementPromise;
-		await waitFor(() => opens.length === 2);
+		await waitFor(() => opens.length === 3);
 		await waitFor(() => liveQueryRefetches >= 2);
 		await waitFor(() =>
 			controls.some(
 				(control) =>
-					control.sessionId === "pusher-edge-2" &&
+					control.sessionId === "pusher-edge-3" &&
 					control.topology.subscriptions.some(
 						(subscription: any) => subscription.id === "crdt:new",
 					),
@@ -1183,7 +1324,7 @@ describe("internal CRDT realtime session", () => {
 		expect(errors[0]?.message).toBe("Realtime control session is unavailable");
 		const replacementTopology = controls.find(
 			(control) =>
-				control.sessionId === "pusher-edge-2" &&
+				control.sessionId === "pusher-edge-3" &&
 				control.topology.subscriptions.some(
 					(subscription: any) => subscription.id === "crdt:new",
 				),


### PR DESCRIPTION
## Summary
- reopen an established query-only SSE edge before returning a late CRDT capability
- do the same for shared-provider/Pusher sessions while retaining query demand
- document the one-time edge replacement and add a patch changeset

Fixes #237

## Validation
- `bun test packages/questpie/test/client/crdt-realtime-session.test.ts`
- `bun run --filter questpie check-types`
- `bun run lint`
- `bun run format:check`