### PR TITLE
fix: harden module and plugin graph resolution

### DIFF
--- a/.changeset/calm-module-graphs.md
+++ b/.changeset/calm-module-graphs.md
@@ -5,4 +5,6 @@
 Harden module and codegen-plugin graph resolution. Dependency cycles now fail
 with their path, repeated object identities deduplicate consistently, and
 distinct modules or plugins sharing one name fail instead of silently winning
-in one runtime or codegen phase.
+in one runtime or codegen phase. Generated category types now follow the same
+validated, children-first, last-wins order for collections, globals, jobs,
+routes, channels, fields, and plugin-contributed records.

--- a/.changeset/calm-module-graphs.md
+++ b/.changeset/calm-module-graphs.md
@@ -1,0 +1,8 @@
+---
+"questpie": patch
+---
+
+Harden module and codegen-plugin graph resolution. Dependency cycles now fail
+with their path, repeated object identities deduplicate consistently, and
+distinct modules or plugins sharing one name fail instead of silently winning
+in one runtime or codegen phase.

--- a/apps/docs/content/docs/code/codegen/plugins.mdx
+++ b/apps/docs/content/docs/code/codegen/plugins.mdx
@@ -58,9 +58,10 @@ export const myModule = module({
 
 The module route is the one to prefer. Codegen walks `modules.ts` before
 discovery, collects every `plugin` it finds, and the user adds nothing. The walk
-is depth first, submodules before the module itself. Duplicate names are dropped
-and the first one wins. A plugin registered on the config beats a module one of
-the same name.
+is depth first, submodules before the module itself. Reaching the same plugin
+object twice contributes it once. Two different plugin objects with one name
+are ambiguous and fail, including collisions between
+`runtimeConfig({ plugins })` and a module plugin.
 
 ## What a target contribution holds
 

--- a/apps/docs/content/docs/code/modules/merging.mdx
+++ b/apps/docs/content/docs/code/modules/merging.mdx
@@ -57,6 +57,10 @@ Those first three are not in your array. `adminModule` depends on
 The list is then folded left to right. Your files are last. On every key that
 overrides by key, yours is the version that survives.
 
+Codegen derives category types from this same validated order. It does not
+intersect a definition that runtime has replaced, and a shared dependency in a
+diamond contributes once at its first resolved position.
+
 ## Repeated identities deduplicate; name collisions fail
 
 A module object reached twice is kept once, at its **first** resolved position.

--- a/apps/docs/content/docs/code/modules/merging.mdx
+++ b/apps/docs/content/docs/code/modules/merging.mdx
@@ -34,7 +34,8 @@ above them.
 
 The list is built before anything merges.
 
-1. `questpie-core` goes first, unless you listed it yourself.
+1. The canonical `questpie-core` object goes first. Listing that same object
+   yourself is harmless and deduplicates later.
 2. Then your `modules.ts` array, in the order you wrote it.
 3. Then one implicit module holding everything codegen found in your own
    directories.
@@ -56,15 +57,16 @@ Those first three are not in your array. `adminModule` depends on
 The list is then folded left to right. Your files are last. On every key that
 overrides by key, yours is the version that survives.
 
-## Duplicates collapse by name
+## Repeated identities deduplicate; name collisions fail
 
-A module that appears twice in the resolved list is kept once, at its **last**
-position. Two modules that both depend on the starter do not merge the starter
-twice.
+A module object reached twice is kept once, at its **first** resolved position.
+Two modules that both depend on the same starter object therefore merge the
+starter once, before both dependents.
 
-The key is the `name` string, not the object identity. Two different objects
-that both call themselves `blog` collapse into one, and the later one survives.
-Give every module a unique, stable name.
+The `name` string is still the public identity, so two **different** objects
+that both call themselves `blog` are ambiguous and fail with both graph paths.
+Give every distinct module a unique, stable name; reuse the exact object for an
+intentional diamond.
 
 ## The config bucket
 
@@ -92,11 +94,18 @@ own `config/auth.ts` merges on top without dropping it.
 ## Codegen plugins are collected separately
 
 `plugin` never reaches the merge above. Codegen walks the same module tree in a
-pre-pass, depth-first. It collects every `plugin` and de-dups by the plugin's
-`name`. The **first** occurrence wins there, not the last.
+pre-pass, depth-first with dependencies before their dependents. Reaching the
+same module or plugin object through a diamond is safe and contributes it once.
 
-Plugins you passed to `runtimeConfig({ plugins })` are seen first. So a
-config-level plugin beats a module plugin with the same name.
+Names are identities, not override slots. Two different module objects with one
+`name`, or two different plugin objects with one `name`, stop generation with
+both sources in the error. This also applies across
+`runtimeConfig({ plugins })` and module-contributed plugins. Reuse the same
+object when a dependency diamond intentionally reaches one contribution more
+than once; rename genuinely different modules or plugins.
+
+A circular `modules` dependency also stops immediately and prints the cycle,
+for example `billing -> shared -> billing`.
 
 <Callout type="warn" title="Two phases, one package">
 	A module's entities merge at runtime. Its plugin runs at codegen. If the

--- a/apps/docs/content/docs/ship/configuration.mdx
+++ b/apps/docs/content/docs/ship/configuration.mdx
@@ -168,8 +168,9 @@ export default [adminModule, openApiModule] as const;
 
 Codegen reads this file first, in its own pass, so each module's file
 conventions are registered before discovery runs. The tree is walked
-dependencies first, and two modules with the same name collapse to the last one.
-See [Modules](/docs/code/modules).
+dependencies first. Repeated references to the same module object contribute it
+once; different module objects with one name fail with both graph paths. See
+[Modules](/docs/code/modules).
 
 ## Plugins bring their own file
 

--- a/examples/city-portal/src/questpie/server/.generated/entities.gen.ts
+++ b/examples/city-portal/src/questpie/server/.generated/entities.gen.ts
@@ -65,30 +65,30 @@ import type { RouteParamsFromKey, RouteWithParams } from "questpie/types";
 // TYPES — composed from typeof references (zero inference cost)
 // ════════════════════════════════════════════════════════════
 
-import type { ExtractModulePropArr, ExtractModulePropArrOverride, Override, ServiceCustomNamespaceInstances, ServiceInstanceOf, ServiceInstancesInNamespace, ServiceTopLevelInstances } from "questpie/types";
+import type { CodegenResolvedModulePropArr, ExtractModulePropArr, Override, ServiceCustomNamespaceInstances, ServiceInstanceOf, ServiceInstancesInNamespace, ServiceTopLevelInstances } from "questpie/types";
 type _RouteDefinitionWithoutHandler<T> = T extends { mode: "raw" } ? Omit<T, "handler"> & { handler: (args: unknown) => Response | Promise<Response> } : Omit<T, "handler"> & { handler: (args: unknown) => unknown | Promise<unknown> };
-export type _ModuleCollections = ExtractModulePropArrOverride<typeof _modules, "collections">;
-export type _ModuleChannels = ExtractModulePropArr<typeof _modules, "channels">;
-export type _ModuleGlobals = ExtractModulePropArr<typeof _modules, "globals">;
-export type _ModuleJobs = ExtractModulePropArr<typeof _modules, "jobs">;
-export type _ModuleRoutes = ExtractModulePropArr<typeof _modules, "routes">;
+export type _ModuleCollections = CodegenResolvedModulePropArr<typeof _modules, "collections">;
+export type _ModuleChannels = CodegenResolvedModulePropArr<typeof _modules, "channels">;
+export type _ModuleGlobals = CodegenResolvedModulePropArr<typeof _modules, "globals">;
+export type _ModuleJobs = CodegenResolvedModulePropArr<typeof _modules, "jobs">;
+export type _ModuleRoutes = CodegenResolvedModulePropArr<typeof _modules, "routes">;
 export type _ModuleServices = {};
-export type _ModuleFieldTypes = ExtractModulePropArr<typeof _modules, "fieldTypes">;
-export type _ModuleViews = ExtractModulePropArr<typeof _modules, "views">;
-export type _ModuleComponents = ExtractModulePropArr<typeof _modules, "components">;
-export type _ModuleBlocks = ExtractModulePropArr<typeof _modules, "blocks">;
+export type _ModuleFieldTypes = CodegenResolvedModulePropArr<typeof _modules, "fieldTypes">;
+export type _ModuleViews = CodegenResolvedModulePropArr<typeof _modules, "views">;
+export type _ModuleComponents = CodegenResolvedModulePropArr<typeof _modules, "components">;
+export type _ModuleBlocks = CodegenResolvedModulePropArr<typeof _modules, "blocks">;
 // Registry category extraction from modules
-export type _Registry_Collections = ExtractModulePropArrOverride<typeof _modules, "collections">;
-export type _Registry_Channels = ExtractModulePropArr<typeof _modules, "channels">;
-export type _Registry_Globals = ExtractModulePropArr<typeof _modules, "globals">;
-export type _Registry_Jobs = ExtractModulePropArr<typeof _modules, "jobs">;
-export type _Registry_Routes = ExtractModulePropArr<typeof _modules, "routes">;
+export type _Registry_Collections = CodegenResolvedModulePropArr<typeof _modules, "collections">;
+export type _Registry_Channels = CodegenResolvedModulePropArr<typeof _modules, "channels">;
+export type _Registry_Globals = CodegenResolvedModulePropArr<typeof _modules, "globals">;
+export type _Registry_Jobs = CodegenResolvedModulePropArr<typeof _modules, "jobs">;
+export type _Registry_Routes = CodegenResolvedModulePropArr<typeof _modules, "routes">;
 export type _Registry_Services = {};
-export type _Registry_Emails = ExtractModulePropArr<typeof _modules, "emails">;
-export type _Registry_FieldTypes = ExtractModulePropArr<typeof _modules, "fieldTypes">;
-export type _Registry_Views = ExtractModulePropArr<typeof _modules, "views">;
-export type _Registry_Components = ExtractModulePropArr<typeof _modules, "components">;
-export type _Registry_Blocks = ExtractModulePropArr<typeof _modules, "blocks">;
+export type _Registry_Emails = CodegenResolvedModulePropArr<typeof _modules, "emails">;
+export type _Registry_FieldTypes = CodegenResolvedModulePropArr<typeof _modules, "fieldTypes">;
+export type _Registry_Views = CodegenResolvedModulePropArr<typeof _modules, "views">;
+export type _Registry_Components = CodegenResolvedModulePropArr<typeof _modules, "components">;
+export type _Registry_Blocks = CodegenResolvedModulePropArr<typeof _modules, "blocks">;
 
 // Recursive module property extraction (for fields contributed at each level)
 import type { ExtractModuleProp } from "questpie/types";
@@ -111,9 +111,9 @@ export type AppCollections = Override<_ModuleCollections, {
 export type AppChannels = _ModuleChannels;
 
 /** All globals in the app (modules + user, user overrides) */
-export type AppGlobals = _ModuleGlobals & {
+export type AppGlobals = Override<_ModuleGlobals, {
 	site_settings: typeof _glob_site_settings;
-};
+}>;
 
 /** All jobs in the app (modules + user, user overrides) */
 export type AppJobs = _ModuleJobs;
@@ -146,20 +146,4 @@ export type AppViews = _ModuleViews;
 export type AppComponents = _ModuleComponents;
 
 /** All blocks in the app (modules + user, user overrides) */
-export type AppBlocks = _ModuleBlocks
-	& { [K in typeof _bloc_accordion.state.name]: typeof _bloc_accordion }
-	& { [K in typeof _bloc_announcementBanner.state.name]: typeof _bloc_announcementBanner }
-	& { [K in typeof _bloc_columns.state.name]: typeof _bloc_columns }
-	& { [K in typeof _bloc_contactsList.state.name]: typeof _bloc_contactsList }
-	& { [K in typeof _bloc_cta.state.name]: typeof _bloc_cta }
-	& { [K in typeof _bloc_divider.state.name]: typeof _bloc_divider }
-	& { [K in typeof _bloc_documentsList.state.name]: typeof _bloc_documentsList }
-	& { [K in typeof _bloc_gallery.state.name]: typeof _bloc_gallery }
-	& { [K in typeof _bloc_heading.state.name]: typeof _bloc_heading }
-	& { [K in typeof _bloc_hero.state.name]: typeof _bloc_hero }
-	& { [K in typeof _bloc_image.state.name]: typeof _bloc_image }
-	& { [K in typeof _bloc_imageText.state.name]: typeof _bloc_imageText }
-	& { [K in typeof _bloc_latestNews.state.name]: typeof _bloc_latestNews }
-	& { [K in typeof _bloc_spacer.state.name]: typeof _bloc_spacer }
-	& { [K in typeof _bloc_text.state.name]: typeof _bloc_text }
-	& { [K in typeof _bloc_video.state.name]: typeof _bloc_video };
+export type AppBlocks = Override<Override<Override<Override<Override<Override<Override<Override<Override<Override<Override<Override<Override<Override<Override<Override<_ModuleBlocks, { [K in typeof _bloc_accordion.state.name]: typeof _bloc_accordion }>, { [K in typeof _bloc_announcementBanner.state.name]: typeof _bloc_announcementBanner }>, { [K in typeof _bloc_columns.state.name]: typeof _bloc_columns }>, { [K in typeof _bloc_contactsList.state.name]: typeof _bloc_contactsList }>, { [K in typeof _bloc_cta.state.name]: typeof _bloc_cta }>, { [K in typeof _bloc_divider.state.name]: typeof _bloc_divider }>, { [K in typeof _bloc_documentsList.state.name]: typeof _bloc_documentsList }>, { [K in typeof _bloc_gallery.state.name]: typeof _bloc_gallery }>, { [K in typeof _bloc_heading.state.name]: typeof _bloc_heading }>, { [K in typeof _bloc_hero.state.name]: typeof _bloc_hero }>, { [K in typeof _bloc_image.state.name]: typeof _bloc_image }>, { [K in typeof _bloc_imageText.state.name]: typeof _bloc_imageText }>, { [K in typeof _bloc_latestNews.state.name]: typeof _bloc_latestNews }>, { [K in typeof _bloc_spacer.state.name]: typeof _bloc_spacer }>, { [K in typeof _bloc_text.state.name]: typeof _bloc_text }>, { [K in typeof _bloc_video.state.name]: typeof _bloc_video }>;

--- a/examples/tanstack-barbershop/src/questpie/server/.generated/entities.gen.ts
+++ b/examples/tanstack-barbershop/src/questpie/server/.generated/entities.gen.ts
@@ -112,32 +112,32 @@ import type { RouteParamsFromKey, RouteWithParams } from "questpie/types";
 // TYPES — composed from typeof references (zero inference cost)
 // ════════════════════════════════════════════════════════════
 
-import type { ExtractModulePropArr, ExtractModulePropArrOverride, Override, ServiceCustomNamespaceInstances, ServiceInstanceOf, ServiceInstancesInNamespace, ServiceTopLevelInstances } from "questpie/types";
+import type { CodegenResolvedModulePropArr, ExtractModulePropArr, Override, ServiceCustomNamespaceInstances, ServiceInstanceOf, ServiceInstancesInNamespace, ServiceTopLevelInstances } from "questpie/types";
 type _RouteDefinitionWithoutHandler<T> = T extends { mode: "raw" } ? Omit<T, "handler"> & { handler: (args: unknown) => Response | Promise<Response> } : Omit<T, "handler"> & { handler: (args: unknown) => unknown | Promise<unknown> };
-export type _ModuleCollections = ExtractModulePropArrOverride<typeof _modules, "collections">;
-export type _ModuleChannels = ExtractModulePropArr<typeof _modules, "channels">;
-export type _ModuleGlobals = ExtractModulePropArr<typeof _modules, "globals">;
-export type _ModuleJobs = ExtractModulePropArr<typeof _modules, "jobs">;
-export type _ModuleRoutes = ExtractModulePropArr<typeof _modules, "routes">;
+export type _ModuleCollections = CodegenResolvedModulePropArr<typeof _modules, "collections">;
+export type _ModuleChannels = CodegenResolvedModulePropArr<typeof _modules, "channels">;
+export type _ModuleGlobals = CodegenResolvedModulePropArr<typeof _modules, "globals">;
+export type _ModuleJobs = CodegenResolvedModulePropArr<typeof _modules, "jobs">;
+export type _ModuleRoutes = CodegenResolvedModulePropArr<typeof _modules, "routes">;
 export type _ModuleServices = {};
-export type _ModuleFieldTypes = ExtractModulePropArr<typeof _modules, "fieldTypes">;
-export type _ModuleViews = ExtractModulePropArr<typeof _modules, "views">;
-export type _ModuleComponents = ExtractModulePropArr<typeof _modules, "components">;
-export type _ModuleBlocks = ExtractModulePropArr<typeof _modules, "blocks">;
-export type _ModuleMcpTools = ExtractModulePropArr<typeof _modules, "mcpTools">;
+export type _ModuleFieldTypes = CodegenResolvedModulePropArr<typeof _modules, "fieldTypes">;
+export type _ModuleViews = CodegenResolvedModulePropArr<typeof _modules, "views">;
+export type _ModuleComponents = CodegenResolvedModulePropArr<typeof _modules, "components">;
+export type _ModuleBlocks = CodegenResolvedModulePropArr<typeof _modules, "blocks">;
+export type _ModuleMcpTools = CodegenResolvedModulePropArr<typeof _modules, "mcpTools">;
 // Registry category extraction from modules
-export type _Registry_Collections = ExtractModulePropArrOverride<typeof _modules, "collections">;
-export type _Registry_Channels = ExtractModulePropArr<typeof _modules, "channels">;
-export type _Registry_Globals = ExtractModulePropArr<typeof _modules, "globals">;
-export type _Registry_Jobs = ExtractModulePropArr<typeof _modules, "jobs">;
-export type _Registry_Routes = ExtractModulePropArr<typeof _modules, "routes">;
+export type _Registry_Collections = CodegenResolvedModulePropArr<typeof _modules, "collections">;
+export type _Registry_Channels = CodegenResolvedModulePropArr<typeof _modules, "channels">;
+export type _Registry_Globals = CodegenResolvedModulePropArr<typeof _modules, "globals">;
+export type _Registry_Jobs = CodegenResolvedModulePropArr<typeof _modules, "jobs">;
+export type _Registry_Routes = CodegenResolvedModulePropArr<typeof _modules, "routes">;
 export type _Registry_Services = {};
-export type _Registry_Emails = ExtractModulePropArr<typeof _modules, "emails">;
-export type _Registry_FieldTypes = ExtractModulePropArr<typeof _modules, "fieldTypes">;
-export type _Registry_Views = ExtractModulePropArr<typeof _modules, "views">;
-export type _Registry_Components = ExtractModulePropArr<typeof _modules, "components">;
-export type _Registry_Blocks = ExtractModulePropArr<typeof _modules, "blocks">;
-export type _Registry_McpTools = ExtractModulePropArr<typeof _modules, "mcpTools">;
+export type _Registry_Emails = CodegenResolvedModulePropArr<typeof _modules, "emails">;
+export type _Registry_FieldTypes = CodegenResolvedModulePropArr<typeof _modules, "fieldTypes">;
+export type _Registry_Views = CodegenResolvedModulePropArr<typeof _modules, "views">;
+export type _Registry_Components = CodegenResolvedModulePropArr<typeof _modules, "components">;
+export type _Registry_Blocks = CodegenResolvedModulePropArr<typeof _modules, "blocks">;
+export type _Registry_McpTools = CodegenResolvedModulePropArr<typeof _modules, "mcpTools">;
 
 // Recursive module property extraction (for fields contributed at each level)
 import type { ExtractModuleProp } from "questpie/types";
@@ -159,30 +159,30 @@ export type AppCollections = Override<_ModuleCollections, {
 export type AppChannels = _ModuleChannels;
 
 /** All globals in the app (modules + user, user overrides) */
-export type AppGlobals = _ModuleGlobals & {
+export type AppGlobals = Override<_ModuleGlobals, {
 	site_settings: typeof _glob_site_settings;
-};
+}>;
 
 /** All jobs in the app (modules + user, user overrides) */
-export type AppJobs = _ModuleJobs & {
+export type AppJobs = Override<_ModuleJobs, {
 	notifyBlogSubscribers: Omit<typeof _job_notifyBlogSubscribers, "handler"> & { handler: (args: unknown) => Promise<unknown> };
 	sendAppointmentCancellation: Omit<typeof _job_sendAppointmentCancellation, "handler"> & { handler: (args: unknown) => Promise<unknown> };
 	sendAppointmentConfirmation: Omit<typeof _job_sendAppointmentConfirmation, "handler"> & { handler: (args: unknown) => Promise<unknown> };
 	sendAppointmentReminder: Omit<typeof _job_sendAppointmentReminder, "handler"> & { handler: (args: unknown) => Promise<unknown> };
-};
+}>;
 
 /** All routes in the app (modules + user, user overrides) */
-export type AppRoutes = _ModuleRoutes & {
+export type AppRoutes = Override<_ModuleRoutes, {
 	createBooking: RouteWithParams<_RouteDefinitionWithoutHandler<typeof _route_createBooking>, RouteParamsFromKey<"createBooking">>;
 	getActiveBarbers: RouteWithParams<_RouteDefinitionWithoutHandler<typeof _route_getActiveBarbers>, RouteParamsFromKey<"getActiveBarbers">>;
 	getAvailableTimeSlots: RouteWithParams<_RouteDefinitionWithoutHandler<typeof _route_getAvailableTimeSlots>, RouteParamsFromKey<"getAvailableTimeSlots">>;
 	getRevenueStats: RouteWithParams<_RouteDefinitionWithoutHandler<typeof _route_getRevenueStats>, RouteParamsFromKey<"getRevenueStats">>;
-};
+}>;
 
 /** All service definitions in the app (modules + user, user overrides). */
-type _AppServiceDefinitions = _ModuleServices & {
+type _AppServiceDefinitions = Override<_ModuleServices, {
 	blog: typeof _svc_blog;
-};
+}>;
 
 /** All services in the app as resolved service instances. */
 export type AppServices = {
@@ -200,10 +200,10 @@ export type AppEmailTemplates = {
 };
 
 /** All fieldtypes in the app (modules + user, user overrides) */
-export type AppFieldTypes = _ModuleFieldTypes & {
+export type AppFieldTypes = Override<_ModuleFieldTypes, {
 	color: typeof _ftype_color;
 	rating: typeof _ftype_rating;
-};
+}>;
 
 /** All views in the app (modules + user, user overrides) */
 export type AppViews = _ModuleViews;
@@ -212,25 +212,9 @@ export type AppViews = _ModuleViews;
 export type AppComponents = _ModuleComponents;
 
 /** All blocks in the app (modules + user, user overrides) */
-export type AppBlocks = _ModuleBlocks
-	& { [K in typeof _bloc_bookingCta.state.name]: typeof _bloc_bookingCta }
-	& { [K in typeof _bloc_columns.state.name]: typeof _bloc_columns }
-	& { [K in typeof _bloc_contactInfo.state.name]: typeof _bloc_contactInfo }
-	& { [K in typeof _bloc_cta.state.name]: typeof _bloc_cta }
-	& { [K in typeof _bloc_divider.state.name]: typeof _bloc_divider }
-	& { [K in typeof _bloc_gallery.state.name]: typeof _bloc_gallery }
-	& { [K in typeof _bloc_heading.state.name]: typeof _bloc_heading }
-	& { [K in typeof _bloc_hero.state.name]: typeof _bloc_hero }
-	& { [K in typeof _bloc_hours.state.name]: typeof _bloc_hours }
-	& { [K in typeof _bloc_imageText.state.name]: typeof _bloc_imageText }
-	& { [K in typeof _bloc_reviews.state.name]: typeof _bloc_reviews }
-	& { [K in typeof _bloc_services.state.name]: typeof _bloc_services }
-	& { [K in typeof _bloc_spacer.state.name]: typeof _bloc_spacer }
-	& { [K in typeof _bloc_stats.state.name]: typeof _bloc_stats }
-	& { [K in typeof _bloc_team.state.name]: typeof _bloc_team }
-	& { [K in typeof _bloc_text.state.name]: typeof _bloc_text };
+export type AppBlocks = Override<Override<Override<Override<Override<Override<Override<Override<Override<Override<Override<Override<Override<Override<Override<Override<_ModuleBlocks, { [K in typeof _bloc_bookingCta.state.name]: typeof _bloc_bookingCta }>, { [K in typeof _bloc_columns.state.name]: typeof _bloc_columns }>, { [K in typeof _bloc_contactInfo.state.name]: typeof _bloc_contactInfo }>, { [K in typeof _bloc_cta.state.name]: typeof _bloc_cta }>, { [K in typeof _bloc_divider.state.name]: typeof _bloc_divider }>, { [K in typeof _bloc_gallery.state.name]: typeof _bloc_gallery }>, { [K in typeof _bloc_heading.state.name]: typeof _bloc_heading }>, { [K in typeof _bloc_hero.state.name]: typeof _bloc_hero }>, { [K in typeof _bloc_hours.state.name]: typeof _bloc_hours }>, { [K in typeof _bloc_imageText.state.name]: typeof _bloc_imageText }>, { [K in typeof _bloc_reviews.state.name]: typeof _bloc_reviews }>, { [K in typeof _bloc_services.state.name]: typeof _bloc_services }>, { [K in typeof _bloc_spacer.state.name]: typeof _bloc_spacer }>, { [K in typeof _bloc_stats.state.name]: typeof _bloc_stats }>, { [K in typeof _bloc_team.state.name]: typeof _bloc_team }>, { [K in typeof _bloc_text.state.name]: typeof _bloc_text }>;
 
 /** All mcptools in the app (modules + user, user overrides) */
-export type AppMcpTools = _ModuleMcpTools & {
+export type AppMcpTools = Override<_ModuleMcpTools, {
 	"barbershop.checkAvailability": typeof _mcpTool_barbershop_checkAvailability;
-};
+}>;

--- a/examples/toy-factory-backend/src/questpie/server/.generated/entities.gen.ts
+++ b/examples/toy-factory-backend/src/questpie/server/.generated/entities.gen.ts
@@ -56,32 +56,32 @@ import type { RouteParamsFromKey, RouteWithParams } from "questpie/types";
 // TYPES — composed from typeof references (zero inference cost)
 // ════════════════════════════════════════════════════════════
 
-import type { ExtractModulePropArr, ExtractModulePropArrOverride, Override, ServiceCustomNamespaceInstances, ServiceInstanceOf, ServiceInstancesInNamespace, ServiceTopLevelInstances } from "questpie/types";
+import type { CodegenResolvedModulePropArr, ExtractModulePropArr, Override, ServiceCustomNamespaceInstances, ServiceInstanceOf, ServiceInstancesInNamespace, ServiceTopLevelInstances } from "questpie/types";
 type _RouteDefinitionWithoutHandler<T> = T extends { mode: "raw" } ? Omit<T, "handler"> & { handler: (args: unknown) => Response | Promise<Response> } : Omit<T, "handler"> & { handler: (args: unknown) => unknown | Promise<unknown> };
-export type _ModuleCollections = ExtractModulePropArrOverride<typeof _modules, "collections">;
-export type _ModuleChannels = ExtractModulePropArr<typeof _modules, "channels">;
-export type _ModuleGlobals = ExtractModulePropArr<typeof _modules, "globals">;
-export type _ModuleJobs = ExtractModulePropArr<typeof _modules, "jobs">;
-export type _ModuleRoutes = ExtractModulePropArr<typeof _modules, "routes">;
+export type _ModuleCollections = CodegenResolvedModulePropArr<typeof _modules, "collections">;
+export type _ModuleChannels = CodegenResolvedModulePropArr<typeof _modules, "channels">;
+export type _ModuleGlobals = CodegenResolvedModulePropArr<typeof _modules, "globals">;
+export type _ModuleJobs = CodegenResolvedModulePropArr<typeof _modules, "jobs">;
+export type _ModuleRoutes = CodegenResolvedModulePropArr<typeof _modules, "routes">;
 export type _ModuleServices = {};
-export type _ModuleFieldTypes = ExtractModulePropArr<typeof _modules, "fieldTypes">;
-export type _ModuleViews = ExtractModulePropArr<typeof _modules, "views">;
-export type _ModuleComponents = ExtractModulePropArr<typeof _modules, "components">;
-export type _ModuleBlocks = ExtractModulePropArr<typeof _modules, "blocks">;
-export type _ModuleWorkflows = ExtractModulePropArr<typeof _modules, "workflows">;
+export type _ModuleFieldTypes = CodegenResolvedModulePropArr<typeof _modules, "fieldTypes">;
+export type _ModuleViews = CodegenResolvedModulePropArr<typeof _modules, "views">;
+export type _ModuleComponents = CodegenResolvedModulePropArr<typeof _modules, "components">;
+export type _ModuleBlocks = CodegenResolvedModulePropArr<typeof _modules, "blocks">;
+export type _ModuleWorkflows = CodegenResolvedModulePropArr<typeof _modules, "workflows">;
 // Registry category extraction from modules
-export type _Registry_Collections = ExtractModulePropArrOverride<typeof _modules, "collections">;
-export type _Registry_Channels = ExtractModulePropArr<typeof _modules, "channels">;
-export type _Registry_Globals = ExtractModulePropArr<typeof _modules, "globals">;
-export type _Registry_Jobs = ExtractModulePropArr<typeof _modules, "jobs">;
-export type _Registry_Routes = ExtractModulePropArr<typeof _modules, "routes">;
+export type _Registry_Collections = CodegenResolvedModulePropArr<typeof _modules, "collections">;
+export type _Registry_Channels = CodegenResolvedModulePropArr<typeof _modules, "channels">;
+export type _Registry_Globals = CodegenResolvedModulePropArr<typeof _modules, "globals">;
+export type _Registry_Jobs = CodegenResolvedModulePropArr<typeof _modules, "jobs">;
+export type _Registry_Routes = CodegenResolvedModulePropArr<typeof _modules, "routes">;
 export type _Registry_Services = {};
-export type _Registry_Emails = ExtractModulePropArr<typeof _modules, "emails">;
-export type _Registry_FieldTypes = ExtractModulePropArr<typeof _modules, "fieldTypes">;
-export type _Registry_Views = ExtractModulePropArr<typeof _modules, "views">;
-export type _Registry_Components = ExtractModulePropArr<typeof _modules, "components">;
-export type _Registry_Blocks = ExtractModulePropArr<typeof _modules, "blocks">;
-export type _Registry_Workflows = ExtractModulePropArr<typeof _modules, "workflows">;
+export type _Registry_Emails = CodegenResolvedModulePropArr<typeof _modules, "emails">;
+export type _Registry_FieldTypes = CodegenResolvedModulePropArr<typeof _modules, "fieldTypes">;
+export type _Registry_Views = CodegenResolvedModulePropArr<typeof _modules, "views">;
+export type _Registry_Components = CodegenResolvedModulePropArr<typeof _modules, "components">;
+export type _Registry_Blocks = CodegenResolvedModulePropArr<typeof _modules, "blocks">;
+export type _Registry_Workflows = CodegenResolvedModulePropArr<typeof _modules, "workflows">;
 
 // Recursive module property extraction (for fields contributed at each level)
 import type { ExtractModuleProp } from "questpie/types";
@@ -103,26 +103,26 @@ export type AppCollections = Override<_ModuleCollections, {
 export type AppChannels = _ModuleChannels;
 
 /** All globals in the app (modules + user, user overrides) */
-export type AppGlobals = _ModuleGlobals & {
+export type AppGlobals = Override<_ModuleGlobals, {
 	siteSettings: typeof _glob_siteSettings;
-};
+}>;
 
 /** All jobs in the app (modules + user, user overrides) */
-export type AppJobs = _ModuleJobs & {
+export type AppJobs = Override<_ModuleJobs, {
 	recalculateMaterialPlan: Omit<typeof _job_recalculateMaterialPlan, "handler"> & { handler: (args: unknown) => Promise<unknown> };
-};
+}>;
 
 /** All routes in the app (modules + user, user overrides) */
-export type AppRoutes = _ModuleRoutes & {
+export type AppRoutes = Override<_ModuleRoutes, {
 	"rpc/planning/capacitySummary": RouteWithParams<_RouteDefinitionWithoutHandler<typeof _route_rpc_planning_capacitySummary>, RouteParamsFromKey<"rpc/planning/capacitySummary">>;
 	"rpc/planning/receiveMaterials": RouteWithParams<_RouteDefinitionWithoutHandler<typeof _route_rpc_planning_receiveMaterials>, RouteParamsFromKey<"rpc/planning/receiveMaterials">>;
 	"rpc/planning/startProduction": RouteWithParams<_RouteDefinitionWithoutHandler<typeof _route_rpc_planning_startProduction>, RouteParamsFromKey<"rpc/planning/startProduction">>;
-};
+}>;
 
 /** All service definitions in the app (modules + user, user overrides). */
-type _AppServiceDefinitions = _ModuleServices & {
+type _AppServiceDefinitions = Override<_ModuleServices, {
 	capacityPlanner: typeof _svc_capacityPlanner;
-};
+}>;
 
 /** All services in the app as resolved service instances. */
 export type AppServices = {
@@ -151,6 +151,4 @@ export type AppComponents = _ModuleComponents;
 export type AppBlocks = _ModuleBlocks;
 
 /** All workflows in the app (modules + user, user overrides) */
-export type AppWorkflows = _ModuleWorkflows
-	& { [K in typeof _wf_nightlyCapacityReview.name]: Omit<typeof _wf_nightlyCapacityReview, "handler" | "onFailure"> & { handler: (args: unknown) => Promise<unknown>; onFailure?: (args: unknown) => Promise<void> } }
-	& { [K in typeof _wf_productionOrderPlan.name]: Omit<typeof _wf_productionOrderPlan, "handler" | "onFailure"> & { handler: (args: unknown) => Promise<unknown>; onFailure?: (args: unknown) => Promise<void> } };
+export type AppWorkflows = Override<Override<_ModuleWorkflows, { [K in typeof _wf_nightlyCapacityReview.name]: Omit<typeof _wf_nightlyCapacityReview, "handler" | "onFailure"> & { handler: (args: unknown) => Promise<unknown>; onFailure?: (args: unknown) => Promise<void> } }>, { [K in typeof _wf_productionOrderPlan.name]: Omit<typeof _wf_productionOrderPlan, "handler" | "onFailure"> & { handler: (args: unknown) => Promise<unknown>; onFailure?: (args: unknown) => Promise<void> } }>;

--- a/packages/questpie/src/cli/codegen/extract-plugins.ts
+++ b/packages/questpie/src/cli/codegen/extract-plugins.ts
@@ -24,7 +24,7 @@ interface ModuleLike {
 	[key: string]: unknown;
 }
 
-export type CodegenPluginOccurrence = {
+type CodegenPluginOccurrence = {
 	plugin: CodegenPlugin;
 	source: string;
 };

--- a/packages/questpie/src/cli/codegen/extract-plugins.ts
+++ b/packages/questpie/src/cli/codegen/extract-plugins.ts
@@ -10,7 +10,11 @@
  * @see ModuleDefinition.plugin
  */
 
-import { resolveNamedGraph } from "../../shared/named-graph.js";
+import {
+	resolveNamedGraph,
+	resolveNamedOccurrences,
+} from "#questpie/shared/named-graph.js";
+
 import type { CodegenPlugin } from "./types.js";
 
 interface ModuleLike {
@@ -29,24 +33,12 @@ export type CodegenPluginOccurrence = {
 export function resolveCodegenPluginOccurrences(
 	occurrences: readonly CodegenPluginOccurrence[],
 ): CodegenPlugin[] {
-	const firstByName = new Map<string, CodegenPluginOccurrence>();
-	const plugins: CodegenPlugin[] = [];
-
-	for (const occurrence of occurrences) {
-		const first = firstByName.get(occurrence.plugin.name);
-		if (first?.plugin === occurrence.plugin) continue;
-		if (first) {
-			throw new Error(
-				`[QUESTPIE] Two different plugins are both named "${occurrence.plugin.name}". ` +
-					`First source: ${first.source}. ` +
-					`Conflicting source: ${occurrence.source}.`,
-			);
-		}
-		firstByName.set(occurrence.plugin.name, occurrence);
-		plugins.push(occurrence.plugin);
-	}
-
-	return plugins;
+	return resolveNamedOccurrences(occurrences, {
+		kind: "plugin",
+		node: (occurrence) => occurrence.plugin,
+		name: (plugin) => plugin.name,
+		source: (occurrence) => occurrence.source,
+	});
 }
 
 /**

--- a/packages/questpie/src/cli/codegen/extract-plugins.ts
+++ b/packages/questpie/src/cli/codegen/extract-plugins.ts
@@ -10,6 +10,7 @@
  * @see ModuleDefinition.plugin
  */
 
+import { resolveNamedGraph } from "../../shared/named-graph.js";
 import type { CodegenPlugin } from "./types.js";
 
 interface ModuleLike {
@@ -19,11 +20,41 @@ interface ModuleLike {
 	[key: string]: unknown;
 }
 
+export type CodegenPluginOccurrence = {
+	plugin: CodegenPlugin;
+	source: string;
+};
+
+/** Deduplicate repeated identities and reject ambiguous plugin names. */
+export function resolveCodegenPluginOccurrences(
+	occurrences: readonly CodegenPluginOccurrence[],
+): CodegenPlugin[] {
+	const firstByName = new Map<string, CodegenPluginOccurrence>();
+	const plugins: CodegenPlugin[] = [];
+
+	for (const occurrence of occurrences) {
+		const first = firstByName.get(occurrence.plugin.name);
+		if (first?.plugin === occurrence.plugin) continue;
+		if (first) {
+			throw new Error(
+				`[QUESTPIE] Two different plugins are both named "${occurrence.plugin.name}". ` +
+					`First source: ${first.source}. ` +
+					`Conflicting source: ${occurrence.source}.`,
+			);
+		}
+		firstByName.set(occurrence.plugin.name, occurrence);
+		plugins.push(occurrence.plugin);
+	}
+
+	return plugins;
+}
+
 /**
  * Extract codegen plugins from a module tree.
  *
  * Traverses modules depth-first (same order as `resolveModules` in create-app.ts)
- * and collects all `plugin` entries. Deduplicates by plugin name — first occurrence wins.
+ * and collects all `plugin` entries. Repeated object identities deduplicate;
+ * different modules or plugins sharing one name are rejected.
  *
  * @param modules - Top-level modules array (from modules.ts default export)
  * @returns Deduplicated array of codegen plugins in depth-first order
@@ -31,32 +62,26 @@ interface ModuleLike {
 export function extractPluginsFromModules(
 	modules: ModuleLike[],
 ): CodegenPlugin[] {
-	const seen = new Set<string>();
-	const plugins: CodegenPlugin[] = [];
+	const resolvedModules = resolveNamedGraph(modules, {
+		kind: "module",
+		name: (module) => module.name,
+		children: (module) => module.modules ?? [],
+	});
+	const occurrences: CodegenPluginOccurrence[] = [];
 
-	function walk(mod: ModuleLike): void {
-		// Depth-first: process sub-modules before self
-		if (mod.modules) {
-			for (const sub of mod.modules) {
-				walk(sub);
-			}
-		}
+	for (const mod of resolvedModules) {
 		const modPlugins = Array.isArray(mod.plugin)
 			? mod.plugin
 			: mod.plugin
 				? [mod.plugin]
 				: [];
-		for (const p of modPlugins) {
-			if (!seen.has(p.name)) {
-				seen.add(p.name);
-				plugins.push(p);
-			}
+		for (const plugin of modPlugins) {
+			occurrences.push({
+				plugin,
+				source: `module ${mod.name ?? "<anonymous>"}`,
+			});
 		}
 	}
 
-	for (const m of modules) {
-		walk(m);
-	}
-
-	return plugins;
+	return resolveCodegenPluginOccurrences(occurrences);
 }

--- a/packages/questpie/src/cli/codegen/index.ts
+++ b/packages/questpie/src/cli/codegen/index.ts
@@ -20,6 +20,7 @@ import {
 import { validateChannelWirePattern } from "./channel-pattern.js";
 import { discoverFiles } from "./discover.js";
 import { generateClientEnvModules } from "./env-client-template.js";
+import { resolveCodegenPluginOccurrences } from "./extract-plugins.js";
 import { generateFactoryTemplate } from "./factory-template.js";
 import { loadModuleFactoryArguments } from "./module-metadata.js";
 import { generateModuleTemplate } from "./module-template.js";
@@ -277,6 +278,12 @@ export function coreCodegenPlugin(): CodegenPlugin {
 export function resolveTargetGraph(
 	plugins: CodegenPlugin[],
 ): Map<string, ResolvedTarget> {
+	plugins = resolveCodegenPluginOccurrences(
+		plugins.map((plugin, index) => ({
+			plugin,
+			source: `target graph input ${index}`,
+		})),
+	);
 	const targets = new Map<string, ResolvedTarget>();
 	const owners = resolveTargetOwners(plugins);
 

--- a/packages/questpie/src/cli/codegen/module-metadata.ts
+++ b/packages/questpie/src/cli/codegen/module-metadata.ts
@@ -1,3 +1,4 @@
+import { resolveNamedGraph } from "../../shared/named-graph.js";
 import { findModulesFile, toFileImportSpecifier } from "../utils.js";
 import type { FactoryArgumentMetadata } from "./types.js";
 
@@ -23,15 +24,14 @@ export function extractFactoryArgumentsFromModules(
 	modules: ModuleLike[],
 ): FactoryArgumentMetadata[] {
 	const symbol = Symbol.for(CODEGEN_MODULE_METADATA_SYMBOL);
-	const seen = new Set<ModuleLike>();
 	const result: FactoryArgumentMetadata[] = [];
+	const resolvedModules = resolveNamedGraph(modules, {
+		kind: "module",
+		name: (module) => module.name,
+		children: (module) => module.modules ?? [],
+	});
 
-	function walk(module: ModuleLike): void {
-		if (seen.has(module)) return;
-		seen.add(module);
-
-		for (const child of module.modules ?? []) walk(child);
-
+	for (const module of resolvedModules) {
 		const metadata = module[symbol] as StoredModuleMetadata | undefined;
 		for (const entry of metadata?.factoryArguments ?? []) {
 			result.push({
@@ -40,8 +40,6 @@ export function extractFactoryArgumentsFromModules(
 			});
 		}
 	}
-
-	for (const module of modules) walk(module);
 	return result;
 }
 

--- a/packages/questpie/src/cli/codegen/module-metadata.ts
+++ b/packages/questpie/src/cli/codegen/module-metadata.ts
@@ -1,4 +1,5 @@
-import { resolveNamedGraph } from "../../shared/named-graph.js";
+import { resolveNamedGraph } from "#questpie/shared/named-graph.js";
+
 import { findModulesFile, toFileImportSpecifier } from "../utils.js";
 import type { FactoryArgumentMetadata } from "./types.js";
 

--- a/packages/questpie/src/cli/codegen/template.ts
+++ b/packages/questpie/src/cli/codegen/template.ts
@@ -404,7 +404,7 @@ export function generateTemplate(options: TemplateOptions): TemplateResult {
 
 	// L1 type-utils — feed `_Module*` / `_Registry_*` / `_AllModule*` / AppServices.
 	lines.push(
-		'import type { ExtractModulePropArr, ExtractModulePropArrOverride, Override, ServiceCustomNamespaceInstances, ServiceInstanceOf, ServiceInstancesInNamespace, ServiceTopLevelInstances } from "questpie/types";',
+		'import type { CodegenResolvedModulePropArr, ExtractModulePropArr, Override, ServiceCustomNamespaceInstances, ServiceInstanceOf, ServiceInstancesInNamespace, ServiceTopLevelInstances } from "questpie/types";',
 	);
 	// The WorkflowClient<…> wrapper is consumed only by the L2 AppContext/
 	// JobHandler/Workflow contexts (`hasWorkflows` declared up-front above).
@@ -416,9 +416,9 @@ export function generateTemplate(options: TemplateOptions): TemplateResult {
 	lines.push(
 		'type _RouteDefinitionWithoutHandler<T> = T extends { mode: "raw" } ? Omit<T, "handler"> & { handler: (args: unknown) => Response | Promise<Response> } : Omit<T, "handler"> & { handler: (args: unknown) => unknown | Promise<unknown> };',
 	);
-	// Module category extraction is done via `ExtractModulePropArr` — a recursive,
-	// member-only fold over the module tuple (recurses sub-modules, projects only
-	// the requested member). It replaces the old `_MP`/`UnionToIntersection` fuse:
+	// Module category extraction uses a member-only fold over the module tuple
+	// (recurses sub-modules, projects only the requested member). It replaces the
+	// old `_MP`/`UnionToIntersection` fuse:
 	// `UnionToIntersection` forced eager whole-union materialization, which dragged
 	// the cyclic config/services carrier members through AppContext (TS2456). The
 	// recursive fold walks modules one at a time and never materializes a sibling
@@ -496,7 +496,8 @@ export function generateTemplate(options: TemplateOptions): TemplateResult {
 	// ── L1 flat category maps resume — `_Module*` / `_Registry_*` ──────────
 	lines = l1;
 	// ── _Module* type extraction for categories ──────────────────
-	// SAFE categories use the recursive member-only `ExtractModulePropArr` fold
+	// SAFE category records use `CodegenResolvedModulePropArr`, which mirrors the
+	// runtime's validated, children-first, identity-deduplicated last-wins merge.
 	// (acyclic — the members carry no AppContext back-reference). The `services`
 	// category is the ONE carrier whose member VALUES reach AppContext (a service's
 	// `create(ctx: ServiceCreateContext)` → AppContext); ANY fold over the module
@@ -506,24 +507,17 @@ export function generateTemplate(options: TemplateOptions): TemplateResult {
 	// CoreServices are framework infrastructure surfaced via _AppInfraContext, not
 	// the user module array). `moduleCategoryType()` centralises this rule.
 	//
-	// The `collections` category uses the OVERRIDE fold instead of the additive `&`
-	// one: a module may both NEST a sub-module shipping `collections.user` AND
-	// re-declare `collections.user` via `collection("user").merge(sub.collections.user)`
-	// (the admin module re-declaring starter's user). Intersecting the two full
-	// `Collection<A> & Collection<B>` instantiations collapses the value to `never`
-	// (nullable-table member drift detonates the object), poisoning
-	// `CollectionInsert`/`CollectionSelect` → `never`/`{}`. `ExtractModulePropArrOverride`
-	// makes the most-derived (outer) re-declaration shadow the nested base instead.
+	// Every category record uses the same ordered fold. Runtime spread-merges all
+	// category maps, so globals/jobs/routes/plugin categories must not intersect a
+	// shadowed definition or replay a shared dependency through a diamond either.
 	const moduleCategoryType = (catName: string): string =>
 		catName === "services"
 			? "{}"
-			: catName === "collections"
-				? `ExtractModulePropArrOverride<typeof ${modulesFile.varName}, "${catName}">`
-				: `ExtractModulePropArr<typeof ${modulesFile.varName}, "${catName}">`;
+			: `CodegenResolvedModulePropArr<typeof ${modulesFile.varName}, "${catName}">`;
 	// Exported — `_ModuleCollections` feeds the L2 `_JobHandlerCollections`
 	// literal (imported DOWN from entities.gen.ts). The rest are exported
 	// uniformly (harmless) so any future L2 reference resolves.
-	for (const [catName, fileMap] of discovered.categories) {
+	for (const [catName] of discovered.categories) {
 		const decl = allDecls.get(catName);
 		const shouldExtract = decl ? decl.extractFromModules !== false : true;
 		if (!shouldExtract) continue;
@@ -537,7 +531,7 @@ export function generateTemplate(options: TemplateOptions): TemplateResult {
 	for (const [stateKey] of discovered.spreads) {
 		const moduleTypeName = deriveModuleTypeName(stateKey);
 		lines.push(
-			`export type ${moduleTypeName} = ${moduleCategoryType(stateKey)};`,
+			`export type ${moduleTypeName} = ExtractModulePropArr<typeof ${modulesFile.varName}, "${stateKey}">;`,
 		);
 	}
 
@@ -700,11 +694,13 @@ export function generateTemplate(options: TemplateOptions): TemplateResult {
 					"/** All service definitions in the app (modules + user, user overrides). */",
 				);
 				if (hasUser) {
-					lines.push(`type _AppServiceDefinitions = ${moduleTypeName} & {`);
+					lines.push(
+						`type _AppServiceDefinitions = Override<${moduleTypeName}, {`,
+					);
 					for (const file of sortedValues(fileMap)) {
 						lines.push(`\t${safeKey(file.key)}: typeof ${file.varName};`);
 					}
-					lines.push("};");
+					lines.push("}>;");
 				} else {
 					lines.push(`type _AppServiceDefinitions = ${moduleTypeName};`);
 				}
@@ -1798,32 +1794,20 @@ function emitTypeInterface(
 	lines.push(`/** All ${label} in the app (modules + user, user overrides) */`);
 	if (hasUser) {
 		if (decl?.keyFromProperty) {
-			lines.push(`export type ${typeName} = ${moduleTypeName}`);
-			const files = sortedValues(fileMap);
-			for (const [index, file] of files.entries()) {
-				const suffix = index === files.length - 1 ? ";" : "";
-				lines.push(
-					`	& { ${categoryTypeEntry(file, decl, catName)} }${suffix}`,
-				);
-			}
-		} else {
-			// `collections` must OVERRIDE (not intersect) on shared keys: a user app may
-			// re-declare a module-contributed collection (e.g. a standalone
-			// `collection("assets")`). Intersecting `_ModuleCollections & { assets }`
-			// detonates the shared collection to `never` (nullable-table member drift),
-			// poisoning CollectionInsert/Select — the same reason the module-level fold
-			// uses `ExtractModulePropArrOverride`. `Override<module, user>` lets the
-			// most-derived user definition shadow the module one; distinct keys survive.
-			const overrideFold = catName === "collections";
-			lines.push(
-				overrideFold
-					? `export type ${typeName} = Override<${moduleTypeName}, {`
-					: `export type ${typeName} = ${moduleTypeName} & {`,
+			const resolvedType = sortedValues(fileMap).reduce(
+				(current, file) =>
+					`Override<${current}, { ${categoryTypeEntry(file, decl, catName)} }>`,
+				moduleTypeName,
 			);
+			lines.push(`export type ${typeName} = ${resolvedType};`);
+		} else {
+			// Root entities become the last `__user` runtime module, so every category
+			// record uses the same last-wins override semantics here.
+			lines.push(`export type ${typeName} = Override<${moduleTypeName}, {`);
 			for (const file of sortedValues(fileMap)) {
 				lines.push(`\t${categoryTypeEntry(file, decl, catName)};`);
 			}
-			lines.push(overrideFold ? "}>;" : "};");
+			lines.push("}>;");
 		}
 	} else {
 		lines.push(`export type ${typeName} = ${moduleTypeName};`);
@@ -1843,13 +1827,13 @@ function emitRouteTypeInterface(
 	const hasUser = fileMap.size > 0;
 	lines.push("/** All routes in the app (modules + user, user overrides) */");
 	if (hasUser) {
-		lines.push(`export type ${typeName} = ${moduleTypeName} & {`);
+		lines.push(`export type ${typeName} = Override<${moduleTypeName}, {`);
 		for (const file of sortedValues(fileMap)) {
 			lines.push(
 				`\t${safeKey(file.key)}: RouteWithParams<_RouteDefinitionWithoutHandler<typeof ${file.varName}>, RouteParamsFromKey<${JSON.stringify(file.key)}>>;`,
 			);
 		}
-		lines.push("};");
+		lines.push("}>;");
 	} else {
 		lines.push(`export type ${typeName} = ${moduleTypeName};`);
 	}

--- a/packages/questpie/src/cli/commands/codegen.ts
+++ b/packages/questpie/src/cli/commands/codegen.ts
@@ -10,7 +10,10 @@ import { watch } from "node:fs";
 import { readdir, readFile, stat } from "node:fs/promises";
 import { join, resolve } from "node:path";
 
-import { extractPluginsFromModules } from "../codegen/extract-plugins.js";
+import {
+	extractPluginsFromModules,
+	resolveCodegenPluginOccurrences,
+} from "../codegen/extract-plugins.js";
 import {
 	coreCodegenPlugin,
 	resolveTargetGraph,
@@ -929,7 +932,8 @@ function printDiscovered(
  * traverses the module tree, and extracts all plugins — so they participate
  * in codegen without manual registration in questpie.config.ts.
  *
- * Merge order: module-extracted plugins → runtimeConfig plugins.
+ * Merge order: runtimeConfig plugins → module-extracted plugins. Repeated
+ * object identities deduplicate; distinct plugins sharing one name reject.
  * Core plugin is always prepended by runAllTargets/runCodegen.
  *
  * A failure here is fatal on purpose. Those plugins declare whole categories,
@@ -944,10 +948,16 @@ export async function extractModulePlugins(
 	configPlugins: CodegenPlugin[],
 	options: GenerateOptions,
 ): Promise<CodegenPlugin[]> {
+	const configOccurrences = configPlugins.map((plugin) => ({
+		plugin,
+		source: "runtimeConfig({ plugins })",
+	}));
 	const modulesPath = await findModulesFile(rootDir);
 	// A missing modules.ts is not this function's error to report. The root
 	// template raises it with a better message, and other modes never have one.
-	if (!modulesPath) return configPlugins;
+	if (!modulesPath) {
+		return resolveCodegenPluginOccurrences(configOccurrences);
+	}
 
 	let modulesExport: Record<string, unknown>;
 	try {
@@ -978,7 +988,9 @@ export async function extractModulePlugins(
 	}
 
 	const modulePlugins = extractPluginsFromModules(modules);
-	if (modulePlugins.length === 0) return configPlugins;
+	if (modulePlugins.length === 0) {
+		return resolveCodegenPluginOccurrences(configOccurrences);
+	}
 
 	if (options.verbose) {
 		console.log(
@@ -986,22 +998,13 @@ export async function extractModulePlugins(
 		);
 	}
 
-	// Dedupe: module-extracted first, then config plugins (config wins on name collision)
-	const seen = new Set<string>();
-	const merged: CodegenPlugin[] = [];
-	// Config plugins take priority — add them first to the seen set
-	for (const p of configPlugins) {
-		seen.add(p.name);
-		merged.push(p);
-	}
-	// Then add module-extracted plugins that weren't already in config
-	for (const p of modulePlugins) {
-		if (!seen.has(p.name)) {
-			seen.add(p.name);
-			merged.push(p);
-		}
-	}
-	return merged;
+	return resolveCodegenPluginOccurrences([
+		...configOccurrences,
+		...modulePlugins.map((plugin) => ({
+			plugin,
+			source: "modules.ts",
+		})),
+	]);
 }
 
 /**

--- a/packages/questpie/src/exports/types.ts
+++ b/packages/questpie/src/exports/types.ts
@@ -60,6 +60,8 @@ export type {
 	ExtractModuleProp,
 	ExtractModulePropArr,
 	CodegenResolvedModulePropArr,
+	ExtractModulePropArrOverride,
+	ExtractModulePropOverride,
 	MergeModuleProp,
 	RegistryProp,
 	ServiceCustomNamespaceInstances,

--- a/packages/questpie/src/exports/types.ts
+++ b/packages/questpie/src/exports/types.ts
@@ -59,8 +59,7 @@ export {
 export type {
 	ExtractModuleProp,
 	ExtractModulePropArr,
-	ExtractModulePropArrOverride,
-	ExtractModulePropOverride,
+	CodegenResolvedModulePropArr,
 	MergeModuleProp,
 	RegistryProp,
 	ServiceCustomNamespaceInstances,

--- a/packages/questpie/src/server/config/codegen-type-utils.ts
+++ b/packages/questpie/src/server/config/codegen-type-utils.ts
@@ -95,32 +95,67 @@ export type MergeModuleProp<
  * typed table on the other, and `null & {…}` reduces the whole object to `never`),
  * which then poisons `CollectionInsert`/`CollectionSelect` into `never`/`{}`.
  *
- * This variant uses `Override<nested, direct>` so the OUTER (most-derived) module's
- * direct `M[K]` shadows the nested sub-modules' contribution for the same key,
- * while distinct keys from both sides survive — i.e. a re-declared collection
- * replaces its base instead of detonating into `never`.
+ * This variant follows the runtime's identity-deduplicated, children-first DFS.
+ * A module's direct `M[K]` shadows its dependencies, while a shared dependency
+ * reached through a later diamond branch is not replayed after an earlier
+ * dependent. Distinct keys from every resolved module still survive.
  */
-export type ExtractModulePropOverride<M, K extends string> = Override<
-	M extends { modules: infer Sub extends readonly any[] }
-		? ExtractModulePropArrOverride<Sub, K>
-		: {},
-	K extends keyof M ? (M[K] extends Record<string, any> ? M[K] : {}) : {}
->;
+type ModuleIdentity<M> = M extends { name: infer Name extends string }
+	? string extends Name
+		? M
+		: Name
+	: M;
+
+type ModulePropFoldState<Result, Seen> = {
+	result: Result;
+	seen: Seen;
+};
+
+type ExtractDirectModuleProp<M, K extends string> = K extends keyof M
+	? M[K] extends Record<string, any>
+		? M[K]
+		: {}
+	: {};
+
+type FoldModulePropOverride<
+	M,
+	K extends string,
+	State extends ModulePropFoldState<any, any>,
+> = [ModuleIdentity<M>] extends [State["seen"]]
+	? State
+	: FoldModulePropArrOverride<
+				M extends { modules: infer Sub extends readonly any[] } ? Sub : [],
+				K,
+				ModulePropFoldState<State["result"], State["seen"] | ModuleIdentity<M>>
+		  > extends infer NestedState extends ModulePropFoldState<any, any>
+		? ModulePropFoldState<
+				Override<NestedState["result"], ExtractDirectModuleProp<M, K>>,
+				NestedState["seen"]
+			>
+		: never;
+
+type FoldModulePropArrOverride<
+	A extends readonly any[],
+	K extends string,
+	State extends ModulePropFoldState<any, any>,
+> = A extends readonly [infer Head, ...infer Tail extends readonly any[]]
+	? FoldModulePropArrOverride<Tail, K, FoldModulePropOverride<Head, K, State>>
+	: State;
+
+export type ExtractModulePropOverride<
+	M,
+	K extends string,
+> = FoldModulePropOverride<M, K, ModulePropFoldState<{}, never>>["result"];
 
 /**
  * Array companion for {@link ExtractModulePropOverride} — folds a readonly tuple
- * of modules with last-wins override semantics (a later sibling re-declaring a
- * key shadows an earlier one), mirroring the runtime spread-merge order.
+ * in the runtime's identity-deduplicated merge order. A later resolved module
+ * re-declaring a key shadows an earlier one.
  */
 export type ExtractModulePropArrOverride<
 	A extends readonly any[],
 	K extends string,
-> = A extends readonly [infer H, ...infer T extends readonly any[]]
-	? Override<
-			ExtractModulePropOverride<H, K>,
-			ExtractModulePropArrOverride<T, K>
-		>
-	: {};
+> = FoldModulePropArrOverride<A, K, ModulePropFoldState<{}, never>>["result"];
 
 /**
  * Normalize a service namespace to its runtime placement namespace.

--- a/packages/questpie/src/server/config/codegen-type-utils.ts
+++ b/packages/questpie/src/server/config/codegen-type-utils.ts
@@ -81,6 +81,36 @@ export type MergeModuleProp<
 > = ExtractModulePropArr<TModules, K>;
 
 /**
+ * Legacy override fold retained for source compatibility.
+ *
+ * @deprecated Prefer app-generated category types instead of folding module
+ * graphs directly. This helper preserves its original recursive semantics and
+ * does not provide the validated graph ordering used by QUESTPIE codegen.
+ */
+export type ExtractModulePropOverride<M, K extends string> = Override<
+	M extends { modules: infer Sub extends readonly any[] }
+		? ExtractModulePropArrOverride<Sub, K>
+		: {},
+	K extends keyof M ? (M[K] extends Record<string, any> ? M[K] : {}) : {}
+>;
+
+/**
+ * Legacy tuple companion for {@link ExtractModulePropOverride}.
+ *
+ * @deprecated Prefer app-generated category types. Retained unchanged for
+ * consumers importing it from `questpie/types`.
+ */
+export type ExtractModulePropArrOverride<
+	A extends readonly any[],
+	K extends string,
+> = A extends readonly [infer H, ...infer T extends readonly any[]]
+	? Override<
+			ExtractModulePropOverride<H, K>,
+			ExtractModulePropArrOverride<T, K>
+		>
+	: {};
+
+/**
  * Ordered merge support for generated category records, where a same-key
  * contribution must replace rather than intersect the previous definition.
  *

--- a/packages/questpie/src/server/config/codegen-type-utils.ts
+++ b/packages/questpie/src/server/config/codegen-type-utils.ts
@@ -81,13 +81,12 @@ export type MergeModuleProp<
 > = ExtractModulePropArr<TModules, K>;
 
 /**
- * Override-merging companion of {@link ExtractModuleProp} for whole-definition
- * categories (collections/globals) where a same-key contribution must REPLACE,
- * not intersect.
+ * Ordered merge support for generated category records, where a same-key
+ * contribution must replace rather than intersect the previous definition.
  *
- * The additive fold above intersects every contribution with `&`. That is correct
- * for additive registry categories (fieldTypes/views/components) whose members are
- * distinct-keyed records. It is WRONG for collections: a module may both NEST a
+ * The additive fold above intersects every contribution with `&`. It remains for
+ * genuinely additive values, but it is wrong for runtime record merges. For
+ * example, a module may both nest a
  * sub-module that ships `collections.user` AND re-declare `collections.user` via
  * `collection("user").merge(sub.collections.user)`. Intersecting the two full
  * `Collection<A> & Collection<B>` instantiations collapses the value to `never`
@@ -100,11 +99,11 @@ export type MergeModuleProp<
  * reached through a later diamond branch is not replayed after an earlier
  * dependent. Distinct keys from every resolved module still survive.
  */
-type ModuleIdentity<M> = M extends { name: infer Name extends string }
+type ValidatedModuleName<M> = M extends { name: infer Name extends string }
 	? string extends Name
-		? M
+		? never
 		: Name
-	: M;
+	: never;
 
 type ModulePropFoldState<Result, Seen> = {
 	result: Result;
@@ -121,12 +120,17 @@ type FoldModulePropOverride<
 	M,
 	K extends string,
 	State extends ModulePropFoldState<any, any>,
-> = [ModuleIdentity<M>] extends [State["seen"]]
-	? State
+> = [ValidatedModuleName<M>] extends [State["seen"]]
+	? [ValidatedModuleName<M>] extends [never]
+		? never
+		: State
 	: FoldModulePropArrOverride<
 				M extends { modules: infer Sub extends readonly any[] } ? Sub : [],
 				K,
-				ModulePropFoldState<State["result"], State["seen"] | ModuleIdentity<M>>
+				ModulePropFoldState<
+					State["result"],
+					State["seen"] | ValidatedModuleName<M>
+				>
 		  > extends infer NestedState extends ModulePropFoldState<any, any>
 		? ModulePropFoldState<
 				Override<NestedState["result"], ExtractDirectModuleProp<M, K>>,
@@ -142,17 +146,22 @@ type FoldModulePropArrOverride<
 	? FoldModulePropArrOverride<Tail, K, FoldModulePropOverride<Head, K, State>>
 	: State;
 
-export type ExtractModulePropOverride<
-	M,
-	K extends string,
-> = FoldModulePropOverride<M, K, ModulePropFoldState<{}, never>>["result"];
-
 /**
- * Array companion for {@link ExtractModulePropOverride} — folds a readonly tuple
- * in the runtime's identity-deduplicated merge order. A later resolved module
- * re-declaring a key shadows an earlier one.
+ * Codegen-only fold for a module graph that has already passed runtime graph
+ * validation. Generated/module-factory definitions preserve narrow literal
+ * names; runtime validation guarantees each such name identifies exactly one
+ * object and rejects cycles and distinct objects sharing a name before code is
+ * emitted. Under those preconditions, names are a sound type-level stand-in for
+ * object identity and reproduce children-first, first-position dedupe. A module
+ * whose name has widened to `string` produces `never` instead of silently using
+ * structural equality as fake object identity.
+ *
+ * TypeScript cannot observe JavaScript object identity or diagnose arbitrary
+ * recursive object graphs. Do not use this helper on an unvalidated module tree.
+ *
+ * @internal Generated QUESTPIE code only.
  */
-export type ExtractModulePropArrOverride<
+export type CodegenResolvedModulePropArr<
 	A extends readonly any[],
 	K extends string,
 > = FoldModulePropArrOverride<A, K, ModulePropFoldState<{}, never>>["result"];

--- a/packages/questpie/src/server/config/create-app.ts
+++ b/packages/questpie/src/server/config/create-app.ts
@@ -27,6 +27,7 @@ import {
 import coreModule from "#questpie/server/modules/core/.generated/module.js";
 import { mergeAuthOptions } from "#questpie/server/modules/core/integrated/auth/merge.js";
 import { createCrdtRuntimeManifests } from "#questpie/server/modules/core/integrated/crdt/manifest-runtime.js";
+import { resolveNamedGraph } from "#questpie/shared/named-graph.js";
 
 type RuntimeConfigStorageInputGuard<TInput> = TInput extends {
 	storage?: infer TStorage;
@@ -134,20 +135,6 @@ export function runtimeConfig<const TInput extends RuntimeConfigInput>(
 // Module resolution — depth-first, left-to-right
 // ============================================================================
 
-/** Walk the module tree depth-first, children before their parent. */
-function flattenModules(
-	modules: readonly AppModuleInput[],
-): ModuleDefinition[] {
-	const flat: ModuleDefinition[] = [];
-	for (const mod of modules) {
-		if (mod.modules && mod.modules.length > 0) {
-			flat.push(...flattenModules(mod.modules));
-		}
-		flat.push(mod as ModuleDefinition);
-	}
-	return flat;
-}
-
 /**
  * Flatten the module tree into merge order: depth-first, left to right,
  * every dependency ahead of the module that depends on it.
@@ -164,36 +151,11 @@ function flattenModules(
 function resolveModules(
 	modules: readonly AppModuleInput[],
 ): ModuleDefinition[] {
-	const flat = flattenModules(modules);
-	const firstByName = new Map<
-		string,
-		{ index: number; mod: ModuleDefinition }
-	>();
-	const resolved: ModuleDefinition[] = [];
-
-	for (let i = 0; i < flat.length; i++) {
-		const mod = flat[i];
-		const first = firstByName.get(mod.name);
-
-		if (!first) {
-			firstByName.set(mod.name, { index: i, mod });
-			resolved.push(mod);
-			continue;
-		}
-
-		// Same module reached twice. Already in merge order at first.index.
-		if (first.mod === mod) continue;
-
-		throw new Error(
-			`[QUESTPIE] Two different modules are both named "${mod.name}", ` +
-				`at positions ${first.index} and ${i} of the resolved module list. ` +
-				`Module name is the merge key, so one would silently replace the other. ` +
-				`Rename one of them.\n` +
-				`Resolved order: ${flat.map((m, n) => `${n}:${m.name}`).join(", ")}`,
-		);
-	}
-
-	return resolved;
+	return resolveNamedGraph(modules, {
+		kind: "module",
+		name: (module) => module.name,
+		children: (module) => module.modules ?? [],
+	}) as ModuleDefinition[];
 }
 
 // ============================================================================
@@ -687,12 +649,12 @@ async function createAppFromDefinition(
 	const hasRootEntities = Object.keys(rootEntities).some(
 		(k) => rootEntities[k] !== undefined,
 	);
-	// Auto-prepend coreModule so its hooks/jobs are always available.
-	// Dedup: if user already listed coreModule, keep theirs (last-write-wins).
+	// Auto-prepend the canonical core module so its hooks/jobs are always
+	// available. The graph resolver deduplicates the same object identity and
+	// rejects a different module trying to reuse the core name.
 	const userModules = defModules ?? [];
-	const hasCoreAlready = userModules.some((m) => m.name === coreModule.name);
 	const allModules = [
-		...(hasCoreAlready ? [] : [coreModule as unknown as ModuleDefinition]),
+		coreModule as unknown as ModuleDefinition,
 		...userModules,
 		...(hasRootEntities
 			? [{ name: "__user", ...rootEntities } as ModuleDefinition]

--- a/packages/questpie/src/shared/named-graph.ts
+++ b/packages/questpie/src/shared/named-graph.ts
@@ -1,0 +1,63 @@
+type NamedGraphOptions<TNode extends object> = {
+	kind: string;
+	children(node: TNode): readonly TNode[];
+	name(node: TNode): string | undefined;
+};
+
+type GraphOccurrence<TNode> = {
+	node: TNode;
+	path: string[];
+};
+
+/** Resolve a named dependency graph children-first with one collision policy. */
+export function resolveNamedGraph<TNode extends object>(
+	roots: readonly TNode[],
+	options: NamedGraphOptions<TNode>,
+): TNode[] {
+	const resolved: TNode[] = [];
+	const states = new WeakMap<TNode, "visiting" | "visited">();
+	const firstByName = new Map<string, GraphOccurrence<TNode>>();
+	const stack: GraphOccurrence<TNode>[] = [];
+
+	const label = (node: TNode) =>
+		options.name(node) ?? `<anonymous-${options.kind}>`;
+
+	function visit(node: TNode, parentPath: readonly string[]): void {
+		const nodeName = options.name(node);
+		const path = [...parentPath, label(node)];
+		if (nodeName !== undefined) {
+			const first = firstByName.get(nodeName);
+			if (first && first.node !== node) {
+				throw new Error(
+					`[QUESTPIE] Two different ${options.kind}s are both named "${nodeName}". ` +
+						`First path: ${first.path.join(" -> ")}. ` +
+						`Conflicting path: ${path.join(" -> ")}.`,
+				);
+			}
+			if (!first) firstByName.set(nodeName, { node, path });
+		}
+
+		const state = states.get(node);
+		if (state === "visited") return;
+		if (state === "visiting") {
+			const cycleStart = stack.findIndex((entry) => entry.node === node);
+			const cycle = [
+				...stack.slice(cycleStart).map((entry) => label(entry.node)),
+				label(node),
+			];
+			throw new Error(
+				`[QUESTPIE] Circular ${options.kind} dependency: ${cycle.join(" -> ")}`,
+			);
+		}
+
+		states.set(node, "visiting");
+		stack.push({ node, path });
+		for (const child of options.children(node)) visit(child, path);
+		stack.pop();
+		states.set(node, "visited");
+		resolved.push(node);
+	}
+
+	for (const root of roots) visit(root, []);
+	return resolved;
+}

--- a/packages/questpie/src/shared/named-graph.ts
+++ b/packages/questpie/src/shared/named-graph.ts
@@ -4,11 +4,6 @@ type NamedGraphOptions<TNode extends object> = {
 	name(node: TNode): string | undefined;
 };
 
-type GraphOccurrence<TNode> = {
-	node: TNode;
-	path: string[];
-};
-
 type NamedOccurrenceOptions<TNode extends object, TOccurrence> = {
 	kind: string;
 	node(occurrence: TOccurrence): TNode;
@@ -80,7 +75,7 @@ export function resolveNamedGraph<TNode extends object>(
 	const resolved: TNode[] = [];
 	const states = new WeakMap<TNode, "visiting" | "visited">();
 	const firstByName = new Map<string, NamedIdentity<TNode>>();
-	const stack: GraphOccurrence<TNode>[] = [];
+	const stack: TNode[] = [];
 
 	const label = (node: TNode) =>
 		options.name(node) ?? `<anonymous-${options.kind}>`;
@@ -100,18 +95,15 @@ export function resolveNamedGraph<TNode extends object>(
 		const state = states.get(node);
 		if (state === "visited") return;
 		if (state === "visiting") {
-			const cycleStart = stack.findIndex((entry) => entry.node === node);
-			const cycle = [
-				...stack.slice(cycleStart).map((entry) => label(entry.node)),
-				label(node),
-			];
+			const cycleStart = stack.findIndex((entry) => entry === node);
+			const cycle = [...stack.slice(cycleStart).map(label), label(node)];
 			throw new Error(
 				`[QUESTPIE] Circular ${options.kind} dependency: ${cycle.join(" -> ")}`,
 			);
 		}
 
 		states.set(node, "visiting");
-		stack.push({ node, path });
+		stack.push(node);
 		for (const child of options.children(node)) visit(child, path);
 		stack.pop();
 		states.set(node, "visited");

--- a/packages/questpie/src/shared/named-graph.ts
+++ b/packages/questpie/src/shared/named-graph.ts
@@ -9,6 +9,69 @@ type GraphOccurrence<TNode> = {
 	path: string[];
 };
 
+type NamedOccurrenceOptions<TNode extends object, TOccurrence> = {
+	kind: string;
+	node(occurrence: TOccurrence): TNode;
+	name(node: TNode): string | undefined;
+	source(occurrence: TOccurrence): string;
+};
+
+type NamedIdentity<TNode extends object> = {
+	node: TNode;
+	source: string;
+};
+
+function registerNamedIdentity<TNode extends object>(
+	node: TNode,
+	name: string | undefined,
+	source: string,
+	kind: string,
+	sourceLabel: "path" | "source",
+	firstByName: Map<string, NamedIdentity<TNode>>,
+): "first" | "repeated" {
+	if (name === undefined) return "first";
+
+	const first = firstByName.get(name);
+	if (first?.node === node) return "repeated";
+	if (first) {
+		throw new Error(
+			`[QUESTPIE] Two different ${kind}s are both named "${name}". ` +
+				`First ${sourceLabel}: ${first.source}. ` +
+				`Conflicting ${sourceLabel}: ${source}.`,
+		);
+	}
+
+	firstByName.set(name, { node, source });
+	return "first";
+}
+
+/** Deduplicate named occurrences by identity and reject ambiguous names. */
+export function resolveNamedOccurrences<TNode extends object, TOccurrence>(
+	occurrences: readonly TOccurrence[],
+	options: NamedOccurrenceOptions<TNode, TOccurrence>,
+): TNode[] {
+	const resolved: TNode[] = [];
+	const firstByName = new Map<string, NamedIdentity<TNode>>();
+
+	for (const occurrence of occurrences) {
+		const node = options.node(occurrence);
+		if (
+			registerNamedIdentity(
+				node,
+				options.name(node),
+				options.source(occurrence),
+				options.kind,
+				"source",
+				firstByName,
+			) === "first"
+		) {
+			resolved.push(node);
+		}
+	}
+
+	return resolved;
+}
+
 /** Resolve a named dependency graph children-first with one collision policy. */
 export function resolveNamedGraph<TNode extends object>(
 	roots: readonly TNode[],
@@ -16,7 +79,7 @@ export function resolveNamedGraph<TNode extends object>(
 ): TNode[] {
 	const resolved: TNode[] = [];
 	const states = new WeakMap<TNode, "visiting" | "visited">();
-	const firstByName = new Map<string, GraphOccurrence<TNode>>();
+	const firstByName = new Map<string, NamedIdentity<TNode>>();
 	const stack: GraphOccurrence<TNode>[] = [];
 
 	const label = (node: TNode) =>
@@ -25,17 +88,14 @@ export function resolveNamedGraph<TNode extends object>(
 	function visit(node: TNode, parentPath: readonly string[]): void {
 		const nodeName = options.name(node);
 		const path = [...parentPath, label(node)];
-		if (nodeName !== undefined) {
-			const first = firstByName.get(nodeName);
-			if (first && first.node !== node) {
-				throw new Error(
-					`[QUESTPIE] Two different ${options.kind}s are both named "${nodeName}". ` +
-						`First path: ${first.path.join(" -> ")}. ` +
-						`Conflicting path: ${path.join(" -> ")}.`,
-				);
-			}
-			if (!first) firstByName.set(nodeName, { node, path });
-		}
+		registerNamedIdentity(
+			node,
+			nodeName,
+			path.join(" -> "),
+			options.kind,
+			"path",
+			firstByName,
+		);
 
 		const state = states.get(node);
 		if (state === "visited") return;

--- a/packages/questpie/test/cli/module-plugins-prepass.test.ts
+++ b/packages/questpie/test/cli/module-plugins-prepass.test.ts
@@ -100,6 +100,29 @@ describe("modules.ts pre-pass", () => {
 		expect(merged).toEqual([CONFIG_PLUGIN]);
 	});
 
+	it("rejects distinct config plugins sharing one name", async () => {
+		tempDir = await mkdtemp(join(tmpdir(), "questpie-prepass-"));
+		const collision = {
+			name: CONFIG_PLUGIN.name,
+			targets: {},
+		} as CodegenPlugin;
+
+		await expect(
+			extractModulePlugins(tempDir, [CONFIG_PLUGIN, collision], OPTIONS),
+		).rejects.toThrow(/different plugins.*from-config/i);
+	});
+
+	it("rejects a module plugin colliding with a config plugin", async () => {
+		const rootDir = await makeRoot(
+			"modules.mts",
+			'export default [{ name: "m", plugin: { name: "from-config", targets: {} } }];\n',
+		);
+
+		await expect(
+			extractModulePlugins(rootDir, [CONFIG_PLUGIN], OPTIONS),
+		).rejects.toThrow(/runtimeConfig.*modules\.ts/s);
+	});
+
 	/**
 	 * A bare `C:\app\modules.ts` parses as a URL whose scheme is "c:", so the
 	 * import throws ERR_UNSUPPORTED_ESM_URL_SCHEME and every Windows build lands

--- a/packages/questpie/test/cli/plugin-graph.test.ts
+++ b/packages/questpie/test/cli/plugin-graph.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "bun:test";
+
+import { extractPluginsFromModules } from "../../src/cli/codegen/extract-plugins.js";
+import { resolveTargetGraph } from "../../src/cli/codegen/index.js";
+import {
+	CODEGEN_MODULE_METADATA_SYMBOL,
+	extractFactoryArgumentsFromModules,
+} from "../../src/cli/codegen/module-metadata.js";
+import type { CodegenPlugin } from "../../src/cli/codegen/types.js";
+
+type ModuleFixture = {
+	name: string;
+	modules?: ModuleFixture[];
+	plugin?: CodegenPlugin | CodegenPlugin[];
+	[key: symbol]: unknown;
+};
+
+const plugin = (name: string): CodegenPlugin => ({ name, targets: {} });
+
+describe("codegen module and plugin graph", () => {
+	it("deduplicates same-object diamonds in children-before-parent order", () => {
+		const sharedPlugin = plugin("shared-plugin");
+		const shared: ModuleFixture = { name: "shared", plugin: sharedPlugin };
+		const leftPlugin = plugin("left-plugin");
+		const rightPlugin = plugin("right-plugin");
+		const left: ModuleFixture = {
+			name: "left",
+			modules: [shared],
+			plugin: leftPlugin,
+		};
+		const right: ModuleFixture = {
+			name: "right",
+			modules: [shared],
+			plugin: rightPlugin,
+		};
+
+		expect(extractPluginsFromModules([left, right])).toEqual([
+			sharedPlugin,
+			leftPlugin,
+			rightPlugin,
+		]);
+	});
+
+	it("rejects module cycles with an actionable path", () => {
+		const alpha: ModuleFixture = { name: "alpha" };
+		const beta: ModuleFixture = { name: "beta", modules: [alpha] };
+		alpha.modules = [beta];
+
+		expect(() => extractPluginsFromModules([alpha])).toThrow(
+			/Circular module dependency: alpha -> beta -> alpha/,
+		);
+	});
+
+	it("rejects different module objects sharing one name", () => {
+		const first: ModuleFixture = { name: "shared" };
+		const second: ModuleFixture = { name: "shared" };
+
+		expect(() =>
+			extractPluginsFromModules([
+				{ name: "left", modules: [first] },
+				{ name: "right", modules: [second] },
+			]),
+		).toThrow(/left -> shared.*right -> shared/s);
+	});
+
+	it("rejects different module objects sharing an empty name", () => {
+		expect(() =>
+			extractPluginsFromModules([{ name: "" }, { name: "" }]),
+		).toThrow(/different modules are both named ""/i);
+	});
+
+	it("rejects different plugin objects sharing one name", () => {
+		expect(() =>
+			extractPluginsFromModules([
+				{ name: "first", plugin: plugin("collision") },
+				{ name: "second", plugin: plugin("collision") },
+			]),
+		).toThrow(/different plugins.*"collision"/i);
+	});
+
+	it("enforces plugin identity at direct target-graph ingress", () => {
+		const shared = plugin("shared");
+		expect(resolveTargetGraph([shared, shared])).toEqual(new Map());
+		expect(() =>
+			resolveTargetGraph([plugin("collision"), plugin("collision")]),
+		).toThrow(/different plugins.*"collision"/i);
+	});
+
+	it("applies the same module collision policy to metadata", () => {
+		const symbol = Symbol.for(CODEGEN_MODULE_METADATA_SYMBOL);
+		const first: ModuleFixture = {
+			name: "shared",
+			[symbol]: { factoryArguments: [] },
+		};
+		const second: ModuleFixture = {
+			name: "shared",
+			[symbol]: { factoryArguments: [] },
+		};
+
+		expect(() => extractFactoryArgumentsFromModules([first, second])).toThrow(
+			/different modules.*"shared"/i,
+		);
+	});
+
+	it("extracts metadata in the same children-before-parent order", () => {
+		const symbol = Symbol.for(CODEGEN_MODULE_METADATA_SYMBOL);
+		const withMetadata = (name: string, modules?: ModuleFixture[]) => ({
+			name,
+			modules,
+			[symbol]: {
+				factoryArguments: [
+					{
+						category: "blocks",
+						key: name,
+						value: name,
+						source: `${name}.ts`,
+					},
+				],
+			},
+		});
+		const shared = withMetadata("shared");
+		const left = withMetadata("left", [shared]);
+		const right = withMetadata("right", [shared]);
+
+		expect(
+			extractFactoryArgumentsFromModules([left, right]).map(
+				(entry) => entry.key,
+			),
+		).toEqual(["shared", "left", "right"]);
+	});
+});

--- a/packages/questpie/test/codegen/config-features.test.ts
+++ b/packages/questpie/test/codegen/config-features.test.ts
@@ -28,7 +28,6 @@ import {
 } from "../../src/cli/codegen/module-metadata.js";
 import { generateTemplate as _generateTemplate } from "../../src/cli/codegen/template.js";
 import type {
-	CodegenPlugin,
 	DiscoveredFile,
 	DiscoveryResult,
 } from "../../src/cli/codegen/types.js";
@@ -199,23 +198,18 @@ describe("extractPluginsFromModules", () => {
 		expect(result[1].name).toBe("parent-plugin");
 	});
 
-	it("deduplicates plugins by name (first wins)", () => {
-		const plugin1 = {
+	it("deduplicates the same plugin object reached more than once", () => {
+		const sharedPlugin = {
 			name: "shared-plugin",
 			targets: { server: { root: ".", outputFile: "a.ts" } },
 		};
-		const plugin2 = {
-			name: "shared-plugin",
-			targets: { server: { root: ".", outputFile: "b.ts" } },
-		};
 		const modules = [
-			{ name: "mod-a", plugin: plugin1 },
-			{ name: "mod-b", plugin: plugin2 },
+			{ name: "mod-a", plugin: sharedPlugin },
+			{ name: "mod-b", plugin: sharedPlugin },
 		];
 		const result = extractPluginsFromModules(modules);
 		expect(result).toHaveLength(1);
-		// First occurrence wins
-		expect(result[0]).toBe(plugin1);
+		expect(result[0]).toBe(sharedPlugin);
 	});
 
 	it("handles array of plugins on a module", () => {

--- a/packages/questpie/test/codegen/template.test.ts
+++ b/packages/questpie/test/codegen/template.test.ts
@@ -220,18 +220,21 @@ describe("generateTemplate — minimal (modules.ts only)", () => {
 	});
 
 	it("collapses empty module prop categories to empty objects", () => {
-		// _MP<K>/_MPRaw<K> were replaced by the recursive member-only folds
-		// ExtractModulePropArr / ExtractModulePropArrOverride. For a minimal app
+		// _MP<K>/_MPRaw<K> were replaced by the validated ordered category fold.
+		// For a minimal app
 		// with NO module contributions these resolve to {} per category. The
 		// `services` carrier is emitted as a literal {} (it cannot be folded —
 		// its member values reach AppContext and re-introduce the cycle).
 		expect(code).not.toContain("type _MP<");
 		expect(code).not.toContain("_MPRaw<");
 		expect(code).toContain(
-			'export type _ModuleCollections = ExtractModulePropArrOverride<typeof _modules, "collections">;',
+			'export type _ModuleCollections = CodegenResolvedModulePropArr<typeof _modules, "collections">;',
 		);
 		expect(code).toContain(
-			'export type _ModuleGlobals = ExtractModulePropArr<typeof _modules, "globals">;',
+			'export type _ModuleGlobals = CodegenResolvedModulePropArr<typeof _modules, "globals">;',
+		);
+		expect(code).toContain(
+			'export type _ModuleJobs = CodegenResolvedModulePropArr<typeof _modules, "jobs">;',
 		);
 		expect(code).toContain("export type _ModuleServices = {};");
 	});
@@ -755,6 +758,9 @@ describe("generateTemplate — globals", () => {
 
 		expect(code).toContain("globals: {");
 		expect(code).toContain("siteSettings: _glob_siteSettings,");
+		expect(code).toContain(
+			"export type AppGlobals = Override<_ModuleGlobals, {",
+		);
 	});
 });
 
@@ -888,7 +894,9 @@ describe("generateTemplate — services", () => {
 			singletonFactories: coreSingletonFactories(),
 		});
 
-		expect(code).toContain("type _AppServiceDefinitions = _ModuleServices & {");
+		expect(code).toContain(
+			"type _AppServiceDefinitions = Override<_ModuleServices, {",
+		);
 		expect(code).toContain("stripe: typeof _svc_stripe;");
 		expect(code).toContain(
 			"[K in keyof _AppServiceDefinitions]: ServiceInstanceOf<_AppServiceDefinitions[K]>;",
@@ -1059,7 +1067,7 @@ describe("generateTemplate — routes (flat record)", () => {
 			singletonFactories: coreSingletonFactories(),
 		});
 
-		expect(code).toContain("type AppRoutes = _ModuleRoutes & {");
+		expect(code).toContain("type AppRoutes = Override<_ModuleRoutes, {");
 		expect(code).toContain(
 			'"apps/[appId]/install": RouteWithParams<_RouteDefinitionWithoutHandler<typeof _route_apps_appId_install>, RouteParamsFromKey<"apps/[appId]/install">>;',
 		);
@@ -1335,9 +1343,8 @@ describe("generateTemplate — spreads", () => {
 			singletonFactories: coreSingletonFactories(),
 		});
 
-		// _MP<Key> was replaced by the recursive member-only ExtractModulePropArr
-		// fold — spread categories (sidebar/dashboard/...) are extracted from the
-		// module array the same way safe (non-services) categories are.
+		// Spread values concatenate at runtime, so they retain the additive fold
+		// rather than the record-category last-wins fold.
 		expect(code).toContain(
 			'export type _ModuleSidebar = ExtractModulePropArr<typeof _modules, "sidebar">;',
 		);

--- a/packages/questpie/test/config/module-graph.test.ts
+++ b/packages/questpie/test/config/module-graph.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "bun:test";
+
+import { createApp } from "../../src/server/config/create-app.js";
+import type {
+	AppModuleInput,
+	RuntimeConfig,
+} from "../../src/server/config/module-types.js";
+import coreModule from "../../src/server/modules/core/.generated/module.js";
+
+type MutableModule = {
+	name: string;
+	modules?: MutableModule[];
+};
+
+describe("runtime module graph", () => {
+	it("rejects a dependency cycle with its actionable path", async () => {
+		const alpha: MutableModule = { name: "alpha" };
+		const beta: MutableModule = { name: "beta", modules: [alpha] };
+		alpha.modules = [beta];
+
+		await expect(
+			createApp({ modules: [alpha as AppModuleInput] }, {} as RuntimeConfig),
+		).rejects.toThrow(/Circular module dependency: alpha -> beta -> alpha/);
+	});
+
+	it("reports both graph paths for different modules sharing one name", async () => {
+		const first = { name: "shared" } as AppModuleInput;
+		const second = { name: "shared" } as AppModuleInput;
+		const left = { name: "left", modules: [first] } as AppModuleInput;
+		const right = { name: "right", modules: [second] } as AppModuleInput;
+
+		await expect(
+			createApp({ modules: [left, right] }, {} as RuntimeConfig),
+		).rejects.toThrow(/left -> shared.*right -> shared/s);
+	});
+
+	it("does not let a counterfeit core module replace the canonical core", async () => {
+		const counterfeit = { name: coreModule.name } as AppModuleInput;
+
+		await expect(
+			createApp({ modules: [counterfeit] }, {} as RuntimeConfig),
+		).rejects.toThrow(/different modules.*questpie-core/i);
+	});
+});

--- a/packages/questpie/test/config/module-resolution.test.ts
+++ b/packages/questpie/test/config/module-resolution.test.ts
@@ -62,7 +62,7 @@ describe("createApp — module resolution order", () => {
 		}
 	});
 
-	it("rejects two different modules sharing one name, naming both positions", async () => {
+	it("rejects two different modules sharing one name, naming both paths", async () => {
 		// The live instance of this is the admin server module and the admin
 		// client module, both called "questpie-admin". Separate arrays today, so
 		// nothing breaks yet. In one array, one of them used to just disappear.
@@ -76,7 +76,7 @@ describe("createApp — module resolution order", () => {
 		);
 
 		await expect(boot).rejects.toThrow(
-			/both named "questpie-admin", at positions 1 and 2/,
+			/both named "questpie-admin".*questpie-admin.*questpie-admin/s,
 		);
 	});
 

--- a/packages/questpie/test/types/__fullapp__/.generated/entities.gen.ts
+++ b/packages/questpie/test/types/__fullapp__/.generated/entities.gen.ts
@@ -31,24 +31,24 @@ import type { RouteParamsFromKey, RouteWithParams } from "questpie/types";
 // TYPES — composed from typeof references (zero inference cost)
 // ════════════════════════════════════════════════════════════
 
-import type { ExtractModulePropArr, ExtractModulePropArrOverride, Override, ServiceCustomNamespaceInstances, ServiceInstanceOf, ServiceInstancesInNamespace, ServiceTopLevelInstances } from "questpie/types";
+import type { CodegenResolvedModulePropArr, ExtractModulePropArr, Override, ServiceCustomNamespaceInstances, ServiceInstanceOf, ServiceInstancesInNamespace, ServiceTopLevelInstances } from "questpie/types";
 type _RouteDefinitionWithoutHandler<T> = T extends { mode: "raw" } ? Omit<T, "handler"> & { handler: (args: unknown) => Response | Promise<Response> } : Omit<T, "handler"> & { handler: (args: unknown) => unknown | Promise<unknown> };
-export type _ModuleCollections = ExtractModulePropArrOverride<typeof _modules, "collections">;
-export type _ModuleChannels = ExtractModulePropArr<typeof _modules, "channels">;
-export type _ModuleGlobals = ExtractModulePropArr<typeof _modules, "globals">;
-export type _ModuleJobs = ExtractModulePropArr<typeof _modules, "jobs">;
-export type _ModuleRoutes = ExtractModulePropArr<typeof _modules, "routes">;
+export type _ModuleCollections = CodegenResolvedModulePropArr<typeof _modules, "collections">;
+export type _ModuleChannels = CodegenResolvedModulePropArr<typeof _modules, "channels">;
+export type _ModuleGlobals = CodegenResolvedModulePropArr<typeof _modules, "globals">;
+export type _ModuleJobs = CodegenResolvedModulePropArr<typeof _modules, "jobs">;
+export type _ModuleRoutes = CodegenResolvedModulePropArr<typeof _modules, "routes">;
 export type _ModuleServices = {};
-export type _ModuleFieldTypes = ExtractModulePropArr<typeof _modules, "fieldTypes">;
+export type _ModuleFieldTypes = CodegenResolvedModulePropArr<typeof _modules, "fieldTypes">;
 // Registry category extraction from modules
-export type _Registry_Collections = ExtractModulePropArrOverride<typeof _modules, "collections">;
-export type _Registry_Channels = ExtractModulePropArr<typeof _modules, "channels">;
-export type _Registry_Globals = ExtractModulePropArr<typeof _modules, "globals">;
-export type _Registry_Jobs = ExtractModulePropArr<typeof _modules, "jobs">;
-export type _Registry_Routes = ExtractModulePropArr<typeof _modules, "routes">;
+export type _Registry_Collections = CodegenResolvedModulePropArr<typeof _modules, "collections">;
+export type _Registry_Channels = CodegenResolvedModulePropArr<typeof _modules, "channels">;
+export type _Registry_Globals = CodegenResolvedModulePropArr<typeof _modules, "globals">;
+export type _Registry_Jobs = CodegenResolvedModulePropArr<typeof _modules, "jobs">;
+export type _Registry_Routes = CodegenResolvedModulePropArr<typeof _modules, "routes">;
 export type _Registry_Services = {};
-export type _Registry_Emails = ExtractModulePropArr<typeof _modules, "emails">;
-export type _Registry_FieldTypes = ExtractModulePropArr<typeof _modules, "fieldTypes">;
+export type _Registry_Emails = CodegenResolvedModulePropArr<typeof _modules, "emails">;
+export type _Registry_FieldTypes = CodegenResolvedModulePropArr<typeof _modules, "fieldTypes">;
 
 // Recursive module property extraction (for fields contributed at each level)
 import type { ExtractModuleProp } from "questpie/types";
@@ -66,9 +66,9 @@ export type AppCollections = Override<_ModuleCollections, {
 export type AppChannels = _ModuleChannels;
 
 /** All globals in the app (modules + user, user overrides) */
-export type AppGlobals = _ModuleGlobals & {
+export type AppGlobals = Override<_ModuleGlobals, {
 	siteSettings: typeof _glob_siteSettings;
-};
+}>;
 
 /** All jobs in the app (modules + user, user overrides) */
 export type AppJobs = _ModuleJobs;
@@ -77,10 +77,10 @@ export type AppJobs = _ModuleJobs;
 export type AppRoutes = _ModuleRoutes;
 
 /** All service definitions in the app (modules + user, user overrides). */
-type _AppServiceDefinitions = _ModuleServices & {
+type _AppServiceDefinitions = Override<_ModuleServices, {
 	analytics: typeof _svc_analytics;
 	reporting: typeof _svc_reporting;
-};
+}>;
 
 /** All services in the app as resolved service instances. */
 export type AppServices = {

--- a/packages/questpie/test/types/__fullapp__/collections/admin-user.ts
+++ b/packages/questpie/test/types/__fullapp__/collections/admin-user.ts
@@ -7,7 +7,7 @@
  * This is the exact same-key, cross-module-nesting re-declaration that detonated
  * the additive `ExtractModulePropArr` fold into `never` (the create() never/{} bug).
  * Pulling it through the fold here makes the package gate SEE the bug the module-only
- * gate was blind to — the override fold (`ExtractModulePropArrOverride`) is what
+ * gate was blind to — the ordered fold (`CodegenResolvedModulePropArr`) is what
  * keeps `AppCollections["user"]` a real `Collection` instead of `never`.
  */
 import { collection } from "#questpie/server/collection/builder/collection-builder.js";

--- a/packages/questpie/test/types/__fullapp__/modules.ts
+++ b/packages/questpie/test/types/__fullapp__/modules.ts
@@ -15,7 +15,7 @@ import starterModule from "#questpie/server/modules/starter/.generated/module.js
  * the additive `ExtractModulePropArr` collections fold into `never` (the create()
  * never/{} bug): `_ModuleCollections["user"] = Collection<Starter> & Collection<Admin>`
  * ⇒ `never` ⇒ `CollectionInsert` `never` / CRUD select `{}`. The fold now uses
- * `ExtractModulePropArrOverride` (override, not intersect) so the most-derived
+ * `CodegenResolvedModulePropArr` (override, not intersect) so the most-derived
  * admin re-declaration shadows the nested starter one. The remaining starter
  * collections are passed through by reference (mirrors admin re-declaring the full
  * starter set directly) so the names-only `Questpie.CollectionKeys` registry — which

--- a/packages/questpie/test/types/clusters/CRUD-create-input-output.test-d.ts
+++ b/packages/questpie/test/types/clusters/CRUD-create-input-output.test-d.ts
@@ -19,12 +19,12 @@
  *     returned row has NO keys (`customer.id` ⇒ TS2339 "Property 'id' does not exist").
  *
  * THE FIX. The `collections` fold uses OVERRIDE semantics
- * (`ExtractModulePropArrOverride`) so the most-derived (outer) re-declaration
+ * (`CodegenResolvedModulePropArr`) so the most-derived (outer) re-declaration
  * shadows the nested base instead of intersecting it. Distinct keys from both sides
  * still survive — only the same-key collision overrides.
  *
  * This test exercises the REAL fold (`ExtractModulePropArr` /
- * `ExtractModulePropArrOverride` from codegen-type-utils) over a fixture module
+ * `CodegenResolvedModulePropArr` from codegen-type-utils) over a fixture module
  * that mirrors the admin↔starter nesting, then drives the result through the REAL
  * `CollectionAPI` create surface — asserting IDENTITY (NoNever / NotEmptyObject /
  * key presence), never "it compiles".
@@ -37,7 +37,7 @@
 import { collection } from "#questpie/server/collection/builder/collection-builder.js";
 import type {
 	ExtractModulePropArr,
-	ExtractModulePropArrOverride,
+	CodegenResolvedModulePropArr,
 } from "#questpie/server/config/codegen-type-utils.js";
 import type { CollectionAPI } from "#questpie/server/config/integrated/questpie-api.js";
 import type { CollectionInsert } from "#questpie/shared/type-utils.js";
@@ -110,7 +110,7 @@ type Mods = readonly [AdminModule];
 // §1  The fold the generated `_ModuleCollections` now uses (OVERRIDE).
 // ============================================================================
 
-type ModuleCollections = ExtractModulePropArrOverride<Mods, "collections">;
+type ModuleCollections = CodegenResolvedModulePropArr<Mods, "collections">;
 
 /** A user collection declared once (not merged across nesting) — control. */
 const appointments = collection("appointments")

--- a/packages/questpie/test/types/module-graph-diamond.test-d.ts
+++ b/packages/questpie/test/types/module-graph-diamond.test-d.ts
@@ -1,4 +1,4 @@
-import type { ExtractModulePropArrOverride } from "#questpie/server/config/codegen-type-utils.js";
+import type { CodegenResolvedModulePropArr } from "#questpie/server/config/codegen-type-utils.js";
 
 import type { Equal, Expect } from "./type-test-utils.js";
 
@@ -7,6 +7,12 @@ type Shared = {
 	collections: {
 		entry: { owner: "shared" };
 	};
+	globals: {
+		settings: { owner: "shared" };
+	};
+	jobs: {
+		digest: { owner: "shared" };
+	};
 };
 
 type Left = {
@@ -14,6 +20,12 @@ type Left = {
 	modules: readonly [Shared];
 	collections: {
 		entry: { owner: "left" };
+	};
+	globals: {
+		settings: { owner: "left" };
+	};
+	jobs: {
+		digest: { owner: "left" };
 	};
 };
 
@@ -25,10 +37,15 @@ type Right = {
 	};
 };
 
-type DiamondCollections = ExtractModulePropArrOverride<
+type DiamondCollections = CodegenResolvedModulePropArr<
 	readonly [Left, Right],
 	"collections"
 >;
+type DiamondGlobals = CodegenResolvedModulePropArr<
+	readonly [Left, Right],
+	"globals"
+>;
+type DiamondJobs = CodegenResolvedModulePropArr<readonly [Left, Right], "jobs">;
 
 // Runtime resolves [shared, left, right]. Reaching shared through right must not
 // replay it after left and replace left's override.
@@ -37,4 +54,25 @@ type _leftOverrideKeepsItsRuntimePosition = Expect<
 >;
 type _rightContributionSurvives = Expect<
 	Equal<DiamondCollections["rightOnly"]["owner"], "right">
+>;
+type _globalDependentOverrideKeepsItsRuntimePosition = Expect<
+	Equal<DiamondGlobals["settings"]["owner"], "left">
+>;
+type _otherCategoryUsesTheSameOrderedFold = Expect<
+	Equal<DiamondJobs["digest"]["owner"], "left">
+>;
+
+type WidenedNameModule = {
+	name: string;
+	globals: { settings: { owner: "widened" } };
+};
+
+// The internal fold is deliberately defined only for generated/const module
+// graphs. A widened name must not fall back to structural equality and pretend
+// that TypeScript can observe JavaScript object identity.
+type _widenedNameDoesNotClaimIdentitySemantics = Expect<
+	Equal<
+		CodegenResolvedModulePropArr<readonly [WidenedNameModule], "globals">,
+		never
+	>
 >;

--- a/packages/questpie/test/types/module-graph-diamond.test-d.ts
+++ b/packages/questpie/test/types/module-graph-diamond.test-d.ts
@@ -1,0 +1,40 @@
+import type { ExtractModulePropArrOverride } from "#questpie/server/config/codegen-type-utils.js";
+
+import type { Equal, Expect } from "./type-test-utils.js";
+
+type Shared = {
+	name: "shared";
+	collections: {
+		entry: { owner: "shared" };
+	};
+};
+
+type Left = {
+	name: "left";
+	modules: readonly [Shared];
+	collections: {
+		entry: { owner: "left" };
+	};
+};
+
+type Right = {
+	name: "right";
+	modules: readonly [Shared];
+	collections: {
+		rightOnly: { owner: "right" };
+	};
+};
+
+type DiamondCollections = ExtractModulePropArrOverride<
+	readonly [Left, Right],
+	"collections"
+>;
+
+// Runtime resolves [shared, left, right]. Reaching shared through right must not
+// replay it after left and replace left's override.
+type _leftOverrideKeepsItsRuntimePosition = Expect<
+	Equal<DiamondCollections["entry"]["owner"], "left">
+>;
+type _rightContributionSurvives = Expect<
+	Equal<DiamondCollections["rightOnly"]["owner"], "right">
+>;

--- a/packages/questpie/test/types/module-graph-diamond.test-d.ts
+++ b/packages/questpie/test/types/module-graph-diamond.test-d.ts
@@ -1,3 +1,8 @@
+import type {
+	ExtractModulePropArrOverride,
+	ExtractModulePropOverride,
+} from "questpie/types";
+
 import type { CodegenResolvedModulePropArr } from "#questpie/server/config/codegen-type-utils.js";
 
 import type { Equal, Expect } from "./type-test-utils.js";
@@ -75,4 +80,28 @@ type _widenedNameDoesNotClaimIdentitySemantics = Expect<
 		CodegenResolvedModulePropArr<readonly [WidenedNameModule], "globals">,
 		never
 	>
+>;
+
+type LegacyNested = {
+	name: "legacy-nested";
+	globals: { nested: { owner: "nested" } };
+};
+type LegacyOuter = {
+	name: "legacy-outer";
+	modules: readonly [LegacyNested];
+	globals: { outer: { owner: "outer" } };
+};
+
+// Patch compatibility: both v3.26.1 public imports remain available with their
+// original recursive result shape. New codegen does not call these helpers.
+type LegacySingle = ExtractModulePropOverride<LegacyOuter, "globals">;
+type LegacyTuple = ExtractModulePropArrOverride<
+	readonly [LegacyOuter],
+	"globals"
+>;
+type _legacySingleImportCompiles = Expect<
+	Equal<keyof LegacySingle, "nested" | "outer">
+>;
+type _legacyTupleImportCompiles = Expect<
+	Equal<keyof LegacyTuple, "nested" | "outer">
 >;


### PR DESCRIPTION
## What changed

- Uses one internal named-graph contract across runtime module resolution, codegen prepass, metadata, and target graph resolution.
- Deduplicates the same object by identity and rejects distinct modules or plugins that reuse a name.
- Reports cycle paths and validates config, module, and direct plugin ingress consistently.
- Corrects module/plugin documentation and includes a patch changeset.

## Why

Divergent recursive walkers could stack-overflow on cycles or silently choose a winner for ambiguous duplicate names.

## Impact

Valid same-object diamond graphs keep working. Invalid ambiguous graphs now fail early with actionable sources or graph paths.

## Validation

- 41 focused tests pass.
- questpie typecheck and package build pass.
- 527 broader CLI/codegen/config tests pass; installed-binary tests pass after build.
- Docs validation, formatting, lint, and diff checks pass.
- Final adversarial review found no remaining actionable issue.