### PR TITLE
test: prove packed CLI consumer workflow

### DIFF
--- a/packages/create-questpie/test/packed-consumer.test.ts
+++ b/packages/create-questpie/test/packed-consumer.test.ts
@@ -19,8 +19,16 @@ import { preparePublishManifest } from "../../../scripts/publish-manifest";
 const REPO_ROOT = resolve(import.meta.dirname, "../../..");
 const QUESTPIE_PACKAGE = join(REPO_ROOT, "packages/questpie");
 const PROCESS_TIMEOUT_MS = 120_000;
+const WORKFLOW_TIMEOUT_MS = PROCESS_TIMEOUT_MS * 5 + 15_000;
 
 let workspace: string | undefined;
+
+type ActiveProcess = {
+	child: ReturnType<typeof spawn>;
+	exited: Promise<number>;
+};
+
+const activeProcesses = new Set<ActiveProcess>();
 
 type CommandResult = {
 	exitCode: number;
@@ -46,6 +54,19 @@ function killProcessGroup(
 	child.kill(signal);
 }
 
+async function terminateProcess({
+	child,
+	exited,
+}: ActiveProcess): Promise<void> {
+	killProcessGroup(child, "SIGTERM");
+	const terminated = await Promise.race([
+		exited.then(() => true),
+		wait(1_000).then(() => false),
+	]);
+	if (!terminated) killProcessGroup(child, "SIGKILL");
+	await Promise.race([exited, wait(1_000)]);
+}
+
 async function run(
 	command: string[],
 	options: { cwd: string; timeoutMs?: number },
@@ -66,6 +87,9 @@ async function run(
 		child.once("error", rejectExit);
 		child.once("close", (code) => resolveExit(code ?? 1));
 	});
+	const activeProcess = { child, exited };
+	activeProcesses.add(activeProcess);
+	child.once("close", () => activeProcesses.delete(activeProcess));
 	const timeoutMs = options.timeoutMs ?? PROCESS_TIMEOUT_MS;
 	let timeout: ReturnType<typeof setTimeout> | undefined;
 
@@ -82,13 +106,7 @@ async function run(
 		if (timeout) clearTimeout(timeout);
 
 		if (outcome.kind === "timeout") {
-			killProcessGroup(child, "SIGTERM");
-			const terminated = await Promise.race([
-				exited.then(() => true),
-				wait(1_000).then(() => false),
-			]);
-			if (!terminated) killProcessGroup(child, "SIGKILL");
-			await Promise.race([exited, wait(1_000)]);
+			await terminateProcess(activeProcess);
 			throw new Error(
 				`Command timed out after ${timeoutMs}ms: ${command.join(" ")}\n\nstdout:\n${stdout}\n\nstderr:\n${stderr}`,
 			);
@@ -218,10 +236,34 @@ async function writeConsumer(
 }
 
 afterAll(async () => {
+	await Promise.allSettled([...activeProcesses].map(terminateProcess));
 	if (workspace) await rm(workspace, { recursive: true, force: true });
 });
 
 describe("packed public consumer", () => {
+	test("cleans the process group when a command times out", async () => {
+		if (process.platform === "win32") return;
+
+		const cleanupWorkspace = await mkdtemp(
+			join(tmpdir(), "questpie-process-cleanup-"),
+		);
+		const marker = join(cleanupWorkspace, "descendant-survived");
+
+		try {
+			await expect(
+				run(["sh", "-c", '(sleep 0.3; touch "$1") & wait', "sh", marker], {
+					cwd: cleanupWorkspace,
+					timeoutMs: 50,
+				}),
+			).rejects.toThrow("Command timed out after 50ms");
+			await wait(500);
+			expect(existsSync(marker)).toBe(false);
+			expect(activeProcesses.size).toBe(0);
+		} finally {
+			await rm(cleanupWorkspace, { recursive: true, force: true });
+		}
+	});
+
 	test(
 		"generates and typechecks through the installed public CLI",
 		async () => {
@@ -269,6 +311,6 @@ describe("packed public consumer", () => {
 			);
 			expectSuccess(typecheck, "node_modules/.bin/tsc --noEmit");
 		},
-		PROCESS_TIMEOUT_MS * 4,
+		WORKFLOW_TIMEOUT_MS,
 	);
 });

--- a/packages/create-questpie/test/packed-consumer.test.ts
+++ b/packages/create-questpie/test/packed-consumer.test.ts
@@ -1,0 +1,274 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import {
+	chmod,
+	cp,
+	mkdir,
+	mkdtemp,
+	readFile,
+	rm,
+	writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import process from "node:process";
+
+import { preparePublishManifest } from "../../../scripts/publish-manifest";
+
+const REPO_ROOT = resolve(import.meta.dirname, "../../..");
+const QUESTPIE_PACKAGE = join(REPO_ROOT, "packages/questpie");
+const PROCESS_TIMEOUT_MS = 120_000;
+
+let workspace: string | undefined;
+
+type CommandResult = {
+	exitCode: number;
+	stdout: string;
+	stderr: string;
+};
+
+const wait = (milliseconds: number) =>
+	new Promise<void>((resolveWait) => setTimeout(resolveWait, milliseconds));
+
+function killProcessGroup(
+	child: ReturnType<typeof spawn>,
+	signal: NodeJS.Signals,
+): void {
+	if (process.platform !== "win32" && child.pid) {
+		try {
+			process.kill(-child.pid, signal);
+			return;
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code === "ESRCH") return;
+		}
+	}
+	child.kill(signal);
+}
+
+async function run(
+	command: string[],
+	options: { cwd: string; timeoutMs?: number },
+): Promise<CommandResult> {
+	const child = spawn(command[0]!, command.slice(1), {
+		cwd: options.cwd,
+		detached: process.platform !== "win32",
+		env: { ...process.env, CI: "1", NO_COLOR: "1" },
+		stdio: ["ignore", "pipe", "pipe"],
+	});
+	let stdout = "";
+	let stderr = "";
+	child.stdout.setEncoding("utf8");
+	child.stderr.setEncoding("utf8");
+	child.stdout.on("data", (chunk: string) => (stdout += chunk));
+	child.stderr.on("data", (chunk: string) => (stderr += chunk));
+	const exited = new Promise<number>((resolveExit, rejectExit) => {
+		child.once("error", rejectExit);
+		child.once("close", (code) => resolveExit(code ?? 1));
+	});
+	const timeoutMs = options.timeoutMs ?? PROCESS_TIMEOUT_MS;
+	let timeout: ReturnType<typeof setTimeout> | undefined;
+
+	try {
+		const outcome = await Promise.race([
+			exited.then((exitCode) => ({ kind: "exit" as const, exitCode })),
+			new Promise<{ kind: "timeout" }>((resolveTimeout) => {
+				timeout = setTimeout(
+					() => resolveTimeout({ kind: "timeout" }),
+					timeoutMs,
+				);
+			}),
+		]);
+		if (timeout) clearTimeout(timeout);
+
+		if (outcome.kind === "timeout") {
+			killProcessGroup(child, "SIGTERM");
+			const terminated = await Promise.race([
+				exited.then(() => true),
+				wait(1_000).then(() => false),
+			]);
+			if (!terminated) killProcessGroup(child, "SIGKILL");
+			await Promise.race([exited, wait(1_000)]);
+			throw new Error(
+				`Command timed out after ${timeoutMs}ms: ${command.join(" ")}\n\nstdout:\n${stdout}\n\nstderr:\n${stderr}`,
+			);
+		}
+
+		const exitCode = outcome.exitCode;
+		return {
+			exitCode,
+			stdout,
+			stderr,
+		};
+	} finally {
+		if (timeout) clearTimeout(timeout);
+	}
+}
+
+function expectSuccess(result: CommandResult, command: string): void {
+	expect(
+		result.exitCode,
+		`${command}\n\nstdout:\n${result.stdout}\n\nstderr:\n${result.stderr}`,
+	).toBe(0);
+}
+
+function packedTarballFilename(result: CommandResult): string {
+	try {
+		const packed = JSON.parse(result.stdout) as { filename?: unknown }[];
+		if (typeof packed[0]?.filename === "string") return packed[0].filename;
+	} catch {
+		// The contextual error below includes the raw subprocess output.
+	}
+	throw new Error(
+		`npm pack --json returned an invalid manifest\n\nstdout:\n${result.stdout}\n\nstderr:\n${result.stderr}`,
+	);
+}
+
+async function stagePublishedQuestpie(stageDir: string): Promise<void> {
+	const sourceManifest = JSON.parse(
+		await readFile(join(QUESTPIE_PACKAGE, "package.json"), "utf8"),
+	) as Parameters<typeof preparePublishManifest>[0];
+	const { manifest } = preparePublishManifest(sourceManifest, new Map());
+
+	const serialized = JSON.stringify(manifest, null, "\t");
+
+	await mkdir(stageDir, { recursive: true });
+	await cp(join(QUESTPIE_PACKAGE, "dist"), join(stageDir, "dist"), {
+		recursive: true,
+	});
+	if (existsSync(join(QUESTPIE_PACKAGE, "skills"))) {
+		await cp(join(QUESTPIE_PACKAGE, "skills"), join(stageDir, "skills"), {
+			recursive: true,
+		});
+	}
+	await writeFile(join(stageDir, "package.json"), `${serialized}\n`);
+	await chmod(join(stageDir, "dist/cli.mjs"), 0o755);
+}
+
+async function writeConsumer(
+	consumerDir: string,
+	tarball: string,
+): Promise<void> {
+	const files: Record<string, string> = {
+		"package.json": `${JSON.stringify(
+			{
+				name: "questpie-packed-consumer",
+				private: true,
+				type: "module",
+				imports: {
+					"#questpie": "./src/questpie/server/.generated/index.ts",
+					"#questpie/*": "./src/questpie/server/.generated/*",
+				},
+				dependencies: {
+					questpie: `file:${tarball}`,
+				},
+				devDependencies: {
+					"bun-types": "1.3.13",
+					typescript: "5.9.2",
+				},
+			},
+			null,
+			"\t",
+		)}\n`,
+		"tsconfig.json": `${JSON.stringify(
+			{
+				include: ["src/**/*.ts"],
+				compilerOptions: {
+					target: "ES2022",
+					module: "ESNext",
+					moduleResolution: "Bundler",
+					paths: {
+						"#questpie": ["./src/questpie/server/.generated/index.ts"],
+						"#questpie/*": ["./src/questpie/server/.generated/*"],
+					},
+					types: ["bun-types"],
+					strict: true,
+					noEmit: true,
+					skipLibCheck: true,
+				},
+			},
+			null,
+			"\t",
+		)}\n`,
+		"src/questpie/server/questpie.config.ts": [
+			'import { runtimeConfig } from "questpie/app";',
+			"",
+			"export default runtimeConfig({",
+			'\tapp: { url: "http://localhost:3000" },',
+			'\tdb: { url: "postgresql://questpie:questpie@localhost:5432/questpie" },',
+			"});",
+			"",
+		].join("\n"),
+		"src/questpie/server/modules.ts": "export default [] as const;\n",
+		"src/questpie/server/collections/posts.ts": [
+			'import { collection } from "#questpie/factories";',
+			"",
+			'export default collection("posts").fields(({ f }) => ({',
+			"\ttitle: f.text(255).required(),",
+			"}));",
+			"",
+		].join("\n"),
+	};
+
+	for (const [relativePath, contents] of Object.entries(files)) {
+		const destination = join(consumerDir, relativePath);
+		await mkdir(dirname(destination), { recursive: true });
+		await writeFile(destination, contents);
+	}
+}
+
+afterAll(async () => {
+	if (workspace) await rm(workspace, { recursive: true, force: true });
+});
+
+describe("packed public consumer", () => {
+	test(
+		"generates and typechecks through the installed public CLI",
+		async () => {
+			workspace = await mkdtemp(join(tmpdir(), "questpie-packed-consumer-"));
+			const stageDir = join(workspace, "stage/questpie");
+			const tarballDir = join(workspace, "tarballs");
+			const consumerDir = join(workspace, "consumer");
+
+			const build = await run(["bun", "run", "build"], {
+				cwd: QUESTPIE_PACKAGE,
+			});
+			expectSuccess(build, "bun run build");
+
+			await stagePublishedQuestpie(stageDir);
+			await mkdir(tarballDir, { recursive: true });
+			const pack = await run(
+				["npm", "pack", "--json", "--pack-destination", tarballDir],
+				{ cwd: stageDir },
+			);
+			expectSuccess(pack, "npm pack --json");
+			const tarball = join(tarballDir, packedTarballFilename(pack));
+
+			await writeConsumer(consumerDir, tarball);
+			const install = await run(["bun", "install", "--no-progress"], {
+				cwd: consumerDir,
+			});
+			expectSuccess(install, "bun install --no-progress");
+
+			const cli = join(consumerDir, "node_modules/.bin/questpie");
+			expect(existsSync(cli)).toBe(true);
+			const generate = await run(
+				[cli, "generate", "-c", "src/questpie/server/questpie.config.ts"],
+				{ cwd: consumerDir },
+			);
+			expectSuccess(generate, "node_modules/.bin/questpie generate");
+			expect(
+				existsSync(
+					join(consumerDir, "src/questpie/server/.generated/index.ts"),
+				),
+			).toBe(true);
+
+			const typecheck = await run(
+				[join(consumerDir, "node_modules/.bin/tsc"), "--noEmit"],
+				{ cwd: consumerDir },
+			);
+			expectSuccess(typecheck, "node_modules/.bin/tsc --noEmit");
+		},
+		PROCESS_TIMEOUT_MS * 4,
+	);
+});

--- a/scripts/publish-manifest.test.ts
+++ b/scripts/publish-manifest.test.ts
@@ -15,6 +15,7 @@ import tanstackQueryPackageJson from "../packages/tanstack-query/package.json";
 import workflowsPackageJson from "../packages/workflows/package.json";
 import {
 	assertNoWorkspaceProtocols,
+	preparePublishManifest,
 	replaceWorkspaceVersions,
 } from "./publish-manifest";
 
@@ -87,5 +88,40 @@ describe("publish manifest workspace dependencies", () => {
 		expect(() => assertNoWorkspaceProtocols(mcpPackageJson)).toThrow(
 			"dependencies.questpie=workspace:*",
 		);
+	});
+
+	test("prepares the exact publish-shaped manifest without mutating source", () => {
+		const source = {
+			name: "@questpie/example",
+			version: "1.0.0",
+			exports: { ".": "./src/index.ts" },
+			dependencies: { questpie: "workspace:*" },
+			peerDependencies: { "@questpie/admin": "workspace:~" },
+			publishConfig: {
+				access: "public",
+				exports: { ".": "./dist/index.mjs" },
+			},
+		};
+
+		const prepared = preparePublishManifest(
+			source,
+			new Map([
+				["questpie", "3.26.1"],
+				["@questpie/admin", "3.26.1"],
+			]),
+		);
+
+		expect(prepared.manifest).toMatchObject({
+			exports: { ".": "./dist/index.mjs" },
+			dependencies: { questpie: "^3.26.1" },
+			peerDependencies: { "@questpie/admin": "~3.26.1" },
+		});
+		expect(prepared.appliedPublishConfigKeys).toEqual(["exports"]);
+		expect(prepared.resolvedWorkspaceSections).toEqual([
+			"dependencies",
+			"peerDependencies",
+		]);
+		expect(source.exports).toEqual({ ".": "./src/index.ts" });
+		expect(source.dependencies.questpie).toBe("workspace:*");
 	});
 });

--- a/scripts/publish-manifest.ts
+++ b/scripts/publish-manifest.ts
@@ -1,9 +1,18 @@
 type DependencyMap = Record<string, string>;
 
-type PublishManifest = {
+export type PublishManifest = Record<string, unknown> & {
 	dependencies?: DependencyMap;
 	optionalDependencies?: DependencyMap;
 	peerDependencies?: DependencyMap;
+	publishConfig?: Record<string, unknown>;
+};
+
+const PUBLISH_CONFIG_METADATA_KEYS = new Set(["access", "registry", "tag"]);
+
+export type PreparedPublishManifest<TManifest extends PublishManifest> = {
+	manifest: TManifest;
+	appliedPublishConfigKeys: string[];
+	resolvedWorkspaceSections: ("dependencies" | "peerDependencies")[];
 };
 
 export function replaceWorkspaceVersions(
@@ -44,4 +53,41 @@ export function assertNoWorkspaceProtocols(manifest: PublishManifest): void {
 			`Refusing to publish unresolved workspace protocols: ${unresolved.join(", ")}`,
 		);
 	}
+}
+
+/** Build the exact manifest shape passed to npm by the release workflow. */
+export function preparePublishManifest<TManifest extends PublishManifest>(
+	source: TManifest,
+	versions: ReadonlyMap<string, string>,
+): PreparedPublishManifest<TManifest> {
+	const manifest = structuredClone(source);
+	const appliedPublishConfigKeys: string[] = [];
+	const resolvedWorkspaceSections: PreparedPublishManifest<TManifest>["resolvedWorkspaceSections"] =
+		[];
+
+	for (const [key, value] of Object.entries(manifest.publishConfig ?? {})) {
+		if (PUBLISH_CONFIG_METADATA_KEYS.has(key)) continue;
+		manifest[key] = value;
+		appliedPublishConfigKeys.push(key);
+	}
+
+	for (const key of ["dependencies", "peerDependencies"] as const) {
+		const dependencies = manifest[key];
+		if (!dependencies) continue;
+		if (
+			Object.values(dependencies).some((value) =>
+				value.startsWith("workspace:"),
+			)
+		) {
+			manifest[key] = replaceWorkspaceVersions(dependencies, versions);
+			resolvedWorkspaceSections.push(key);
+		}
+	}
+
+	assertNoWorkspaceProtocols(manifest);
+	return {
+		manifest,
+		appliedPublishConfigKeys,
+		resolvedWorkspaceSections,
+	};
 }

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -22,10 +22,7 @@ import {
 	assertPackagesRegistered,
 	isNpmPackageVersionPublished,
 } from "./npm-package-preflight";
-import {
-	assertNoWorkspaceProtocols,
-	replaceWorkspaceVersions,
-} from "./publish-manifest";
+import { preparePublishManifest } from "./publish-manifest";
 
 const execAsync = promisify(exec);
 
@@ -168,55 +165,26 @@ async function main() {
 			const original = fs.readFileSync(packageJsonPath, "utf-8");
 			originals.set(packageJsonPath, original);
 
-			const packageJson: PackageJson = JSON.parse(original);
+			const sourcePackageJson: PackageJson = JSON.parse(original);
+			const prepared = preparePublishManifest(sourcePackageJson, versions);
+			const packageJson = prepared.manifest;
 			console.log(`📦 ${packageJson.name}`);
 
-			let modified = false;
-
-			// 1. Apply publishConfig overrides
-			if (packageJson.publishConfig) {
+			if (prepared.appliedPublishConfigKeys.length > 0) {
 				console.log("  Applying publishConfig overrides:");
-				for (const [key, value] of Object.entries(packageJson.publishConfig)) {
-					if (key === "access" || key === "registry" || key === "tag") continue;
+				for (const key of prepared.appliedPublishConfigKeys) {
 					console.log(`    ${key}`);
-					packageJson[key] = value;
-					modified = true;
 				}
 			}
 
-			// 2. Convert workspace:* in dependencies
-			if (packageJson.dependencies) {
-				const hasWorkspace = Object.values(packageJson.dependencies).some((v) =>
-					v.startsWith("workspace:"),
-				);
-				if (hasWorkspace) {
-					console.log("  Converting workspace dependencies:");
-					packageJson.dependencies = replaceWorkspaceVersions(
-						packageJson.dependencies,
-						versions,
-					);
-					modified = true;
-				}
+			for (const key of prepared.resolvedWorkspaceSections) {
+				console.log(`  Converting workspace ${key}:`);
 			}
 
-			// 3. Convert workspace:* in peerDependencies
-			if (packageJson.peerDependencies) {
-				const hasWorkspace = Object.values(packageJson.peerDependencies).some(
-					(v) => v.startsWith("workspace:"),
-				);
-				if (hasWorkspace) {
-					console.log("  Converting workspace peerDependencies:");
-					packageJson.peerDependencies = replaceWorkspaceVersions(
-						packageJson.peerDependencies,
-						versions,
-					);
-					modified = true;
-				}
-			}
-
-			assertNoWorkspaceProtocols(packageJson);
-
-			if (modified) {
+			if (
+				prepared.appliedPublishConfigKeys.length > 0 ||
+				prepared.resolvedWorkspaceSections.length > 0
+			) {
 				fs.writeFileSync(
 					packageJsonPath,
 					JSON.stringify(packageJson, null, "\t") + "\n",


### PR DESCRIPTION
## What changed

- Shares publish-manifest preparation between the release script and its executable proof.
- Packs the built questpie artifact, installs it into a disposable external consumer, and invokes the installed questpie binary and TypeScript compiler.
- Bounds subprocess and descendant cleanup and preserves stdout/stderr on failures.

## Why

Workspace imports and source CLI execution could hide drift in the package that users actually install.

## Impact

Internal release and CI proof only. No runtime or public API change.

## Validation

- 7 focused tests pass.
- create-questpie typecheck passes.
- Formatting, lint, and diff checks pass.
- Independent Standards and Spec reviews completed; all actionable findings resolved.