### PR TITLE
fix(query): type ordered string filters

### DIFF
--- a/.changeset/tidy-strings-order.md
+++ b/.changeset/tidy-strings-order.md
@@ -1,0 +1,5 @@
+---
+"questpie": patch
+---
+
+Expose `gt`, `gte`, `lt`, and `lte` in typed string and system-ID filters.

--- a/apps/docs/content/docs/schema/fields/email.mdx
+++ b/apps/docs/content/docs/schema/fields/email.mdx
@@ -57,12 +57,14 @@ email: f.email(320).required().min(6),
 
 ## Filtering
 
-Email carries `emailOps`, the fourteen string operators plus two of its own.
+Email carries `emailOps`, the eighteen string operators plus two of its own.
 
 | Operator               | Operand             | Matches                                     |
 | ---------------------- | ------------------- | ------------------------------------------- |
 | `eq` / `ne`            | `string`            | Equal, not equal                            |
 | `not`                  | `string`, or `null` | Not equal, or `IS NOT NULL` when given null |
+| `gt` / `gte`           | `string`            | After, or at/after, in database collation   |
+| `lt` / `lte`           | `string`            | Before, or at/before, in database collation |
 | `in` / `notIn`         | `string[]`          | In the list, not in the list                |
 | `like` / `notLike`     | `string`            | `LIKE`, case-sensitive, you write the `%`   |
 | `ilike` / `notIlike`   | `string`            | The same, case-insensitive                  |

--- a/apps/docs/content/docs/schema/fields/text.mdx
+++ b/apps/docs/content/docs/schema/fields/text.mdx
@@ -64,12 +64,14 @@ username: f.text(32).required().min(3).pattern(/^[a-z0-9_]+$/),
 
 ## Filtering
 
-Text carries the `stringOps` set, fourteen operators.
+Text carries the `stringOps` set, eighteen operators.
 
 | Operator               | Operand             | Matches                                     |
 | ---------------------- | ------------------- | ------------------------------------------- |
 | `eq` / `ne`            | `string`            | Equal, not equal                            |
 | `not`                  | `string`, or `null` | Not equal, or `IS NOT NULL` when given null |
+| `gt` / `gte`           | `string`            | After, or at/after, in database collation   |
+| `lt` / `lte`           | `string`            | Before, or at/before, in database collation |
 | `in` / `notIn`         | `string[]`          | In the list, not in the list                |
 | `like` / `notLike`     | `string`            | `LIKE`, case-sensitive, you write the `%`   |
 | `ilike` / `notIlike`   | `string`            | The same, case-insensitive                  |
@@ -87,6 +89,10 @@ const { docs } = await app.collections.posts.find({
 `contains`, `startsWith` and `endsWith` build the pattern around a bound
 parameter. The value is parameterized, but a `%` or `_` inside it still reads as
 a wildcard.
+
+Ordered comparisons use the database column's configured collation. A keyset
+cursor must use the same column and direction in `orderBy` and its `gt`/`lt`
+predicate; QUESTPIE does not apply JavaScript string ordering.
 
 ## In the admin
 

--- a/apps/docs/content/docs/schema/fields/text.mdx
+++ b/apps/docs/content/docs/schema/fields/text.mdx
@@ -94,6 +94,10 @@ Ordered comparisons use the database column's configured collation. A keyset
 cursor must use the same column and direction in `orderBy` and its `gt`/`lt`
 predicate; QUESTPIE does not apply JavaScript string ordering.
 
+The framework-owned system `id` exposes the same ordered string operators, so
+it can act as a typed keyset tie-breaker: pair `id: { lt: cursor.id }` with
+`orderBy: { id: "desc" }`.
+
 ## In the admin
 
 The form control is `TextField`. The list cell is `TextCell`, which truncates

--- a/apps/docs/content/docs/schema/fields/textarea.mdx
+++ b/apps/docs/content/docs/schema/fields/textarea.mdx
@@ -10,7 +10,7 @@ package: questpie
 | Column       | `text`, no length cap                               |
 | Value        | `string`, or `string \| null` without `.required()` |
 | Schema       | `z.string()`, no cap                                |
-| Operators    | `stringOps`, fourteen of them                       |
+| Operators    | `stringOps`, eighteen of them                       |
 | Form control | `TextareaField`, a plain textarea                   |
 | List cell    | `TextCell`, truncated, off the default columns      |
 
@@ -51,13 +51,15 @@ Both write a validation bound and nothing else. The column stays unbounded
 
 ## Filtering
 
-Textarea carries `stringOps`, the same fourteen operators as
+Textarea carries `stringOps`, the same eighteen operators as
 [`f.text()`](/docs/schema/fields/text).
 
 | Operator               | Operand             | Matches                                     |
 | ---------------------- | ------------------- | ------------------------------------------- |
 | `eq` / `ne`            | `string`            | Equal, not equal                            |
 | `not`                  | `string`, or `null` | Not equal, or `IS NOT NULL` when given null |
+| `gt` / `gte`           | `string`            | After, or at/after, in database collation   |
+| `lt` / `lte`           | `string`            | Before, or at/before, in database collation |
 | `in` / `notIn`         | `string[]`          | In the list, not in the list                |
 | `like` / `notLike`     | `string`            | `LIKE`, case-sensitive, you write the `%`   |
 | `ilike` / `notIlike`   | `string`            | The same, case-insensitive                  |

--- a/apps/docs/content/docs/schema/fields/url.mdx
+++ b/apps/docs/content/docs/schema/fields/url.mdx
@@ -79,12 +79,14 @@ endpoint: f.url(500).required().min(12),
 
 ## Filtering
 
-URL carries `urlOps`, the fourteen string operators plus three of its own.
+URL carries `urlOps`, the eighteen string operators plus three of its own.
 
 | Operator               | Operand             | Matches                                     |
 | ---------------------- | ------------------- | ------------------------------------------- |
 | `eq` / `ne`            | `string`            | Equal, not equal                            |
 | `not`                  | `string`, or `null` | Not equal, or `IS NOT NULL` when given null |
+| `gt` / `gte`           | `string`            | After, or at/after, in database collation   |
+| `lt` / `lte`           | `string`            | Before, or at/before, in database collation |
 | `in` / `notIn`         | `string[]`          | In the list, not in the list                |
 | `like` / `notLike`     | `string`            | `LIKE`, case-sensitive, you write the `%`   |
 | `ilike` / `notIlike`   | `string`            | The same, case-insensitive                  |

--- a/packages/questpie/src/server/fields/operators/builtin.ts
+++ b/packages/questpie/src/server/fields/operators/builtin.ts
@@ -134,6 +134,10 @@ export const stringOps = operatorSet({
 		not: operator<string | null, unknown>((col, value) =>
 			value === null ? isNotNull(col) : ne(col, value),
 		),
+		gt: operator<string, unknown>((col, value) => gt(col, value)),
+		gte: operator<string, unknown>((col, value) => gte(col, value)),
+		lt: operator<string, unknown>((col, value) => lt(col, value)),
+		lte: operator<string, unknown>((col, value) => lte(col, value)),
 		in: operator<string[], unknown>((col, values) => inArray(col, values)),
 		notIn: operator<string[], unknown>((col, values) =>
 			notInArray(col, values),

--- a/packages/questpie/test/collection/ordered-string-operators.test.ts
+++ b/packages/questpie/test/collection/ordered-string-operators.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+
+import { stringOps } from "#questpie/server/fields/operators/builtin.js";
+import { resolveContextualOperators } from "#questpie/server/fields/operators/resolve.js";
+
+import { collection } from "../../src/exports/index.js";
+import { buildMockApp } from "../utils/mocks/mock-app-builder";
+import { createTestContext } from "../utils/test-context";
+import { runTestDbMigrations } from "../utils/test-db";
+
+const articles = collection("articles").fields(({ f }) => ({
+	title: f.text().required(),
+	metadata: f.object({ author: f.text().required() }),
+}));
+
+describe("ordered string operators", () => {
+	let setup: Awaited<ReturnType<typeof buildMockApp>>;
+
+	beforeEach(async () => {
+		setup = await buildMockApp({ collections: { articles } });
+		await runTestDbMigrations(setup.app);
+	});
+
+	afterEach(async () => {
+		await setup.cleanup();
+	});
+
+	it("uses the database collation consistently for system-id cursors", async () => {
+		const ctx = createTestContext();
+
+		for (const id of ["A", "a", "aa", "z", "ä"]) {
+			await setup.app.collections.articles.create(
+				{ id, title: id, metadata: { author: id } },
+				ctx,
+			);
+		}
+
+		const ordered = await setup.app.collections.articles.find(
+			{ orderBy: { id: "desc" } },
+			ctx,
+		);
+		const expected = ordered.docs.map((doc) => doc.id);
+		const seen: string[] = [];
+		let cursor: string | undefined;
+
+		for (;;) {
+			const page = await setup.app.collections.articles.find(
+				{
+					where: cursor === undefined ? undefined : { id: { lt: cursor } },
+					orderBy: { id: "desc" },
+					limit: 1,
+				},
+				ctx,
+			);
+
+			const doc = page.docs[0];
+			if (!doc) break;
+			seen.push(doc.id);
+			cursor = doc.id;
+		}
+
+		expect(seen).toEqual(expected);
+	});
+
+	it("executes strict and inclusive comparisons on a JSONB text path", async () => {
+		const ctx = createTestContext();
+		for (const author of ["Alice", "Bob", "Cara"]) {
+			await setup.app.collections.articles.create(
+				{
+					id: author.toLowerCase(),
+					title: author,
+					metadata: { author },
+				},
+				ctx,
+			);
+		}
+
+		const table = setup.app.collections.articles["~internalRelatedTable"];
+		const operators = resolveContextualOperators(stringOps).jsonb;
+		const path = { jsonbPath: ["author"] };
+		const greaterThan = await setup.app.db
+			.select({ id: table.id })
+			.from(table)
+			.where(operators.gt(table.metadata, "Bob", path));
+		const atMost = await setup.app.db
+			.select({ id: table.id })
+			.from(table)
+			.where(operators.lte(table.metadata, "Bob", path))
+			.orderBy(table.id);
+
+		expect(greaterThan.map(({ id }) => id)).toEqual(["cara"]);
+		expect(atMost.map(({ id }) => id)).toEqual(["alice", "bob"]);
+	});
+});

--- a/packages/questpie/test/collection/system-timestamps.test.ts
+++ b/packages/questpie/test/collection/system-timestamps.test.ts
@@ -146,4 +146,38 @@ describe("system timestamp precision (timestamp(3) contract)", () => {
 		// Later ms first, then the tied-.123 group by id desc — no skips, no dups
 		expect(seen).toEqual(["d", "c", "b", "a"]);
 	});
+
+	it("uses the database collation consistently for id ordering and cursors", async () => {
+		const ctx = createTestContext();
+
+		for (const id of ["A", "a", "aa", "z", "ä"]) {
+			await setup.app.collections.events.create({ id, title: id }, ctx);
+		}
+
+		const ordered = await setup.app.collections.events.find(
+			{ orderBy: { id: "desc" } },
+			ctx,
+		);
+		const expected = ordered.docs.map((doc) => doc.id);
+		const seen: string[] = [];
+		let cursor: string | undefined;
+
+		for (;;) {
+			const page = await setup.app.collections.events.find(
+				{
+					where: cursor === undefined ? undefined : { id: { lt: cursor } },
+					orderBy: { id: "desc" },
+					limit: 1,
+				},
+				ctx,
+			);
+
+			const doc = page.docs[0];
+			if (!doc) break;
+			seen.push(doc.id);
+			cursor = doc.id;
+		}
+
+		expect(seen).toEqual(expected);
+	});
 });

--- a/packages/questpie/test/collection/system-timestamps.test.ts
+++ b/packages/questpie/test/collection/system-timestamps.test.ts
@@ -146,38 +146,4 @@ describe("system timestamp precision (timestamp(3) contract)", () => {
 		// Later ms first, then the tied-.123 group by id desc — no skips, no dups
 		expect(seen).toEqual(["d", "c", "b", "a"]);
 	});
-
-	it("uses the database collation consistently for id ordering and cursors", async () => {
-		const ctx = createTestContext();
-
-		for (const id of ["A", "a", "aa", "z", "ä"]) {
-			await setup.app.collections.events.create({ id, title: id }, ctx);
-		}
-
-		const ordered = await setup.app.collections.events.find(
-			{ orderBy: { id: "desc" } },
-			ctx,
-		);
-		const expected = ordered.docs.map((doc) => doc.id);
-		const seen: string[] = [];
-		let cursor: string | undefined;
-
-		for (;;) {
-			const page = await setup.app.collections.events.find(
-				{
-					where: cursor === undefined ? undefined : { id: { lt: cursor } },
-					orderBy: { id: "desc" },
-					limit: 1,
-				},
-				ctx,
-			);
-
-			const doc = page.docs[0];
-			if (!doc) break;
-			seen.push(doc.id);
-			cursor = doc.id;
-		}
-
-		expect(seen).toEqual(expected);
-	});
 });

--- a/packages/questpie/test/fields/v2/field.test.ts
+++ b/packages/questpie/test/fields/v2/field.test.ts
@@ -305,6 +305,15 @@ describe("Field V2 — getOperators()", () => {
 		expect(typeof ops.jsonb.eq).toBe("function");
 	});
 
+	it("exposes ordered text comparisons in column and JSONB contexts", () => {
+		const ops = createTestTextField().getOperators();
+
+		for (const name of ["gt", "gte", "lt", "lte"] as const) {
+			expect(typeof ops.column[name]).toBe("function");
+			expect(typeof ops.jsonb[name]).toBe("function");
+		}
+	});
+
 	it("tolerates field types without column operators", () => {
 		const ops = resolveContextualOperators({
 			column: undefined as any,

--- a/packages/questpie/test/types/crud-deep-typesafety.test-d.ts
+++ b/packages/questpie/test/types/crud-deep-typesafety.test-d.ts
@@ -648,9 +648,9 @@ type _commentsAggHasContent = Expect<
 
 type AWhere = WhereType<typeof articles, TAppManual>;
 
-// Text field should NOT accept numeric operator gt
+// Text field gt requires a string operand
 // (fixed by sealing operator maps — Omit<DefaultFieldState, "operators">)
-// @ts-expect-error — gt is not a string operator
+// @ts-expect-error — gt on a string field requires a string operand
 const _badTitleGt: AWhere = { title: { gt: 100 } };
 
 // Datetime field should NOT accept contains

--- a/packages/questpie/test/types/field-input-integrity.test-d.ts
+++ b/packages/questpie/test/types/field-input-integrity.test-d.ts
@@ -201,7 +201,7 @@ const _wRelBad: OwnersWhere = {
 const _wRelNestedBad: OwnersWhere = {
 	toys: {
 		some: {
-			// @ts-expect-error — gt is not a string operator
+			// @ts-expect-error — gt on a string field requires a string operand
 			name: { gt: 100 },
 		},
 	},

--- a/packages/questpie/test/types/unified-api-types.test-d.ts
+++ b/packages/questpie/test/types/unified-api-types.test-d.ts
@@ -1155,8 +1155,8 @@ type _myDatetimeWhereGt = Expect<
 
 // These prove that the where clause REJECTS invalid operators.
 // (fixed by sealing operator maps — Omit<DefaultFieldState, "operators">)
-// title is a text field — should NOT accept gt (numeric operator)
-// @ts-expect-error — gt is not a string operator
+// title is a text field — gt requires a string operand
+// @ts-expect-error — gt on a string field requires a string operand
 const _badTitleGt: PostsWhereCheck = { title: { gt: 100 } };
 
 // views is a number field — should NOT accept contains (string operator)

--- a/packages/questpie/test/types/unified-api-types.test-d.ts
+++ b/packages/questpie/test/types/unified-api-types.test-d.ts
@@ -901,6 +901,10 @@ const _whereTitleStartsWith: PostsWhereCheck = {
 	title: { startsWith: "A" },
 };
 const _whereTitleLike: PostsWhereCheck = { title: { like: "%foo%" } };
+const _whereTitleGt: PostsWhereCheck = { title: { gt: "alpha" } };
+const _whereTitleGte: PostsWhereCheck = { title: { gte: "alpha" } };
+const _whereTitleLt: PostsWhereCheck = { title: { lt: "omega" } };
+const _whereTitleLte: PostsWhereCheck = { title: { lte: "omega" } };
 
 // --- Top-level: views operators are concrete numeric ---
 const _whereViewsGt: PostsWhereCheck = { views: { gt: 100 } };
@@ -913,6 +917,7 @@ const _whereCreatedAtGt: PostsWhereCheck = {
 };
 const _whereIdEq: PostsWhereCheck = { id: "some-uuid" };
 const _whereIdIn: PostsWhereCheck = { id: { in: ["a", "b"] } };
+const _whereIdLt: PostsWhereCheck = { id: { lt: "cursor-id" } };
 const _whereDeletedAtIsNull: PostsWhereCheck = {
 	deletedAt: { isNull: true },
 };

--- a/skills/questpie/AGENTS.md
+++ b/skills/questpie/AGENTS.md
@@ -6048,6 +6048,10 @@ Applies to: `text`, `textarea`, `email`, `url`. (`slug` is just a `text` field; 
 | `eq`         | `{ title: { eq: "Hello" } }`       | Exact match                                 |
 | `ne`         | `{ title: { ne: "Hello" } }`       | Not equal                                   |
 | `not`        | `{ title: { not: "Hello" } }`      | Alias for `ne`; `not: null` → `IS NOT NULL` |
+| `gt`         | `{ title: { gt: "Hello" } }`       | Greater than in database collation order    |
+| `gte`        | `{ title: { gte: "Hello" } }`      | Greater than or equal in collation order    |
+| `lt`         | `{ title: { lt: "World" } }`       | Less than in database collation order       |
+| `lte`        | `{ title: { lte: "World" } }`      | Less than or equal in collation order       |
 | `in`         | `{ title: { in: ["A", "B"] } }`    | One of values                               |
 | `notIn`      | `{ title: { notIn: ["A", "B"] } }` | None of values                              |
 | `contains`   | `{ title: { contains: "ell" } }`   | Substring match                             |
@@ -6059,6 +6063,10 @@ Applies to: `text`, `textarea`, `email`, `url`. (`slug` is just a `text` field; 
 | `notIlike`   | `{ title: { notIlike: "he%o" } }`  | Negated case-insensitive LIKE               |
 | `isNull`     | `{ title: { isNull: true } }`      | Is NULL                                     |
 | `isNotNull`  | `{ title: { isNotNull: true } }`   | Is NOT NULL                                 |
+
+Text ordering uses the database column's configured collation. Use the same
+column and direction for `orderBy` and the ordered cursor predicate; QUESTPIE
+does not replace that collation with JavaScript string ordering.
 
 `email` fields add domain matching on top of the text operators:
 

--- a/skills/questpie/AGENTS.md
+++ b/skills/questpie/AGENTS.md
@@ -6040,7 +6040,9 @@ Full reference for all `where` clause operators in QUESTPIE CRUD queries.
 
 ## Text Fields
 
-Applies to: `text`, `textarea`, `email`, `url`. (`slug` is just a `text` field; rich-text content is stored as blocks/JSON, not queried with these operators.)
+Applies to: `text`, `textarea`, `email`, `url`, and the framework-owned system
+`id`. (`slug` is just a `text` field; rich-text content is stored as blocks/JSON,
+not queried with these operators.)
 
 | Operator     | Example                            | Description                                 |
 | ------------ | ---------------------------------- | ------------------------------------------- |
@@ -6067,6 +6069,9 @@ Applies to: `text`, `textarea`, `email`, `url`. (`slug` is just a `text` field; 
 Text ordering uses the database column's configured collation. Use the same
 column and direction for `orderBy` and the ordered cursor predicate; QUESTPIE
 does not replace that collation with JavaScript string ordering.
+
+This makes system `id` suitable as a typed keyset tie-breaker, for example
+`where: { id: { lt: cursor.id } }` with `orderBy: { id: "desc" }`.
 
 `email` fields add domain matching on top of the text operators:
 

--- a/skills/questpie/references/query-operators.md
+++ b/skills/questpie/references/query-operators.md
@@ -17,7 +17,9 @@ Full reference for all `where` clause operators in QUESTPIE CRUD queries.
 
 ## Text Fields
 
-Applies to: `text`, `textarea`, `email`, `url`. (`slug` is just a `text` field; rich-text content is stored as blocks/JSON, not queried with these operators.)
+Applies to: `text`, `textarea`, `email`, `url`, and the framework-owned system
+`id`. (`slug` is just a `text` field; rich-text content is stored as blocks/JSON,
+not queried with these operators.)
 
 | Operator     | Example                            | Description                                 |
 | ------------ | ---------------------------------- | ------------------------------------------- |
@@ -44,6 +46,9 @@ Applies to: `text`, `textarea`, `email`, `url`. (`slug` is just a `text` field; 
 Text ordering uses the database column's configured collation. Use the same
 column and direction for `orderBy` and the ordered cursor predicate; QUESTPIE
 does not replace that collation with JavaScript string ordering.
+
+This makes system `id` suitable as a typed keyset tie-breaker, for example
+`where: { id: { lt: cursor.id } }` with `orderBy: { id: "desc" }`.
 
 `email` fields add domain matching on top of the text operators:
 

--- a/skills/questpie/references/query-operators.md
+++ b/skills/questpie/references/query-operators.md
@@ -25,6 +25,10 @@ Applies to: `text`, `textarea`, `email`, `url`. (`slug` is just a `text` field; 
 | `eq`         | `{ title: { eq: "Hello" } }`       | Exact match                                 |
 | `ne`         | `{ title: { ne: "Hello" } }`       | Not equal                                   |
 | `not`        | `{ title: { not: "Hello" } }`      | Alias for `ne`; `not: null` → `IS NOT NULL` |
+| `gt`         | `{ title: { gt: "Hello" } }`       | Greater than in database collation order    |
+| `gte`        | `{ title: { gte: "Hello" } }`      | Greater than or equal in collation order    |
+| `lt`         | `{ title: { lt: "World" } }`       | Less than in database collation order       |
+| `lte`        | `{ title: { lte: "World" } }`      | Less than or equal in collation order       |
 | `in`         | `{ title: { in: ["A", "B"] } }`    | One of values                               |
 | `notIn`      | `{ title: { notIn: ["A", "B"] } }` | None of values                              |
 | `contains`   | `{ title: { contains: "ell" } }`   | Substring match                             |
@@ -36,6 +40,10 @@ Applies to: `text`, `textarea`, `email`, `url`. (`slug` is just a `text` field; 
 | `notIlike`   | `{ title: { notIlike: "he%o" } }`  | Negated case-insensitive LIKE               |
 | `isNull`     | `{ title: { isNull: true } }`      | Is NULL                                     |
 | `isNotNull`  | `{ title: { isNotNull: true } }`   | Is NOT NULL                                 |
+
+Text ordering uses the database column's configured collation. Use the same
+column and direction for `orderBy` and the ordered cursor predicate; QUESTPIE
+does not replace that collation with JavaScript string ordering.
 
 `email` fields add domain matching on top of the text operators:
 


### PR DESCRIPTION
## Summary

- expose the already-supported `gt`, `gte`, `lt`, and `lte` operators in the public `stringOps` contract
- cover text fields, system `id`, runtime operator lookup, JSONB, and collation-consistent keyset paging
- update query-operator docs and generated skill reference

## Why

The runtime query compiler already accepts ordered comparisons for text columns, but `CollectionWhere` rejects them. Autopilot reproduced this with a typed string/id keyset query. This PR aligns the public type with the installed runtime instead of requiring consumer casts.

## Verification

- narrow query suites: 40 passing
- package typechecks: passing
- full package suite: 3,105 passing, 65 environment skips, 0 failures
- root format, lint, docs validation, and skill-doc generation/check: passing

Includes a patch changeset.