### PR TITLE
feat(realtime): add resolved channel authority API

### DIFF
--- a/.changeset/typed-channels-authority.md
+++ b/.changeset/typed-channels-authority.md
@@ -1,0 +1,8 @@
+---
+"questpie": patch
+---
+
+Add resolved typed Channel handles and exact authority invalidation, isolate
+live-query scheduler work by session unless an explicit `accessCacheKey` opts
+equivalent output into sharing, and deprecate `subscriptionScope` authority
+partitioning ahead of its 4.0 removal.

--- a/apps/docs/content/docs/client/channels.mdx
+++ b/apps/docs/content/docs/client/channels.mdx
@@ -47,7 +47,7 @@ The registry/API key is `chatRoom`, derived from the default-export filename. Th
 
 Server service names such as `publish`, `authorize`, and `revokeAuthority` are
 reserved for canonical handle projection. Existing server collisions remain
-available through the deprecated root API in 3.x. Client channels with those
+available through the root API during 3.x. Client channels with those
 names keep their handle; only actual client controls such as `destroy`,
 `channelCount`, and `subscriberCount` collide. Rename a colliding file/export
 to adopt the canonical handle; its explicit wire pattern may stay unchanged.
@@ -144,7 +144,7 @@ leaves the durable cut pending for an idempotent retry.
 
 <Callout type="info" title="The old root method remains during 3.x">
 	`channels.revokeAuthority("chatRoom", { params, subject, idempotencyKey })`
-	is a deprecated compatibility entry point backed by the same authority ledger. New code
+	is a 3.x compatibility entry point backed by the same authority ledger. New code
 	should resolve once and call `chatRoom.invalidateAuthority()`.
 </Callout>
 

--- a/apps/docs/content/docs/client/channels.mdx
+++ b/apps/docs/content/docs/client/channels.mdx
@@ -45,6 +45,13 @@ export default channel("chat-room-[roomId]")
 
 The registry/API key is `chatRoom`, derived from the default-export filename. The explicit builder string is the stable wire pattern. Renaming the file changes the typed API and causes compile errors at call sites; it does **not** silently rename the wire channel. `[roomId]` becomes a required `{ roomId: string }` parameter everywhere.
 
+Server service names such as `publish`, `authorize`, and `revokeAuthority` are
+reserved for canonical handle projection. Existing server collisions remain
+available through the deprecated root API in 3.x. Client channels with those
+names keep their handle; only actual client controls such as `destroy`,
+`channelCount`, and `subscriberCount` collide. Rename a colliding file/export
+to adopt the canonical handle; its explicit wire pattern may stay unchanged.
+
 Run codegen after adding or renaming a channel:
 
 ```bash
@@ -74,10 +81,10 @@ export default route()
 	.post()
 	.schema(z.object({ roomId: z.string(), id: z.string(), text: z.string() }))
 	.handler(async ({ input, channels }) => {
-		return channels.publish("chatRoom", {
-			params: { roomId: input.roomId },
-			event: "message",
-			data: { id: input.id, text: input.text },
+		const chatRoom = channels.chatRoom({ roomId: input.roomId });
+		return chatRoom.publish("message", {
+			id: input.id,
+			text: input.text,
 		});
 	});
 ```
@@ -91,49 +98,55 @@ Use the hook's injected `{ channels }` argument. It carries the same generated t
 ```ts
 .hooks({
   afterChange: [async ({ data, channels }) => {
-    await channels.publish("chatRoom", {
-      params: { roomId: data.room },
-      event: "message",
-      data: { id: data.id, text: data.text },
-    });
+		const chatRoom = channels.chatRoom({ roomId: data.room });
+		await chatRoom.publish("message", { id: data.id, text: data.text });
   }],
 })
 ```
 
 Do not import the generated `app` into a collection/hook file, and do not resolve channels later through ambient `getContext()`. Contextless update/delete calls do not guarantee an ambient scope; the injected hook argument is the reliable and transaction-aware path.
 
-## Revoke delivery authority after a domain change
+## Invalidate delivery authority after a domain change
 
 When a membership or authorization write removes access, call the request-bound
-service in the same transaction:
+resolved Channel handle in the same transaction:
 
 ```ts
-await channels.revokeAuthority("chatRoom", {
-	params: { roomId },
+const chatRoom = channels.chatRoom({ roomId });
+
+await chatRoom.invalidateAuthority({
 	subject: { kind: "user", id: removedUserId },
 	idempotencyKey: `chat-room:${roomId}:${removedUserId}:membership-v2`,
 });
 ```
 
-The command advances a durable generation for the exact resolved
-channel/subject and returns `{ generation, scope }`. With SSE,
-`scope: "exact-subscription"` closes only that logical binding with
-`access_revoked`; other channel bindings on the multiplexed stream remain
-active. Fresh request context, subscribe authorization, and the presence
-resolver are evaluated outside database locks, then a short generation check
-publishes the binding, latest freshly resolved presence payload, and optional
-presence lease atomically. A stale result and stale member payload publish
-nothing. Dropped authority notices heal through a demand-driven ledger poll
-that also stops when internal revocation closes the last local binding.
+The resolved handle is the complete target: channel definition plus validated
+params. The subject says whose binding must be checked. There is no second
+company/workspace scope and no scope-wide live-query invalidation.
 
-Pusher/Soketi reports `scope: "principal-connections"` because its termination
-API is user-wide. QUESTPIE signs the browser into Pusher with an opaque user id,
-terminates every current connection for that user, and lets reconnect obtain
-fresh user and per-channel authorization. Channel authorization waits for
-signed-user completion and rejects stale sockets or owners. An unrelated
-still-authorized binding can reconnect; the removed binding cannot.
-Provider channel auth is explicitly side-effect-free signed-blob encoding; a
-concurrent authority cut discards the blob before it can reach the browser.
+The command advances the existing durable generation for that exact
+channel/subject, obtains a fresh `AppContext`, and reruns subscribe
+authorization. A binding that is still allowed continues; a denied binding
+ends with `access_revoked`. The receipt is
+`{ generation, transportEffect }`.
+
+| Transport     | `transportEffect`         | Physical effect                                 |
+| ------------- | ------------------------- | ----------------------------------------------- |
+| SSE           | `"exact-binding"`         | Only the matching logical binding is cut        |
+| Pusher/Soketi | `"principal-connections"` | Current physical connections for that principal |
+
+Pusher/Soketi reconnects and reauthorizes every desired binding. An unrelated
+still-authorized binding returns; the invalid one does not. Provider effects
+run inline under a bounded call in a managed caller transaction. Provider
+failure throws and rolls back the database transaction; a conservative
+disconnect may survive a later caller rollback. Standalone provider failure
+leaves the durable cut pending for an idempotent retry.
+
+<Callout type="info" title="The old root method remains during 3.x">
+	`channels.revokeAuthority("chatRoom", { params, subject, idempotencyKey })`
+	is a deprecated compatibility entry point backed by the same authority ledger. New code
+	should resolve once and call `chatRoom.invalidateAuthority()`.
+</Callout>
 
 <Callout type="warn" title="Managed providers have an in-flight frame window">
 	Pusher cannot guarantee that a frame already accepted by the physical
@@ -148,8 +161,9 @@ concurrent authority cut discards the blob before it can reach the browser.
 `createClient<AppConfig>()` exposes one handle per generated channel:
 
 ```ts
-const stop = client.channels.chatRoom.subscribe(
-	{ roomId },
+const chatRoom = client.channels.chatRoom({ roomId });
+
+const stop = chatRoom.subscribe(
 	(message) => {
 		if (message.event === "message") {
 			console.log(message.eventId, message.data.text);
@@ -164,11 +178,7 @@ const stop = client.channels.chatRoom.subscribe(
 	},
 );
 
-const receipt = await client.channels.chatRoom.publish({
-	params: { roomId },
-	event: "typing",
-	data: { active: true },
-});
+const receipt = await chatRoom.publish("typing", { active: true });
 
 stop();
 ```
@@ -191,10 +201,7 @@ Client publish is server-mediated even on Pusher/Soketi: the request uses the sa
 For async iteration:
 
 ```ts
-for await (const message of client.channels.chatRoom.iter(
-	{ roomId },
-	{ signal: controller.signal },
-)) {
+for await (const message of chatRoom.iter({ signal: controller.signal })) {
 	consume(message);
 }
 ```
@@ -206,21 +213,17 @@ Call `client.channels.destroy()` only when disposing the whole client-side chann
 Only a channel with `.presence()` has a callable presence API:
 
 ```ts
-const members = await client.channels.chatRoom.presence({ roomId });
+const chatRoom = client.channels.chatRoom({ roomId });
+const members = await chatRoom.presence();
 // readonly Array<{ id: string; roomId: string; name: string }>
 ```
 
 Use `subscribePresence()` for a live typed roster, or `presenceIter()` when an `AbortSignal` fits the consumer better:
 
 ```ts
-const stop = client.channels.chatRoom.subscribePresence({ roomId }, (members) =>
-	renderRoster(members),
-);
+const stop = chatRoom.subscribePresence((members) => renderRoster(members));
 
-for await (const members of client.channels.chatRoom.presenceIter(
-	{ roomId },
-	{ signal },
-)) {
+for await (const members of chatRoom.presenceIter({ signal })) {
 	renderRoster(members);
 }
 ```

--- a/apps/docs/content/docs/client/channels/authorization.mdx
+++ b/apps/docs/content/docs/client/channels/authorization.mdx
@@ -72,40 +72,59 @@ Nothing else does.
 | A hook fired during an HTTP request       | no               | yes               |
 | `POST /channels/publish` from the browser | no               | yes               |
 
-HTTP contexts are created with `accessMode: "user"`. So `channels.publish()`
-inside a route handler is judged by the same rule the browser is. On a public
+HTTP contexts are created with `accessMode: "user"`. So a resolved Channel's
+`publish()` inside a route handler is judged by the same rule the browser is. On a public
 channel there is no rule to fall back on, and the answer is no. Add
 `publish: true` if the check belongs in your handler rather than the channel.
 
-## Revoking access mid-session
+## Invalidating access mid-session
 
 The subscribe rule runs when the subscription opens, and then not again.
 Removing someone from a room later does not close the stream they already hold.
-Call `revokeAuthority()` in the same transaction as the write that removed them.
+Resolve the Channel once and call `invalidateAuthority()` in the same
+transaction as the write that removed them.
 
 ```ts
-await channels.revokeAuthority("chatRoom", {
-	params: { roomId },
+const chatRoom = channels.chatRoom({ roomId });
+
+await chatRoom.invalidateAuthority({
 	subject: { kind: "user", id: removedUserId },
 	idempotencyKey: `chat-room:${roomId}:${removedUserId}:v2`,
 });
 ```
 
 The subject `kind` is `"user"`, `"oauth"` or `"session"`, and its `id` must be
-non-empty and at most 256 characters. The call advances a durable generation for
-that exact channel and subject, then returns `{ generation, scope }`.
+non-empty and at most 256 characters. Channel definition plus validated params
+is the exact authority target; there is no extra application scope. The call
+advances its durable generation for that subject, then returns
+`{ generation, transportEffect }`.
 
-`scope` tells you how wide the cut was. It is set by the transport, not by you.
+`transportEffect` reports the transport's honest physical capability. It is not
+an OAuth, tenant, Global, or live-query scope.
 
-| Transport     | `scope`                   | What closed                                    |
+| Transport     | `transportEffect`         | What closed                                    |
 | ------------- | ------------------------- | ---------------------------------------------- |
-| SSE           | `"exact-subscription"`    | That one binding, with reason `access_revoked` |
+| SSE           | `"exact-binding"`         | That one binding, with reason `access_revoked` |
 | Pusher/Soketi | `"principal-connections"` | Every current connection for that principal    |
 
 SSE closes the single logical binding. Other channels on the same multiplexed
 stream keep running. Pusher's termination API is user-wide, so QUESTPIE
 terminates the principal's connections and lets the reconnect reauthorize.
 Bindings that are still allowed come straight back. The revoked one does not.
+
+In a managed caller transaction, Pusher termination and authority
+acknowledgement run inline under a bounded call. Provider failure throws and
+rolls back the database transaction; a conservative disconnect may survive a
+later caller rollback. Standalone provider failure leaves the durable cut
+pending. Retry the same domain transition with the same `idempotencyKey`;
+QUESTPIE returns the original generation instead of advancing it twice. Reusing
+that key for another target or subject is a conflict.
+
+<Callout type="info" title="3.x compatibility">
+	The old `channels.revokeAuthority("chatRoom", { params, ... })` method remains
+	as a deprecated entry point backed by the same ledger. It does not create a second
+	invalidation mechanism.
+</Callout>
 
 <Callout type="warn" title="Managed providers have an in-flight window">
 	Pusher cannot promise that a frame already accepted by the socket will not

--- a/apps/docs/content/docs/client/channels/authorization.mdx
+++ b/apps/docs/content/docs/client/channels/authorization.mdx
@@ -122,7 +122,7 @@ that key for another target or subject is a conflict.
 
 <Callout type="info" title="3.x compatibility">
 	The old `channels.revokeAuthority("chatRoom", { params, ... })` method remains
-	as a deprecated entry point backed by the same ledger. It does not create a second
+	as a 3.x compatibility entry point backed by the same ledger. It does not create a second
 	invalidation mechanism.
 </Callout>
 

--- a/apps/docs/content/docs/client/channels/delivery.mdx
+++ b/apps/docs/content/docs/client/channels/delivery.mdx
@@ -65,7 +65,7 @@ subscribing again from now and accepting the hole.
 fires once the server has authorized that subscription and replay has run dry.
 
 ```ts
-client.channels.chatRoom.subscribe({ roomId }, render, {
+client.channels.chatRoom({ roomId }).subscribe(render, {
 	onReady: () => setCaughtUp(true),
 });
 ```

--- a/apps/docs/content/docs/client/channels/presence.mdx
+++ b/apps/docs/content/docs/client/channels/presence.mdx
@@ -37,26 +37,22 @@ principal is refused, so gate the channel behind a session.
 Three methods appear on the client handle, and only on channels that declared
 `.presence()`. Calling them on a plain channel is a compile error.
 
-| Method                           | Shape                           |
-| -------------------------------- | ------------------------------- |
-| `presence(params)`               | `Promise<readonly Member[]>`    |
-| `subscribePresence(params, cb)`  | Returns the stop function       |
-| `presenceIter(params, options?)` | Async generator of full rosters |
+| Bound method             | Shape                           |
+| ------------------------ | ------------------------------- |
+| `presence()`             | `Promise<readonly Member[]>`    |
+| `subscribePresence(cb)`  | Returns the stop function       |
+| `presenceIter(options?)` | Async generator of full rosters |
 
-`params` is required on a channel with a `[param]`. A channel without one drops
-that argument.
+Bind the required `[param]` values once. A channel without params is already a
+resolved handle.
 
 ```ts
-const members = await client.channels.chatRoom.presence({ roomId });
+const chatRoom = client.channels.chatRoom({ roomId });
+const members = await chatRoom.presence();
 
-const stop = client.channels.chatRoom.subscribePresence({ roomId }, (members) =>
-	renderRoster(members),
-);
+const stop = chatRoom.subscribePresence((members) => renderRoster(members));
 
-for await (const members of client.channels.chatRoom.presenceIter(
-	{ roomId },
-	{ signal },
-)) {
+for await (const members of chatRoom.presenceIter({ signal })) {
 	renderRoster(members);
 }
 ```

--- a/apps/docs/content/docs/client/reactive-apps/high-frequency-events.mdx
+++ b/apps/docs/content/docs/client/reactive-apps/high-frequency-events.mdx
@@ -31,16 +31,14 @@ function ReactionBursts({ reviewId }: { reviewId: string }) {
 	>([]);
 
 	useEffect(() => {
-		return client.channels.reviewReactions.subscribe(
-			{ reviewId },
-			(message) => {
-				if (message.event !== "burst") return;
-				setBursts((current) => [
-					...current.slice(-(MAX_BURSTS - 1)),
-					{ eventId: message.eventId, emoji: message.data.emoji },
-				]);
-			},
-		);
+		const reviewReactions = client.channels.reviewReactions({ reviewId });
+		return reviewReactions.subscribe((message) => {
+			if (message.event !== "burst") return;
+			setBursts((current) => [
+				...current.slice(-(MAX_BURSTS - 1)),
+				{ eventId: message.eventId, emoji: message.data.emoji },
+			]);
+		});
 	}, [reviewId]);
 
 	return <ReactionOverlay bursts={bursts} />;

--- a/apps/docs/content/docs/client/reactive-apps/subscription-cost.mdx
+++ b/apps/docs/content/docs/client/reactive-apps/subscription-cost.mdx
@@ -46,33 +46,59 @@ A channel does the opposite. Ordered events are never coalesced, and a consumer
 that falls behind gets an explicit error. Live queries are for state. Channels
 are for events you must not lose.
 
-## Equivalent work is shared per principal
+## Equivalent work is session-isolated by default
 
 The refresh scheduler groups by the topic plus an access key. The key is built
-from the identity, the server scope, the locale, the stage and the access mode.
-Identity is the signed-in user's id when there is one. Failing that it is an
-OAuth token id, and failing that the connection itself.
+from the identity, the effective authorized query, context extensions, locale,
+stage, access mode, and delivery mode. Identity is the authenticated session id
+when there is one. Failing that it is an OAuth token id, and failing that the
+connection itself.
 
-So two tabs of the same user watching the same list run the query once per
-server instance. Two different users watching the same list run it twice.
+Two separate sessions belonging to the same user therefore do not share work by
+default. Neither do two OAuth tokens or two anonymous connections.
 
-That default is deliberate. Row access, field access and `afterRead` can all
-read the session, so two principals may get different bytes from the same query.
+That default is deliberate. Field access, relations, output hooks and
+`afterRead` can all read the request context, so matching row predicates alone
+do not prove byte-identical output.
 
-### Widening the sharing
+### Compute once, fan out to 100,000 subscribers
 
-Return the same key from `accessCacheKey` and those principals share one
-refresh.
+Return the same key from `accessCacheKey` and equivalent subscribers share one
+refresh computation.
 
-```ts title="src/questpie/server/collections/public-posts.ts"
-collection("public-posts").options({
-	realtime: { accessCacheKey: () => "public" },
-});
+```ts title="src/questpie/server/collections/public-announcements.ts"
+collection("public-announcements")
+	.access({ read: true })
+	.options({
+		realtime: {
+			accessCacheKey: () => "public-announcements:v1",
+		},
+	});
 ```
 
-Only do this where the result is identical for every principal that resolves to
-the key. There is no check. A key that is too broad serves one user's rows to
-another.
+With 100,000 clients watching the same authorized query, one application
+instance runs one database computation per refresh and fans out the result to
+all 100,000. Ten replicas can run up to ten computations because scheduler
+groups are local to each server instance; they are not a distributed cache.
+
+The resolver is an explicit proof that every context returning the key produces
+byte-identical output for the same effective authorized topic, including field
+access and `afterRead`. The effective query plus read-access predicate, context
+extension digest, locale, stage, access mode, and delivery mode still partition
+groups automatically. An invalid, over-long, or throwing resolver fails closed
+to an isolated edge group.
+
+`accessCacheKey` is a compute-sharing optimization, not authorization. Derive a
+selected tenant through `appConfig.context` and enforce it in collection/global
+`.access()`. If the tenant filter is missing there, normal CRUD and realtime are
+both misconfigured; no scheduler key can fix it.
+
+<Callout type="warn" title="subscriptionScope is deprecated">
+	`realtime.subscriptionScope` remains only for 3.x compatibility and is removed
+	in QUESTPIE 4. Move tenant selection to `appConfig.context`, keep tenant row
+	filtering in `.access()`, and use `accessCacheKey` only when intentionally
+	widening byte-identical compute sharing.
+</Callout>
 
 ## Turning it off
 

--- a/apps/docs/content/docs/client/reactive-apps/subscription-cost.mdx
+++ b/apps/docs/content/docs/client/reactive-apps/subscription-cost.mdx
@@ -93,7 +93,7 @@ selected tenant through `appConfig.context` and enforce it in collection/global
 `.access()`. If the tenant filter is missing there, normal CRUD and realtime are
 both misconfigured; no scheduler key can fix it.
 
-<Callout type="warn" title="subscriptionScope is deprecated">
+<Callout type="warn" title="subscriptionScope compatibility notice">
 	`realtime.subscriptionScope` remains only for 3.x compatibility and is removed
 	in QUESTPIE 4. Move tenant selection to `appConfig.context`, keep tenant row
 	filtering in `.access()`, and use `accessCacheKey` only when intentionally

--- a/apps/docs/content/docs/infrastructure/realtime/pusher.mdx
+++ b/apps/docs/content/docs/infrastructure/realtime/pusher.mdx
@@ -65,26 +65,26 @@ handing the blob over. A concurrent revocation discards it before it reaches the
 browser. A shared transport that does not declare this capability is rejected
 before policy runs at all.
 
-## Revocation, honestly
+## Authority invalidation, honestly
 
-`channels.revokeAuthority(channel, { subject })` persists the authorization
-generation in the caller's database transaction. Pusher declares
-`authorityRevocationScope: "principal-connections"`, which is the honest claim:
+`channels.<name>(params).invalidateAuthority({ subject, idempotencyKey })`
+persists the authorization generation in the caller's database transaction.
+Pusher reports `transportEffect: "principal-connections"`, which is the honest claim:
 it can terminate every current connection for one user, but it cannot terminate
 one logical channel subscription. After termination, fresh per-channel
 authorization readmits the still-valid bindings and denies the revoked one. The
 subject must be a `user`.
 
-| Caller                       | Failure behavior                                                                             |
-| ---------------------------- | -------------------------------------------------------------------------------------------- |
-| Inside a managed transaction | Termination and acknowledgement run inline. A failure throws and rolls back                  |
-| Standalone command           | The durable cut stands, provider dispatch stays fail-closed, an idempotent retry finishes it |
+In a managed caller transaction, provider termination and authority
+acknowledgement run inline under a bounded call. Provider failure throws and
+rolls back the database transaction; a conservative disconnect may survive a
+later caller rollback. Standalone provider failure leaves the durable cut
+pending for an idempotent retry while provider dispatch stays fail-closed.
 
 <Callout type="warn" title="Revocation is not frame-atomic">
 	A frame Pusher already accepted can still arrive during termination, and a
-	conservative disconnect can outlive a later database rollback. A custom shared
-	transport must declare its own revocation scope. QUESTPIE never assumes an
-	unknown provider revokes exactly.
+	custom shared transport must declare its own transport effect. QUESTPIE never
+	assumes an unknown provider revokes exactly.
 </Callout>
 
 ## Direct client events

--- a/apps/docs/content/docs/infrastructure/realtime/scaling.mdx
+++ b/apps/docs/content/docs/infrastructure/realtime/scaling.mdx
@@ -59,74 +59,97 @@ partitions, because ordinary writes move rows across those boundaries.
 ## What a subscription group is keyed by
 
 Two subscribers share one group, and therefore one query per wake, only when
-the topic shape matches and all five of these agree.
+the authorized topic shape and all framework-owned dimensions agree.
 
-| Part        | Value                                                                     |
-| ----------- | ------------------------------------------------------------------------- |
-| Identity    | `shared:<key>`, `principal:<userId>`, `oauth:<tokenId>`, or `edge:<uuid>` |
-| Scope       | Whatever `subscriptionScope` returned, or `null`                          |
-| Locale      | The topic's content locale                                                |
-| Stage       | The resolved publish stage                                                |
-| Access mode | `user` or `system`                                                        |
+| Part        | Value                                                                      |
+| ----------- | -------------------------------------------------------------------------- |
+| Identity    | `shared:<key>`, `session:<sessionId>`, `oauth:<tokenId>`, or `edge:<uuid>` |
+| Context     | The deterministic digest of `appConfig.context` extensions                 |
+| Locale      | The topic's content locale                                                 |
+| Stage       | The resolved publish stage                                                 |
+| Access mode | `user` or `system`                                                         |
 
-### `subscriptionScope`
+The safe default is session-isolated: two sessions belonging to the same user
+do not share a computation. OAuth tokens are isolated by token id and anonymous
+connections by edge id. This matters because field access and `afterRead` may
+produce different bytes even when row access produced the same `where`.
 
-One resolver on the app config, run once per realtime connection and frozen for
-its lifetime. Reconnecting resolves it again.
+### Tenant authority belongs in context and access
 
-```ts title="src/questpie/server/questpie.config.ts"
-import { runtimeConfig } from "questpie/app";
+Derive the selected tenant once in `appConfig.context`, validate that selection
+there, and apply it in collection/global read access. Realtime then runs the
+same authorized CRUD read as a normal `find()`.
 
-import env from "./env";
+```ts title="src/questpie/server/config/app.ts"
+import { appConfig } from "questpie/app";
 
-export default runtimeConfig({
-	db: { url: env.DATABASE_URL },
-	realtime: {
-		subscriptionScope: ({ request, session }) => {
-			if (!session) return null;
-			return request?.headers.get("x-workspace-id") ?? null;
-		},
+export default appConfig({
+	context: async ({ request, session, collections }) => {
+		const workspaceId = request.headers.get("x-workspace-id");
+		if (!workspaceId || !session?.user) return { workspaceId: null };
+
+		const member = await collections.workspaceMembers.findOne({
+			where: { workspace: workspaceId, user: session.user.id },
+		});
+		if (!member) throw new Error("No access to this workspace");
+
+		return { workspaceId };
 	},
 });
 ```
 
-`null` or `undefined` means explicitly unscoped. Any other value must be a
-non-empty string of at most 256 UTF-8 bytes, or QUESTPIE throws for you. The
-value only ever appears inside the server group key, never in an observer label
-or an error payload.
-
-<Callout type="warn" title="A scope partitions work, it does not authorize">
-	A scope decides who shares a computation — it is not a second check on top of
-	one. Within a group the snapshot is computed once, by the subscriber that
-	created it, and the resulting bytes are sent to everyone in that group.
-
-    Row-level rules are safe by construction, because the access predicate is
-    merged into the topic and the topic is part of the group key, so subscribers
-    with different row scopes land in different groups. What is **not** re-run
-    per subscriber is field-level access, `columns` and `afterRead`. Widen a key
-    only where every principal that resolves to it is entitled to byte-identical
-    rows.
-
-</Callout>
-
-### `accessCacheKey`
-
-The identity part of the key isolates each principal by default, and
-`edge:<uuid>` is minted fresh per connection, so anonymous subscribers never
-share with each other. A collection or global can override that with
-`realtime.accessCacheKey`, the only way many principals collapse into one group
-and one query, and the only source of the `shared:` form.
-
-```ts
-export const posts = collection("posts")
-	.access({ read: true })
-	.options({ realtime: { accessCacheKey: () => "public" } });
+```ts title="src/questpie/server/collections/projects.ts"
+export default collection("projects").access({
+	read: ({ workspaceId }) => (workspaceId ? { workspace: workspaceId } : false),
+});
 ```
 
-Return the same deterministic key only where you can prove the output is
-identical for every principal that gets it. The key is bounded to 256 UTF-8
-bytes as well. A resolver that throws, or returns a non-string or an over-long
-key, isolates that subscriber to its own edge group instead of a shared one.
+If this filter is missing, both normal CRUD and realtime can return cross-tenant
+rows. A realtime cache setting cannot repair an incorrect access rule.
+
+<Callout type="warn" title="subscriptionScope is deprecated">
+	`realtime.subscriptionScope` was a second, global scheduler partition. It did
+	not authorize rows and could mask where tenant selection actually belonged. It
+	remains as a 3.x compatibility dimension and is removed in QUESTPIE 4. Move
+	request-derived tenant state to `appConfig.context`, enforce it in
+	collection/global access, then remove `subscriptionScope` from runtime config.
+</Callout>
+
+### `accessCacheKey`: compute once, fan out
+
+The identity part of the key isolates each session, OAuth token, or anonymous
+edge by default. A collection or global can replace that identity with
+`realtime.accessCacheKey`, the explicit way many subscribers collapse into one
+group and one computation.
+
+```ts
+export const publicAnnouncements = collection("public-announcements")
+	.access({ read: true })
+	.options({
+		realtime: {
+			accessCacheKey: () => "public-announcements:v1",
+		},
+	});
+```
+
+If 100,000 clients subscribe to the same authorized query, one server instance
+now runs one database computation per refresh and fans the resulting bytes out
+to those 100,000 subscribers. With ten application replicas, each replica owns
+its local group, so the fleet may run up to ten computations rather than one
+global computation.
+
+Return the same deterministic key only where you can prove this byte-identical
+contract:
+
+> For the same effective authorized topic and framework-owned dimensions,
+> every context returning this key produces identical output, including field
+> access, relations, output hooks, and `afterRead`.
+
+QUESTPIE still includes the effective query plus read-access predicate, context
+extension digest, locale, stage, access mode, and delivery mode in the group
+key. `accessCacheKey` widens compute sharing; it never grants access or removes
+those dimensions. The key is bounded to 256 UTF-8 bytes. A resolver that throws
+or returns an invalid or over-long key fails closed to an isolated edge group.
 
 ## Conservative candidate routing
 

--- a/apps/docs/content/docs/infrastructure/realtime/tuning.mdx
+++ b/apps/docs/content/docs/infrastructure/realtime/tuning.mdx
@@ -14,23 +14,23 @@ untuned server, and most apps ship without touching any of them.
 import type { RealtimeConfig } from "questpie/realtime";
 ```
 
-| Option                     | Default                                                   | What it controls                                                                                                                              |
-| -------------------------- | --------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| `nativeDeltas`             | `false`                                                   | Keyed row deltas. While off, qualifying topics are served as snapshots                                                                        |
-| `rowLiveQueries`           | `true`                                                    | App-wide switch for collection and global row topics                                                                                          |
-| `subscriptionScope`        | none                                                      | **Deprecated in 3.x; removed in 4.** Compatibility-only scheduler partition. Put tenant state in `appConfig.context` and enforce it in access |
-| `observer`                 | none                                                      | Lifecycle, admission and transport events. Observer failures never break delivery                                                             |
-| `admission`                | see below                                                 | Per-session topic, connection and query-shape caps                                                                                            |
-| `connectionAcceptPacingMs` | none                                                      | Random delay before accepting a new edge session, itself clamped to 30000 ms                                                                  |
-| `changeBroker`             | `PgNotifyChangeBroker` when a pg connection string exists | The cross-instance notice seam                                                                                                                |
-| `clientTransport`          | SSE                                                       | The edge delivery seam                                                                                                                        |
-| `channelEvents`            | see below                                                 | Ordered-channel retention, lease and buffer tuning                                                                                            |
-| `channelPresence`          | see below                                                 | SSE presence leases and convergence                                                                                                           |
-| `channelSecurity`          | see below                                                 | Trusted origins, publish rate, authorization deadline                                                                                         |
-| `pollIntervalMs`           | `15000` with push, `2000` without                         | Reconciliation interval. `0` gives up that recovery path                                                                                      |
-| `batchSize`                | `500`                                                     | Maximum outbox rows read per drain                                                                                                            |
-| `retentionDays`            | `3`                                                       | Minimum time a row remains after it first becomes drainable. `0` disables cleanup                                                             |
-| `keepAliveIntervalMs`      | `8000`                                                    | Ping interval on each SSE stream                                                                                                              |
+| Option                     | Default                                                   | What it controls                                                                                                                   |
+| -------------------------- | --------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `nativeDeltas`             | `false`                                                   | Keyed row deltas. While off, qualifying topics are served as snapshots                                                             |
+| `rowLiveQueries`           | `true`                                                    | App-wide switch for collection and global row topics                                                                               |
+| `subscriptionScope`        | none                                                      | **Compatibility-only in 3.x; removed in 4.** Scheduler partition. Put tenant state in `appConfig.context` and enforce it in access |
+| `observer`                 | none                                                      | Lifecycle, admission and transport events. Observer failures never break delivery                                                  |
+| `admission`                | see below                                                 | Per-session topic, connection and query-shape caps                                                                                 |
+| `connectionAcceptPacingMs` | none                                                      | Random delay before accepting a new edge session, itself clamped to 30000 ms                                                       |
+| `changeBroker`             | `PgNotifyChangeBroker` when a pg connection string exists | The cross-instance notice seam                                                                                                     |
+| `clientTransport`          | SSE                                                       | The edge delivery seam                                                                                                             |
+| `channelEvents`            | see below                                                 | Ordered-channel retention, lease and buffer tuning                                                                                 |
+| `channelPresence`          | see below                                                 | SSE presence leases and convergence                                                                                                |
+| `channelSecurity`          | see below                                                 | Trusted origins, publish rate, authorization deadline                                                                              |
+| `pollIntervalMs`           | `15000` with push, `2000` without                         | Reconciliation interval. `0` gives up that recovery path                                                                           |
+| `batchSize`                | `500`                                                     | Maximum outbox rows read per drain                                                                                                 |
+| `retentionDays`            | `3`                                                       | Minimum time a row remains after it first becomes drainable. `0` disables cleanup                                                  |
+| `keepAliveIntervalMs`      | `8000`                                                    | Ping interval on each SSE stream                                                                                                   |
 
 The poll runs alongside a broker rather than instead of it, and a provider
 failure temporarily tightens it to at most 2000 ms. Cleanup never uses a

--- a/apps/docs/content/docs/infrastructure/realtime/tuning.mdx
+++ b/apps/docs/content/docs/infrastructure/realtime/tuning.mdx
@@ -14,23 +14,23 @@ untuned server, and most apps ship without touching any of them.
 import type { RealtimeConfig } from "questpie/realtime";
 ```
 
-| Option                     | Default                                                   | What it controls                                                                                           |
-| -------------------------- | --------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| `nativeDeltas`             | `false`                                                   | Keyed row deltas. While off, qualifying topics are served as snapshots                                     |
-| `rowLiveQueries`           | `true`                                                    | App-wide switch for collection and global row topics                                                       |
-| `subscriptionScope`        | none                                                      | Server-owned principal scope folded into scheduler identity. A non-null result over 256 UTF-8 bytes throws |
-| `observer`                 | none                                                      | Lifecycle, admission and transport events. Observer failures never break delivery                          |
-| `admission`                | see below                                                 | Per-session topic, connection and query-shape caps                                                         |
-| `connectionAcceptPacingMs` | none                                                      | Random delay before accepting a new edge session, itself clamped to 30000 ms                               |
-| `changeBroker`             | `PgNotifyChangeBroker` when a pg connection string exists | The cross-instance notice seam                                                                             |
-| `clientTransport`          | SSE                                                       | The edge delivery seam                                                                                     |
-| `channelEvents`            | see below                                                 | Ordered-channel retention, lease and buffer tuning                                                         |
-| `channelPresence`          | see below                                                 | SSE presence leases and convergence                                                                        |
-| `channelSecurity`          | see below                                                 | Trusted origins, publish rate, authorization deadline                                                      |
-| `pollIntervalMs`           | `15000` with push, `2000` without                         | Reconciliation interval. `0` gives up that recovery path                                                   |
-| `batchSize`                | `500`                                                     | Maximum outbox rows read per drain                                                                         |
-| `retentionDays`            | `3`                                                       | Minimum time a row remains after it first becomes drainable. `0` disables cleanup                          |
-| `keepAliveIntervalMs`      | `8000`                                                    | Ping interval on each SSE stream                                                                           |
+| Option                     | Default                                                   | What it controls                                                                                                                              |
+| -------------------------- | --------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `nativeDeltas`             | `false`                                                   | Keyed row deltas. While off, qualifying topics are served as snapshots                                                                        |
+| `rowLiveQueries`           | `true`                                                    | App-wide switch for collection and global row topics                                                                                          |
+| `subscriptionScope`        | none                                                      | **Deprecated in 3.x; removed in 4.** Compatibility-only scheduler partition. Put tenant state in `appConfig.context` and enforce it in access |
+| `observer`                 | none                                                      | Lifecycle, admission and transport events. Observer failures never break delivery                                                             |
+| `admission`                | see below                                                 | Per-session topic, connection and query-shape caps                                                                                            |
+| `connectionAcceptPacingMs` | none                                                      | Random delay before accepting a new edge session, itself clamped to 30000 ms                                                                  |
+| `changeBroker`             | `PgNotifyChangeBroker` when a pg connection string exists | The cross-instance notice seam                                                                                                                |
+| `clientTransport`          | SSE                                                       | The edge delivery seam                                                                                                                        |
+| `channelEvents`            | see below                                                 | Ordered-channel retention, lease and buffer tuning                                                                                            |
+| `channelPresence`          | see below                                                 | SSE presence leases and convergence                                                                                                           |
+| `channelSecurity`          | see below                                                 | Trusted origins, publish rate, authorization deadline                                                                                         |
+| `pollIntervalMs`           | `15000` with push, `2000` without                         | Reconciliation interval. `0` gives up that recovery path                                                                                      |
+| `batchSize`                | `500`                                                     | Maximum outbox rows read per drain                                                                                                            |
+| `retentionDays`            | `3`                                                       | Minimum time a row remains after it first becomes drainable. `0` disables cleanup                                                             |
+| `keepAliveIntervalMs`      | `8000`                                                    | Ping interval on each SSE stream                                                                                                              |
 
 The poll runs alongside a broker rather than instead of it, and a provider
 failure temporarily tightens it to at most 2000 ms. Cleanup never uses a

--- a/apps/docs/content/docs/schema/hooks/side-effects.mdx
+++ b/apps/docs/content/docs/schema/hooks/side-effects.mdx
@@ -26,7 +26,7 @@ callbacks, which is the whole point of them.
 | Writes through `ctx.db`                                         | yes   |
 | Nested CRUD through `ctx.collections` and `ctx.globals`         | yes   |
 | `ctx.queue.<job>.publish()`                                     | yes   |
-| `ctx.channels.publish()`                                        | yes   |
+| `ctx.channels.<name>(params).publish()`                         | yes   |
 | Email, `fetch`, `ctx.realtime.notify()`, a second db connection | no    |
 
 A job published inside a transaction either goes to the broker in that

--- a/examples/city-portal/src/questpie/server/.generated/context.gen.ts
+++ b/examples/city-portal/src/questpie/server/.generated/context.gen.ts
@@ -60,7 +60,7 @@ import _openapi from "../config/openapi";
 
 import type { AppCollections, AppChannels, AppGlobals, AppJobs, _ModuleCollections, _AppDefaultServices, _AppServicesSeam, _AppTopLevelServices, _AppCustomServiceNamespaces, _Registry_Collections, _Registry_Channels, _Registry_Globals, _Registry_Jobs, _Registry_Routes, _Registry_Services, _Registry_Emails, _Registry_FieldTypes, _Registry_Views, _Registry_Components, _Registry_Blocks, _AllModuleFields } from "./entities.gen";
 import type { AnyCollectionOrBuilder, AnyGlobalOrBuilder, AuthorityActor, CollectionAPI, CrdtClientAPI, CrdtRegistryFromApp, CrdtServerAPI, DrizzleClientFromQuestpieConfig, InferContextExtensionsFromAppConfig, InferSessionFromAuthConfig, MailerService, Principal, Questpie, QuestpieConfig, QueueClient, QueueJobType, ServiceInstancesInNamespace, TablesFromConfig, z } from "questpie/types";
-import type { ChannelsService } from "questpie/channels";
+import type { Channels } from "questpie/channels";
 
 type _MPSubModules<M> = M extends { modules: infer S extends readonly any[] } ? S : readonly [];
 type _MPConfigValue<M, K extends string> = M extends { config: infer C } ? (C extends Record<K, infer V> ? V : {}) : {};
@@ -136,7 +136,7 @@ type _AppInfraRecord = {
 	realtime: _AppQuestpie["realtime"];
 	executor: _AppQuestpie["executor"];
 	observability: _AppQuestpie["observability"];
-	channels: ChannelsService<AppChannels>;
+	channels: Channels<AppChannels>;
 	crdt: AppCrdtServer;
 
 	// Entity APIs
@@ -171,7 +171,7 @@ declare global {
 			logger: _AppQuestpie["logger"];
 			search: _AppQuestpie["search"];
 			realtime: _AppQuestpie["realtime"];
-			channels: ChannelsService<AppChannels>;
+			channels: Channels<AppChannels>;
 
 			// Entity APIs
 			collections: _JobHandlerCollectionsAPI;
@@ -199,7 +199,7 @@ declare global {
 			logger: _AppQuestpie["logger"];
 			search: _AppQuestpie["search"];
 			realtime: _AppQuestpie["realtime"];
-			channels: ChannelsService<AppChannels>;
+			channels: Channels<AppChannels>;
 
 			// Entity APIs
 			collections: _JobHandlerCollectionsAPI;

--- a/examples/tanstack-barbershop/src/questpie/server/.generated/context.gen.ts
+++ b/examples/tanstack-barbershop/src/questpie/server/.generated/context.gen.ts
@@ -107,7 +107,7 @@ import _openapi from "../config/openapi";
 
 import type { AppCollections, AppChannels, AppGlobals, AppJobs, _ModuleCollections, _AppDefaultServices, _AppServicesSeam, _AppTopLevelServices, _AppCustomServiceNamespaces, AppEmailTemplates, _Registry_Collections, _Registry_Channels, _Registry_Globals, _Registry_Jobs, _Registry_Routes, _Registry_Services, _Registry_Emails, _Registry_FieldTypes, _Registry_Views, _Registry_Components, _Registry_Blocks, _Registry_McpTools, _AllModuleFields } from "./entities.gen";
 import type { AnyCollectionOrBuilder, AnyGlobalOrBuilder, AuthorityActor, CollectionAPI, CrdtClientAPI, CrdtRegistryFromApp, CrdtServerAPI, DrizzleClientFromQuestpieConfig, InferContextExtensionsFromAppConfig, InferSessionFromAuthConfig, MailerService, Principal, Questpie, QuestpieConfig, QueueClient, QueueJobType, ServiceInstancesInNamespace, TablesFromConfig, z } from "questpie/types";
-import type { ChannelsService } from "questpie/channels";
+import type { Channels } from "questpie/channels";
 
 type _MPSubModules<M> = M extends { modules: infer S extends readonly any[] } ? S : readonly [];
 type _MPConfigValue<M, K extends string> = M extends { config: infer C } ? (C extends Record<K, infer V> ? V : {}) : {};
@@ -191,7 +191,7 @@ type _AppInfraRecord = {
 	realtime: _AppQuestpie["realtime"];
 	executor: _AppQuestpie["executor"];
 	observability: _AppQuestpie["observability"];
-	channels: ChannelsService<AppChannels>;
+	channels: Channels<AppChannels>;
 	crdt: AppCrdtServer;
 
 	// Entity APIs
@@ -226,7 +226,7 @@ declare global {
 			logger: _AppQuestpie["logger"];
 			search: _AppQuestpie["search"];
 			realtime: _AppQuestpie["realtime"];
-			channels: ChannelsService<AppChannels>;
+			channels: Channels<AppChannels>;
 
 			// Entity APIs
 			collections: _JobHandlerCollectionsAPI;
@@ -254,7 +254,7 @@ declare global {
 			logger: _AppQuestpie["logger"];
 			search: _AppQuestpie["search"];
 			realtime: _AppQuestpie["realtime"];
-			channels: ChannelsService<AppChannels>;
+			channels: Channels<AppChannels>;
 
 			// Entity APIs
 			collections: _JobHandlerCollectionsAPI;

--- a/examples/toy-factory-backend/src/questpie/server/.generated/context.gen.ts
+++ b/examples/toy-factory-backend/src/questpie/server/.generated/context.gen.ts
@@ -51,7 +51,7 @@ import _openapi from "../config/openapi";
 
 import type { AppCollections, AppChannels, AppGlobals, AppJobs, _ModuleCollections, _AppDefaultServices, _AppServicesSeam, _AppTopLevelServices, _AppCustomServiceNamespaces, AppEmailTemplates, AppWorkflows, _Registry_Collections, _Registry_Channels, _Registry_Globals, _Registry_Jobs, _Registry_Routes, _Registry_Services, _Registry_Emails, _Registry_FieldTypes, _Registry_Views, _Registry_Components, _Registry_Blocks, _Registry_Workflows, _AllModuleFields } from "./entities.gen";
 import type { AnyCollectionOrBuilder, AnyGlobalOrBuilder, AuthorityActor, CollectionAPI, CrdtClientAPI, CrdtRegistryFromApp, CrdtServerAPI, DrizzleClientFromQuestpieConfig, InferContextExtensionsFromAppConfig, InferSessionFromAuthConfig, MailerService, Principal, Questpie, QuestpieConfig, QueueClient, QueueJobType, ServiceInstancesInNamespace, TablesFromConfig, z } from "questpie/types";
-import type { ChannelsService } from "questpie/channels";
+import type { Channels } from "questpie/channels";
 
 import type { WorkflowClient } from "@questpie/workflows/server";
 type _MPSubModules<M> = M extends { modules: infer S extends readonly any[] } ? S : readonly [];
@@ -132,7 +132,7 @@ type _AppInfraRecord = {
 	realtime: _AppQuestpie["realtime"];
 	executor: _AppQuestpie["executor"];
 	observability: _AppQuestpie["observability"];
-	channels: ChannelsService<AppChannels>;
+	channels: Channels<AppChannels>;
 	crdt: AppCrdtServer;
 
 	// Entity APIs
@@ -169,7 +169,7 @@ declare global {
 			logger: _AppQuestpie["logger"];
 			search: _AppQuestpie["search"];
 			realtime: _AppQuestpie["realtime"];
-			channels: ChannelsService<AppChannels>;
+			channels: Channels<AppChannels>;
 
 			// Entity APIs
 			collections: _JobHandlerCollectionsAPI;
@@ -197,7 +197,7 @@ declare global {
 			logger: _AppQuestpie["logger"];
 			search: _AppQuestpie["search"];
 			realtime: _AppQuestpie["realtime"];
-			channels: ChannelsService<AppChannels>;
+			channels: Channels<AppChannels>;
 
 			// Entity APIs
 			collections: _JobHandlerCollectionsAPI;

--- a/packages/questpie/src/cli/codegen/template.ts
+++ b/packages/questpie/src/cli/codegen/template.ts
@@ -317,7 +317,7 @@ export function generateTemplate(options: TemplateOptions): TemplateResult {
 	l2.push(
 		'import type { AnyCollectionOrBuilder, AnyGlobalOrBuilder, AuthorityActor, CollectionAPI, CrdtClientAPI, CrdtRegistryFromApp, CrdtServerAPI, DrizzleClientFromQuestpieConfig, InferContextExtensionsFromAppConfig, InferSessionFromAuthConfig, MailerService, Principal, Questpie, QuestpieConfig, QueueClient, QueueJobType, ServiceInstancesInNamespace, TablesFromConfig, z } from "questpie/types";',
 	);
-	l2.push('import type { ChannelsService } from "questpie/channels";');
+	l2.push('import type { Channels } from "questpie/channels";');
 	if (extraImports && extraImports.length > 0) {
 		l2.push("// ── Plugin Imports ─────────────────────────────────────────");
 		for (const imp of extraImports) {
@@ -1003,7 +1003,7 @@ export function generateTemplate(options: TemplateOptions): TemplateResult {
 		// ctx.observability were on the object and rejected by the compiler.
 		lines.push('\texecutor: _AppQuestpie["executor"];');
 		lines.push('\tobservability: _AppQuestpie["observability"];');
-		lines.push("\tchannels: ChannelsService<AppChannels>;");
+		lines.push("\tchannels: Channels<AppChannels>;");
 		lines.push("\tcrdt: AppCrdtServer;");
 		lines.push("");
 		lines.push("\t// Entity APIs");
@@ -1145,7 +1145,7 @@ export function generateTemplate(options: TemplateOptions): TemplateResult {
 			lines.push('\t\t\tlogger: _AppQuestpie["logger"];');
 			lines.push('\t\t\tsearch: _AppQuestpie["search"];');
 			lines.push('\t\t\trealtime: _AppQuestpie["realtime"];');
-			lines.push("\t\t\tchannels: ChannelsService<AppChannels>;");
+			lines.push("\t\t\tchannels: Channels<AppChannels>;");
 			lines.push("");
 			lines.push("\t\t\t// Entity APIs");
 			lines.push("\t\t\tcollections: _JobHandlerCollectionsAPI;");

--- a/packages/questpie/src/client/channels/index.ts
+++ b/packages/questpie/src/client/channels/index.ts
@@ -1,5 +1,4 @@
 import type { ChannelDefinitions } from "#questpie/server/channels/channel-builder.js";
-import { isClientChannelFacadeReservedKey } from "#questpie/shared/channel-facade.js";
 import { stringifyTypedWire } from "#questpie/shared/typed-wire.js";
 
 import type { GetAuthHeaders } from "../auth.js";
@@ -427,7 +426,8 @@ export function createChannelsAPI<
 		get(target, property, receiver) {
 			if (
 				typeof property !== "string" ||
-				isClientChannelFacadeReservedKey(property)
+				property === "then" ||
+				property in target
 			) {
 				return Reflect.get(target, property, receiver);
 			}

--- a/packages/questpie/src/client/channels/index.ts
+++ b/packages/questpie/src/client/channels/index.ts
@@ -1,4 +1,5 @@
 import type { ChannelDefinitions } from "#questpie/server/channels/channel-builder.js";
+import { isClientChannelFacadeReservedKey } from "#questpie/shared/channel-facade.js";
 import { stringifyTypedWire } from "#questpie/shared/typed-wire.js";
 
 import type { GetAuthHeaders } from "../auth.js";
@@ -193,7 +194,7 @@ export function createChannelsAPI<
 	const getHandle = (registryKey: string) => {
 		let handle = handles.get(registryKey);
 		if (handle) return handle;
-		handle = {
+		const legacyHandle = {
 			subscribe: (...args: unknown[]) => {
 				const hasParams = typeof args[0] !== "function";
 				const params = (hasParams ? args[0] : {}) as Record<string, string>;
@@ -233,7 +234,11 @@ export function createChannelsAPI<
 					stopInner?.();
 				};
 			},
-			publish: async (input: Record<string, unknown>) => {
+			publish: async (...args: unknown[]) => {
+				const input =
+					typeof args[0] === "string"
+						? { event: args[0], data: args[1] }
+						: (args[0] as Record<string, unknown>);
 				await getTransport();
 				descriptorFor(registryKey);
 				const authHeaders = await options.getAuthHeaders?.();
@@ -375,6 +380,28 @@ export function createChannelsAPI<
 				);
 			},
 		};
+		const bind = (params: Record<string, string>) => {
+			const boundParams = Object.freeze({ ...params });
+			return {
+				subscribe: (
+					callback: (message: ChannelTransportMessage) => void,
+					options?: ChannelSubscribeOptions,
+				) => legacyHandle.subscribe(boundParams, callback, options),
+				publish: (event: string, data: unknown) =>
+					legacyHandle.publish({ params: boundParams, event, data }),
+				iter: (options?: ChannelSubscribeOptions) =>
+					legacyHandle.iter(boundParams, options),
+				presence: (options?: ChannelPresenceOptions) =>
+					legacyHandle.presence(boundParams, options),
+				subscribePresence: (
+					callback: (members: readonly unknown[]) => void,
+					options?: ChannelSubscribeOptions,
+				) => legacyHandle.subscribePresence(boundParams, callback, options),
+				presenceIter: (options?: ChannelSubscribeOptions) =>
+					legacyHandle.presenceIter(boundParams, options),
+			};
+		};
+		handle = Object.assign(bind, legacyHandle);
 		handles.set(registryKey, handle);
 		return handle;
 	};
@@ -398,8 +425,12 @@ export function createChannelsAPI<
 
 	return new Proxy(control, {
 		get(target, property, receiver) {
-			if (property in target) return Reflect.get(target, property, receiver);
-			if (typeof property !== "string") return undefined;
+			if (
+				typeof property !== "string" ||
+				isClientChannelFacadeReservedKey(property)
+			) {
+				return Reflect.get(target, property, receiver);
+			}
 			return getHandle(property);
 		},
 	}) as ChannelsClient<TChannels>;

--- a/packages/questpie/src/client/channels/types.ts
+++ b/packages/questpie/src/client/channels/types.ts
@@ -8,6 +8,7 @@ import type {
 	ChannelPresenceOf,
 	ChannelVisibility,
 } from "#questpie/server/channels/channel-builder.js";
+import type { ClientChannelFacadeReservedKey } from "#questpie/shared/channel-facade.js";
 
 type EventOutput<TDefinition extends AnyChannelDefinition> = {
 	[TEvent in keyof ChannelEventsOf<TDefinition> & string]: {
@@ -36,6 +37,13 @@ export type ChannelPublishInput<TDefinition extends AnyChannelDefinition> =
 	EventInput<TDefinition> & ParamsInput<TDefinition>;
 
 export type ChannelPublishReceipt = Readonly<{ eventId: string }>;
+
+type BoundPublishMethod<TDefinition extends AnyChannelDefinition> = <
+	TEvent extends keyof ChannelEventsOf<TDefinition> & string,
+>(
+	event: TEvent,
+	data: z.input<ChannelEventsOf<TDefinition>[TEvent]>,
+) => Promise<ChannelPublishReceipt>;
 
 export type ChannelSubscribeOptions = {
 	signal?: AbortSignal;
@@ -122,8 +130,9 @@ type PresenceIterMethod<TDefinition extends AnyChannelDefinition> = [
 				unknown
 			>;
 
-export type ChannelClient<TDefinition extends AnyChannelDefinition> = {
+type LegacyChannelClient<TDefinition extends AnyChannelDefinition> = {
 	subscribe: SubscribeMethod<TDefinition>;
+	/** @deprecated Bind params once, then call `publish(event, data)`. */
 	publish: (
 		input: ChannelPublishInput<TDefinition>,
 	) => Promise<ChannelPublishReceipt>;
@@ -133,8 +142,60 @@ export type ChannelClient<TDefinition extends AnyChannelDefinition> = {
 	presenceIter: PresenceIterMethod<TDefinition>;
 };
 
+type BoundPresenceClient<TDefinition extends AnyChannelDefinition> = [
+	ChannelPresenceOf<TDefinition>,
+] extends [never]
+	? {}
+	: {
+			presence(
+				options?: ChannelPresenceOptions,
+			): Promise<readonly ChannelPresenceOf<TDefinition>[]>;
+			subscribePresence(
+				callback: (members: readonly ChannelPresenceOf<TDefinition>[]) => void,
+				options?: ChannelSubscribeOptions,
+			): () => void;
+			presenceIter(
+				options?: ChannelSubscribeOptions,
+			): AsyncGenerator<
+				readonly ChannelPresenceOf<TDefinition>[],
+				void,
+				unknown
+			>;
+		};
+
+export type BoundChannelClient<TDefinition extends AnyChannelDefinition> = {
+	subscribe(
+		callback: (message: ChannelMessage<TDefinition>) => void,
+		options?: ChannelSubscribeOptions,
+	): () => void;
+	publish: BoundPublishMethod<TDefinition>;
+	iter(
+		options?: ChannelSubscribeOptions,
+	): AsyncGenerator<ChannelMessage<TDefinition>, void, unknown>;
+} & BoundPresenceClient<TDefinition>;
+
+type NoParamChannelClient<TDefinition extends AnyChannelDefinition> = Omit<
+	LegacyChannelClient<TDefinition>,
+	"publish"
+> & {
+	/** The object form remains a deprecated QUESTPIE 3.x compatibility overload. */
+	publish: LegacyChannelClient<TDefinition>["publish"] &
+		BoundPublishMethod<TDefinition>;
+};
+
+export type ChannelClient<TDefinition extends AnyChannelDefinition> =
+	keyof ChannelParamsOf<TDefinition> extends never
+		? NoParamChannelClient<TDefinition>
+		: LegacyChannelClient<TDefinition> &
+				((
+					params: ChannelParamsOf<TDefinition>,
+				) => BoundChannelClient<TDefinition>);
+
 export type ChannelsClient<TChannels extends ChannelDefinitions> = {
-	[TChannel in keyof TChannels]: ChannelClient<TChannels[TChannel]>;
+	[TChannel in Exclude<
+		keyof TChannels,
+		ClientChannelFacadeReservedKey
+	>]: ChannelClient<TChannels[TChannel]>;
 } & {
 	destroy(): void;
 	readonly channelCount: number;

--- a/packages/questpie/src/server/channels/service.ts
+++ b/packages/questpie/src/server/channels/service.ts
@@ -204,6 +204,28 @@ function isSystemContext(context: StoredChannelServiceContext): boolean {
 	return !context.session && !context.principal;
 }
 
+function revokeResolvedChannelAuthority(
+	publisher: ChannelPublisher,
+	db: AppendChannelEventOptions["db"] | undefined,
+	resolvedName: string,
+	input: ChannelAuthorityInvalidationInput,
+): Promise<ChannelAuthorityRevocationReceipt> {
+	if (!input.subject.id || input.subject.id.length > 256) {
+		throw new Error("Channel authority subject is invalid");
+	}
+	if (!publisher.revokeChannelAuthority) {
+		throw new Error("Channel authority revocation is unavailable");
+	}
+	return publisher.revokeChannelAuthority(
+		{
+			channel: resolvedName,
+			subject: input.subject,
+			idempotencyKey: input.idempotencyKey,
+		},
+		{ db },
+	);
+}
+
 /** Request-bound typed facade over the shared realtime client transport. */
 export class ChannelsService<
 	TChannels extends ChannelDefinitions = ChannelDefinitions,
@@ -322,21 +344,13 @@ export class ChannelsService<
 		channel: TChannel,
 		input: ChannelAuthorityRevocationInput<TChannels[TChannel]>,
 	): Promise<ChannelAuthorityRevocationReceipt> {
-		if (!input.subject.id || input.subject.id.length > 256) {
-			throw new Error("Channel authority subject is invalid");
-		}
 		const params = (input.params ?? {}) as ChannelParamsOf<TChannels[TChannel]>;
 		const resolvedName = this.resolveName(channel, params);
-		if (!this.publisher.revokeChannelAuthority) {
-			throw new Error("Channel authority revocation is unavailable");
-		}
-		return this.publisher.revokeChannelAuthority(
-			{
-				channel: resolvedName,
-				subject: input.subject,
-				idempotencyKey: input.idempotencyKey,
-			},
-			{ db: this.context.db },
+		return revokeResolvedChannelAuthority(
+			this.publisher,
+			this.context.db,
+			resolvedName,
+			input,
 		);
 	}
 
@@ -533,7 +547,7 @@ export function createChannels<
 		const boundParams = Object.freeze({ ...params }) as ChannelParamsOf<
 			TChannels[TChannel]
 		>;
-		service.resolveName(channel, boundParams);
+		const resolvedName = service.resolveName(channel, boundParams);
 		return Object.freeze({
 			publish: <
 				TEvent extends keyof ChannelEventsOf<TChannels[TChannel]> & string,
@@ -541,19 +555,23 @@ export function createChannels<
 				event: TEvent,
 				data: z.input<ChannelEventsOf<TChannels[TChannel]>[TEvent]>,
 			) =>
-				service.publish(channel, {
-					params: boundParams,
-					event,
-					data,
-				} as unknown as ChannelPublishInput<TChannels[TChannel]>),
+				service
+					.preparePublishRequest(channel, {
+						params: boundParams,
+						event,
+						data,
+					})
+					.then((prepared) => service.publishPrepared(prepared)),
 			authorize: (verb: "subscribe" | "publish") =>
 				service.authorize(channel, boundParams, verb),
 			resolvePresence: () => service.resolvePresence(channel, boundParams),
 			invalidateAuthority: async (input: ChannelAuthorityInvalidationInput) => {
-				const receipt = await service.revokeAuthority(channel, {
-					params: boundParams,
-					...input,
-				} as unknown as ChannelAuthorityRevocationInput<TChannels[TChannel]>);
+				const receipt = await revokeResolvedChannelAuthority(
+					publisher,
+					context.db,
+					resolvedName,
+					input,
+				);
 				return {
 					generation: receipt.generation,
 					transportEffect:

--- a/packages/questpie/src/server/channels/service.ts
+++ b/packages/questpie/src/server/channels/service.ts
@@ -8,6 +8,10 @@ import {
 	type ChannelEventReceipt,
 	hashResolvedChannel,
 } from "#questpie/server/modules/core/integrated/realtime/channel-event-ledger.js";
+import {
+	isServerChannelFacadeReservedKey,
+	type ServerChannelFacadeReservedKey,
+} from "#questpie/shared/channel-facade.js";
 
 import type { ChannelAuthoritySubject } from "./authority.js";
 import {
@@ -74,6 +78,11 @@ export type ChannelAuthorityRevocationReceipt = Readonly<{
 	generation: number;
 }>;
 
+export type ChannelAuthorityInvalidationReceipt = Readonly<{
+	transportEffect: "exact-binding" | "principal-connections";
+	generation: number;
+}>;
+
 export type ChannelServiceContext = AppContext & {
 	accessMode?: string;
 	db?: AppendChannelEventOptions["db"];
@@ -109,6 +118,66 @@ export type ChannelAuthorityRevocationInput<
 	idempotencyKey: string;
 }> &
 	ParamsInput<TDefinition>;
+
+export type ChannelAuthorityInvalidationInput = Readonly<{
+	subject: ChannelAuthoritySubject;
+	idempotencyKey: string;
+}>;
+
+type BoundPublishMethod<TDefinition extends AnyChannelDefinition> = <
+	TEvent extends keyof ChannelEventsOf<TDefinition> & string,
+>(
+	event: TEvent,
+	data: z.input<ChannelEventsOf<TDefinition>[TEvent]>,
+) => Promise<ChannelPublishReceipt>;
+
+type PresenceHandle<TDefinition extends AnyChannelDefinition> = [
+	ChannelPresenceOf<TDefinition>,
+] extends [never]
+	? {}
+	: {
+			resolvePresence(): Promise<ChannelPresenceOf<TDefinition>>;
+		};
+
+export type ResolvedChannelHandle<TDefinition extends AnyChannelDefinition> =
+	Readonly<
+		{
+			publish: BoundPublishMethod<TDefinition>;
+			authorize(verb: "subscribe" | "publish"): Promise<boolean>;
+			invalidateAuthority(
+				input: ChannelAuthorityInvalidationInput,
+			): Promise<ChannelAuthorityInvalidationReceipt>;
+		} & PresenceHandle<TDefinition>
+	>;
+
+type ChannelHandle<TDefinition extends AnyChannelDefinition> =
+	keyof ChannelParamsOf<TDefinition> extends never
+		? ResolvedChannelHandle<TDefinition>
+		: (
+				params: ChannelParamsOf<TDefinition>,
+			) => ResolvedChannelHandle<TDefinition>;
+
+type LegacyChannelsFacade<TChannels extends ChannelDefinitions> = Pick<
+	ChannelsService<TChannels>,
+	| "authorize"
+	| "getDefinition"
+	| "preparePublish"
+	| "preparePublishRequest"
+	| "publish"
+	| "publishBatch"
+	| "publishPrepared"
+	| "resolveName"
+	| "resolvePresence"
+	| "revokeAuthority"
+>;
+
+export type Channels<TChannels extends ChannelDefinitions> =
+	LegacyChannelsFacade<TChannels> & {
+		readonly [TChannel in Exclude<
+			keyof TChannels,
+			ServerChannelFacadeReservedKey
+		>]: ChannelHandle<TChannels[TChannel]>;
+	};
 
 export type ChannelPublishRequest<TChannels extends ChannelDefinitions> = {
 	[TChannel in keyof TChannels & string]: {
@@ -226,6 +295,9 @@ export class ChannelsService<
 	 * In collection/global hooks, use the injected `{ channels }` argument.
 	 * Contextless update/delete calls do not establish an ALS scope, so resolving
 	 * the service later through ambient `getContext()` is not reliable there.
+	 *
+	 * @deprecated Use `channels.<name>(params).publish(event, data)`. This
+	 * compatibility method remains available throughout QUESTPIE 3.x.
 	 */
 	async publish<TChannel extends keyof TChannels & string>(
 		channel: TChannel,
@@ -241,6 +313,10 @@ export class ChannelsService<
 	 * The provider-neutral receipt documents whether the configured transport
 	 * closed the exact logical subscription or conservatively terminated all
 	 * physical connections for that principal.
+	 *
+	 * @deprecated Use
+	 * `channels.<name>(params).invalidateAuthority({ subject, idempotencyKey })`.
+	 * This compatibility method remains available throughout QUESTPIE 3.x.
 	 */
 	revokeAuthority<TChannel extends keyof TChannels & string>(
 		channel: TChannel,
@@ -431,4 +507,88 @@ export class ChannelsService<
 			error,
 		);
 	}
+}
+
+/** Create the canonical registry-first Channel facade used by AppContext. */
+export function createChannels<
+	TChannels extends ChannelDefinitions = ChannelDefinitions,
+>(
+	definitions: TChannels,
+	publisher: ChannelPublisher,
+	context: ChannelServiceContext,
+	security: ChannelSecurityConfig = {},
+): Channels<TChannels> {
+	const service = new ChannelsService(
+		definitions,
+		publisher,
+		context,
+		security,
+	);
+	const handles = new Map<string, unknown>();
+
+	const resolveHandle = <TChannel extends keyof TChannels & string>(
+		channel: TChannel,
+		params: ChannelParamsOf<TChannels[TChannel]>,
+	): ResolvedChannelHandle<TChannels[TChannel]> => {
+		const boundParams = Object.freeze({ ...params }) as ChannelParamsOf<
+			TChannels[TChannel]
+		>;
+		service.resolveName(channel, boundParams);
+		return Object.freeze({
+			publish: <
+				TEvent extends keyof ChannelEventsOf<TChannels[TChannel]> & string,
+			>(
+				event: TEvent,
+				data: z.input<ChannelEventsOf<TChannels[TChannel]>[TEvent]>,
+			) =>
+				service.publish(channel, {
+					params: boundParams,
+					event,
+					data,
+				} as unknown as ChannelPublishInput<TChannels[TChannel]>),
+			authorize: (verb: "subscribe" | "publish") =>
+				service.authorize(channel, boundParams, verb),
+			resolvePresence: () => service.resolvePresence(channel, boundParams),
+			invalidateAuthority: async (input: ChannelAuthorityInvalidationInput) => {
+				const receipt = await service.revokeAuthority(channel, {
+					params: boundParams,
+					...input,
+				} as unknown as ChannelAuthorityRevocationInput<TChannels[TChannel]>);
+				return {
+					generation: receipt.generation,
+					transportEffect:
+						receipt.scope === "exact-subscription"
+							? "exact-binding"
+							: "principal-connections",
+				};
+			},
+		}) as ResolvedChannelHandle<TChannels[TChannel]>;
+	};
+
+	return new Proxy(service, {
+		get(target, property, receiver) {
+			if (
+				typeof property !== "string" ||
+				isServerChannelFacadeReservedKey(property)
+			) {
+				const value = Reflect.get(target, property, receiver);
+				return typeof value === "function" ? value.bind(target) : value;
+			}
+			const definition = Object.hasOwn(definitions, property)
+				? definitions[property]
+				: undefined;
+			if (!definition) {
+				const value = Reflect.get(target, property, receiver);
+				return typeof value === "function" ? value.bind(target) : value;
+			}
+			const cached = handles.get(property);
+			if (cached) return cached;
+			const handle = definition.pattern.includes("[")
+				? (params: Record<string, string>) =>
+						resolveHandle(property, params as never)
+				: resolveHandle(property, {} as never);
+			handles.set(property, handle);
+			return handle;
+		},
+	}) as Channels<TChannels>;
 }

--- a/packages/questpie/src/server/modules/core/integrated/realtime/AUTHORITY.md
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/AUTHORITY.md
@@ -1,0 +1,120 @@
+# Realtime authority and sharing
+
+## Invariants
+
+1. Collection and global live-query output is defined by the ordinary CRUD
+   read pipeline: request query, resolved `AppContext`, read access, field
+   access, output hooks, and `afterRead`. Realtime adds no tenant or authority
+   filter of its own.
+2. A resolved typed Channel is the complete authority target for that Channel.
+   Its registry definition and validated params resolve to one transport-safe
+   channel identity; no second scope is attached to it.
+3. Channel authority invalidation is exact: one resolved Channel and one opaque
+   subject. It advances the existing durable authority fence and re-runs the
+   Channel subscribe rule with a fresh context.
+4. Scheduler sharing is an optimization, never authorization. By default,
+   equivalent live queries share only inside the same authenticated session,
+   OAuth token, or anonymous edge connection.
+5. `realtime.accessCacheKey` is an explicit proof that byte-identical output may
+   be shared more widely. The effective authorized topic, locale, stage, access
+   mode, and delivery mode remain part of the scheduler key.
+6. `realtime.subscriptionScope` is not an authority primitive. It is deprecated
+   in 3.x and removed in 4.0 after callers migrate tenant selection into
+   `appConfig.context` and collection/global access.
+
+## Canonical Channels interface
+
+Parametric Channels resolve once and retain their validated params:
+
+```ts
+const conversation = channels.conversation({ sessionId });
+
+await conversation.publish("message.persisted", data);
+await conversation.invalidateAuthority({
+	subject: { kind: "user", id: userId },
+	idempotencyKey,
+});
+```
+
+Channels without params are already resolved:
+
+```ts
+await channels.news.publish("published", data);
+```
+
+The client mirrors the same binding model. Authority invalidation remains
+server-only.
+
+The released root methods remain deprecated compatibility entry points
+throughout 3.x. They use the same service and ledger.
+
+## `accessCacheKey` contract
+
+A valid explicit key replaces the default session/principal sharing identity.
+It is a claim made by the collection/global author:
+
+> For the same effective authorized topic and framework-owned dimensions,
+> every context returning this key produces byte-identical output, including
+> field access and `afterRead`.
+
+This makes compute-once/fan-out possible:
+
+```ts
+collection("publicAnnouncements")
+	.access({ read: true })
+	.options({
+		realtime: { accessCacheKey: () => "public-announcements:v1" },
+	});
+```
+
+One server instance may then serve 100,000 equivalent subscribers with one
+database computation per refresh. Multiple server replicas each own their
+local scheduler group. Invalid, over-long, or throwing resolvers fail closed to
+the default isolated identity.
+
+## Transport truthfulness
+
+SSE can close an exact logical binding. Shared providers such as Pusher may
+only terminate every physical connection for a principal and let desired
+topology reconnect and reauthorize. Public receipts call this
+`transportEffect`, not `scope`, so it cannot be confused with data or OAuth
+scope.
+
+In a managed caller transaction, shared-provider termination and authority
+acknowledgement run inline under a bounded call. Provider failure throws and
+rolls back the database transaction; a conservative disconnect may survive a
+later caller rollback. Standalone provider failure leaves the durable cut
+pending for an idempotent retry. A fully rollback-safe provider effect would
+require a provider-prepared opaque target plus a distributed claim/lease; this
+patch intentionally does not introduce that second outbox contract.
+
+No transport can retract bytes already accepted into a socket buffer. The
+framework guarantee is that no new ordered frame is logically admitted under
+an authority generation older than the committed fence.
+
+## Non-goals
+
+- No company, workspace, membership, role, ACL, or ABAC model in the framework.
+- No scope-wide Channel or live-query invalidation.
+- No app-side enumeration of active subscriptions.
+- No second realtime event bus, authority ledger, or polling subsystem.
+- Scoped Globals remain their existing data-model feature and are unrelated.
+
+## Verification
+
+- Server and client Channel handles infer params, events, and payloads.
+- A handle cannot be constructed with missing or unknown params.
+- Exact invalidation preserves allowed subscriptions and closes denied ones.
+- A different resolved Channel or subject is untouched.
+- Duplicate idempotency keys return the original generation; conflicting reuse
+  fails.
+- SSE reconciliation starts after commit; rollback does not change its local
+  bindings.
+- Shared-provider failure rolls back the database mutation; a completed
+  conservative disconnect may survive a later caller rollback.
+- SSE and Pusher report their real transport effect.
+- Effective collection access remains part of every live-query scheduler key.
+- Different sessions of one user do not share by default.
+- A valid `accessCacheKey` collapses equivalent principals to one computation.
+- Context-dependent output remains isolated without an explicit sharing key.
+- Existing root Channel methods remain operational during 3.x.

--- a/packages/questpie/src/server/modules/core/integrated/realtime/refresh-scheduler.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/refresh-scheduler.ts
@@ -176,6 +176,7 @@ export async function resolveRealtimeAccessKey<TContext extends AccessContext>(
 ): Promise<string> {
 	let identity: string | undefined;
 	let isolateToEdge = false;
+	let explicitlyShared = false;
 	const extensionsDigest = await contextExtensionsDigest(
 		context["~contextExtensions"],
 	);
@@ -191,6 +192,7 @@ export async function resolveRealtimeAccessKey<TContext extends AccessContext>(
 				new TextEncoder().encode(sharedKey).byteLength <= 256
 			) {
 				identity = `shared:${sharedKey}`;
+				explicitlyShared = true;
 			} else if (
 				sharedKey !== null &&
 				sharedKey !== undefined &&
@@ -205,17 +207,17 @@ export async function resolveRealtimeAccessKey<TContext extends AccessContext>(
 
 	const principal = context.principal;
 	if (!identity) {
-		const userId = principal?.user?.id ?? context.session?.user?.id;
+		const sessionId = principal?.session?.id ?? context.session?.session?.id;
 		if (isolateToEdge) {
 			identity = `edge:${edgeSessionId}`;
-		} else if (typeof userId === "string" && userId) {
-			identity = `principal:${userId}`;
 		} else if (
 			principal?.kind === "oauth" &&
 			typeof principal.tokenId === "string" &&
 			principal.tokenId
 		) {
 			identity = `oauth:${principal.tokenId}`;
+		} else if (typeof sessionId === "string" && sessionId) {
+			identity = `session:${sessionId}`;
 		} else {
 			identity = `edge:${edgeSessionId}`;
 		}
@@ -225,7 +227,9 @@ export async function resolveRealtimeAccessKey<TContext extends AccessContext>(
 	// access rule may read `principal.scopes` — so the same identity can be
 	// entitled to different bytes. The token is part of what decides them.
 	const token =
-		typeof principal?.tokenId === "string" && principal.tokenId
+		!explicitlyShared &&
+		typeof principal?.tokenId === "string" &&
+		principal.tokenId
 			? principal.tokenId
 			: "";
 
@@ -236,7 +240,7 @@ export async function resolveRealtimeAccessKey<TContext extends AccessContext>(
 		context.stage ?? "",
 		context.accessMode ?? "",
 		extensionsDigest ?? "",
-		principal?.kind ?? "",
+		explicitlyShared ? "" : (principal?.kind ?? ""),
 		token,
 	]);
 }

--- a/packages/questpie/src/server/modules/core/integrated/realtime/types.ts
+++ b/packages/questpie/src/server/modules/core/integrated/realtime/types.ts
@@ -167,6 +167,10 @@ export interface RealtimeConfig {
 	/**
 	 * Resolve one stable server-owned scope at admission. `null`/`undefined`
 	 * means explicitly unscoped; switching scope requires a new subscription.
+	 *
+	 * @deprecated Tenant selection belongs in `appConfig.context` and read
+	 * access. Use collection/global `realtime.accessCacheKey` only when widening
+	 * compute sharing for byte-identical output. Removed in QUESTPIE 4.
 	 */
 	subscriptionScope?: RealtimeSubscriptionScopeResolver;
 	/** Diagnostic event sink. Observer failures are isolated from delivery. */

--- a/packages/questpie/src/server/modules/core/services/channels.ts
+++ b/packages/questpie/src/server/modules/core/services/channels.ts
@@ -1,6 +1,6 @@
 import {
+	createChannels,
 	type ChannelServiceContext,
-	ChannelsService,
 } from "#questpie/server/channels/service.js";
 import { service } from "#questpie/server/services/define-service.js";
 
@@ -10,7 +10,7 @@ export default service({
 	lifecycle: "request",
 	create: (ctx) => {
 		const { app } = ctx;
-		return new ChannelsService(
+		return createChannels(
 			app.config.channels ?? {},
 			app.realtime,
 			// The only construction site that does NOT go through

--- a/packages/questpie/src/shared/channel-facade.ts
+++ b/packages/questpie/src/shared/channel-facade.ts
@@ -48,11 +48,3 @@ export const CLIENT_CHANNEL_FACADE_RESERVED_KEYS = [
 
 export type ClientChannelFacadeReservedKey =
 	(typeof CLIENT_CHANNEL_FACADE_RESERVED_KEYS)[number];
-
-const clientReservedKeys = new Set<string>(CLIENT_CHANNEL_FACADE_RESERVED_KEYS);
-
-export function isClientChannelFacadeReservedKey(
-	key: string,
-): key is ClientChannelFacadeReservedKey {
-	return clientReservedKeys.has(key);
-}

--- a/packages/questpie/src/shared/channel-facade.ts
+++ b/packages/questpie/src/shared/channel-facade.ts
@@ -1,0 +1,58 @@
+const OBJECT_FACADE_KEYS = [
+	"__proto__",
+	"__defineGetter__",
+	"__defineSetter__",
+	"__lookupGetter__",
+	"__lookupSetter__",
+	"constructor",
+	"hasOwnProperty",
+	"isPrototypeOf",
+	"propertyIsEnumerable",
+	"then",
+	"toLocaleString",
+	"toString",
+	"valueOf",
+] as const;
+
+export const SERVER_CHANNEL_FACADE_RESERVED_KEYS = [
+	...OBJECT_FACADE_KEYS,
+	"authorize",
+	"getDefinition",
+	"preparePublish",
+	"preparePublishRequest",
+	"publish",
+	"publishBatch",
+	"publishPrepared",
+	"resolveName",
+	"resolvePresence",
+	"revokeAuthority",
+] as const;
+
+export type ServerChannelFacadeReservedKey =
+	(typeof SERVER_CHANNEL_FACADE_RESERVED_KEYS)[number];
+
+const serverReservedKeys = new Set<string>(SERVER_CHANNEL_FACADE_RESERVED_KEYS);
+
+export function isServerChannelFacadeReservedKey(
+	key: string,
+): key is ServerChannelFacadeReservedKey {
+	return serverReservedKeys.has(key);
+}
+
+export const CLIENT_CHANNEL_FACADE_RESERVED_KEYS = [
+	...OBJECT_FACADE_KEYS,
+	"channelCount",
+	"destroy",
+	"subscriberCount",
+] as const;
+
+export type ClientChannelFacadeReservedKey =
+	(typeof CLIENT_CHANNEL_FACADE_RESERVED_KEYS)[number];
+
+const clientReservedKeys = new Set<string>(CLIENT_CHANNEL_FACADE_RESERVED_KEYS);
+
+export function isClientChannelFacadeReservedKey(
+	key: string,
+): key is ClientChannelFacadeReservedKey {
+	return clientReservedKeys.has(key);
+}

--- a/packages/questpie/test/client/client-channels.test.ts
+++ b/packages/questpie/test/client/client-channels.test.ts
@@ -304,9 +304,9 @@ describe("channels client", () => {
 		transport.destroy();
 	});
 
-	test("keeps explicit plain JSON channel publishing interoperable", async () => {
+	test("supports bound publishing while keeping plain JSON interoperable", async () => {
 		const instant = new Date("2026-03-29T00:30:00.000Z");
-		let publishRequest: RequestInit | undefined;
+		const publishRequests: RequestInit[] = [];
 		const client = createClient<any>({
 			baseURL: "http://localhost:3000",
 			useSuperJSON: false,
@@ -317,11 +317,12 @@ describe("channels client", () => {
 						transport: "sse",
 						channels: {
 							news: { pattern: "news", visibility: "public" },
+							room: { pattern: "room-[roomId]", visibility: "private" },
 						},
 					});
 				}
 				if (url.endsWith("/channels/publish")) {
-					publishRequest = init;
+					publishRequests.push(init ?? {});
 					return Response.json({ eventId: "event-1" });
 				}
 				throw new Error(`Unexpected request: ${url}`);
@@ -332,16 +333,86 @@ describe("channels client", () => {
 			event: "updated",
 			data: { startsAt: instant },
 		});
+		await client.channels.news.publish("updated", { startsAt: instant });
+		const roomParams = { roomId: "one" };
+		const room = client.channels.room(roomParams);
+		roomParams.roomId = "two";
+		await room.publish("message", {
+			text: "hello",
+		});
 
-		expect(new Headers(publishRequest?.headers).get("Content-Type")).toBe(
+		expect(new Headers(publishRequests[0]?.headers).get("Content-Type")).toBe(
 			"application/json",
 		);
-		expect(JSON.parse(String(publishRequest?.body))).toEqual({
-			channel: "news",
-			params: {},
-			event: "updated",
-			data: { startsAt: instant.toISOString() },
+		expect(
+			publishRequests.map((request) => JSON.parse(String(request.body))),
+		).toEqual([
+			{
+				channel: "news",
+				params: {},
+				event: "updated",
+				data: { startsAt: instant.toISOString() },
+			},
+			{
+				channel: "news",
+				params: {},
+				event: "updated",
+				data: { startsAt: instant.toISOString() },
+			},
+			{
+				channel: "room",
+				params: { roomId: "one" },
+				event: "message",
+				data: { text: "hello" },
+			},
+		]);
+		client.channels.destroy();
+	});
+
+	test("keeps non-control client channel names and actual control methods", async () => {
+		const publishRequests: RequestInit[] = [];
+		const client = createClient<any>({
+			baseURL: "http://localhost:3000",
+			fetch: async (input, init) => {
+				if (String(input).endsWith("/channels/config")) {
+					return Response.json({
+						transport: "sse",
+						channels: {
+							destroy: { pattern: "destroy", visibility: "public" },
+							news: { pattern: "news", visibility: "public" },
+							publish: { pattern: "wire-publish", visibility: "public" },
+						},
+					});
+				}
+				if (String(input).endsWith("/channels/publish")) {
+					publishRequests.push(init ?? {});
+					return Response.json({ eventId: "event-1" });
+				}
+				throw new Error(`Unexpected request: ${String(input)}`);
+			},
 		});
+
+		await client.channels.news.publish("updated", { id: "one" });
+		await client.channels.publish.publish({
+			event: "message",
+			data: { text: "legacy client channel name" },
+		});
+		expect(publishRequests).toHaveLength(2);
+		client.channels.destroy();
+	});
+
+	test("does not turn the client facade into a thenable", async () => {
+		const client = createClient<any>({
+			baseURL: "http://localhost:3000",
+			fetch: async () => {
+				throw new Error("thenable checks must not initialize the transport");
+			},
+		});
+
+		expect(Reflect.get(client.channels, "then")).toBeUndefined();
+		await expect(Promise.resolve(client.channels)).resolves.toBe(
+			client.channels,
+		);
 		client.channels.destroy();
 	});
 

--- a/packages/questpie/test/codegen/template.test.ts
+++ b/packages/questpie/test/codegen/template.test.ts
@@ -259,7 +259,7 @@ describe("generateTemplate — minimal (modules.ts only)", () => {
 	it("emits channels in the app and client config types", () => {
 		expect(code).toContain("export type AppChannels = _ModuleChannels;");
 		expect(code).toContain("\tchannels: AppChannels;");
-		expect(code).toContain("\tchannels: ChannelsService<AppChannels>;");
+		expect(code).toContain("\tchannels: Channels<AppChannels>;");
 		expect(code).toContain(
 			'Omit<QuestpieConfig, "app" | "db" | "collections" | "channels"',
 		);

--- a/packages/questpie/test/integration/channel-routes.test.ts
+++ b/packages/questpie/test/integration/channel-routes.test.ts
@@ -6,6 +6,7 @@ import { collection } from "../../src/exports/index.js";
 import { createFetchHandler } from "../../src/server/adapters/http.js";
 import { channel } from "../../src/server/channels/channel-builder.js";
 import { ChannelTokenBucketLimiter } from "../../src/server/channels/security.js";
+import { createChannels } from "../../src/server/channels/service.js";
 import { questpieChannelAuthorityRevocationTable } from "../../src/server/modules/core/integrated/realtime/collection.js";
 import type { RealtimeObservation } from "../../src/server/modules/core/integrated/realtime/observer.js";
 import type { PusherProvider } from "../../src/server/modules/core/integrated/realtime/pusher-transport.js";
@@ -653,15 +654,14 @@ describe("channel module routes", () => {
 			identityKey: "provider-secret",
 		});
 		const allowedSpaces = new Set(["a", "b"]);
+		const definitions = {
+			space: channel("space-[spaceId]").authorize(
+				({ params, allowedSpaces: current }: any) =>
+					current.has(params.spaceId),
+			),
+		};
 		const setup = await buildMockApp(
-			{
-				channels: {
-					space: channel("space-[spaceId]").authorize(
-						({ params, allowedSpaces: current }: any) =>
-							current.has(params.spaceId),
-					),
-				},
-			},
+			{ channels: definitions },
 			{
 				app: { url: "https://app.example.com" },
 				realtime: {
@@ -683,10 +683,18 @@ describe("channel module routes", () => {
 		});
 
 		allowedSpaces.delete("a");
-		await setup.app.realtime!.revokeChannelAuthority({
-			channel: "private-space-a",
-			subject: { kind: "user", id: "user-1" },
-			idempotencyKey: "space-a:user-1:membership-v3",
+		const channels = createChannels(definitions, setup.app.realtime!, {
+			accessMode: "system",
+			db: setup.app.db,
+		} as any);
+		await expect(
+			channels.space({ spaceId: "a" }).invalidateAuthority({
+				subject: { kind: "user", id: "user-1" },
+				idempotencyKey: "space-a:user-1:membership-v3",
+			}),
+		).resolves.toEqual({
+			generation: 1,
+			transportEffect: "principal-connections",
 		});
 		expect(terminated).toHaveLength(1);
 

--- a/packages/questpie/test/integration/realtime-channel-reconciliation.test.ts
+++ b/packages/questpie/test/integration/realtime-channel-reconciliation.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
 
 import { opaqueChannelAuthoritySubject } from "../../src/server/channels/authority.js";
+import { channel } from "../../src/server/channels/channel-builder.js";
+import { createChannels } from "../../src/server/channels/service.js";
 import type {
 	ClientCloseReason,
 	ClientSink,
@@ -20,8 +22,11 @@ async function waitFor(assertion: () => boolean): Promise<void> {
 describe("default SSE channel reconciliation", () => {
 	test("a demand-driven ledger poll heals a dropped authority wake and stops with the last binding", async () => {
 		const database = await createTestDb();
+		const definitions = {
+			space: channel("space-[spaceId]").authorize(true),
+		};
 		const revoker = await buildMockApp(
-			{},
+			{ channels: definitions },
 			{
 				db: { pglite: database },
 				realtime: {
@@ -107,10 +112,18 @@ describe("default SSE channel reconciliation", () => {
 			expect(topologyStarts).toBe(0);
 
 			authorized = false;
-			await revoker.app.realtime.revokeChannelAuthority({
-				channel: "private-space-a",
-				subject: { kind: "user", id: "user-1" },
-				idempotencyKey: "space-a:user-1:dropped-wake",
+			const channels = createChannels(definitions, revoker.app.realtime, {
+				accessMode: "system",
+				db: revoker.app.db,
+			} as any);
+			await expect(
+				channels.space({ spaceId: "a" }).invalidateAuthority({
+					subject: { kind: "user", id: "user-1" },
+					idempotencyKey: "space-a:user-1:dropped-wake",
+				}),
+			).resolves.toEqual({
+				generation: 1,
+				transportEffect: "exact-binding",
 			});
 			expect(closeReasons).toEqual([]);
 			await waitFor(() => closeReasons.length === 1);

--- a/packages/questpie/test/integration/realtime.test.ts
+++ b/packages/questpie/test/integration/realtime.test.ts
@@ -3577,6 +3577,47 @@ describe("realtime matrix", () => {
 			);
 		});
 
+		it("isolates separate sessions for the same user by default", async () => {
+			const adapter = new MockChangeBroker();
+			let pipelineRuns = 0;
+			const items = collection("items")
+				.fields(({ f }) => ({ name: f.textarea().required() }))
+				.hooks({ beforeRead: () => void (pipelineRuns += 1) })
+				.access({ read: true });
+			setup = await buildMockApp(
+				{ collections: { items } },
+				{ realtime: { changeBroker: adapter } },
+			);
+			await runTestDbMigrations(setup.app);
+
+			const sessions = [
+				createMockSession({ id: "alice" }),
+				createMockSession({ id: "alice" }),
+			];
+			const readers = await Promise.all(
+				sessions.map(async (session) => {
+					const response = await realtimeSubscribe(
+						setup.app,
+						createRealtimeRequest([collectionTopic("items")]),
+						{},
+						{
+							appContext: createTestContext({
+								session: session as any,
+								accessMode: "user",
+							}),
+						},
+						{ accessMode: "user" },
+					);
+					const reader = createSSEReader(response.body!);
+					await reader.readSnapshot();
+					return reader;
+				}),
+			);
+
+			expect(pipelineRuns).toBe(2);
+			await Promise.all(readers.map((reader) => reader.close()));
+		});
+
 		it("isolates row, field, and afterRead output between principals", async () => {
 			const adapter = new MockChangeBroker();
 			const documents = collection("documents")

--- a/packages/questpie/test/types/channel-builder.test-d.ts
+++ b/packages/questpie/test/types/channel-builder.test-d.ts
@@ -6,7 +6,7 @@ import {
 	type ChannelParamsOf,
 	type ExtractChannelParams,
 } from "#questpie/server/channels/channel-builder.js";
-import type { ChannelsService } from "#questpie/server/channels/service.js";
+import type { Channels } from "#questpie/server/channels/service.js";
 
 import type { Equal, Expect } from "./type-test-utils.js";
 
@@ -21,6 +21,10 @@ type _noParams = Expect<Equal<ExtractChannelParams<"news">, {}>>;
 const publicNews = channel("news").events({
 	updated: z.object({ id: z.string(), count: z.number() }),
 });
+const contextChannel = channel("wire-context").events({
+	message: z.object({ text: z.string() }),
+});
+const thenChannel = channel("wire-then");
 const privateRoom = channel("room-[roomId]")
 	.events({
 		message: z.object({ text: z.string() }),
@@ -54,10 +58,36 @@ type _events = Expect<
 channel("public-presence").presence(() => ({ id: "x" }));
 
 type AppChannels = {
+	context: typeof contextChannel;
 	news: typeof publicNews;
 	room: typeof privateRoom;
+	then: typeof thenChannel;
 };
-declare const channels: ChannelsService<AppChannels>;
+declare const channels: Channels<AppChannels>;
+
+channels.news.publish("updated", { id: "1", count: 1 });
+channels.context.publish("message", { text: "registry first" });
+// @ts-expect-error the facade must never become a Promise-like thenable
+channels.then;
+const room = channels.room({ roomId: "one" });
+room.publish("message", { text: "hello" });
+const boundPresence = room.resolvePresence();
+type _boundPresence = Expect<
+	Equal<Awaited<typeof boundPresence>, { id: string; roomId: string }>
+>;
+room.invalidateAuthority({
+	subject: { kind: "user", id: "user-1" },
+	idempotencyKey: "room-one:user-1:v1",
+});
+
+// @ts-expect-error parametric channel requires its complete params
+channels.room();
+// @ts-expect-error unknown param
+channels.room({ room: "one" });
+// @ts-expect-error wrong bound event payload
+room.publish("message", { text: 123 });
+// @ts-expect-error unknown bound event
+room.publish("typing", { text: "hello" });
 
 channels.publish("news", {
 	event: "updated",

--- a/packages/questpie/test/types/channel-client.test-d.ts
+++ b/packages/questpie/test/types/channel-client.test-d.ts
@@ -8,6 +8,10 @@ import type { Equal, Expect } from "./type-test-utils.js";
 const news = channel("news").events({
 	metric: z.object({ value: z.string().transform(Number) }),
 });
+const publish = channel("wire-publish").events({
+	message: z.object({ text: z.string() }),
+});
+const thenChannel = channel("wire-then");
 const room = channel("room-[roomId]")
 	.events({
 		message: z.object({ text: z.string() }),
@@ -18,7 +22,12 @@ const room = channel("room-[roomId]")
 
 type App = {
 	collections: {};
-	channels: { news: typeof news; room: typeof room };
+	channels: {
+		news: typeof news;
+		publish: typeof publish;
+		room: typeof room;
+		then: typeof thenChannel;
+	};
 	globals: {};
 	routes: {};
 };
@@ -54,6 +63,29 @@ client.channels.room.publish({
 	event: "message",
 	data: { text: "hello" },
 });
+
+client.channels.news.publish("metric", { value: "42" });
+client.channels.publish.publish({
+	event: "message",
+	data: { text: "legacy client channel name" },
+});
+// @ts-expect-error the facade must never become a Promise-like thenable
+client.channels.then;
+const boundRoom = client.channels.room({ roomId: "one" });
+boundRoom.publish("message", { text: "hello" });
+boundRoom.subscribe((message) => {
+	type _boundMessage = Expect<
+		Equal<typeof message, ChannelMessage<typeof room>>
+	>;
+});
+boundRoom.presence();
+
+// @ts-expect-error bound params are required
+client.channels.room();
+// @ts-expect-error wrong bound param key
+client.channels.room({ id: "one" });
+// @ts-expect-error bound payload remains schema-typed
+boundRoom.publish("typing", { active: "yes" });
 
 const roomMessages = client.channels.room.iter({ roomId: "one" });
 type _iterMessage = Expect<

--- a/packages/questpie/test/units/channel-builder.test.ts
+++ b/packages/questpie/test/units/channel-builder.test.ts
@@ -6,7 +6,10 @@ import {
 	channel,
 	resolveChannelName,
 } from "../../src/server/channels/channel-builder.js";
-import { ChannelsService } from "../../src/server/channels/service.js";
+import {
+	createChannels,
+	ChannelsService,
+} from "../../src/server/channels/service.js";
 import { extractAppServices } from "../../src/server/config/app-context.js";
 import { buildMockApp } from "../utils/mocks/mock-app-builder.js";
 
@@ -67,6 +70,11 @@ describe("channel ChannelsService", () => {
 				{ roomId: "one" },
 				"subscribe",
 			),
+		).toBe(true);
+		expect(
+			await (ctx.channels as any)
+				.room({ roomId: "one" })
+				.authorize("subscribe"),
 		).toBe(true);
 		await setup.cleanup();
 	});
@@ -245,6 +253,129 @@ describe("channel ChannelsService", () => {
 			scope: "principal-connections",
 			generation: 1,
 		});
+	});
+
+	test("binds params once for publish and authority invalidation", async () => {
+		const definitions = {
+			room: channel("room-[roomId]")
+				.events({ message: z.object({ text: z.string() }) })
+				.authorize(() => true),
+		};
+		const publishes: unknown[] = [];
+		const revocations: unknown[] = [];
+		const channels = createChannels(
+			definitions,
+			{
+				appendChannelEvent: async (input) => {
+					publishes.push(input);
+					return { eventId: "event-1" };
+				},
+				revokeChannelAuthority: async (input) => {
+					revocations.push(input);
+					return { scope: "exact-subscription", generation: 3 };
+				},
+			},
+			userContext,
+		);
+
+		const params = { roomId: "one" };
+		const room = channels.room(params);
+		params.roomId = "two";
+		await expect(room.publish("message", { text: "hello" })).resolves.toEqual({
+			eventId: "event-1",
+		});
+		await expect(
+			room.invalidateAuthority({
+				subject: { kind: "user", id: "user-2" },
+				idempotencyKey: "room-one:user-2:v3",
+			}),
+		).resolves.toEqual({
+			generation: 3,
+			transportEffect: "exact-binding",
+		});
+
+		expect(publishes).toEqual([
+			expect.objectContaining({
+				channel: "private-room-one",
+				event: "message",
+				data: { text: "hello" },
+			}),
+		]);
+		expect(revocations).toEqual([
+			{
+				channel: "private-room-one",
+				subject: { kind: "user", id: "user-2" },
+				idempotencyKey: "room-one:user-2:v3",
+			},
+		]);
+	});
+
+	test("keeps legacy root methods when registry keys collide with the facade", async () => {
+		const frames: unknown[] = [];
+		const channels = createChannels(
+			{
+				publish: channel("wire-publish")
+					.events({ message: z.object({ text: z.string() }) })
+					.authorize(() => true),
+			},
+			{
+				appendChannelEvent: async (input) => {
+					frames.push(input);
+					return { eventId: "event-1" };
+				},
+			},
+			userContext,
+		);
+
+		await channels.publish("publish", {
+			params: {},
+			event: "message",
+			data: { text: "legacy" },
+		});
+		expect(frames).toEqual([
+			expect.objectContaining({
+				channel: "private-wire-publish",
+				event: "message",
+			}),
+		]);
+	});
+
+	test("projects channel handles over private service member names", async () => {
+		const frames: unknown[] = [];
+		const channels = createChannels(
+			{
+				context: channel("wire-context")
+					.events({ message: z.object({ text: z.string() }) })
+					.authorize(() => true),
+			},
+			{
+				appendChannelEvent: async (input) => {
+					frames.push(input);
+					return { eventId: "event-1" };
+				},
+			},
+			userContext,
+		);
+
+		await channels.context.publish("message", { text: "registry first" });
+		expect(frames).toEqual([
+			expect.objectContaining({
+				channel: "private-wire-context",
+				event: "message",
+			}),
+		]);
+	});
+
+	test("does not turn the server facade into a thenable", async () => {
+		const channels = createChannels(
+			// oxlint-disable-next-line unicorn/no-thenable -- exercises a hostile registry key
+			Object.fromEntries([["then", channel("wire-then")]]),
+			{ appendChannelEvent: async () => ({ eventId: "unused" }) },
+			userContext,
+		);
+
+		expect(Reflect.get(channels, "then")).toBeUndefined();
+		await expect(Promise.resolve(channels)).resolves.toBe(channels);
 	});
 
 	test("publishes a batch in input order", async () => {

--- a/packages/questpie/test/units/realtime-refresh-scheduler.test.ts
+++ b/packages/questpie/test/units/realtime-refresh-scheduler.test.ts
@@ -877,7 +877,7 @@ describe("realtime scheduler", () => {
 });
 
 describe("realtime scheduler access keys", () => {
-	it("isolates stable principal, scope, and locale identity", async () => {
+	it("isolates sessions by default and shares only through an explicit key", async () => {
 		const base = {
 			locale: "en",
 			stage: "published",
@@ -903,13 +903,34 @@ describe("realtime scheduler access keys", () => {
 		const aliceDefault = await resolveRealtimeAccessKey("edge-a", alice);
 		const bobDefault = await resolveRealtimeAccessKey("edge-b", bob);
 		expect(aliceDefault).not.toBe(bobDefault);
+		const oauth = {
+			...base,
+			principal: {
+				kind: "oauth" as const,
+				user: { id: "carol" },
+				clientId: "client",
+				scopes: ["read"],
+				tokenId: "token-carol",
+			},
+		};
+		expect(await resolveRealtimeAccessKey("edge-oauth", oauth as any)).not.toBe(
+			await resolveRealtimeAccessKey("edge-oauth", {
+				...oauth,
+				principal: { ...oauth.principal, tokenId: "token-other" },
+			} as any),
+		);
+		const aliceOtherSession = await resolveRealtimeAccessKey("edge-c", {
+			...alice,
+			principal: {
+				...alice.principal,
+				session: { id: "session-c" },
+			},
+		});
+		expect(aliceOtherSession).not.toBe(aliceDefault);
 		expect(
 			await resolveRealtimeAccessKey("edge-c", {
 				...alice,
-				principal: {
-					...alice.principal,
-					session: { id: "session-c" },
-				},
+				principal: { ...alice.principal },
 			}),
 		).toBe(aliceDefault);
 		expect(
@@ -932,8 +953,15 @@ describe("realtime scheduler access keys", () => {
 		);
 
 		const resolver = async () => "public-read";
-		expect(await resolveRealtimeAccessKey("edge-a", alice, resolver)).toBe(
+		const shared = await resolveRealtimeAccessKey("edge-a", alice, resolver);
+		expect(shared).toBe(
 			await resolveRealtimeAccessKey("edge-b", bob, resolver),
+		);
+		expect(shared).toBe(
+			await resolveRealtimeAccessKey("edge-oauth", oauth as any, resolver),
+		);
+		expect(shared).toBe(
+			await resolveRealtimeAccessKey("edge-anonymous", base, resolver),
 		);
 
 		const failingResolver = async () => {

--- a/packages/tanstack-query/src/index.ts
+++ b/packages/tanstack-query/src/index.ts
@@ -162,7 +162,7 @@ type GlobalKeys<TApp extends QuestpieApp> = Extract<
 /** Extract generated channel registry keys without client control properties. */
 type ChannelKeys<TApp extends QuestpieApp> = Extract<
 	keyof NonNullable<TApp["channels"]>,
-	string
+	keyof QuestpieClient<TApp>["channels"]
 >;
 
 type ChannelIter<

--- a/scripts/any-census.json
+++ b/scripts/any-census.json
@@ -58,7 +58,7 @@
 		"questpie": {
 			": any": 544,
 			"as any": 464,
-			"as unknown as": 50,
+			"as unknown as": 49,
 			"@ts-expect-error": 0
 		},
 		"sandbox": {

--- a/skills/questpie/AGENTS.md
+++ b/skills/questpie/AGENTS.md
@@ -6394,7 +6394,7 @@ The resolved Channel plus subject is the complete target; no second authority
 scope is attached. SSE reports `exact-binding`. Pusher's honest transport effect
 is `principal-connections`: it terminates current connections for that user,
 then fresh user/channel authentication allows still-authorized bindings to
-return. The old root `revokeAuthority()` remains a deprecated 3.x forward to the
+return. The old root `revokeAuthority()` remains a 3.x forward to the
 same ledger. See `references/channels.md` for commit, retry, and in-flight-frame
 contracts.
 
@@ -6435,7 +6435,7 @@ row.
 - Derive request-selected tenant/workspace state in `appConfig.context`, validate
   it there, and enforce it in collection/global read access. Realtime runs the
   same authorized CRUD pipeline; it adds no tenant filter.
-- `realtime.subscriptionScope` is deprecated in 3.x and removed in 4.0. It was
+- `realtime.subscriptionScope` is compatibility-only in 3.x and removed in 4.0. It was
   only a global scheduler partition, never authority. Remove it after migrating
   tenant state into context and access.
 - Collection/global `realtime.accessCacheKey` is an explicit proof that output
@@ -6612,7 +6612,7 @@ twice. Reusing that key for a different target or subject is a conflict.
 
 The released root method
 `channels.revokeAuthority("chatRoom", { params, subject, idempotencyKey })`
-remains a deprecated 3.x compatibility forward to the same ledger. New code
+remains a 3.x compatibility forward to the same ledger. New code
 uses the resolved handle.
 
 Pusher does not provide zero-frame atomicity: a frame already accepted by the
@@ -10613,7 +10613,7 @@ or anonymous edge by default. A collection/global `accessCacheKey` can collapse
 instance, but only as an explicit proof that field access, relations, output
 hooks, and `afterRead` produce byte-identical output. Tenant authority belongs
 in `appConfig.context` plus collection/global access; `subscriptionScope` is
-deprecated.
+compatibility-only during 3.x.
 
 ## Checklist
 

--- a/skills/questpie/AGENTS.md
+++ b/skills/questpie/AGENTS.md
@@ -125,8 +125,8 @@ Files starting with `_`, `index.ts`, declaration files, tests, and specs are int
 | CRUD API          | `references/crud-api.md`                | `find`, `create`, `updateById`/`updateMany`, `deleteById`/`deleteMany`, atomic conditional updates, globals API                                                    |
 | Seeds             | `references/seeds.md`                   | `seed()` vs `seed.steps()`, idempotency, checkpointed steps, categories, `dependsOn`, `undo`, `autoSeed`, seed CLI                                                 |
 | Query Operators   | `references/query-operators.md`         | `where` clause operators by field type                                                                                                                             |
-| Realtime          | `references/realtime.md`                | Transactional outbox, reconciliation, live queries, broker/client transport seams, admission                                                                       |
-| Channels          | `references/channels.md`                | Typed application events, authorization, publish contexts, client, presence, TanStack Query                                                                        |
+| Realtime          | `references/realtime.md`                | Transactional outbox, live queries, session-isolated sharing, `accessCacheKey` compute-once fan-out, admission                                                     |
+| Channels          | `references/channels.md`                | Typed resolved handles, exact authority invalidation, events, authorization, client, presence, TanStack Query                                                      |
 | Collaboration     | `references/collaborative-documents.md` | Collection/global CRDT aggregates, Yjs engines, generated client, authority, lifecycle, Fetch + shared realtime transport                                          |
 
 ### Infrastructure
@@ -3660,13 +3660,11 @@ transaction. Their `db` and injected services share that scope. A thrown error
 propagates and rolls back the mutation plus transaction-joined work:
 
 ```ts
-.hooks({
+	.hooks({
 	afterChange: async ({ data, channels }) => {
-		await channels.publish("postActivity", {
-			params: { postId: data.id },
-			event: "changed",
-			data: { id: data.id },
-		});
+		await channels
+			.postActivity({ postId: data.id })
+			.publish("changed", { id: data.id });
 	},
 })
 ```
@@ -6289,7 +6287,10 @@ Enable it with `realtime: true`. Do not write CRUD hooks to emit live-query chan
 3. An unconditional reconciliation poll drains missed outbox rows. Default: 15s with push, 2s without; provider failure tightens to at most 2s.
 4. The server re-runs matching queries under the subscriber's session, including row/field access and `afterRead`, then a `ClientTransport` delivers authorized frames.
 
-The broker is a latency hint; the transactional outbox plus reconciliation is the guarantee. Brokers must never carry rows or snapshots. Equivalent snapshot work is shared per principal by default, never across users unless the application proves deterministic access equivalence.
+The broker is a latency hint; the transactional outbox plus reconciliation is
+the guarantee. Brokers must never carry rows or snapshots. Equivalent snapshot
+work is session-, OAuth-token-, or anonymous-edge-isolated by default. Widen it
+only with an explicit `accessCacheKey` proof of byte-identical output.
 
 ## Client usage
 
@@ -6380,12 +6381,22 @@ both `client.realtime` and
 `client.channels` (or recreate the client) so the shared physical connection is
 also recreated under the new identity.
 
-Channel-scoped authority cuts use the generic `channels.revokeAuthority()` seam.
-SSE closes only the denied logical binding. Pusher's honest capability is
-`principal-connections`: it terminates all current connections for that user,
+Exact Channel authority invalidation uses the resolved handle:
+
+```ts
+await channels.chatRoom({ roomId }).invalidateAuthority({
+	subject: { kind: "user", id: removedUserId },
+	idempotencyKey,
+});
+```
+
+The resolved Channel plus subject is the complete target; no second authority
+scope is attached. SSE reports `exact-binding`. Pusher's honest transport effect
+is `principal-connections`: it terminates current connections for that user,
 then fresh user/channel authentication allows still-authorized bindings to
-return. See `references/channels.md` for the transaction and in-flight-frame
-contract.
+return. The old root `revokeAuthority()` remains a deprecated 3.x forward to the
+same ledger. See `references/channels.md` for commit, retry, and in-flight-frame
+contracts.
 
 ## Admission and lifecycle
 
@@ -6421,16 +6432,15 @@ row.
   `principalId`, `recipientId`, or `audienceId` on ordinary realtime rows.
 - Let TanStack DB compose joins, ordering, limits, and derived live views from
   authorized normalized rows.
-- At admission, freeze only stable principal, server-derived scope, topic
-  locale, stage, and access mode. Never store expanded membership or permission
-  id sets in subscription context.
-- Resolve scope with
-  `realtime.subscriptionScope(({ request }) => request?.headers.get("x-scope-id") ?? null)`.
-  `null` means unscoped; a value is capped at 256 UTF-8 bytes. A scope switch
-  opens a new subscription and bootstraps a fresh client store.
+- Derive request-selected tenant/workspace state in `appConfig.context`, validate
+  it there, and enforce it in collection/global read access. Realtime runs the
+  same authorized CRUD pipeline; it adds no tenant filter.
+- `realtime.subscriptionScope` is deprecated in 3.x and removed in 4.0. It was
+  only a global scheduler partition, never authority. Remove it after migrating
+  tenant state into context and access.
 - Collection/global `realtime.accessCacheKey` is an explicit proof that output
-  may be shared across principals within the frozen scope tuple. Its key is
-  capped at 256 UTF-8 bytes; invalid or throwing resolvers stay edge-isolated.
+  may be shared more widely. Its key is capped at 256 UTF-8 bytes; invalid or
+  throwing resolvers stay edge-isolated.
 - Mutable membership/access stays in the database. Watched-resource changes
   trigger targeted reset; periodic delta re-bootstrap is only the safety net.
 
@@ -6467,8 +6477,16 @@ that `@questpie/tanstack-db` matches optimistic writes against. Typed channels,
 channel presence, and CRDT document sync are unaffected; CRDT canonical
 projection still writes its own outbox row per commit.
 
-A personalized relation query for 100,000 principals in one shared scope can
-cause 100,000 authoritative recomputations. Snapshot fallback is correct but
+A public collection with `accessCacheKey: () => "public:v1"` can compute one
+authorized query per refresh per server instance and fan the bytes out to
+100,000 equivalent subscribers. The key is a proof that field access, relations,
+output hooks, and `afterRead` are byte-identical for every matching context. The
+effective authorized topic, context extension digest, locale, stage, access
+mode, and delivery mode still partition groups. This is a local scheduler
+optimization: ten server replicas may run up to ten computations.
+
+A personalized relation query for 100,000 isolated contexts can still cause
+100,000 authoritative recomputations. Snapshot fallback is correct but
 expensive. Prefer materialized inbox rows with direct `recipientId`, a shared
 typed audience channel, an invalidation/refetch event, or a normal query.
 `bun --cwd packages/questpie run bench:realtime:routing` runs the deterministic
@@ -6533,20 +6551,14 @@ Framework handlers and hooks receive a generated `channels` service:
 
 ```ts
 .handler(async ({ input, channels }) => {
-	return channels.publish("chatRoom", {
-		params: { roomId: input.roomId },
-		event: "message",
-		data: { id: input.id, text: input.text },
-	});
+	const chatRoom = channels.chatRoom({ roomId: input.roomId });
+	return chatRoom.publish("message", { id: input.id, text: input.text });
 });
 
 .hooks({
 	afterChange: [async ({ data, channels }) => {
-		await channels.publish("chatRoom", {
-			params: { roomId: data.roomId },
-			event: "message",
-			data: { id: data.id, text: data.text },
-		});
+		const chatRoom = channels.chatRoom({ roomId: data.roomId });
+		await chatRoom.publish("message", { id: data.id, text: data.text });
 	}],
 });
 ```
@@ -6557,26 +6569,28 @@ mutation and ordered channel-ledger append. Never import the generated `app` or
 defer lookup through ambient `getContext()`; the injected service is
 generated-type-safe and mutation-context aware.
 
-## Revoke current delivery authority
+## Invalidate current delivery authority
 
 When a membership or authorization mutation removes access, cut the affected
 resolved channel in the same transaction:
 
 ```ts
-await channels.revokeAuthority("chatRoom", {
-	params: { roomId },
+const chatRoom = channels.chatRoom({ roomId });
+
+await chatRoom.invalidateAuthority({
 	subject: { kind: "user", id: removedUserId },
 	idempotencyKey: `chat-room:${roomId}:${removedUserId}:membership-v2`,
 });
 ```
 
-The idempotency key identifies the domain authorization transition. QUESTPIE
-advances a durable per-channel/subject generation and returns
-`{ generation, scope }`. `scope: "exact-subscription"` means the local SSE
-binding is cut without closing unrelated channel bindings.
-`scope: "principal-connections"` means the provider can only conservatively
-terminate every current connection for the signed-in user. Pusher supports the
-`user` subject for that capability.
+The resolved handle is the complete authority target: registry definition plus
+validated params. There is no second tenant/workspace scope. The idempotency key
+identifies one domain authorization transition. QUESTPIE advances the existing
+durable per-channel/subject generation and returns
+`{ generation, transportEffect }`. `transportEffect: "exact-binding"` means
+SSE cut only that logical binding. `"principal-connections"` means the provider
+can only terminate every current connection for the signed-in user. Pusher
+supports the `user` subject for that capability.
 
 Fresh request context, subscribe authorization, and the presence resolver (for
 presence channels) run outside database locks. A short expected-generation
@@ -6591,11 +6605,15 @@ post-cut blob is discarded before reaching the client. Thus removing Space A
 may disconnect Space B briefly, but Space B can reconnect while Space A remains
 denied.
 
-In a managed caller transaction, Pusher termination and authority
-acknowledgement run inline under a bounded call. Provider failure throws and
-rolls back the database transaction; a conservative disconnect may survive a
-later caller rollback. Standalone provider failure leaves the durable cut
-pending for an idempotent retry.
+Provider termination runs after the caller's database commit. Rollback does not
+disconnect the principal. Once committed, a pending provider effect is durable;
+retrying the same idempotency key finishes it without advancing the generation
+twice. Reusing that key for a different target or subject is a conflict.
+
+The released root method
+`channels.revokeAuthority("chatRoom", { params, subject, idempotencyKey })`
+remains a deprecated 3.x compatibility forward to the same ledger. New code
+uses the resolved handle.
 
 Pusher does not provide zero-frame atomicity: a frame already accepted by the
 physical provider connection may arrive while termination is in flight. The
@@ -6605,8 +6623,9 @@ cut; reconnect and replay reauthorize against current application state.
 ## Client, presence, and TanStack Query
 
 ```ts
-const stop = client.channels.chatRoom.subscribe(
-	{ roomId },
+const chatRoom = client.channels.chatRoom({ roomId });
+
+const stop = chatRoom.subscribe(
 	(message) => {
 		if (message.event === "message") console.log(message.data.text);
 	},
@@ -6617,17 +6636,10 @@ const stop = client.channels.chatRoom.subscribe(
 	},
 );
 
-await client.channels.chatRoom.publish({
-	params: { roomId },
-	event: "typing",
-	data: { active: true },
-});
+await chatRoom.publish("typing", { active: true });
 
-const members = await client.channels.chatRoom.presence({ roomId });
-const stopPresence = client.channels.chatRoom.subscribePresence(
-	{ roomId },
-	onMembers,
-);
+const members = await chatRoom.presence();
+const stopPresence = chatRoom.subscribePresence(onMembers);
 stop();
 stopPresence();
 ```
@@ -6643,7 +6655,7 @@ cleanup, and later reconnects.
 
 `presence()` returns one typed snapshot. `subscribePresence()` emits the initial and later rosters, and `presenceIter(params, { signal })` provides the async-generator form. Pusher/Soketi uses native membership; SSE uses Postgres leases across instances and deduplicates multiple connections by authenticated principal. Crash leave converges after the lease TTL.
 
-Async consumers use `client.channels.chatRoom.iter(params, { signal })`. TanStack Query exposes an accumulating event query:
+Async consumers use `chatRoom.iter({ signal })`. TanStack Query exposes an accumulating event query:
 
 ```tsx
 const { data: messages = [] } = useQuery(
@@ -10564,12 +10576,10 @@ Throttle noisy producers such as cursor/typing updates, keep payloads small, and
 `.authorize(...).presence(resolver)` creates a typed presence channel. The client can read once, subscribe, iterate, or use a latest-snapshot TanStack query:
 
 ```ts
-const members = await client.channels.chatRoom.presence({ roomId });
-const stop = client.channels.chatRoom.subscribePresence({ roomId }, onMembers);
-for await (const members of client.channels.chatRoom.presenceIter(
-	{ roomId },
-	{ signal },
-)) {
+const chatRoom = client.channels.chatRoom({ roomId });
+const members = await chatRoom.presence();
+const stop = chatRoom.subscribePresence(onMembers);
+for await (const members of chatRoom.presenceIter({ signal })) {
 	onMembers(members);
 }
 ```
@@ -10597,7 +10607,13 @@ client.channels.channelCount;
 client.channels.subscriberCount;
 ```
 
-Equivalent server refresh work is shared per principal by default. Never share across principals without proving deterministic row/field access and `afterRead` equivalence.
+Equivalent server refresh work is isolated by authenticated session, OAuth token,
+or anonymous edge by default. A collection/global `accessCacheKey` can collapse
+100,000 equivalent subscribers into one computation per refresh per server
+instance, but only as an explicit proof that field access, relations, output
+hooks, and `afterRead` produce byte-identical output. Tenant authority belongs
+in `appConfig.context` plus collection/global access; `subscriptionScope` is
+deprecated.
 
 ## Checklist
 

--- a/skills/questpie/AGENTS.md
+++ b/skills/questpie/AGENTS.md
@@ -6549,6 +6549,12 @@ Authorization rules:
 
 Framework handlers and hooks receive a generated `channels` service:
 
+Server facade member names are reserved for canonical handle projection;
+existing server collisions keep working through the root API during
+3.x. Client channels only collide with actual controls such as `destroy`,
+`channelCount`, and `subscriberCount`. Rename a colliding file/export to adopt
+handles; keep the wire pattern unchanged.
+
 ```ts
 .handler(async ({ input, channels }) => {
 	const chatRoom = channels.chatRoom({ roomId: input.roomId });
@@ -6605,14 +6611,16 @@ post-cut blob is discarded before reaching the client. Thus removing Space A
 may disconnect Space B briefly, but Space B can reconnect while Space A remains
 denied.
 
-Provider termination runs after the caller's database commit. Rollback does not
-disconnect the principal. Once committed, a pending provider effect is durable;
-retrying the same idempotency key finishes it without advancing the generation
-twice. Reusing that key for a different target or subject is a conflict.
+In a managed caller transaction, Pusher termination and authority
+acknowledgement run inline under a bounded call. Provider failure throws and
+rolls back the database transaction; a conservative disconnect may survive a
+later caller rollback. Standalone provider failure leaves the durable cut
+pending for an idempotent retry. Reusing the same key for another target or
+subject is a conflict.
 
 The released root method
 `channels.revokeAuthority("chatRoom", { params, subject, idempotencyKey })`
-remains a 3.x compatibility forward to the same ledger. New code
+remains a 3.x compatibility entry point backed by the same ledger. New code
 uses the resolved handle.
 
 Pusher does not provide zero-frame atomicity: a frame already accepted by the

--- a/skills/questpie/SKILL.md
+++ b/skills/questpie/SKILL.md
@@ -128,8 +128,8 @@ Files starting with `_`, `index.ts`, declaration files, tests, and specs are int
 | CRUD API          | `references/crud-api.md`                | `find`, `create`, `updateById`/`updateMany`, `deleteById`/`deleteMany`, atomic conditional updates, globals API                                                    |
 | Seeds             | `references/seeds.md`                   | `seed()` vs `seed.steps()`, idempotency, checkpointed steps, categories, `dependsOn`, `undo`, `autoSeed`, seed CLI                                                 |
 | Query Operators   | `references/query-operators.md`         | `where` clause operators by field type                                                                                                                             |
-| Realtime          | `references/realtime.md`                | Transactional outbox, reconciliation, live queries, broker/client transport seams, admission                                                                       |
-| Channels          | `references/channels.md`                | Typed application events, authorization, publish contexts, client, presence, TanStack Query                                                                        |
+| Realtime          | `references/realtime.md`                | Transactional outbox, live queries, session-isolated sharing, `accessCacheKey` compute-once fan-out, admission                                                     |
+| Channels          | `references/channels.md`                | Typed resolved handles, exact authority invalidation, events, authorization, client, presence, TanStack Query                                                      |
 | Collaboration     | `references/collaborative-documents.md` | Collection/global CRDT aggregates, Yjs engines, generated client, authority, lifecycle, Fetch + shared realtime transport                                          |
 
 ### Infrastructure

--- a/skills/questpie/coverage.json
+++ b/skills/questpie/coverage.json
@@ -165,6 +165,7 @@
 		"createCollectionValidationSchemas": "validation engine internal",
 		"createCompletedStepsMap": "workflow engine internal",
 		"createComponentCallbackProxy": "server-driven admin UI internal",
+		"createChannels": "service wiring behind generated ctx.channels; applications use the resolved registry handles",
 		"createContextFactory": "only consumed by generated code (.generated/index.ts)",
 		"createCrdtClientAPI": "client factory wiring behind createClient()",
 		"createFieldBuilder": "builder engine internal",

--- a/skills/questpie/references/channels.md
+++ b/skills/questpie/references/channels.md
@@ -51,7 +51,7 @@ Authorization rules:
 Framework handlers and hooks receive a generated `channels` service:
 
 Server facade member names are reserved for canonical handle projection;
-existing server collisions keep working through the deprecated root API in
+existing server collisions keep working through the root API during
 3.x. Client channels only collide with actual controls such as `destroy`,
 `channelCount`, and `subscriberCount`. Rename a colliding file/export to adopt
 handles; keep the wire pattern unchanged.
@@ -121,7 +121,7 @@ subject is a conflict.
 
 The released root method
 `channels.revokeAuthority("chatRoom", { params, subject, idempotencyKey })`
-remains a deprecated 3.x compatibility entry point backed by the same ledger. New code
+remains a 3.x compatibility entry point backed by the same ledger. New code
 uses the resolved handle.
 
 Pusher does not provide zero-frame atomicity: a frame already accepted by the

--- a/skills/questpie/references/channels.md
+++ b/skills/questpie/references/channels.md
@@ -50,22 +50,22 @@ Authorization rules:
 
 Framework handlers and hooks receive a generated `channels` service:
 
+Server facade member names are reserved for canonical handle projection;
+existing server collisions keep working through the deprecated root API in
+3.x. Client channels only collide with actual controls such as `destroy`,
+`channelCount`, and `subscriberCount`. Rename a colliding file/export to adopt
+handles; keep the wire pattern unchanged.
+
 ```ts
 .handler(async ({ input, channels }) => {
-	return channels.publish("chatRoom", {
-		params: { roomId: input.roomId },
-		event: "message",
-		data: { id: input.id, text: input.text },
-	});
+	const chatRoom = channels.chatRoom({ roomId: input.roomId });
+	return chatRoom.publish("message", { id: input.id, text: input.text });
 });
 
 .hooks({
 	afterChange: [async ({ data, channels }) => {
-		await channels.publish("chatRoom", {
-			params: { roomId: data.roomId },
-			event: "message",
-			data: { id: data.id, text: data.text },
-		});
+		const chatRoom = channels.chatRoom({ roomId: data.roomId });
+		await chatRoom.publish("message", { id: data.id, text: data.text });
 	}],
 });
 ```
@@ -76,26 +76,28 @@ mutation and ordered channel-ledger append. Never import the generated `app` or
 defer lookup through ambient `getContext()`; the injected service is
 generated-type-safe and mutation-context aware.
 
-## Revoke current delivery authority
+## Invalidate current delivery authority
 
 When a membership or authorization mutation removes access, cut the affected
 resolved channel in the same transaction:
 
 ```ts
-await channels.revokeAuthority("chatRoom", {
-	params: { roomId },
+const chatRoom = channels.chatRoom({ roomId });
+
+await chatRoom.invalidateAuthority({
 	subject: { kind: "user", id: removedUserId },
 	idempotencyKey: `chat-room:${roomId}:${removedUserId}:membership-v2`,
 });
 ```
 
-The idempotency key identifies the domain authorization transition. QUESTPIE
-advances a durable per-channel/subject generation and returns
-`{ generation, scope }`. `scope: "exact-subscription"` means the local SSE
-binding is cut without closing unrelated channel bindings.
-`scope: "principal-connections"` means the provider can only conservatively
-terminate every current connection for the signed-in user. Pusher supports the
-`user` subject for that capability.
+The resolved handle is the complete authority target: registry definition plus
+validated params. There is no second tenant/workspace scope. The idempotency key
+identifies one domain authorization transition. QUESTPIE advances the existing
+durable per-channel/subject generation and returns
+`{ generation, transportEffect }`. `transportEffect: "exact-binding"` means
+SSE cut only that logical binding. `"principal-connections"` means the provider
+can only terminate every current connection for the signed-in user. Pusher
+supports the `user` subject for that capability.
 
 Fresh request context, subscribe authorization, and the presence resolver (for
 presence channels) run outside database locks. A short expected-generation
@@ -114,7 +116,13 @@ In a managed caller transaction, Pusher termination and authority
 acknowledgement run inline under a bounded call. Provider failure throws and
 rolls back the database transaction; a conservative disconnect may survive a
 later caller rollback. Standalone provider failure leaves the durable cut
-pending for an idempotent retry.
+pending for an idempotent retry. Reusing the same key for another target or
+subject is a conflict.
+
+The released root method
+`channels.revokeAuthority("chatRoom", { params, subject, idempotencyKey })`
+remains a deprecated 3.x compatibility entry point backed by the same ledger. New code
+uses the resolved handle.
 
 Pusher does not provide zero-frame atomicity: a frame already accepted by the
 physical provider connection may arrive while termination is in flight. The
@@ -124,8 +132,9 @@ cut; reconnect and replay reauthorize against current application state.
 ## Client, presence, and TanStack Query
 
 ```ts
-const stop = client.channels.chatRoom.subscribe(
-	{ roomId },
+const chatRoom = client.channels.chatRoom({ roomId });
+
+const stop = chatRoom.subscribe(
 	(message) => {
 		if (message.event === "message") console.log(message.data.text);
 	},
@@ -136,17 +145,10 @@ const stop = client.channels.chatRoom.subscribe(
 	},
 );
 
-await client.channels.chatRoom.publish({
-	params: { roomId },
-	event: "typing",
-	data: { active: true },
-});
+await chatRoom.publish("typing", { active: true });
 
-const members = await client.channels.chatRoom.presence({ roomId });
-const stopPresence = client.channels.chatRoom.subscribePresence(
-	{ roomId },
-	onMembers,
-);
+const members = await chatRoom.presence();
+const stopPresence = chatRoom.subscribePresence(onMembers);
 stop();
 stopPresence();
 ```
@@ -162,7 +164,7 @@ cleanup, and later reconnects.
 
 `presence()` returns one typed snapshot. `subscribePresence()` emits the initial and later rosters, and `presenceIter(params, { signal })` provides the async-generator form. Pusher/Soketi uses native membership; SSE uses Postgres leases across instances and deduplicates multiple connections by authenticated principal. Crash leave converges after the lease TTL.
 
-Async consumers use `client.channels.chatRoom.iter(params, { signal })`. TanStack Query exposes an accumulating event query:
+Async consumers use `chatRoom.iter({ signal })`. TanStack Query exposes an accumulating event query:
 
 ```tsx
 const { data: messages = [] } = useQuery(

--- a/skills/questpie/references/reactive-apps.md
+++ b/skills/questpie/references/reactive-apps.md
@@ -64,12 +64,10 @@ Throttle noisy producers such as cursor/typing updates, keep payloads small, and
 `.authorize(...).presence(resolver)` creates a typed presence channel. The client can read once, subscribe, iterate, or use a latest-snapshot TanStack query:
 
 ```ts
-const members = await client.channels.chatRoom.presence({ roomId });
-const stop = client.channels.chatRoom.subscribePresence({ roomId }, onMembers);
-for await (const members of client.channels.chatRoom.presenceIter(
-	{ roomId },
-	{ signal },
-)) {
+const chatRoom = client.channels.chatRoom({ roomId });
+const members = await chatRoom.presence();
+const stop = chatRoom.subscribePresence(onMembers);
+for await (const members of chatRoom.presenceIter({ signal })) {
 	onMembers(members);
 }
 ```
@@ -97,7 +95,13 @@ client.channels.channelCount;
 client.channels.subscriberCount;
 ```
 
-Equivalent server refresh work is shared per principal by default. Never share across principals without proving deterministic row/field access and `afterRead` equivalence.
+Equivalent server refresh work is isolated by authenticated session, OAuth token,
+or anonymous edge by default. A collection/global `accessCacheKey` can collapse
+100,000 equivalent subscribers into one computation per refresh per server
+instance, but only as an explicit proof that field access, relations, output
+hooks, and `afterRead` produce byte-identical output. Tenant authority belongs
+in `appConfig.context` plus collection/global access; `subscriptionScope` is
+deprecated.
 
 ## Checklist
 

--- a/skills/questpie/references/reactive-apps.md
+++ b/skills/questpie/references/reactive-apps.md
@@ -101,7 +101,7 @@ or anonymous edge by default. A collection/global `accessCacheKey` can collapse
 instance, but only as an explicit proof that field access, relations, output
 hooks, and `afterRead` produce byte-identical output. Tenant authority belongs
 in `appConfig.context` plus collection/global access; `subscriptionScope` is
-deprecated.
+compatibility-only during 3.x.
 
 ## Checklist
 

--- a/skills/questpie/references/realtime.md
+++ b/skills/questpie/references/realtime.md
@@ -130,7 +130,7 @@ The resolved Channel plus subject is the complete target; no second authority
 scope is attached. SSE reports `exact-binding`. Pusher's honest transport effect
 is `principal-connections`: it terminates current connections for that user,
 then fresh user/channel authentication allows still-authorized bindings to
-return. The old root `revokeAuthority()` remains a deprecated 3.x forward to the
+return. The old root `revokeAuthority()` remains a 3.x forward to the
 same ledger. See `references/channels.md` for commit, retry, and in-flight-frame
 contracts.
 
@@ -171,7 +171,7 @@ row.
 - Derive request-selected tenant/workspace state in `appConfig.context`, validate
   it there, and enforce it in collection/global read access. Realtime runs the
   same authorized CRUD pipeline; it adds no tenant filter.
-- `realtime.subscriptionScope` is deprecated in 3.x and removed in 4.0. It was
+- `realtime.subscriptionScope` is compatibility-only in 3.x and removed in 4.0. It was
   only a global scheduler partition, never authority. Remove it after migrating
   tenant state into context and access.
 - Collection/global `realtime.accessCacheKey` is an explicit proof that output

--- a/skills/questpie/references/realtime.md
+++ b/skills/questpie/references/realtime.md
@@ -23,7 +23,10 @@ Enable it with `realtime: true`. Do not write CRUD hooks to emit live-query chan
 3. An unconditional reconciliation poll drains missed outbox rows. Default: 15s with push, 2s without; provider failure tightens to at most 2s.
 4. The server re-runs matching queries under the subscriber's session, including row/field access and `afterRead`, then a `ClientTransport` delivers authorized frames.
 
-The broker is a latency hint; the transactional outbox plus reconciliation is the guarantee. Brokers must never carry rows or snapshots. Equivalent snapshot work is shared per principal by default, never across users unless the application proves deterministic access equivalence.
+The broker is a latency hint; the transactional outbox plus reconciliation is
+the guarantee. Brokers must never carry rows or snapshots. Equivalent snapshot
+work is session-, OAuth-token-, or anonymous-edge-isolated by default. Widen it
+only with an explicit `accessCacheKey` proof of byte-identical output.
 
 ## Client usage
 
@@ -114,12 +117,22 @@ both `client.realtime` and
 `client.channels` (or recreate the client) so the shared physical connection is
 also recreated under the new identity.
 
-Channel-scoped authority cuts use the generic `channels.revokeAuthority()` seam.
-SSE closes only the denied logical binding. Pusher's honest capability is
-`principal-connections`: it terminates all current connections for that user,
+Exact Channel authority invalidation uses the resolved handle:
+
+```ts
+await channels.chatRoom({ roomId }).invalidateAuthority({
+	subject: { kind: "user", id: removedUserId },
+	idempotencyKey,
+});
+```
+
+The resolved Channel plus subject is the complete target; no second authority
+scope is attached. SSE reports `exact-binding`. Pusher's honest transport effect
+is `principal-connections`: it terminates current connections for that user,
 then fresh user/channel authentication allows still-authorized bindings to
-return. See `references/channels.md` for the transaction and in-flight-frame
-contract.
+return. The old root `revokeAuthority()` remains a deprecated 3.x forward to the
+same ledger. See `references/channels.md` for commit, retry, and in-flight-frame
+contracts.
 
 ## Admission and lifecycle
 
@@ -155,16 +168,15 @@ row.
   `principalId`, `recipientId`, or `audienceId` on ordinary realtime rows.
 - Let TanStack DB compose joins, ordering, limits, and derived live views from
   authorized normalized rows.
-- At admission, freeze only stable principal, server-derived scope, topic
-  locale, stage, and access mode. Never store expanded membership or permission
-  id sets in subscription context.
-- Resolve scope with
-  `realtime.subscriptionScope(({ request }) => request?.headers.get("x-scope-id") ?? null)`.
-  `null` means unscoped; a value is capped at 256 UTF-8 bytes. A scope switch
-  opens a new subscription and bootstraps a fresh client store.
+- Derive request-selected tenant/workspace state in `appConfig.context`, validate
+  it there, and enforce it in collection/global read access. Realtime runs the
+  same authorized CRUD pipeline; it adds no tenant filter.
+- `realtime.subscriptionScope` is deprecated in 3.x and removed in 4.0. It was
+  only a global scheduler partition, never authority. Remove it after migrating
+  tenant state into context and access.
 - Collection/global `realtime.accessCacheKey` is an explicit proof that output
-  may be shared across principals within the frozen scope tuple. Its key is
-  capped at 256 UTF-8 bytes; invalid or throwing resolvers stay edge-isolated.
+  may be shared more widely. Its key is capped at 256 UTF-8 bytes; invalid or
+  throwing resolvers stay edge-isolated.
 - Mutable membership/access stays in the database. Watched-resource changes
   trigger targeted reset; periodic delta re-bootstrap is only the safety net.
 
@@ -201,8 +213,16 @@ that `@questpie/tanstack-db` matches optimistic writes against. Typed channels,
 channel presence, and CRDT document sync are unaffected; CRDT canonical
 projection still writes its own outbox row per commit.
 
-A personalized relation query for 100,000 principals in one shared scope can
-cause 100,000 authoritative recomputations. Snapshot fallback is correct but
+A public collection with `accessCacheKey: () => "public:v1"` can compute one
+authorized query per refresh per server instance and fan the bytes out to
+100,000 equivalent subscribers. The key is a proof that field access, relations,
+output hooks, and `afterRead` are byte-identical for every matching context. The
+effective authorized topic, context extension digest, locale, stage, access
+mode, and delivery mode still partition groups. This is a local scheduler
+optimization: ten server replicas may run up to ten computations.
+
+A personalized relation query for 100,000 isolated contexts can still cause
+100,000 authoritative recomputations. Snapshot fallback is correct but
 expensive. Prefer materialized inbox rows with direct `recipientId`, a shared
 typed audience channel, an invalidation/refetch event, or a normal query.
 `bun --cwd packages/questpie run bench:realtime:routing` runs the deterministic

--- a/skills/questpie/references/rules.md
+++ b/skills/questpie/references/rules.md
@@ -302,13 +302,11 @@ transaction. Their `db` and injected services share that scope. A thrown error
 propagates and rolls back the mutation plus transaction-joined work:
 
 ```ts
-.hooks({
+	.hooks({
 	afterChange: async ({ data, channels }) => {
-		await channels.publish("postActivity", {
-			params: { postId: data.id },
-			event: "changed",
-			data: { id: data.id },
-		});
+		await channels
+			.postActivity({ postId: data.id })
+			.publish("changed", { id: data.id });
 	},
 })
 ```


### PR DESCRIPTION
## Summary
- add registry-first resolved Channel handles on server and client
- expose exact authority invalidation through the existing revoke ledger with honest transportEffect receipts
- isolate live-query scheduler work by session/OAuth token/anonymous edge by default
- make accessCacheKey the explicit byte-identical compute-sharing contract
- deprecate subscriptionScope as scheduler partition magic ahead of 4.0
- document the API, tenant/access model, performance example, and transport limits in docs and the QUESTPIE skill

## Compatibility
- existing root publish and revokeAuthority methods remain available and deprecated through 3.x
- colliding server registry keys keep the legacy root path; client-only names remain typed
- no schema migration and no second realtime/outbox system

## Verification
- 275 focused realtime, Channel, client, scheduler, ledger, transport, and codegen tests pass
- packages/questpie typecheck and build pass
- monorepo typecheck: 27/27 tasks pass
- formatting and docs MDX generation pass
- targeted changed-file oxlint passes
- adversarial Standards and Spec review report no remaining findings

## Transport note
SSE invalidation is exact-binding. Pusher/Soketi honestly reports principal-connections. Managed-provider termination remains bounded and inline with the existing ledger semantics; this PR does not claim rollback-safe provider effects without a future distributed provider-effect contract.