### PR TITLE
fix: harden structured logging boundaries

### DIFF
--- a/.changeset/safe-logging-boundaries.md
+++ b/.changeset/safe-logging-boundaries.md
@@ -1,0 +1,5 @@
+---
+"questpie": patch
+---
+
+Validate inbound correlation identifiers, keep correlated Pino and OTLP records in parity, and redact credentials and Error details from structured logger fields.

--- a/.changeset/safe-logging-boundaries.md
+++ b/.changeset/safe-logging-boundaries.md
@@ -1,5 +1,6 @@
 ---
 "questpie": patch
+"@questpie/observability": patch
 ---
 
-Validate inbound correlation identifiers, keep correlated Pino and OTLP records in parity, and redact credentials and Error details from structured logger fields.
+Validate inbound correlation identifiers and apply one redaction policy to the final effective Pino and OTLP log record. Structured values now use a canonical inert schema: unsupported values, cycles, and non-finite numbers become explicit markers; Date, URL, Map, Set, and TypedArray values use tagged records; URL credentials and fragments are removed. OpenTelemetry log attributes support the recursive AnyValue contract independently from scalar span and metric attributes.

--- a/.changeset/safe-logging-boundaries.md
+++ b/.changeset/safe-logging-boundaries.md
@@ -3,4 +3,4 @@
 "@questpie/observability": patch
 ---
 
-Validate inbound correlation identifiers and apply one redaction policy to the final effective Pino and OTLP log record. Structured values now use a canonical inert schema: unsupported values, cycles, and non-finite numbers become explicit markers; Date, URL, Map, Set, and TypedArray values use tagged records; URL credentials and fragments are removed. OpenTelemetry log attributes support the recursive AnyValue contract independently from scalar span and metric attributes.
+Validate inbound correlation identifiers and apply one redaction policy to the final effective Pino and OTLP log record, including configured paths that target canonical tagged fields. Structured values now use a canonical inert schema: unsupported values, cycles, and non-finite numbers become explicit markers; Date, URL, Map, Set, and TypedArray values use tagged records; URL credentials and fragments are removed. OpenTelemetry log attributes support the recursive AnyValue contract independently from scalar span and metric attributes.

--- a/apps/docs/content/docs/ship/configuration/runtime.mdx
+++ b/apps/docs/content/docs/ship/configuration/runtime.mdx
@@ -31,6 +31,11 @@ Every key is optional at the call site. `RuntimeConfigInput` marks `app` and
 `RuntimeConfig` requires the pair. `crdt` stays dormant until some collection is
 collaborative, so most apps never set it.
 
+`logger.redact` adds application-specific paths to QUESTPIE's default
+structured-field redaction. Common credential keys and `Error` messages/stacks
+are redacted before Pino and the observability tee. It does not inspect the
+caller-owned message string.
+
 ## Resolution from the environment
 
 Four keys are resolved when you leave them out. Your value wins, then the

--- a/apps/docs/content/docs/ship/monitoring.mdx
+++ b/apps/docs/content/docs/ship/monitoring.mdx
@@ -140,11 +140,16 @@ the filters run in, which level a request lands at, and the shape of the record.
 ## Correlation
 
 Every response carries `x-request-id` and `x-trace-id`. The request id is read
-from an inbound `x-request-id` or `x-correlation-id` when there is one. So an id
-your proxy assigned survives. Otherwise it is a fresh UUID.
+from an inbound `x-request-id` or `x-correlation-id` when it is a bounded safe
+identifier (at most 128 characters, using letters, numbers, `.`, `_`, `:`, or
+`-`). So a valid id your proxy assigned survives. Invalid or oversized values
+are replaced with a fresh UUID and are never reflected into response headers or
+structured request logs.
 
 The trace id comes from `x-trace-id` first. Then from the trace id inside
-`traceparent`. Failing both, it falls back to the request id.
+an exact W3C version `00` `traceparent`; zero trace or parent ids are rejected.
+Invalid supplied values are replaced. With no trace input, it falls back to the
+request id.
 
 Both land on the log line and on the request's span. So you can start from
 either and find the other.

--- a/apps/docs/content/docs/ship/monitoring/request-logs.mdx
+++ b/apps/docs/content/docs/ship/monitoring/request-logs.mdx
@@ -111,6 +111,16 @@ serialized without their message or stack. This protection does not inspect the
 caller-owned message string: keep messages stable and put request data in the
 structured object.
 
+The structured object is canonicalized before either sink receives it. The
+effective record includes child bindings, caller fields, and request/trace/span
+context, then applies redaction once. Unsupported values become
+`[Unsupported]`, cycles `[Circular]`, and `NaN`/infinities `[NonFinite]`.
+Dates, URLs, Maps, Sets, and typed arrays become tagged records with `type` plus
+`value`, `entries`, or `values`. URL userinfo and fragments are removed, and
+sensitive query values are redacted. OTLP log attributes retain this recursive
+structure through the Logs AnyValue contract; span and metric attributes remain
+scalar or homogeneous primitive arrays.
+
 Records written inside a request also pick up `trace_id` and `span_id` from the
 open span, once an observability adapter is wired. See
 [Instrumented seams](/docs/infrastructure/observability/seams).

--- a/apps/docs/content/docs/ship/monitoring/request-logs.mdx
+++ b/apps/docs/content/docs/ship/monitoring/request-logs.mdx
@@ -99,9 +99,17 @@ parameterized route, so a request to `/api/posts/42` logs `path` as
 `/api/posts/42` and `route` as `:collection/:id`. All your collections share
 that pattern. Group on `path` when you need them apart.
 
-`error` carries `name` and `message`, and nothing else. It appears only when a
-handler threw. A handler that returns a 500 rather than raising still logs at
-`error` level, but with no `error` object beside it.
+`error` carries the error `name`, while its `message` is written as
+`[Redacted]`. It appears only when a handler threw. A handler that returns a 500
+rather than raising still logs at `error` level, but with no `error` object
+beside it.
+
+QUESTPIE recursively redacts common credential keys in structured log arguments,
+including authorization, cookies, passwords, tokens, secrets, and API keys.
+`logger.redact` adds application-specific structured paths. `Error` values are
+serialized without their message or stack. This protection does not inspect the
+caller-owned message string: keep messages stable and put request data in the
+structured object.
 
 Records written inside a request also pick up `trace_id` and `span_id` from the
 open span, once an observability adapter is wired. See

--- a/apps/docs/content/docs/ship/monitoring/request-logs.mdx
+++ b/apps/docs/content/docs/ship/monitoring/request-logs.mdx
@@ -119,7 +119,9 @@ Dates, URLs, Maps, Sets, and typed arrays become tagged records with `type` plus
 `value`, `entries`, or `values`. URL userinfo and fragments are removed, and
 sensitive query values are redacted. OTLP log attributes retain this recursive
 structure through the Logs AnyValue contract; span and metric attributes remain
-scalar or homogeneous primitive arrays.
+scalar or homogeneous primitive arrays. Configured paths may also target tagged
+fields such as `diagnostic.type`; QUESTPIE applies them before both sinks, not
+again inside Pino.
 
 Records written inside a request also pick up `trace_id` and `span_id` from the
 open span, once an observability adapter is wired. See

--- a/packages/admin/src/server/adapters/tanstack.ts
+++ b/packages/admin/src/server/adapters/tanstack.ts
@@ -102,7 +102,7 @@ export function createTanStackAuthGuard({
 		const request = context.request;
 
 		if (!request) {
-			console.warn(
+			app.logger.warn(
 				"createTanStackAuthGuard: No request in context. " +
 					"Make sure you're using TanStack Start with SSR enabled.",
 			);

--- a/packages/admin/src/server/modules/admin/auth-helpers.ts
+++ b/packages/admin/src/server/modules/admin/auth-helpers.ts
@@ -148,7 +148,7 @@ export async function requireAdminAuth({
 }: RequireAdminAuthOptions): Promise<Response | null> {
 	// Check if auth is configured
 	if (!app.auth) {
-		console.warn("requireAdminAuth: Auth not configured on app instance");
+		app.logger.warn("requireAdminAuth: Auth not configured on app instance");
 		return null;
 	}
 
@@ -177,7 +177,7 @@ export async function requireAdminAuth({
 		// Authenticated with correct role
 		return null;
 	} catch (error) {
-		console.error("requireAdminAuth: Error checking session", error);
+		app.logger.error("requireAdminAuth: Error checking session", error);
 		// On error, redirect to login for safety
 		const currentUrl = new URL(request.url);
 		const redirectUrl = new URL(loginPath, currentUrl.origin);
@@ -220,7 +220,7 @@ export async function getAdminSession({
 
 		return session as AuthSession;
 	} catch (error) {
-		console.error("getAdminSession: Error getting session", error);
+		app.logger.error("getAdminSession: Error getting session", error);
 		return null;
 	}
 }

--- a/packages/admin/src/server/modules/admin/routes/execute-action.ts
+++ b/packages/admin/src/server/modules/admin/routes/execute-action.ts
@@ -323,7 +323,7 @@ export async function executeAction(
 			result,
 		};
 	} catch (error) {
-		console.error(`Action "${actionId}" failed:`, error);
+		app.logger.error("Admin action failed", { actionId, error });
 		return {
 			success: false,
 			result: {
@@ -763,7 +763,7 @@ async function executeBuiltinAction(
 				};
 		}
 	} catch (error) {
-		console.error(`Built-in action "${actionId}" failed:`, error);
+		app.logger.error("Built-in admin action failed", { actionId, error });
 		return {
 			success: false,
 			result: {

--- a/packages/admin/src/server/modules/admin/routes/reactive.ts
+++ b/packages/admin/src/server/modules/admin/routes/reactive.ts
@@ -809,10 +809,11 @@ export const fieldOptions = route()
 				total: result.total,
 			};
 		} catch (error) {
-			console.error(
-				`Error fetching options for ${entityName}.${field}:`,
+			app.logger.error("Admin field options failed", {
+				entityName,
+				field,
 				error,
-			);
+			});
 			return {
 				options: [],
 				hasMore: false,

--- a/packages/admin/test/server/execute-action-runtime-shape.test.ts
+++ b/packages/admin/test/server/execute-action-runtime-shape.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, spyOn } from "bun:test";
+import { describe, expect, it } from "bun:test";
 
 import { tryGetContext } from "questpie";
 import { z } from "zod";
@@ -117,9 +117,24 @@ describe("admin execute action runtime shape", () => {
 
 	it("lets a custom action preserve the expected revision at its generated CRUD mutation", async () => {
 		let mutated = false;
-		const errorLog = spyOn(console, "error").mockImplementation(() => {});
+		const errorLogs: Array<{
+			message: string;
+			fields: Record<string, unknown>;
+		}> = [];
+		const logger = {
+			debug() {},
+			info() {},
+			warn() {},
+			error(message: string, fields: Record<string, unknown>) {
+				errorLogs.push({ message, fields });
+			},
+			child() {
+				return logger;
+			},
+		};
 		const app = {
 			state: {},
+			logger,
 			collections: {
 				posts: {
 					updateById: async (params: Record<string, unknown>) => {
@@ -166,8 +181,22 @@ describe("admin execute action runtime shape", () => {
 			itemId: "post-1",
 			expectedRevision: 3,
 		});
-		expect(stale.success).toBe(false);
+		expect(stale).toEqual({
+			success: false,
+			result: {
+				type: "error",
+				toast: { message: "Optimistic lock conflict" },
+			},
+		});
 		expect(mutated).toBe(false);
+		expect(errorLogs).toHaveLength(1);
+		expect(errorLogs[0]).toMatchObject({
+			message: "Admin action failed",
+			fields: {
+				actionId: "publish",
+				error: { message: "Optimistic lock conflict", code: "CONFLICT" },
+			},
+		});
 
 		const current = await executeAction(app as any, {
 			collection: "posts",
@@ -177,7 +206,7 @@ describe("admin execute action runtime shape", () => {
 		});
 		expect(current.success).toBe(true);
 		expect(mutated).toBe(true);
-		errorLog.mockRestore();
+		expect(errorLogs).toHaveLength(1);
 	});
 
 	it("forwards optimistic-concurrency inputs through every built-in mutation", async () => {

--- a/packages/observability/src/otel-adapter.ts
+++ b/packages/observability/src/otel-adapter.ts
@@ -26,7 +26,11 @@ import {
 	type SpanKind as OtelSpanKind,
 	type Tracer as OtelTracer,
 } from "@opentelemetry/api";
-import { SeverityNumber, logs } from "@opentelemetry/api-logs";
+import {
+	SeverityNumber,
+	logs,
+	type LogAttributes,
+} from "@opentelemetry/api-logs";
 import { AsyncLocalStorageContextManager } from "@opentelemetry/context-async-hooks";
 import { W3CTraceContextPropagator } from "@opentelemetry/core";
 import { OTLPLogExporter } from "@opentelemetry/exporter-logs-otlp-http";
@@ -64,6 +68,7 @@ import type {
 	Meter,
 	ObservabilityAdapter,
 	ObservabilityAttributes,
+	ObservabilityLogAttributes,
 	ObservabilitySpan,
 	SpanKind,
 	StartSpanOptions,
@@ -137,6 +142,12 @@ function toOtelAttributes(attributes?: ObservabilityAttributes): Attributes {
 		if (value !== undefined) out[key] = value;
 	}
 	return out;
+}
+
+function toOtelLogAttributes(
+	attributes?: ObservabilityLogAttributes,
+): LogAttributes {
+	return attributes ?? {};
 }
 
 function wrapSpan(span: OtelSpan): ObservabilitySpan {
@@ -348,7 +359,7 @@ export function otelObservability(
 				severityNumber: SEVERITY[record.level] ?? SeverityNumber.INFO,
 				severityText: record.level.toUpperCase(),
 				body: record.message,
-				attributes: toOtelAttributes(record.attributes),
+				attributes: toOtelLogAttributes(record.attributes),
 			});
 		},
 		async shutdown() {

--- a/packages/observability/test/otel-tree.test.ts
+++ b/packages/observability/test/otel-tree.test.ts
@@ -253,7 +253,11 @@ describe("OTLP log records", () => {
 			service.emitLog({
 				level: "error",
 				message: "boom",
-				attributes: { orderId: "o-1" },
+				attributes: {
+					orderId: "o-1",
+					diagnostic: { error: { type: "TypeError", message: "[Redacted]" } },
+					items: ["one", { status: "safe" }],
+				},
 			});
 		});
 
@@ -264,6 +268,10 @@ describe("OTLP log records", () => {
 		expect(records[0]!.body).toBe("boom");
 		expect(records[0]!.severityText).toBe("ERROR");
 		expect(records[0]!.attributes.orderId).toBe("o-1");
+		expect(records[0]!.attributes.diagnostic).toEqual({
+			error: { type: "TypeError", message: "[Redacted]" },
+		});
+		expect(records[0]!.attributes.items).toEqual(["one", { status: "safe" }]);
 		expect(records[0]!.spanContext?.traceId).toBeDefined();
 	});
 

--- a/packages/questpie/src/server/adapters/http.ts
+++ b/packages/questpie/src/server/adapters/http.ts
@@ -571,7 +571,7 @@ export const createFetchHandler = (
 							// adapter decide the format; the framework has no OpenTelemetry
 							// dependency and W3C is not the only propagator that exists.
 							carrier: {
-								traceparent: request.headers.get("traceparent") ?? undefined,
+								traceparent: getValidTraceparent(request),
 								tracestate: request.headers.get("tracestate") ?? undefined,
 								baggage: request.headers.get("baggage") ?? undefined,
 							},

--- a/packages/questpie/src/server/adapters/http.ts
+++ b/packages/questpie/src/server/adapters/http.ts
@@ -119,6 +119,34 @@ type RequestLoggingOptions = {
 	ignore?: (meta: RequestLogMeta) => boolean;
 };
 
+const CORRELATION_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
+const W3C_TRACEPARENT_PATTERN =
+	/^00-([0-9a-f]{32})-([0-9a-f]{16})-[0-9a-f]{2}$/;
+
+function isSafeCorrelationId(value: string | null): value is string {
+	return value !== null && CORRELATION_ID_PATTERN.test(value);
+}
+
+function generateCorrelationId(): string {
+	return (
+		globalThis.crypto?.randomUUID?.() ??
+		`${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
+	);
+}
+
+function getValidTraceparent(request: Request): string | undefined {
+	const traceparent = request.headers.get("traceparent");
+	if (!traceparent) return undefined;
+	const match = traceparent.match(W3C_TRACEPARENT_PATTERN);
+	if (!match) return undefined;
+
+	const [, traceId, parentId] = match;
+	if (!traceId || !parentId || /^0+$/.test(traceId) || /^0+$/.test(parentId)) {
+		return undefined;
+	}
+	return traceparent;
+}
+
 function resolveRequestLoggingOptions(
 	config: RequestLoggingConfig | undefined,
 ): RequestLoggingOptions {
@@ -149,20 +177,23 @@ function resolveRequestLoggingOptions(
 
 function getTraceId(request: Request): string | undefined {
 	const explicit = request.headers.get("x-trace-id");
-	if (explicit) return explicit;
+	if (explicit !== null) {
+		return isSafeCorrelationId(explicit) ? explicit : generateCorrelationId();
+	}
 
-	const traceparent = request.headers.get("traceparent");
-	const traceId = traceparent?.split("-")[1];
-	return traceId && /^[\da-f]{32}$/i.test(traceId) ? traceId : undefined;
+	if (request.headers.has("traceparent")) {
+		return (
+			getValidTraceparent(request)?.split("-")[1] ?? generateCorrelationId()
+		);
+	}
+	return undefined;
 }
 
 function getRequestId(request: Request): string {
-	return (
+	const explicit =
 		request.headers.get("x-request-id") ??
-		request.headers.get("x-correlation-id") ??
-		globalThis.crypto?.randomUUID?.() ??
-		`${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
-	);
+		request.headers.get("x-correlation-id");
+	return isSafeCorrelationId(explicit) ? explicit : generateCorrelationId();
 }
 
 function getErrorDetails(error: unknown): RequestLogMeta["error"] {

--- a/packages/questpie/src/server/modules/core/integrated/logger/pino-adapter.ts
+++ b/packages/questpie/src/server/modules/core/integrated/logger/pino-adapter.ts
@@ -12,7 +12,11 @@ export class PinoLoggerAdapter implements LoggerAdapter {
 
 		this.logger = pino({
 			level: config.level || "info",
-			redact: config.redact,
+			serializers: {
+				// LoggerService has already converted `err` into an inert canonical
+				// record. Pino's Error serializer must not reinterpret it or add a stack.
+				err: (value) => value,
+			},
 			transport:
 				(config.pretty ?? isDev)
 					? {

--- a/packages/questpie/src/server/modules/core/integrated/logger/redaction.ts
+++ b/packages/questpie/src/server/modules/core/integrated/logger/redaction.ts
@@ -248,10 +248,15 @@ function serializeSupportedValue(
 	try {
 		const timestamp = Date.prototype.getTime.call(value);
 		if (!Number.isNaN(timestamp))
-			return inertRecord({
-				type: "Date",
-				value: new Date(timestamp).toISOString(),
-			});
+			return redactCanonicalRecord(
+				inertRecord({
+					type: "Date",
+					value: new Date(timestamp).toISOString(),
+				}),
+				path,
+				policy,
+				seen,
+			);
 	} catch {}
 	try {
 		const url = new URL(URL.prototype.toString.call(value));
@@ -263,7 +268,12 @@ function serializeSupportedValue(
 				url.searchParams.set(key, REDACTED);
 			}
 		}
-		return inertRecord({ type: "URL", value: url.toString() });
+		return redactCanonicalRecord(
+			inertRecord({ type: "URL", value: url.toString() }),
+			path,
+			policy,
+			seen,
+		);
 	} catch {}
 	try {
 		const result = inertRecord({
@@ -285,7 +295,7 @@ function serializeSupportedValue(
 					: redactValue(nested, [...path, policySegment], policy, seen),
 			]);
 		}
-		return result;
+		return redactCanonicalRecord(result, path, policy, seen);
 	} catch {}
 	try {
 		const result = inertRecord({
@@ -297,7 +307,7 @@ function serializeSupportedValue(
 		) as IterableIterator<unknown>;
 		for (const nested of iterator)
 			result.values.push(redactValue(nested, [...path, "value"], policy, seen));
-		return result;
+		return redactCanonicalRecord(result, path, policy, seen);
 	} catch {}
 	if (ArrayBuffer.isView(value)) {
 		const values = Object.entries(getDescriptors(value) ?? {})
@@ -306,13 +316,27 @@ function serializeSupportedValue(
 			.map(([key, descriptor]) =>
 				redactValue(descriptor.value, [...path, key], policy, seen),
 			);
-		return inertRecord({ type: "TypedArray", values });
+		return redactCanonicalRecord(
+			inertRecord({ type: "TypedArray", values }),
+			path,
+			policy,
+			seen,
+		);
 	}
 	return undefined;
 }
 
 function inertRecord<T extends Record<string, unknown>>(values: T): T {
 	return Object.assign(Object.create(null), values) as T;
+}
+
+function redactCanonicalRecord(
+	value: Record<string, unknown>,
+	path: string[],
+	policy: RedactionPolicy,
+	seen: WeakSet<object>,
+): unknown {
+	return redactValue(value, path, policy, seen);
 }
 
 function isErrorKey(key: string): boolean {

--- a/packages/questpie/src/server/modules/core/integrated/logger/redaction.ts
+++ b/packages/questpie/src/server/modules/core/integrated/logger/redaction.ts
@@ -91,6 +91,10 @@ function redactValue(
 	for (const [key, descriptor] of Object.entries(descriptors)) {
 		if (!descriptor.enumerable || !("value" in descriptor)) continue;
 		const nested = descriptor.value;
+		if (matchesPath([...path, key], policy.paths)) {
+			assignCloneValue(clone, key, REDACTED);
+			continue;
+		}
 		if (isSensitiveKey(key)) {
 			assignCloneValue(clone, key, REDACTED);
 			continue;

--- a/packages/questpie/src/server/modules/core/integrated/logger/redaction.ts
+++ b/packages/questpie/src/server/modules/core/integrated/logger/redaction.ts
@@ -54,7 +54,7 @@ function redactValue(
 	if (existing) return existing;
 	const descriptors = getDescriptors(value);
 	if (!descriptors) return "[Unserializable]";
-	if (isError(value)) return serializeErrorDescriptors(descriptors);
+	if (isError(value)) return serializeErrorDescriptors(value, descriptors);
 	const supported = serializeSupportedValue(value, path, policy, seen);
 	if (supported !== undefined) return supported;
 	const clone: Record<string, unknown> | unknown[] = Array.isArray(value)
@@ -102,10 +102,16 @@ function assignCloneValue(
 }
 
 function serializeErrorDescriptors(
+	error: object,
 	descriptors: Record<string, PropertyDescriptor>,
 ): Record<string, unknown> {
+	const ownName = dataProperty(descriptors, "name");
 	const result: Record<string, unknown> = {
-		type: dataProperty(descriptors, "name") ?? "Error",
+		type:
+			typeof ownName === "string" &&
+			/^[A-Za-z][A-Za-z0-9_.-]{0,63}$/.test(ownName)
+				? ownName
+				: trustedErrorType(error),
 		message: REDACTED,
 	};
 	const code = dataProperty(descriptors, "code");
@@ -121,7 +127,7 @@ function serializeErrorLike(
 	if (!descriptors) return "[Unserializable]";
 	const error = isError(value);
 	if (!error && !descriptors.message && !descriptors.stack) return undefined;
-	if (error) return serializeErrorDescriptors(descriptors);
+	if (error) return serializeErrorDescriptors(value, descriptors);
 	const result: Record<string, unknown> = {};
 	for (const key of ["type", "name", "code", "status", "statusCode"] as const) {
 		const candidate = dataProperty(descriptors, key);
@@ -138,6 +144,27 @@ function isError(value: object): boolean {
 	} catch {
 		return false;
 	}
+}
+
+function trustedErrorType(value: object): string {
+	const trusted = new Map<object, string>([
+		[EvalError.prototype, "EvalError"],
+		[RangeError.prototype, "RangeError"],
+		[ReferenceError.prototype, "ReferenceError"],
+		[SyntaxError.prototype, "SyntaxError"],
+		[TypeError.prototype, "TypeError"],
+		[URIError.prototype, "URIError"],
+		[Error.prototype, "Error"],
+	]);
+	try {
+		let prototype = Object.getPrototypeOf(value);
+		while (prototype) {
+			const type = trusted.get(prototype);
+			if (type) return type;
+			prototype = Object.getPrototypeOf(prototype);
+		}
+	} catch {}
+	return "Error";
 }
 
 function getDescriptors(
@@ -170,7 +197,13 @@ function serializeSupportedValue(
 			return { type: "Date", value: new Date(timestamp).toISOString() };
 	} catch {}
 	try {
-		return { type: "URL", value: URL.prototype.toString.call(value) };
+		const url = new URL(URL.prototype.toString.call(value));
+		url.username = "";
+		url.password = "";
+		for (const key of url.searchParams.keys()) {
+			if (isSensitiveKey(key)) url.searchParams.set(key, REDACTED);
+		}
+		return { type: "URL", value: url.toString() };
 	} catch {}
 	try {
 		const result: { type: "Map"; entries: unknown[] } = {
@@ -182,9 +215,14 @@ function serializeSupportedValue(
 		>;
 		seen.set(value, result);
 		for (const [key, nested] of iterator) {
+			const redactEntry =
+				typeof key === "string" &&
+				(isSensitiveKey(key) || matchesPath([...path, key], policy.paths));
 			result.entries.push([
 				redactValue(key, [...path, "key"], policy, seen),
-				redactValue(nested, [...path, "value"], policy, seen),
+				redactEntry
+					? REDACTED
+					: redactValue(nested, [...path, String(key)], policy, seen),
 			]);
 		}
 		return result;

--- a/packages/questpie/src/server/modules/core/integrated/logger/redaction.ts
+++ b/packages/questpie/src/server/modules/core/integrated/logger/redaction.ts
@@ -148,6 +148,7 @@ function isError(value: object): boolean {
 
 function trustedErrorType(value: object): string {
 	const trusted = new Map<object, string>([
+		[AggregateError.prototype, "AggregateError"],
 		[EvalError.prototype, "EvalError"],
 		[RangeError.prototype, "RangeError"],
 		[ReferenceError.prototype, "ReferenceError"],
@@ -201,7 +202,9 @@ function serializeSupportedValue(
 		url.username = "";
 		url.password = "";
 		for (const key of url.searchParams.keys()) {
-			if (isSensitiveKey(key)) url.searchParams.set(key, REDACTED);
+			if (isSensitiveKey(key) || matchesPath([...path, key], policy.paths)) {
+				url.searchParams.set(key, REDACTED);
+			}
 		}
 		return { type: "URL", value: url.toString() };
 	} catch {}
@@ -215,6 +218,7 @@ function serializeSupportedValue(
 		>;
 		seen.set(value, result);
 		for (const [key, nested] of iterator) {
+			const policySegment = typeof key === "string" ? key : "<non-string-key>";
 			const redactEntry =
 				typeof key === "string" &&
 				(isSensitiveKey(key) || matchesPath([...path, key], policy.paths));
@@ -222,7 +226,7 @@ function serializeSupportedValue(
 				redactValue(key, [...path, "key"], policy, seen),
 				redactEntry
 					? REDACTED
-					: redactValue(nested, [...path, String(key)], policy, seen),
+					: redactValue(nested, [...path, policySegment], policy, seen),
 			]);
 		}
 		return result;

--- a/packages/questpie/src/server/modules/core/integrated/logger/redaction.ts
+++ b/packages/questpie/src/server/modules/core/integrated/logger/redaction.ts
@@ -28,7 +28,7 @@ export function redactLogArgs(
 	args: unknown[],
 	policy: RedactionPolicy,
 ): unknown[] {
-	const seen = new WeakMap<object, unknown>();
+	const seen = new WeakSet<object>();
 	return args.map((value, index) => {
 		const redacted = redactValue(value, [], policy, seen);
 		return index === 0 &&
@@ -44,33 +44,50 @@ export function redactLogBindings(
 	bindings: Record<string, unknown>,
 	policy: RedactionPolicy,
 ): Record<string, unknown> {
-	return redactValue(bindings, [], policy, new WeakMap()) as Record<
-		string,
-		unknown
-	>;
+	const redacted = redactValue(bindings, [], policy, new WeakSet());
+	return redacted && typeof redacted === "object" && !Array.isArray(redacted)
+		? (redacted as Record<string, unknown>)
+		: Object.create(null);
 }
 
 function redactValue(
 	value: unknown,
 	path: string[],
 	policy: RedactionPolicy,
-	seen: WeakMap<object, unknown>,
+	seen: WeakSet<object>,
 ): unknown {
 	if (matchesPath(path, policy.paths)) return REDACTED;
-	if (value === null || ["string", "number", "boolean"].includes(typeof value))
+	if (typeof value === "number")
+		return Number.isFinite(value) ? value : "[NonFinite]";
+	if (value === null || ["string", "boolean"].includes(typeof value))
 		return value;
 	if (typeof value !== "object") return "[Unsupported]";
-	const existing = seen.get(value);
-	if (existing) return existing;
+	if (seen.has(value)) return "[Circular]";
+	seen.add(value);
 	const descriptors = getDescriptors(value);
-	if (!descriptors) return "[Unserializable]";
-	if (isError(value)) return serializeErrorDescriptors(value, descriptors);
+	if (!descriptors) {
+		seen.delete(value);
+		return "[Unserializable]";
+	}
+	if (isError(value)) {
+		const result = serializeErrorDescriptors(
+			value,
+			descriptors,
+			path,
+			policy,
+			seen,
+		);
+		seen.delete(value);
+		return result;
+	}
 	const supported = serializeSupportedValue(value, path, policy, seen);
-	if (supported !== undefined) return supported;
+	if (supported !== undefined) {
+		seen.delete(value);
+		return supported;
+	}
 	const clone: Record<string, unknown> | unknown[] = Array.isArray(value)
 		? []
 		: Object.create(null);
-	seen.set(value, clone);
 	for (const [key, descriptor] of Object.entries(descriptors)) {
 		if (!descriptor.enumerable || !("value" in descriptor)) continue;
 		const nested = descriptor.value;
@@ -83,7 +100,12 @@ function redactValue(
 				assignCloneValue(clone, key, REDACTED);
 				continue;
 			}
-			const errorLike = serializeErrorLike(nested);
+			const errorLike = serializeErrorLike(
+				nested,
+				[...path, key],
+				policy,
+				seen,
+			);
 			if (errorLike !== undefined) {
 				assignCloneValue(clone, key, errorLike);
 				continue;
@@ -95,6 +117,7 @@ function redactValue(
 			redactValue(nested, [...path, key], policy, seen),
 		);
 	}
+	seen.delete(value);
 	return clone;
 }
 
@@ -114,6 +137,9 @@ function assignCloneValue(
 function serializeErrorDescriptors(
 	error: object,
 	descriptors: Record<string, PropertyDescriptor>,
+	path: string[],
+	policy: RedactionPolicy,
+	seen: WeakSet<object>,
 ): Record<string, unknown> {
 	const ownName = dataProperty(descriptors, "name");
 	const result: Record<string, unknown> = Object.assign(Object.create(null), {
@@ -125,24 +151,30 @@ function serializeErrorDescriptors(
 		message: REDACTED,
 	});
 	const code = dataProperty(descriptors, "code");
-	if (["string", "number"].includes(typeof code)) result.code = code;
+	if (["string", "number"].includes(typeof code))
+		result.code = redactValue(code, [...path, "code"], policy, seen);
+	result.type = redactValue(result.type, [...path, "type"], policy, seen);
 	return result;
 }
 
 function serializeErrorLike(
 	value: unknown,
+	path: string[],
+	policy: RedactionPolicy,
+	seen: WeakSet<object>,
 ): Record<string, unknown> | string | undefined {
 	if (!value || typeof value !== "object") return undefined;
 	const descriptors = getDescriptors(value);
 	if (!descriptors) return "[Unserializable]";
 	const error = isError(value);
 	if (!error && !descriptors.message && !descriptors.stack) return undefined;
-	if (error) return serializeErrorDescriptors(value, descriptors);
+	if (error)
+		return serializeErrorDescriptors(value, descriptors, path, policy, seen);
 	const result: Record<string, unknown> = Object.create(null);
 	for (const key of ["type", "name", "code", "status", "statusCode"] as const) {
 		const candidate = dataProperty(descriptors, key);
 		if (["string", "number"].includes(typeof candidate))
-			result[key] = candidate;
+			result[key] = redactValue(candidate, [...path, key], policy, seen);
 	}
 	result.message = REDACTED;
 	return result;
@@ -207,7 +239,7 @@ function serializeSupportedValue(
 	value: object,
 	path: string[],
 	policy: RedactionPolicy,
-	seen: WeakMap<object, unknown>,
+	seen: WeakSet<object>,
 ): unknown {
 	try {
 		const timestamp = Date.prototype.getTime.call(value);
@@ -237,7 +269,6 @@ function serializeSupportedValue(
 		const iterator = Map.prototype.entries.call(value) as IterableIterator<
 			[unknown, unknown]
 		>;
-		seen.set(value, result);
 		for (const [key, nested] of iterator) {
 			const policySegment = typeof key === "string" ? key : "<non-string-key>";
 			const redactEntry =
@@ -260,7 +291,6 @@ function serializeSupportedValue(
 		const iterator = Set.prototype.values.call(
 			value,
 		) as IterableIterator<unknown>;
-		seen.set(value, result);
 		for (const nested of iterator)
 			result.values.push(redactValue(nested, [...path, "value"], policy, seen));
 		return result;

--- a/packages/questpie/src/server/modules/core/integrated/logger/redaction.ts
+++ b/packages/questpie/src/server/modules/core/integrated/logger/redaction.ts
@@ -1,11 +1,19 @@
 const REDACTED = "[Redacted]";
 const SENSITIVE_KEY_SUFFIXES = [
 	"authorization",
+	"authorizations",
 	"cookie",
+	"cookies",
 	"password",
+	"passwords",
+	"passwordhash",
+	"passwordhashes",
 	"token",
+	"tokens",
 	"secret",
+	"secrets",
 	"apikey",
+	"apikeys",
 ] as const;
 
 interface RedactionPolicy {
@@ -27,7 +35,7 @@ export function redactLogArgs(
 			value !== null &&
 			typeof value === "object" &&
 			isError(value)
-			? { err: redacted }
+			? inertRecord({ err: redacted })
 			: redacted;
 	});
 }
@@ -49,7 +57,9 @@ function redactValue(
 	seen: WeakMap<object, unknown>,
 ): unknown {
 	if (matchesPath(path, policy.paths)) return REDACTED;
-	if (!value || typeof value !== "object") return value;
+	if (value === null || ["string", "number", "boolean"].includes(typeof value))
+		return value;
+	if (typeof value !== "object") return "[Unsupported]";
 	const existing = seen.get(value);
 	if (existing) return existing;
 	const descriptors = getDescriptors(value);
@@ -59,7 +69,7 @@ function redactValue(
 	if (supported !== undefined) return supported;
 	const clone: Record<string, unknown> | unknown[] = Array.isArray(value)
 		? []
-		: {};
+		: Object.create(null);
 	seen.set(value, clone);
 	for (const [key, descriptor] of Object.entries(descriptors)) {
 		if (!descriptor.enumerable || !("value" in descriptor)) continue;
@@ -106,14 +116,14 @@ function serializeErrorDescriptors(
 	descriptors: Record<string, PropertyDescriptor>,
 ): Record<string, unknown> {
 	const ownName = dataProperty(descriptors, "name");
-	const result: Record<string, unknown> = {
+	const result: Record<string, unknown> = Object.assign(Object.create(null), {
 		type:
 			typeof ownName === "string" &&
 			/^[A-Za-z][A-Za-z0-9_.-]{0,63}$/.test(ownName)
 				? ownName
 				: trustedErrorType(error),
 		message: REDACTED,
-	};
+	});
 	const code = dataProperty(descriptors, "code");
 	if (["string", "number"].includes(typeof code)) result.code = code;
 	return result;
@@ -128,7 +138,7 @@ function serializeErrorLike(
 	const error = isError(value);
 	if (!error && !descriptors.message && !descriptors.stack) return undefined;
 	if (error) return serializeErrorDescriptors(value, descriptors);
-	const result: Record<string, unknown> = {};
+	const result: Record<string, unknown> = Object.create(null);
 	for (const key of ["type", "name", "code", "status", "statusCode"] as const) {
 		const candidate = dataProperty(descriptors, key);
 		if (["string", "number"].includes(typeof candidate))
@@ -156,7 +166,14 @@ function trustedErrorType(value: object): string {
 		[TypeError.prototype, "TypeError"],
 		[URIError.prototype, "URIError"],
 		[Error.prototype, "Error"],
+		[DOMException.prototype, "DOMException"],
+		[WebAssembly.CompileError.prototype, "WebAssembly.CompileError"],
+		[WebAssembly.LinkError.prototype, "WebAssembly.LinkError"],
+		[WebAssembly.RuntimeError.prototype, "WebAssembly.RuntimeError"],
 	]);
+	const suppressed = (globalThis as { SuppressedError?: { prototype: object } })
+		.SuppressedError;
+	if (suppressed) trusted.set(suppressed.prototype, "SuppressedError");
 	try {
 		let prototype = Object.getPrototypeOf(value);
 		while (prototype) {
@@ -195,24 +212,28 @@ function serializeSupportedValue(
 	try {
 		const timestamp = Date.prototype.getTime.call(value);
 		if (!Number.isNaN(timestamp))
-			return { type: "Date", value: new Date(timestamp).toISOString() };
+			return inertRecord({
+				type: "Date",
+				value: new Date(timestamp).toISOString(),
+			});
 	} catch {}
 	try {
 		const url = new URL(URL.prototype.toString.call(value));
 		url.username = "";
 		url.password = "";
+		url.hash = "";
 		for (const key of url.searchParams.keys()) {
 			if (isSensitiveKey(key) || matchesPath([...path, key], policy.paths)) {
 				url.searchParams.set(key, REDACTED);
 			}
 		}
-		return { type: "URL", value: url.toString() };
+		return inertRecord({ type: "URL", value: url.toString() });
 	} catch {}
 	try {
-		const result: { type: "Map"; entries: unknown[] } = {
+		const result = inertRecord({
 			type: "Map",
-			entries: [],
-		};
+			entries: [] as unknown[],
+		});
 		const iterator = Map.prototype.entries.call(value) as IterableIterator<
 			[unknown, unknown]
 		>;
@@ -232,10 +253,10 @@ function serializeSupportedValue(
 		return result;
 	} catch {}
 	try {
-		const result: { type: "Set"; values: unknown[] } = {
+		const result = inertRecord({
 			type: "Set",
-			values: [],
-		};
+			values: [] as unknown[],
+		});
 		const iterator = Set.prototype.values.call(
 			value,
 		) as IterableIterator<unknown>;
@@ -245,12 +266,19 @@ function serializeSupportedValue(
 		return result;
 	} catch {}
 	if (ArrayBuffer.isView(value)) {
-		const values = Object.values(getDescriptors(value) ?? {})
-			.filter((descriptor) => descriptor.enumerable && "value" in descriptor)
-			.map((descriptor) => descriptor.value);
-		return { type: "TypedArray", values };
+		const values = Object.entries(getDescriptors(value) ?? {})
+			.filter(([key, descriptor]) => /^\d+$/.test(key) && "value" in descriptor)
+			.sort(([left], [right]) => Number(left) - Number(right))
+			.map(([key, descriptor]) =>
+				redactValue(descriptor.value, [...path, key], policy, seen),
+			);
+		return inertRecord({ type: "TypedArray", values });
 	}
 	return undefined;
+}
+
+function inertRecord<T extends Record<string, unknown>>(values: T): T {
+	return Object.assign(Object.create(null), values) as T;
 }
 
 function isErrorKey(key: string): boolean {
@@ -259,9 +287,21 @@ function isErrorKey(key: string): boolean {
 }
 
 function isSensitiveKey(key: string): boolean {
-	const normalized = normalizeKey(key);
-	return SENSITIVE_KEY_SUFFIXES.some(
-		(suffix) => normalized === suffix || normalized.endsWith(suffix),
+	const words = key
+		.replaceAll(/([a-z0-9])([A-Z])/g, "$1 $2")
+		.toLowerCase()
+		.split(/[^a-z0-9]+/)
+		.filter(Boolean);
+	const last = words.at(-1) ?? "";
+	const compound = words.slice(-2).join("");
+	return (
+		SENSITIVE_KEY_SUFFIXES.includes(
+			last as (typeof SENSITIVE_KEY_SUFFIXES)[number],
+		) ||
+		compound === "apikey" ||
+		compound === "apikeys" ||
+		compound === "passwordhash" ||
+		compound === "passwordhashes"
 	);
 }
 

--- a/packages/questpie/src/server/modules/core/integrated/logger/redaction.ts
+++ b/packages/questpie/src/server/modules/core/integrated/logger/redaction.ts
@@ -1,0 +1,170 @@
+const REDACTED = "[Redacted]";
+const SENSITIVE_KEY_SUFFIXES = [
+	"authorization",
+	"cookie",
+	"password",
+	"token",
+	"secret",
+	"apikey",
+] as const;
+
+interface RedactionPolicy {
+	paths: string[][];
+}
+
+export function createRedactionPolicy(paths: string[] = []): RedactionPolicy {
+	return { paths: paths.map(parsePath).filter((path) => path.length > 0) };
+}
+
+export function redactLogArgs(
+	args: unknown[],
+	policy: RedactionPolicy,
+): unknown[] {
+	const seen = new WeakMap<object, unknown>();
+	return args.map((value, index) => {
+		const redacted = redactValue(value, [], policy, seen);
+		return index === 0 && value instanceof Error ? { err: redacted } : redacted;
+	});
+}
+
+export function redactLogBindings(
+	bindings: Record<string, unknown>,
+	policy: RedactionPolicy,
+): Record<string, unknown> {
+	return redactValue(bindings, [], policy, new WeakMap()) as Record<
+		string,
+		unknown
+	>;
+}
+
+function redactValue(
+	value: unknown,
+	path: string[],
+	policy: RedactionPolicy,
+	seen: WeakMap<object, unknown>,
+): unknown {
+	if (matchesPath(path, policy.paths)) return REDACTED;
+	if (value instanceof Error) return serializeError(value);
+	if (!value || typeof value !== "object") return value;
+	const existing = seen.get(value);
+	if (existing) return existing;
+	const clone: Record<string, unknown> | unknown[] = Array.isArray(value)
+		? []
+		: {};
+	seen.set(value, clone);
+	let descriptors: Record<string, PropertyDescriptor>;
+	try {
+		descriptors = Object.getOwnPropertyDescriptors(value);
+	} catch {
+		return "[Unserializable]";
+	}
+	for (const [key, descriptor] of Object.entries(descriptors)) {
+		if (!descriptor.enumerable || !("value" in descriptor)) continue;
+		const nested = descriptor.value;
+		if (isSensitiveKey(key)) {
+			assignCloneValue(clone, key, REDACTED);
+			continue;
+		}
+		if (isErrorKey(key)) {
+			if (typeof nested === "string") {
+				assignCloneValue(clone, key, REDACTED);
+				continue;
+			}
+			if (nested instanceof Error) {
+				assignCloneValue(clone, key, serializeError(nested));
+				continue;
+			}
+			if (isErrorLike(nested)) {
+				assignCloneValue(clone, key, serializeErrorLike(nested));
+				continue;
+			}
+		}
+		assignCloneValue(
+			clone,
+			key,
+			redactValue(nested, [...path, key], policy, seen),
+		);
+	}
+	return clone;
+}
+
+function assignCloneValue(
+	clone: Record<string, unknown> | unknown[],
+	key: string,
+	value: unknown,
+): void {
+	Object.defineProperty(clone, key, {
+		configurable: true,
+		enumerable: true,
+		value,
+		writable: true,
+	});
+}
+
+function serializeError(error: Error): Record<string, unknown> {
+	const result: Record<string, unknown> = {
+		type: error.name,
+		message: REDACTED,
+	};
+	const code = (error as Error & { code?: unknown }).code;
+	if (["string", "number"].includes(typeof code)) result.code = code;
+	return result;
+}
+
+function serializeErrorLike(
+	value: Record<string, unknown>,
+): Record<string, unknown> {
+	const result: Record<string, unknown> = {};
+	for (const key of ["type", "name", "code", "status", "statusCode"] as const) {
+		const candidate = value[key];
+		if (["string", "number"].includes(typeof candidate))
+			result[key] = candidate;
+	}
+	if ("message" in value || "stack" in value) result.message = REDACTED;
+	return result;
+}
+
+function isErrorLike(value: unknown): value is Record<string, unknown> {
+	return (
+		value instanceof Error ||
+		(value !== null &&
+			typeof value === "object" &&
+			("message" in value || "stack" in value))
+	);
+}
+
+function isErrorKey(key: string): boolean {
+	const normalized = normalizeKey(key);
+	return normalized === "err" || normalized === "error";
+}
+
+function isSensitiveKey(key: string): boolean {
+	const normalized = normalizeKey(key);
+	return SENSITIVE_KEY_SUFFIXES.some(
+		(suffix) => normalized === suffix || normalized.endsWith(suffix),
+	);
+}
+
+function normalizeKey(key: string): string {
+	return key.toLowerCase().replaceAll(/[^a-z0-9]/g, "");
+}
+
+function matchesPath(path: string[], patterns: string[][]): boolean {
+	return patterns.some(
+		(pattern) =>
+			pattern.length === path.length &&
+			pattern.every((part, index) => part === "*" || part === path[index]),
+	);
+}
+
+function parsePath(path: string): string[] {
+	const parts: string[] = [];
+	const matcher = /(?:^|\.)([^.[\]]+)|\[(?:"([^"]+)"|'([^']+)'|(\d+|\*))\]/g;
+	for (const match of path.matchAll(matcher)) {
+		const part = match[1] ?? match[2] ?? match[3] ?? match[4];
+		if (part) parts.push(part);
+	}
+	return parts;
+}
+
+export type { RedactionPolicy };

--- a/packages/questpie/src/server/modules/core/integrated/logger/redaction.ts
+++ b/packages/questpie/src/server/modules/core/integrated/logger/redaction.ts
@@ -23,7 +23,12 @@ export function redactLogArgs(
 	const seen = new WeakMap<object, unknown>();
 	return args.map((value, index) => {
 		const redacted = redactValue(value, [], policy, seen);
-		return index === 0 && value instanceof Error ? { err: redacted } : redacted;
+		return index === 0 &&
+			value !== null &&
+			typeof value === "object" &&
+			isError(value)
+			? { err: redacted }
+			: redacted;
 	});
 }
 
@@ -44,20 +49,18 @@ function redactValue(
 	seen: WeakMap<object, unknown>,
 ): unknown {
 	if (matchesPath(path, policy.paths)) return REDACTED;
-	if (value instanceof Error) return serializeError(value);
 	if (!value || typeof value !== "object") return value;
 	const existing = seen.get(value);
 	if (existing) return existing;
+	const descriptors = getDescriptors(value);
+	if (!descriptors) return "[Unserializable]";
+	if (isError(value)) return serializeErrorDescriptors(descriptors);
+	const supported = serializeSupportedValue(value, path, policy, seen);
+	if (supported !== undefined) return supported;
 	const clone: Record<string, unknown> | unknown[] = Array.isArray(value)
 		? []
 		: {};
 	seen.set(value, clone);
-	let descriptors: Record<string, PropertyDescriptor>;
-	try {
-		descriptors = Object.getOwnPropertyDescriptors(value);
-	} catch {
-		return "[Unserializable]";
-	}
 	for (const [key, descriptor] of Object.entries(descriptors)) {
 		if (!descriptor.enumerable || !("value" in descriptor)) continue;
 		const nested = descriptor.value;
@@ -70,12 +73,9 @@ function redactValue(
 				assignCloneValue(clone, key, REDACTED);
 				continue;
 			}
-			if (nested instanceof Error) {
-				assignCloneValue(clone, key, serializeError(nested));
-				continue;
-			}
-			if (isErrorLike(nested)) {
-				assignCloneValue(clone, key, serializeErrorLike(nested));
+			const errorLike = serializeErrorLike(nested);
+			if (errorLike !== undefined) {
+				assignCloneValue(clone, key, errorLike);
 				continue;
 			}
 		}
@@ -101,36 +101,114 @@ function assignCloneValue(
 	});
 }
 
-function serializeError(error: Error): Record<string, unknown> {
+function serializeErrorDescriptors(
+	descriptors: Record<string, PropertyDescriptor>,
+): Record<string, unknown> {
 	const result: Record<string, unknown> = {
-		type: error.name,
+		type: dataProperty(descriptors, "name") ?? "Error",
 		message: REDACTED,
 	};
-	const code = (error as Error & { code?: unknown }).code;
+	const code = dataProperty(descriptors, "code");
 	if (["string", "number"].includes(typeof code)) result.code = code;
 	return result;
 }
 
 function serializeErrorLike(
-	value: Record<string, unknown>,
-): Record<string, unknown> {
+	value: unknown,
+): Record<string, unknown> | string | undefined {
+	if (!value || typeof value !== "object") return undefined;
+	const descriptors = getDescriptors(value);
+	if (!descriptors) return "[Unserializable]";
+	const error = isError(value);
+	if (!error && !descriptors.message && !descriptors.stack) return undefined;
+	if (error) return serializeErrorDescriptors(descriptors);
 	const result: Record<string, unknown> = {};
 	for (const key of ["type", "name", "code", "status", "statusCode"] as const) {
-		const candidate = value[key];
+		const candidate = dataProperty(descriptors, key);
 		if (["string", "number"].includes(typeof candidate))
 			result[key] = candidate;
 	}
-	if ("message" in value || "stack" in value) result.message = REDACTED;
+	result.message = REDACTED;
 	return result;
 }
 
-function isErrorLike(value: unknown): value is Record<string, unknown> {
-	return (
-		value instanceof Error ||
-		(value !== null &&
-			typeof value === "object" &&
-			("message" in value || "stack" in value))
-	);
+function isError(value: object): boolean {
+	try {
+		return value instanceof Error;
+	} catch {
+		return false;
+	}
+}
+
+function getDescriptors(
+	value: object,
+): Record<string, PropertyDescriptor> | undefined {
+	try {
+		return Object.getOwnPropertyDescriptors(value);
+	} catch {
+		return undefined;
+	}
+}
+
+function dataProperty(
+	descriptors: Record<string, PropertyDescriptor>,
+	key: string,
+): unknown {
+	const descriptor = descriptors[key];
+	return descriptor && "value" in descriptor ? descriptor.value : undefined;
+}
+
+function serializeSupportedValue(
+	value: object,
+	path: string[],
+	policy: RedactionPolicy,
+	seen: WeakMap<object, unknown>,
+): unknown {
+	try {
+		const timestamp = Date.prototype.getTime.call(value);
+		if (!Number.isNaN(timestamp))
+			return { type: "Date", value: new Date(timestamp).toISOString() };
+	} catch {}
+	try {
+		return { type: "URL", value: URL.prototype.toString.call(value) };
+	} catch {}
+	try {
+		const result: { type: "Map"; entries: unknown[] } = {
+			type: "Map",
+			entries: [],
+		};
+		const iterator = Map.prototype.entries.call(value) as IterableIterator<
+			[unknown, unknown]
+		>;
+		seen.set(value, result);
+		for (const [key, nested] of iterator) {
+			result.entries.push([
+				redactValue(key, [...path, "key"], policy, seen),
+				redactValue(nested, [...path, "value"], policy, seen),
+			]);
+		}
+		return result;
+	} catch {}
+	try {
+		const result: { type: "Set"; values: unknown[] } = {
+			type: "Set",
+			values: [],
+		};
+		const iterator = Set.prototype.values.call(
+			value,
+		) as IterableIterator<unknown>;
+		seen.set(value, result);
+		for (const nested of iterator)
+			result.values.push(redactValue(nested, [...path, "value"], policy, seen));
+		return result;
+	} catch {}
+	if (ArrayBuffer.isView(value)) {
+		const values = Object.values(getDescriptors(value) ?? {})
+			.filter((descriptor) => descriptor.enumerable && "value" in descriptor)
+			.map((descriptor) => descriptor.value);
+		return { type: "TypedArray", values };
+	}
+	return undefined;
 }
 
 function isErrorKey(key: string): boolean {

--- a/packages/questpie/src/server/modules/core/integrated/logger/service.ts
+++ b/packages/questpie/src/server/modules/core/integrated/logger/service.ts
@@ -73,7 +73,10 @@ export class LoggerService implements LoggerAdapter {
 		if (Object.keys(this.teeBindings).length === 0) return args;
 		const [first, ...rest] = args;
 		if (first && typeof first === "object" && !Array.isArray(first)) {
-			return [{ ...this.teeBindings, ...first }, ...rest];
+			return [
+				Object.assign(Object.create(null), this.teeBindings, first),
+				...rest,
+			];
 		}
 		return [this.teeBindings, ...args];
 	}
@@ -151,7 +154,7 @@ export class LoggerService implements LoggerAdapter {
 			return [{ err: first, ...bindings }, ...rest];
 		}
 		if (first && typeof first === "object" && !Array.isArray(first)) {
-			return [{ ...first, ...bindings }, ...rest];
+			return [Object.assign(Object.create(null), first, bindings), ...rest];
 		}
 		return [bindings, ...args];
 	}

--- a/packages/questpie/src/server/modules/core/integrated/logger/service.ts
+++ b/packages/questpie/src/server/modules/core/integrated/logger/service.ts
@@ -75,9 +75,8 @@ export class LoggerService implements LoggerAdapter {
 			record.err = first;
 			remaining = rest;
 		} else if (first && typeof first === "object" && !Array.isArray(first)) {
-			const before = Object.keys(record).length;
 			this.mergeOwnDataInto(record, first);
-			if (Object.keys(record).length > before) remaining = rest;
+			remaining = rest;
 		}
 		this.mergeOwnDataInto(record, this.contextBindings());
 		const effective =

--- a/packages/questpie/src/server/modules/core/integrated/logger/service.ts
+++ b/packages/questpie/src/server/modules/core/integrated/logger/service.ts
@@ -66,7 +66,7 @@ export class LoggerService implements LoggerAdapter {
 	}
 
 	private safeArgs(args: unknown[]): unknown[] {
-		return redactLogArgs(this.withContext(args), this.redaction);
+		return this.withContext(redactLogArgs(args, this.redaction));
 	}
 
 	private withTeeBindings(args: unknown[]): unknown[] {

--- a/packages/questpie/src/server/modules/core/integrated/logger/service.ts
+++ b/packages/questpie/src/server/modules/core/integrated/logger/service.ts
@@ -1,6 +1,12 @@
 import { tryGetContext } from "#questpie/server/config/context.js";
 
 import { PinoLoggerAdapter } from "./pino-adapter.js";
+import {
+	createRedactionPolicy,
+	redactLogArgs,
+	redactLogBindings,
+	type RedactionPolicy,
+} from "./redaction.js";
 import type { LoggerAdapter, LoggerConfig } from "./types.js";
 
 interface SpanIds {
@@ -10,8 +16,13 @@ interface SpanIds {
 
 export class LoggerService implements LoggerAdapter {
 	private adapter: LoggerAdapter;
+	private redaction: RedactionPolicy;
+	private teeBindings: Record<string, unknown> = {};
 
 	constructor(config: LoggerConfig | { adapter: LoggerAdapter } = {}) {
+		this.redaction = createRedactionPolicy(
+			"redact" in config ? config.redact : undefined,
+		);
 		if ("adapter" in config && config.adapter) {
 			this.adapter = config.adapter;
 		} else {
@@ -20,28 +31,51 @@ export class LoggerService implements LoggerAdapter {
 	}
 
 	debug(msg: string, ...args: any[]) {
-		this.adapter.debug(msg, ...this.withContext(args));
-		this.tee("debug", msg, args);
+		this.log("debug", msg, args);
 	}
 
 	info(msg: string, ...args: any[]) {
-		this.adapter.info(msg, ...this.withContext(args));
-		this.tee("info", msg, args);
+		this.log("info", msg, args);
 	}
 
 	warn(msg: string, ...args: any[]) {
-		this.adapter.warn(msg, ...this.withContext(args));
-		this.tee("warn", msg, args);
+		this.log("warn", msg, args);
 	}
 
 	error(msg: string, ...args: any[]) {
-		this.adapter.error(msg, ...this.withContext(args));
-		this.tee("error", msg, args);
+		this.log("error", msg, args);
 	}
 
 	child(bindings: Record<string, any>): LoggerService {
-		const childAdapter = this.adapter.child(bindings);
-		return new LoggerService({ adapter: childAdapter });
+		const safeBindings = redactLogBindings(bindings, this.redaction);
+		const childAdapter = this.adapter.child(safeBindings);
+		const childLogger = new LoggerService({ adapter: childAdapter });
+		childLogger.redaction = this.redaction;
+		childLogger.teeBindings = { ...this.teeBindings, ...safeBindings };
+		return childLogger;
+	}
+
+	private log(
+		level: "debug" | "info" | "warn" | "error",
+		msg: string,
+		args: unknown[],
+	): void {
+		const contextualArgs = this.safeArgs(args);
+		this.adapter[level](msg, ...contextualArgs);
+		this.tee(level, msg, this.withTeeBindings(contextualArgs));
+	}
+
+	private safeArgs(args: unknown[]): unknown[] {
+		return redactLogArgs(this.withContext(args), this.redaction);
+	}
+
+	private withTeeBindings(args: unknown[]): unknown[] {
+		if (Object.keys(this.teeBindings).length === 0) return args;
+		const [first, ...rest] = args;
+		if (first && typeof first === "object" && !Array.isArray(first)) {
+			return [{ ...this.teeBindings, ...first }, ...rest];
+		}
+		return [this.teeBindings, ...args];
 	}
 
 	/**
@@ -84,7 +118,7 @@ export class LoggerService implements LoggerAdapter {
 		}
 	}
 
-	private withContext(args: any[]): any[] {
+	private withContext(args: unknown[]): unknown[] {
 		const ctx = tryGetContext();
 		// `trace_id`/`span_id` in snake_case on purpose: those are the OTel
 		// semantic-convention keys that log backends join to traces on. The

--- a/packages/questpie/src/server/modules/core/integrated/logger/service.ts
+++ b/packages/questpie/src/server/modules/core/integrated/logger/service.ts
@@ -1,10 +1,13 @@
 import { tryGetContext } from "#questpie/server/config/context.js";
 
+import type {
+	ObservabilityLogAttributes,
+	ObservabilityLogRecord,
+} from "../observability/types.js";
 import { PinoLoggerAdapter } from "./pino-adapter.js";
 import {
 	createRedactionPolicy,
 	redactLogArgs,
-	redactLogBindings,
 	type RedactionPolicy,
 } from "./redaction.js";
 import type { LoggerAdapter, LoggerConfig } from "./types.js";
@@ -17,7 +20,7 @@ interface SpanIds {
 export class LoggerService implements LoggerAdapter {
 	private adapter: LoggerAdapter;
 	private redaction: RedactionPolicy;
-	private teeBindings: Record<string, unknown> = {};
+	private bindings: Record<string, unknown> = Object.create(null);
 
 	constructor(config: LoggerConfig | { adapter: LoggerAdapter } = {}) {
 		this.redaction = createRedactionPolicy(
@@ -47,11 +50,10 @@ export class LoggerService implements LoggerAdapter {
 	}
 
 	child(bindings: Record<string, any>): LoggerService {
-		const safeBindings = redactLogBindings(bindings, this.redaction);
-		const childAdapter = this.adapter.child(safeBindings);
+		const childAdapter = this.adapter.child(Object.create(null));
 		const childLogger = new LoggerService({ adapter: childAdapter });
 		childLogger.redaction = this.redaction;
-		childLogger.teeBindings = { ...this.teeBindings, ...safeBindings };
+		childLogger.bindings = this.mergeOwnData(this.bindings, bindings);
 		return childLogger;
 	}
 
@@ -60,25 +62,27 @@ export class LoggerService implements LoggerAdapter {
 		msg: string,
 		args: unknown[],
 	): void {
-		const contextualArgs = this.safeArgs(args);
+		const contextualArgs = this.finalizeArgs(args);
 		this.adapter[level](msg, ...contextualArgs);
-		this.tee(level, msg, this.withTeeBindings(contextualArgs));
+		this.tee(level, msg, contextualArgs);
 	}
 
-	private safeArgs(args: unknown[]): unknown[] {
-		return this.withContext(redactLogArgs(args, this.redaction));
-	}
-
-	private withTeeBindings(args: unknown[]): unknown[] {
-		if (Object.keys(this.teeBindings).length === 0) return args;
+	private finalizeArgs(args: unknown[]): unknown[] {
+		const record = this.mergeOwnData(this.bindings);
 		const [first, ...rest] = args;
-		if (first && typeof first === "object" && !Array.isArray(first)) {
-			return [
-				Object.assign(Object.create(null), this.teeBindings, first),
-				...rest,
-			];
+		let remaining = args;
+		if (this.isError(first)) {
+			record.err = first;
+			remaining = rest;
+		} else if (first && typeof first === "object" && !Array.isArray(first)) {
+			const before = Object.keys(record).length;
+			this.mergeOwnDataInto(record, first);
+			if (Object.keys(record).length > before) remaining = rest;
 		}
-		return [this.teeBindings, ...args];
+		this.mergeOwnDataInto(record, this.contextBindings());
+		const effective =
+			Object.keys(record).length > 0 ? [record, ...remaining] : remaining;
+		return redactLogArgs(effective, this.redaction);
 	}
 
 	/**
@@ -101,17 +105,15 @@ export class LoggerService implements LoggerAdapter {
 	): void {
 		const observability = (
 			tryGetContext()?.app as
-				| { observability?: { emitLog?(record: unknown): void } }
+				| { observability?: { emitLog?(record: ObservabilityLogRecord): void } }
 				| undefined
 		)?.observability;
 		if (!observability?.emitLog) return;
 
 		const first = args[0];
-		const attributes =
+		const attributes: ObservabilityLogAttributes | undefined =
 			first && typeof first === "object" && !Array.isArray(first)
-				? first instanceof Error
-					? { "exception.message": first.message }
-					: (first as Record<string, unknown>)
+				? (first as ObservabilityLogAttributes)
 				: undefined;
 
 		try {
@@ -121,7 +123,7 @@ export class LoggerService implements LoggerAdapter {
 		}
 	}
 
-	private withContext(args: unknown[]): unknown[] {
+	private contextBindings(): Record<string, unknown> {
 		const ctx = tryGetContext();
 		// `trace_id`/`span_id` in snake_case on purpose: those are the OTel
 		// semantic-convention keys that log backends join to traces on. The
@@ -145,17 +147,34 @@ export class LoggerService implements LoggerAdapter {
 			...(ctx?.traceId ? { traceId: ctx.traceId } : {}),
 			...(span ? { trace_id: span.traceId, span_id: span.spanId } : {}),
 		};
-		if (Object.keys(bindings).length === 0) {
-			return args;
-		}
+		return bindings;
+	}
 
-		const [first, ...rest] = args;
-		if (first instanceof Error) {
-			return [{ err: first, ...bindings }, ...rest];
+	private mergeOwnData(...sources: object[]): Record<string, unknown> {
+		const target: Record<string, unknown> = Object.create(null);
+		for (const source of sources) this.mergeOwnDataInto(target, source);
+		return target;
+	}
+
+	private mergeOwnDataInto(
+		target: Record<string, unknown>,
+		source: object,
+	): void {
+		try {
+			for (const [key, descriptor] of Object.entries(
+				Object.getOwnPropertyDescriptors(source),
+			)) {
+				if (descriptor.enumerable && "value" in descriptor)
+					target[key] = descriptor.value;
+			}
+		} catch {}
+	}
+
+	private isError(value: unknown): value is Error {
+		try {
+			return value instanceof Error;
+		} catch {
+			return false;
 		}
-		if (first && typeof first === "object" && !Array.isArray(first)) {
-			return [Object.assign(Object.create(null), first, bindings), ...rest];
-		}
-		return [bindings, ...args];
 	}
 }

--- a/packages/questpie/src/server/modules/core/integrated/logger/types.ts
+++ b/packages/questpie/src/server/modules/core/integrated/logger/types.ts
@@ -71,7 +71,11 @@ export interface LoggerConfig {
 	 */
 	pretty?: boolean;
 	/**
-	 * Redact keys (e.g. ["req.headers.authorization"])
+	 * Additional paths to redact from structured log arguments. QUESTPIE also
+	 * redacts common credential keys and serializes Error values without their
+	 * message or stack. Caller-owned log message strings are not inspected.
+	 *
+	 * @example ["profile.email", "customers[*].phone"]
 	 */
 	redact?: string[];
 	/**

--- a/packages/questpie/src/server/modules/core/integrated/observability/types.ts
+++ b/packages/questpie/src/server/modules/core/integrated/observability/types.ts
@@ -30,6 +30,19 @@ export type ObservabilityAttributes = Record<
 	ObservabilityAttributeValue | undefined
 >;
 
+/** Recursive canonical values accepted by the OpenTelemetry Logs AnyValueMap. */
+export type ObservabilityLogValue =
+	| string
+	| number
+	| boolean
+	| null
+	| ObservabilityLogValue[]
+	| ObservabilityLogAttributes;
+
+export interface ObservabilityLogAttributes {
+	[key: string]: ObservabilityLogValue;
+}
+
 /** What a span looks like from the framework's side. */
 export interface ObservabilitySpan {
 	setAttribute(key: string, value: ObservabilityAttributeValue): void;
@@ -139,7 +152,7 @@ export interface ObservabilityAdapter {
 export interface ObservabilityLogRecord {
 	level: "debug" | "info" | "warn" | "error";
 	message: string;
-	attributes?: ObservabilityAttributes;
+	attributes?: ObservabilityLogAttributes;
 }
 
 export interface ObservabilityConfig {

--- a/packages/questpie/test/integration/adapter-route-config.test.ts
+++ b/packages/questpie/test/integration/adapter-route-config.test.ts
@@ -334,6 +334,12 @@ describe("adapter route config", () => {
 		});
 
 		it("rejects structurally invalid W3C traceparent values", async () => {
+			let carrier: Record<string, string | undefined> | undefined;
+			const span = setup.app.observability.span.bind(setup.app.observability);
+			setup.app.observability.span = ((name: string, fn: any, options: any) => {
+				carrier = options?.carrier;
+				return span(name, fn, options);
+			}) as typeof setup.app.observability.span;
 			const handler = createFetchHandler(setup.app);
 			const response = await handler(
 				new Request("http://localhost/echo-options", {
@@ -350,6 +356,7 @@ describe("adapter route config", () => {
 			const body = await response?.json();
 			expect(body.traceId).not.toBe("00000000000000000000000000000000");
 			expect(body.traceId).toMatch(/^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/);
+			expect(carrier?.traceparent).toBeUndefined();
 		});
 
 		it("can disable request logging while preserving request headers", async () => {

--- a/packages/questpie/test/integration/adapter-route-config.test.ts
+++ b/packages/questpie/test/integration/adapter-route-config.test.ts
@@ -301,6 +301,57 @@ describe("adapter route config", () => {
 			expect(typeof log?.args[0].durationMs).toBe("number");
 		});
 
+		it("replaces malformed and oversized inbound correlation identifiers", async () => {
+			const hostileRequestId = `../../logs?token=${"r".repeat(512)}`;
+			const hostileTraceId = `not-a-trace/${"t".repeat(512)}`;
+			const handler = createFetchHandler(setup.app);
+
+			const response = await handler(
+				new Request("http://localhost/echo-options", {
+					method: "POST",
+					headers: {
+						"content-type": "application/json",
+						"x-correlation-id": hostileRequestId,
+						"x-trace-id": hostileTraceId,
+					},
+					body: JSON.stringify({}),
+				}),
+			);
+
+			const body = await response?.json();
+			const observed = JSON.stringify({
+				body,
+				requestId: response?.headers.get("x-request-id"),
+				traceId: response?.headers.get("x-trace-id"),
+				log: setup.app.mocks.logger
+					.getLogsContaining("HTTP request completed")
+					.at(-1),
+			});
+			expect(body.requestId).toMatch(/^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/);
+			expect(body.traceId).toMatch(/^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/);
+			expect(observed).not.toContain(hostileRequestId);
+			expect(observed).not.toContain(hostileTraceId);
+		});
+
+		it("rejects structurally invalid W3C traceparent values", async () => {
+			const handler = createFetchHandler(setup.app);
+			const response = await handler(
+				new Request("http://localhost/echo-options", {
+					method: "POST",
+					headers: {
+						"content-type": "application/json",
+						traceparent:
+							"00-00000000000000000000000000000000-0000000000000000-01",
+					},
+					body: JSON.stringify({}),
+				}),
+			);
+
+			const body = await response?.json();
+			expect(body.traceId).not.toBe("00000000000000000000000000000000");
+			expect(body.traceId).toMatch(/^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/);
+		});
+
 		it("can disable request logging while preserving request headers", async () => {
 			setup.app.mocks.logger.clearLogs();
 			const handler = createFetchHandler(setup.app, { requestLogging: false });
@@ -343,7 +394,7 @@ describe("adapter route config", () => {
 				path: "/crash-options",
 				route: "crash-options",
 				status: 500,
-				error: { name: "Error", message: "boom" },
+				error: { name: "Error", message: "[Redacted]" },
 			});
 		});
 

--- a/packages/questpie/test/integration/channel-routes.test.ts
+++ b/packages/questpie/test/integration/channel-routes.test.ts
@@ -1429,7 +1429,7 @@ describe("channel module routes", () => {
 			// The structured diagnostic keeps the error type, while the logger's
 			// safety boundary removes the message and stack from both log sinks.
 			expect(logged[0]!.args[0]).toMatchObject({
-				err: { type: "TypeError", message: "[Redacted]" },
+				err: { type: "Error", message: "[Redacted]" },
 			});
 		} finally {
 			await reader.cancel().catch(() => {});

--- a/packages/questpie/test/integration/channel-routes.test.ts
+++ b/packages/questpie/test/integration/channel-routes.test.ts
@@ -1429,7 +1429,7 @@ describe("channel module routes", () => {
 			// The structured diagnostic keeps the error type, while the logger's
 			// safety boundary removes the message and stack from both log sinks.
 			expect(logged[0]!.args[0]).toMatchObject({
-				err: { type: "Error", message: "[Redacted]" },
+				err: { type: "TypeError", message: "[Redacted]" },
 			});
 		} finally {
 			await reader.cancel().catch(() => {});

--- a/packages/questpie/test/integration/channel-routes.test.ts
+++ b/packages/questpie/test/integration/channel-routes.test.ts
@@ -1426,11 +1426,11 @@ describe("channel module routes", () => {
 			);
 			expect(logged).toHaveLength(1);
 			expect(logged[0]!.level).toBe("error");
-			// The adapter sees either the raw error or `{ err, ...bindings }`,
-			// depending on whether the request carried correlation ids.
-			const payload = logged[0]!.args[0] as Error | { err?: unknown };
-			const cause = payload instanceof Error ? payload : payload.err;
-			expect(String(cause)).toContain("somethingUndeclared");
+			// The structured diagnostic keeps the error type, while the logger's
+			// safety boundary removes the message and stack from both log sinks.
+			expect(logged[0]!.args[0]).toMatchObject({
+				err: { type: "TypeError", message: "[Redacted]" },
+			});
 		} finally {
 			await reader.cancel().catch(() => {});
 		}

--- a/packages/questpie/test/integration/log-trace-correlation.test.ts
+++ b/packages/questpie/test/integration/log-trace-correlation.test.ts
@@ -171,7 +171,11 @@ describe("log records tee onto the observability signal", () => {
 		expect(emitted).toHaveLength(1);
 		expect(emitted[0]!.level).toBe("info");
 		expect(emitted[0]!.message).toBe("hello");
-		expect(emitted[0]!.attributes).toMatchObject({ orderId: "o-1" });
+		expect(emitted[0]!.attributes).toMatchObject({
+			orderId: "o-1",
+			trace_id: TRACE,
+			span_id: SPAN,
+		});
 	});
 
 	it("does not let a failing telemetry backend break the caller", async () => {

--- a/packages/questpie/test/integration/logging-safety-contract.test.ts
+++ b/packages/questpie/test/integration/logging-safety-contract.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "bun:test";
+
+import { runWithContext } from "../../src/server/config/context.js";
+import { LoggerService } from "../../src/server/modules/core/integrated/logger/service.js";
+import type { LoggerAdapter } from "../../src/server/modules/core/integrated/logger/types.js";
+
+function capture() {
+	const records: Array<{ message: string; args: unknown[] }> = [];
+	const adapter: LoggerAdapter = {
+		debug: (message, ...args) => records.push({ message, args }),
+		info: (message, ...args) => records.push({ message, args }),
+		warn: (message, ...args) => records.push({ message, args }),
+		error: (message, ...args) => records.push({ message, args }),
+		child: () => adapter,
+	};
+	return { adapter, records };
+}
+
+describe("logging safety contract", () => {
+	it("tees the same correlated structured record sent to the logger adapter", async () => {
+		const captured = capture();
+		const emitted: unknown[] = [];
+		const logger = new LoggerService({ adapter: captured.adapter });
+		await runWithContext(
+			{
+				requestId: "req-contract",
+				traceId: "framework-trace",
+				app: {
+					observability: {
+						activeSpanContext: () => ({
+							traceId: "a".repeat(32),
+							spanId: "b".repeat(16),
+						}),
+						emitLog: (record: unknown) => emitted.push(record),
+					},
+				},
+			},
+			async () => logger.info("contract event", { event: "contract.event" }),
+		);
+
+		const attributes = captured.records[0]?.args[0];
+		expect(attributes).toMatchObject({
+			event: "contract.event",
+			requestId: "req-contract",
+			traceId: "framework-trace",
+			trace_id: "a".repeat(32),
+			span_id: "b".repeat(16),
+		});
+		expect(emitted[0]).toMatchObject({ message: "contract event", attributes });
+	});
+
+	it("redacts structured credentials and errors but preserves the caller message", () => {
+		const captured = capture();
+		const logger = new LoggerService({ adapter: captured.adapter });
+		logger.error("stable caller message", {
+			authorization: "private",
+			nested: { accessToken: "private" },
+			error: new Error("private error"),
+		});
+
+		expect(captured.records[0]).toEqual({
+			message: "stable caller message",
+			args: [
+				{
+					authorization: "[Redacted]",
+					nested: { accessToken: "[Redacted]" },
+					error: { type: "Error", message: "[Redacted]" },
+				},
+			],
+		});
+	});
+});

--- a/packages/questpie/test/integration/logging-safety-contract.test.ts
+++ b/packages/questpie/test/integration/logging-safety-contract.test.ts
@@ -2,23 +2,11 @@ import { describe, expect, it } from "bun:test";
 
 import { runWithContext } from "../../src/server/config/context.js";
 import { LoggerService } from "../../src/server/modules/core/integrated/logger/service.js";
-import type { LoggerAdapter } from "../../src/server/modules/core/integrated/logger/types.js";
-
-function capture() {
-	const records: Array<{ message: string; args: unknown[] }> = [];
-	const adapter: LoggerAdapter = {
-		debug: (message, ...args) => records.push({ message, args }),
-		info: (message, ...args) => records.push({ message, args }),
-		warn: (message, ...args) => records.push({ message, args }),
-		error: (message, ...args) => records.push({ message, args }),
-		child: () => adapter,
-	};
-	return { adapter, records };
-}
+import { createCapturingLogger } from "../utils/capturing-logger.js";
 
 describe("logging safety contract", () => {
 	it("tees the same correlated structured record sent to the logger adapter", async () => {
-		const captured = capture();
+		const captured = createCapturingLogger();
 		const emitted: unknown[] = [];
 		const logger = new LoggerService({ adapter: captured.adapter });
 		await runWithContext(
@@ -38,7 +26,7 @@ describe("logging safety contract", () => {
 			async () => logger.info("contract event", { event: "contract.event" }),
 		);
 
-		const attributes = captured.records[0]?.args[0];
+		const attributes = captured.records[0]?.args?.[0];
 		expect(attributes).toMatchObject({
 			event: "contract.event",
 			requestId: "req-contract",
@@ -50,7 +38,7 @@ describe("logging safety contract", () => {
 	});
 
 	it("redacts structured credentials and errors but preserves the caller message", () => {
-		const captured = capture();
+		const captured = createCapturingLogger();
 		const logger = new LoggerService({ adapter: captured.adapter });
 		logger.error("stable caller message", {
 			authorization: "private",
@@ -59,6 +47,7 @@ describe("logging safety contract", () => {
 		});
 
 		expect(captured.records[0]).toEqual({
+			level: "error",
 			message: "stable caller message",
 			args: [
 				{

--- a/packages/questpie/test/integration/logging-safety-contract.test.ts
+++ b/packages/questpie/test/integration/logging-safety-contract.test.ts
@@ -15,6 +15,15 @@ const loggerModule = pathToFileURL(
 		"../../src/server/modules/core/integrated/logger/service.ts",
 	),
 ).href;
+const observabilityServiceModule = pathToFileURL(
+	resolve(
+		import.meta.dir,
+		"../../src/server/modules/core/integrated/observability/service.ts",
+	),
+).href;
+const otelAdapterModule = pathToFileURL(
+	resolve(import.meta.dir, "../../../observability/src/otel-adapter.ts"),
+).href;
 
 describe("logging safety contract", () => {
 	it("tees the same correlated structured record sent to the logger adapter", async () => {
@@ -96,7 +105,7 @@ describe("logging safety contract", () => {
 			new Response(child.stderr).text(),
 			child.exited,
 		]);
-		expect(exitCode).toBe(0);
+		if (exitCode !== 0) throw new Error(stderr);
 		expect(stderr).toBe("");
 		expect(stdout).not.toContain("private-request");
 		expect(stdout).not.toContain("private-auth");
@@ -107,6 +116,91 @@ describe("logging safety contract", () => {
 			authorization: "[Redacted]",
 			requestId: "[Redacted]",
 			err: { type: "TypeError", message: "[Redacted]", code: "[Redacted]" },
+		});
+	});
+
+	it("keeps real Pino and the actual OTel exporter on one canonical record", async () => {
+		const child = Bun.spawn(
+			[
+				process.execPath,
+				"--eval",
+				`import { InMemoryLogRecordExporter, SimpleLogRecordProcessor } from "@opentelemetry/sdk-logs";
+				 import { runWithContext } from ${JSON.stringify(contextModule)};
+				 import { LoggerService } from ${JSON.stringify(loggerModule)};
+				 import { ObservabilityService } from ${JSON.stringify(observabilityServiceModule)};
+				 import { otelObservability } from ${JSON.stringify(otelAdapterModule)};
+				 const exporter = new InMemoryLogRecordExporter();
+				 const otel = otelObservability({
+				   serviceName: "logger-parity",
+				   logRecordProcessors: [new SimpleLogRecordProcessor({ exporter })],
+				 });
+				 const observability = new ObservabilityService({ adapter: otel });
+				 const logger = new LoggerService({
+				   pretty: false,
+				   redact: ["diagnostic.type", "err.code"],
+				 });
+				 await runWithContext({ app: { observability } }, async () => {
+				   logger.child({ component: "binding" }).error("collision", {
+				     component: "caller",
+				     diagnostic: new Map([["status", "safe"]]),
+				   });
+				   logger.error("root", Object.assign(new TypeError("private-error"), {
+				     code: "private-code",
+				   }));
+				 });
+				 const records = exporter.getFinishedLogRecords().map((record) => ({
+				   message: record.body,
+				   attributes: record.attributes,
+				 }));
+				 process.stderr.write(JSON.stringify(records));
+				 await otel.shutdown();`,
+			],
+			{
+				cwd: resolve(import.meta.dir, "../../../observability"),
+				env: { ...process.env, NODE_ENV: "production" },
+				stdout: "pipe",
+				stderr: "pipe",
+			},
+		);
+		const [stdout, stderr, exitCode] = await Promise.all([
+			new Response(child.stdout).text(),
+			new Response(child.stderr).text(),
+			child.exited,
+		]);
+		if (exitCode !== 0) throw new Error(stderr);
+		const pino = stdout
+			.trim()
+			.split("\n")
+			.filter(Boolean)
+			.map((line) => JSON.parse(line));
+		const otel = JSON.parse(stderr);
+		expect(pino).toHaveLength(2);
+		expect(otel).toHaveLength(2);
+
+		const pinoCollision = {
+			component: pino[0].component,
+			diagnostic: pino[0].diagnostic,
+		};
+		expect(pinoCollision).toEqual({
+			component: "caller",
+			diagnostic: {
+				type: "[Redacted]",
+				entries: [["status", "safe"]],
+			},
+		});
+		expect(otel[0]).toEqual({
+			message: "collision",
+			attributes: pinoCollision,
+		});
+
+		expect(pino[1].err).toEqual({
+			type: "TypeError",
+			message: "[Redacted]",
+			code: "[Redacted]",
+		});
+		expect(otel[1]).toEqual({
+			message: "root",
+			attributes: { err: pino[1].err },
 		});
 	});
 });

--- a/packages/questpie/test/integration/logging-safety-contract.test.ts
+++ b/packages/questpie/test/integration/logging-safety-contract.test.ts
@@ -1,8 +1,20 @@
 import { describe, expect, it } from "bun:test";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
 
 import { runWithContext } from "../../src/server/config/context.js";
 import { LoggerService } from "../../src/server/modules/core/integrated/logger/service.js";
 import { createCapturingLogger } from "../utils/capturing-logger.js";
+
+const contextModule = pathToFileURL(
+	resolve(import.meta.dir, "../../src/server/config/context.ts"),
+).href;
+const loggerModule = pathToFileURL(
+	resolve(
+		import.meta.dir,
+		"../../src/server/modules/core/integrated/logger/service.ts",
+	),
+).href;
 
 describe("logging safety contract", () => {
 	it("tees the same correlated structured record sent to the logger adapter", async () => {
@@ -56,6 +68,45 @@ describe("logging safety contract", () => {
 					error: { type: "Error", message: "[Redacted]" },
 				},
 			],
+		});
+	});
+
+	it("sends the same safe final record through real Pino", async () => {
+		const child = Bun.spawn(
+			[
+				process.execPath,
+				"--eval",
+				`import { runWithContext } from ${JSON.stringify(contextModule)};
+				 import { LoggerService } from ${JSON.stringify(loggerModule)};
+				 const logger = new LoggerService({ pretty: false, redact: ["requestId", "err.code"] });
+				 await runWithContext({ requestId: "private-request" }, async () => {
+				   logger.child({ component: "billing", authorization: "private-auth" })
+				     .error("stable", Object.assign(new TypeError("private-error"), { code: "private-code" }));
+				 });`,
+			],
+			{
+				cwd: resolve(import.meta.dir, "../../../.."),
+				env: { ...process.env, NODE_ENV: "production" },
+				stdout: "pipe",
+				stderr: "pipe",
+			},
+		);
+		const [stdout, stderr, exitCode] = await Promise.all([
+			new Response(child.stdout).text(),
+			new Response(child.stderr).text(),
+			child.exited,
+		]);
+		expect(exitCode).toBe(0);
+		expect(stderr).toBe("");
+		expect(stdout).not.toContain("private-request");
+		expect(stdout).not.toContain("private-auth");
+		expect(stdout).not.toContain("private-error");
+		expect(stdout).not.toContain("private-code");
+		expect(JSON.parse(stdout.trim())).toMatchObject({
+			component: "billing",
+			authorization: "[Redacted]",
+			requestId: "[Redacted]",
+			err: { type: "TypeError", message: "[Redacted]", code: "[Redacted]" },
 		});
 	});
 });

--- a/packages/questpie/test/unit/services/logger-redaction.test.ts
+++ b/packages/questpie/test/unit/services/logger-redaction.test.ts
@@ -370,13 +370,12 @@ describe("logger structured-field redaction", () => {
 				apiKey: "private-key",
 			});
 		expect(log.records[0]?.args?.[0]).toEqual({
+			component: "billing",
+			authorization: "[Redacted]",
 			customer: { email: "[Redacted]" },
 			apiKey: "[Redacted]",
 		});
-		expect(log.childBindings[0]).toEqual({
-			component: "billing",
-			authorization: "[Redacted]",
-		});
+		expect(log.childBindings[0]).toEqual({});
 	});
 
 	it("tees effective child bindings with the same redaction policy", async () => {
@@ -396,15 +395,45 @@ describe("logger structured-field redaction", () => {
 			},
 		);
 
-		expect(log.childBindings[0]).toEqual({
-			component: "billing",
-			authorization: "[Redacted]",
-		});
+		expect(log.childBindings[0]).toEqual({});
 		expect(emitted[0].attributes).toMatchObject({
 			component: "billing",
 			authorization: "[Redacted]",
 			event: "invoice.created",
 		});
+	});
+
+	it("applies policy once to the final adapter and OTLP record", async () => {
+		const log = createCapturingLogger({ captureMessages: false });
+		const emitted: any[] = [];
+		const logger = new LoggerService({
+			adapter: log.adapter,
+			redact: ["requestId", "err.code", "error"],
+		});
+		await runWithContext(
+			{
+				requestId: "private-request",
+				app: {
+					observability: { emitLog: (record: unknown) => emitted.push(record) },
+				},
+			},
+			async () => {
+				const error = Object.assign(new TypeError("private"), {
+					code: "PRIVATE",
+				});
+				logger.child({ component: "billing" }).error("failed", error);
+				logger.error("caller error", { error: new Error("private") });
+			},
+		);
+		const effective = log.records[0]?.args?.[0];
+		expect(effective).toEqual({
+			component: "billing",
+			err: { type: "TypeError", message: "[Redacted]", code: "[Redacted]" },
+			requestId: "[Redacted]",
+		});
+		expect(emitted[0].attributes).toEqual(effective);
+		expect(log.records[1]?.args?.[0]).toMatchObject({ error: "[Redacted]" });
+		expect(emitted[1].attributes).toEqual(log.records[1]?.args?.[0]);
 	});
 
 	it("does not claim to inspect caller-owned message strings", () => {

--- a/packages/questpie/test/unit/services/logger-redaction.test.ts
+++ b/packages/questpie/test/unit/services/logger-redaction.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from "bun:test";
+
+import { runWithContext } from "../../../src/server/config/context.js";
+import { LoggerService } from "../../../src/server/modules/core/integrated/logger/service.js";
+import type { LoggerAdapter } from "../../../src/server/modules/core/integrated/logger/types.js";
+
+function capturing() {
+	const records: unknown[][] = [];
+	const childBindings: Array<Record<string, unknown>> = [];
+	const adapter: LoggerAdapter = {
+		debug: (_message, ...args) => records.push(args),
+		info: (_message, ...args) => records.push(args),
+		warn: (_message, ...args) => records.push(args),
+		error: (_message, ...args) => records.push(args),
+		child: (bindings) => {
+			childBindings.push(bindings);
+			return adapter;
+		},
+	};
+	return { adapter, childBindings, records };
+}
+
+describe("logger structured-field redaction", () => {
+	it("redacts nested credential keys without discarding diagnostics", () => {
+		const log = capturing();
+		const logger = new LoggerService({ adapter: log.adapter });
+		logger.info("request failed", {
+			event: "request.failed",
+			requestId: "req-1",
+			request: {
+				headers: { Authorization: "Bearer private", cookie: "private" },
+				body: { password: "private" },
+			},
+			auth: {
+				accessToken: "private",
+				client_secret: "private",
+				credentials: { "x-api-key": "private" },
+			},
+		});
+
+		expect(log.records[0]?.[0]).toEqual({
+			event: "request.failed",
+			requestId: "req-1",
+			request: {
+				headers: { Authorization: "[Redacted]", cookie: "[Redacted]" },
+				body: { password: "[Redacted]" },
+			},
+			auth: {
+				accessToken: "[Redacted]",
+				client_secret: "[Redacted]",
+				credentials: { "x-api-key": "[Redacted]" },
+			},
+		});
+	});
+
+	it("safely snapshots enumerable fields on custom objects", () => {
+		class CredentialEnvelope {
+			token = "private-token";
+			nested = { error: new Error("private-error") };
+			self: CredentialEnvelope = this;
+
+			get unsafeGetter(): never {
+				throw new Error("getter must not run");
+			}
+		}
+		const envelope = new CredentialEnvelope();
+		const log = capturing();
+		const logger = new LoggerService({ adapter: log.adapter });
+
+		logger.info("custom object", { envelope });
+
+		const observed = (log.records[0]?.[0] as any).envelope;
+		expect(observed.token).toBe("[Redacted]");
+		expect(observed.nested.error).toEqual({
+			type: "Error",
+			message: "[Redacted]",
+		});
+		expect(observed.self).toBe(observed);
+		expect("unsafeGetter" in observed).toBe(false);
+		expect(envelope.token).toBe("private-token");
+		expect(envelope.nested.error.message).toBe("private-error");
+	});
+
+	it("extends defaults with configured structured paths for adapter and tee", async () => {
+		const log = capturing();
+		const emitted: unknown[] = [];
+		const logger = new LoggerService({
+			adapter: log.adapter,
+			redact: ["profile.email"],
+		});
+		await runWithContext(
+			{
+				app: {
+					observability: { emitLog: (record: unknown) => emitted.push(record) },
+				},
+			},
+			async () =>
+				logger.info("profile updated", {
+					profile: { email: "private@example.com", displayName: "Safe" },
+					token: "private-token",
+				}),
+		);
+		const expected = {
+			profile: { email: "[Redacted]", displayName: "Safe" },
+			token: "[Redacted]",
+		};
+		expect(log.records[0]?.[0]).toEqual(expected);
+		expect(emitted[0]).toMatchObject({ attributes: expected });
+	});
+
+	it("serializes Error values without messages or stacks", () => {
+		const log = capturing();
+		const logger = new LoggerService({ adapter: log.adapter });
+		const error = Object.assign(new TypeError("private body"), {
+			code: "INVALID_INPUT",
+		});
+		logger.error("operation failed", error);
+		logger.error("request failed", {
+			error: {
+				name: "ValidationError",
+				message: "private",
+				stack: "private",
+				status: 400,
+			},
+		});
+		expect(log.records[0]?.[0]).toEqual({
+			err: { type: "TypeError", message: "[Redacted]", code: "INVALID_INPUT" },
+		});
+		expect(log.records[1]?.[0]).toEqual({
+			error: { name: "ValidationError", message: "[Redacted]", status: 400 },
+		});
+	});
+
+	it("retains configured policy on child loggers", () => {
+		const log = capturing();
+		const logger = new LoggerService({
+			adapter: log.adapter,
+			redact: ["customer.email"],
+		});
+		logger
+			.child({ component: "billing", authorization: "private" })
+			.info("customer", {
+				customer: { email: "private@example.com" },
+				apiKey: "private-key",
+			});
+		expect(log.records[0]?.[0]).toEqual({
+			customer: { email: "[Redacted]" },
+			apiKey: "[Redacted]",
+		});
+		expect(log.childBindings[0]).toEqual({
+			component: "billing",
+			authorization: "[Redacted]",
+		});
+	});
+
+	it("tees effective child bindings with the same redaction policy", async () => {
+		const log = capturing();
+		const emitted: any[] = [];
+		const logger = new LoggerService({ adapter: log.adapter });
+		await runWithContext(
+			{
+				app: {
+					observability: { emitLog: (record: unknown) => emitted.push(record) },
+				},
+			},
+			async () => {
+				logger
+					.child({ component: "billing", authorization: "private" })
+					.info("child event", { event: "invoice.created" });
+			},
+		);
+
+		expect(log.childBindings[0]).toEqual({
+			component: "billing",
+			authorization: "[Redacted]",
+		});
+		expect(emitted[0].attributes).toMatchObject({
+			component: "billing",
+			authorization: "[Redacted]",
+			event: "invoice.created",
+		});
+	});
+
+	it("does not claim to inspect caller-owned message strings", () => {
+		const messages: string[] = [];
+		const adapter: LoggerAdapter = {
+			debug: (message) => messages.push(message),
+			info: (message) => messages.push(message),
+			warn: (message) => messages.push(message),
+			error: (message) => messages.push(message),
+			child: () => adapter,
+		};
+		new LoggerService({ adapter }).info("caller message remains unchanged");
+		expect(messages).toEqual(["caller message remains unchanged"]);
+	});
+});

--- a/packages/questpie/test/unit/services/logger-redaction.test.ts
+++ b/packages/questpie/test/unit/services/logger-redaction.test.ts
@@ -133,7 +133,7 @@ describe("logger structured-field redaction", () => {
 		const emitted: any[] = [];
 		const logger = new LoggerService({
 			adapter: log.adapter,
-			redact: ["map.customerEmail"],
+			redact: ["map.customerEmail", "url.customerEmail"],
 		});
 		await runWithContext(
 			{
@@ -145,7 +145,7 @@ describe("logger structured-field redaction", () => {
 				logger.info("diagnostics", {
 					date: new Date("2026-01-02T03:04:05.000Z"),
 					url: new URL(
-						"https://user:password@example.com/path?token=private&safe=ok",
+						"https://user:password@example.com/path?token=private&customerEmail=private%40example.com&safe=ok",
 					),
 					map: new Map([
 						["authorization", "private"],
@@ -160,7 +160,8 @@ describe("logger structured-field redaction", () => {
 			date: { type: "Date", value: "2026-01-02T03:04:05.000Z" },
 			url: {
 				type: "URL",
-				value: "https://example.com/path?token=%5BRedacted%5D&safe=ok",
+				value:
+					"https://example.com/path?token=%5BRedacted%5D&customerEmail=%5BRedacted%5D&safe=ok",
 			},
 			map: {
 				type: "Map",
@@ -173,6 +174,49 @@ describe("logger structured-field redaction", () => {
 			bytes: { type: "TypedArray", values: [1, 2, 3] },
 		});
 		expect(emitted[0].attributes).toEqual(diagnostics);
+	});
+
+	it("covers adversarial Map keys and every built-in Error subtype", () => {
+		const hostileKey = {
+			token: "private-key",
+			toString: () => {
+				throw new Error("must not coerce Map keys");
+			},
+		};
+		const proxyKey = new Proxy(
+			{},
+			{
+				ownKeys: () => {
+					throw new Error("proxy key trap");
+				},
+			},
+		);
+		const errorCases: Array<[string, Error]> = [
+			["Error", new Error("private")],
+			["EvalError", new EvalError("private")],
+			["RangeError", new RangeError("private")],
+			["ReferenceError", new ReferenceError("private")],
+			["SyntaxError", new SyntaxError("private")],
+			["TypeError", new TypeError("private")],
+			["URIError", new URIError("private")],
+			["AggregateError", new AggregateError([], "private")],
+		];
+		const log = createCapturingLogger({ captureMessages: false });
+		new LoggerService({ adapter: log.adapter }).info("matrix", {
+			map: new Map([
+				[hostileKey, "safe"],
+				[proxyKey, "safe"],
+			]),
+			errors: errorCases.map(([, error]) => error),
+		});
+		const record = log.records[0]?.args?.[0] as Record<string, any>;
+		expect(record.map.entries).toEqual([
+			[{ token: "[Redacted]", toString: hostileKey.toString }, "safe"],
+			["[Unserializable]", "safe"],
+		]);
+		expect(record.errors).toEqual(
+			errorCases.map(([type]) => ({ type, message: "[Redacted]" })),
+		);
 	});
 
 	it("extends defaults with configured structured paths for adapter and tee", async () => {

--- a/packages/questpie/test/unit/services/logger-redaction.test.ts
+++ b/packages/questpie/test/unit/services/logger-redaction.test.ts
@@ -69,7 +69,11 @@ describe("logger structured-field redaction", () => {
 
 		logger.info("custom object", { envelope });
 
-		const observed = (log.records[0]?.[0] as any).envelope;
+		const record = log.records[0]?.[0] as
+			| { envelope: Record<string, any> }
+			| undefined;
+		expect(record).toBeDefined();
+		const observed = record!.envelope;
 		expect(observed.token).toBe("[Redacted]");
 		expect(observed.nested.error).toEqual({
 			type: "Error",

--- a/packages/questpie/test/unit/services/logger-redaction.test.ts
+++ b/packages/questpie/test/unit/services/logger-redaction.test.ts
@@ -436,6 +436,31 @@ describe("logger structured-field redaction", () => {
 		expect(emitted[1].attributes).toEqual(log.records[1]?.args?.[0]);
 	});
 
+	it("always consumes the first structured argument after a guarded merge", () => {
+		const log = createCapturingLogger({ captureMessages: false });
+		const logger = new LoggerService({ adapter: log.adapter }).child({
+			component: "binding",
+		});
+		const unreadable = new Proxy(
+			{},
+			{
+				ownKeys() {
+					throw new Error("must stay unread");
+				},
+			},
+		);
+
+		logger.info("collision", { component: "caller" });
+		logger.info("empty", {}, "tail");
+		logger.info("unreadable", unreadable, "tail");
+
+		expect(log.records.map(({ args }) => args)).toEqual([
+			[{ component: "caller" }],
+			[{ component: "binding" }, "tail"],
+			[{ component: "binding" }, "tail"],
+		]);
+	});
+
 	it("does not claim to inspect caller-owned message strings", () => {
 		const messages: string[] = [];
 		const adapter: LoggerAdapter = {

--- a/packages/questpie/test/unit/services/logger-redaction.test.ts
+++ b/packages/questpie/test/unit/services/logger-redaction.test.ts
@@ -131,7 +131,10 @@ describe("logger structured-field redaction", () => {
 	it("preserves supported non-plain diagnostics for both sinks", async () => {
 		const log = createCapturingLogger({ captureMessages: false });
 		const emitted: any[] = [];
-		const logger = new LoggerService({ adapter: log.adapter });
+		const logger = new LoggerService({
+			adapter: log.adapter,
+			redact: ["map.customerEmail"],
+		});
 		await runWithContext(
 			{
 				app: {
@@ -141,8 +144,13 @@ describe("logger structured-field redaction", () => {
 			async () =>
 				logger.info("diagnostics", {
 					date: new Date("2026-01-02T03:04:05.000Z"),
-					url: new URL("https://example.com/path"),
-					map: new Map([["token", { password: "private" }]]),
+					url: new URL(
+						"https://user:password@example.com/path?token=private&safe=ok",
+					),
+					map: new Map([
+						["authorization", "private"],
+						["customerEmail", "private@example.com"],
+					]),
 					set: new Set(["value"]),
 					bytes: new Uint8Array([1, 2, 3]),
 				}),
@@ -150,8 +158,17 @@ describe("logger structured-field redaction", () => {
 		const diagnostics = log.records[0]?.args?.[0];
 		expect(diagnostics).toMatchObject({
 			date: { type: "Date", value: "2026-01-02T03:04:05.000Z" },
-			url: { type: "URL", value: "https://example.com/path" },
-			map: { type: "Map", entries: [["token", { password: "[Redacted]" }]] },
+			url: {
+				type: "URL",
+				value: "https://example.com/path?token=%5BRedacted%5D&safe=ok",
+			},
+			map: {
+				type: "Map",
+				entries: [
+					["authorization", "[Redacted]"],
+					["customerEmail", "[Redacted]"],
+				],
+			},
 			set: { type: "Set", values: ["value"] },
 			bytes: { type: "TypedArray", values: [1, 2, 3] },
 		});
@@ -191,6 +208,10 @@ describe("logger structured-field redaction", () => {
 		const error = Object.assign(new TypeError("private body"), {
 			code: "INVALID_INPUT",
 		});
+		Object.defineProperty(error, "name", {
+			enumerable: true,
+			value: { token: "private-name" },
+		});
 		logger.error("operation failed", error);
 		logger.error("request failed", {
 			error: {
@@ -201,7 +222,7 @@ describe("logger structured-field redaction", () => {
 			},
 		});
 		expect(log.records[0]?.args?.[0]).toEqual({
-			err: { type: "Error", message: "[Redacted]", code: "INVALID_INPUT" },
+			err: { type: "TypeError", message: "[Redacted]", code: "INVALID_INPUT" },
 		});
 		expect(log.records[1]?.args?.[0]).toEqual({
 			error: { name: "ValidationError", message: "[Redacted]", status: 400 },

--- a/packages/questpie/test/unit/services/logger-redaction.test.ts
+++ b/packages/questpie/test/unit/services/logger-redaction.test.ts
@@ -94,6 +94,70 @@ describe("logger structured-field redaction", () => {
 		});
 	});
 
+	it("fails closed for error-like getters, Error subclasses, and proxies", async () => {
+		class UnsafeError extends Error {
+			get name(): never {
+				throw new Error("name getter must not run");
+			}
+		}
+		const proxy = new Proxy(
+			{},
+			{
+				ownKeys: () => {
+					throw new Error("proxy trap");
+				},
+			},
+		);
+		const log = createCapturingLogger({ captureMessages: false });
+		const logger = new LoggerService({ adapter: log.adapter });
+		await runWithContext({ requestId: "req-safe" }, async () => {
+			logger.error("safe", {
+				error: Object.defineProperty({ message: "secret" }, "name", {
+					enumerable: true,
+					get: () => {
+						throw new Error("name getter must not run");
+					},
+				}),
+				cause: new UnsafeError("secret"),
+				proxy,
+			});
+		});
+		const record = log.records[0]?.args?.[0] as Record<string, any>;
+		expect(record.error).toEqual({ message: "[Redacted]" });
+		expect(record.cause).toEqual({ type: "Error", message: "[Redacted]" });
+		expect(record.proxy).toBe("[Unserializable]");
+	});
+
+	it("preserves supported non-plain diagnostics for both sinks", async () => {
+		const log = createCapturingLogger({ captureMessages: false });
+		const emitted: any[] = [];
+		const logger = new LoggerService({ adapter: log.adapter });
+		await runWithContext(
+			{
+				app: {
+					observability: { emitLog: (record: unknown) => emitted.push(record) },
+				},
+			},
+			async () =>
+				logger.info("diagnostics", {
+					date: new Date("2026-01-02T03:04:05.000Z"),
+					url: new URL("https://example.com/path"),
+					map: new Map([["token", { password: "private" }]]),
+					set: new Set(["value"]),
+					bytes: new Uint8Array([1, 2, 3]),
+				}),
+		);
+		const diagnostics = log.records[0]?.args?.[0];
+		expect(diagnostics).toMatchObject({
+			date: { type: "Date", value: "2026-01-02T03:04:05.000Z" },
+			url: { type: "URL", value: "https://example.com/path" },
+			map: { type: "Map", entries: [["token", { password: "[Redacted]" }]] },
+			set: { type: "Set", values: ["value"] },
+			bytes: { type: "TypedArray", values: [1, 2, 3] },
+		});
+		expect(emitted[0].attributes).toEqual(diagnostics);
+	});
+
 	it("extends defaults with configured structured paths for adapter and tee", async () => {
 		const log = createCapturingLogger({ captureMessages: false });
 		const emitted: unknown[] = [];
@@ -137,7 +201,7 @@ describe("logger structured-field redaction", () => {
 			},
 		});
 		expect(log.records[0]?.args?.[0]).toEqual({
-			err: { type: "TypeError", message: "[Redacted]", code: "INVALID_INPUT" },
+			err: { type: "Error", message: "[Redacted]", code: "INVALID_INPUT" },
 		});
 		expect(log.records[1]?.args?.[0]).toEqual({
 			error: { name: "ValidationError", message: "[Redacted]", status: 400 },

--- a/packages/questpie/test/unit/services/logger-redaction.test.ts
+++ b/packages/questpie/test/unit/services/logger-redaction.test.ts
@@ -3,26 +3,11 @@ import { describe, expect, it } from "bun:test";
 import { runWithContext } from "../../../src/server/config/context.js";
 import { LoggerService } from "../../../src/server/modules/core/integrated/logger/service.js";
 import type { LoggerAdapter } from "../../../src/server/modules/core/integrated/logger/types.js";
-
-function capturing() {
-	const records: unknown[][] = [];
-	const childBindings: Array<Record<string, unknown>> = [];
-	const adapter: LoggerAdapter = {
-		debug: (_message, ...args) => records.push(args),
-		info: (_message, ...args) => records.push(args),
-		warn: (_message, ...args) => records.push(args),
-		error: (_message, ...args) => records.push(args),
-		child: (bindings) => {
-			childBindings.push(bindings);
-			return adapter;
-		},
-	};
-	return { adapter, childBindings, records };
-}
+import { createCapturingLogger } from "../../utils/capturing-logger.js";
 
 describe("logger structured-field redaction", () => {
 	it("redacts nested credential keys without discarding diagnostics", () => {
-		const log = capturing();
+		const log = createCapturingLogger({ captureMessages: false });
 		const logger = new LoggerService({ adapter: log.adapter });
 		logger.info("request failed", {
 			event: "request.failed",
@@ -38,7 +23,7 @@ describe("logger structured-field redaction", () => {
 			},
 		});
 
-		expect(log.records[0]?.[0]).toEqual({
+		expect(log.records[0]?.args?.[0]).toEqual({
 			event: "request.failed",
 			requestId: "req-1",
 			request: {
@@ -64,12 +49,12 @@ describe("logger structured-field redaction", () => {
 			}
 		}
 		const envelope = new CredentialEnvelope();
-		const log = capturing();
+		const log = createCapturingLogger({ captureMessages: false });
 		const logger = new LoggerService({ adapter: log.adapter });
 
 		logger.info("custom object", { envelope });
 
-		const record = log.records[0]?.[0] as
+		const record = log.records[0]?.args?.[0] as
 			| { envelope: Record<string, any> }
 			| undefined;
 		expect(record).toBeDefined();
@@ -85,8 +70,32 @@ describe("logger structured-field redaction", () => {
 		expect(envelope.nested.error.message).toBe("private-error");
 	});
 
+	it("does not invoke caller getters while adding request context", async () => {
+		const log = createCapturingLogger({ captureMessages: false });
+		const logger = new LoggerService({ adapter: log.adapter });
+		const structured = Object.defineProperty(
+			{ token: "private-token" },
+			"unsafeGetter",
+			{
+				enumerable: true,
+				get: () => {
+					throw new Error("getter must not run");
+				},
+			},
+		);
+
+		await runWithContext({ requestId: "req-safe" }, async () => {
+			logger.info("contextual object", structured);
+		});
+
+		expect(log.records[0]?.args?.[0]).toEqual({
+			token: "[Redacted]",
+			requestId: "req-safe",
+		});
+	});
+
 	it("extends defaults with configured structured paths for adapter and tee", async () => {
-		const log = capturing();
+		const log = createCapturingLogger({ captureMessages: false });
 		const emitted: unknown[] = [];
 		const logger = new LoggerService({
 			adapter: log.adapter,
@@ -108,12 +117,12 @@ describe("logger structured-field redaction", () => {
 			profile: { email: "[Redacted]", displayName: "Safe" },
 			token: "[Redacted]",
 		};
-		expect(log.records[0]?.[0]).toEqual(expected);
+		expect(log.records[0]?.args?.[0]).toEqual(expected);
 		expect(emitted[0]).toMatchObject({ attributes: expected });
 	});
 
 	it("serializes Error values without messages or stacks", () => {
-		const log = capturing();
+		const log = createCapturingLogger({ captureMessages: false });
 		const logger = new LoggerService({ adapter: log.adapter });
 		const error = Object.assign(new TypeError("private body"), {
 			code: "INVALID_INPUT",
@@ -127,16 +136,16 @@ describe("logger structured-field redaction", () => {
 				status: 400,
 			},
 		});
-		expect(log.records[0]?.[0]).toEqual({
+		expect(log.records[0]?.args?.[0]).toEqual({
 			err: { type: "TypeError", message: "[Redacted]", code: "INVALID_INPUT" },
 		});
-		expect(log.records[1]?.[0]).toEqual({
+		expect(log.records[1]?.args?.[0]).toEqual({
 			error: { name: "ValidationError", message: "[Redacted]", status: 400 },
 		});
 	});
 
 	it("retains configured policy on child loggers", () => {
-		const log = capturing();
+		const log = createCapturingLogger({ captureMessages: false });
 		const logger = new LoggerService({
 			adapter: log.adapter,
 			redact: ["customer.email"],
@@ -147,7 +156,7 @@ describe("logger structured-field redaction", () => {
 				customer: { email: "private@example.com" },
 				apiKey: "private-key",
 			});
-		expect(log.records[0]?.[0]).toEqual({
+		expect(log.records[0]?.args?.[0]).toEqual({
 			customer: { email: "[Redacted]" },
 			apiKey: "[Redacted]",
 		});
@@ -158,7 +167,7 @@ describe("logger structured-field redaction", () => {
 	});
 
 	it("tees effective child bindings with the same redaction policy", async () => {
-		const log = capturing();
+		const log = createCapturingLogger({ captureMessages: false });
 		const emitted: any[] = [];
 		const logger = new LoggerService({ adapter: log.adapter });
 		await runWithContext(

--- a/packages/questpie/test/unit/services/logger-redaction.test.ts
+++ b/packages/questpie/test/unit/services/logger-redaction.test.ts
@@ -64,7 +64,7 @@ describe("logger structured-field redaction", () => {
 			type: "Error",
 			message: "[Redacted]",
 		});
-		expect(observed.self).toBe(observed);
+		expect(observed.self).toBe("[Circular]");
 		expect("unsafeGetter" in observed).toBe(false);
 		expect(envelope.token).toBe("private-token");
 		expect(envelope.nested.error.message).toBe("private-error");
@@ -110,6 +110,53 @@ describe("logger structured-field redaction", () => {
 		expect(json).not.toContain("private-token");
 		expect(json).not.toContain("reintroduced-secret");
 		expect(json).toContain("[Unsupported]");
+	});
+
+	it("applies path policy per alias and normalizes cycles, nonfinite values, errors, and bindings", async () => {
+		const shared = { email: "private@example.com" };
+		const cycle: Record<string, unknown> = {};
+		cycle.self = cycle;
+		const log = createCapturingLogger({ captureMessages: false });
+		const emitted: any[] = [];
+		const logger = new LoggerService({
+			adapter: log.adapter,
+			redact: ["private.email", "error.code", "floats.1"],
+		});
+		await runWithContext(
+			{
+				app: {
+					observability: { emitLog: (record: unknown) => emitted.push(record) },
+				},
+			},
+			async () =>
+				logger.info("invariants", {
+					public: shared,
+					private: shared,
+					cycle,
+					scalar: Number.NaN,
+					floats: new Float64Array([Infinity, -Infinity]),
+					error: Object.assign(new Error("private"), { code: "PRIVATE_CODE" }),
+				}),
+		);
+		const record = log.records[0]?.args?.[0] as Record<string, any>;
+		expect(record.public.email).toBe("private@example.com");
+		expect(record.private.email).toBe("[Redacted]");
+		expect(record.cycle.self).toBe("[Circular]");
+		expect(record.scalar).toBe("[NonFinite]");
+		expect(record.floats.values).toEqual(["[NonFinite]", "[Redacted]"]);
+		expect(record.error.code).toBe("[Redacted]");
+		expect(emitted[0].attributes).toEqual(record);
+
+		const unreadable = new Proxy(
+			{},
+			{
+				ownKeys: () => {
+					throw new Error("trap");
+				},
+			},
+		);
+		expect(() => logger.child(unreadable)).not.toThrow();
+		expect(log.childBindings.at(-1)).toEqual({});
 	});
 
 	it("fails closed for error-like getters, Error subclasses, and proxies", async () => {

--- a/packages/questpie/test/unit/services/logger-redaction.test.ts
+++ b/packages/questpie/test/unit/services/logger-redaction.test.ts
@@ -94,6 +94,24 @@ describe("logger structured-field redaction", () => {
 		});
 	});
 
+	it("produces inert JSON that cannot execute caller toJSON hooks", () => {
+		let invoked = false;
+		const value = {
+			token: "private-token",
+			toJSON: () => {
+				invoked = true;
+				return { token: "reintroduced-secret" };
+			},
+		};
+		const log = createCapturingLogger({ captureMessages: false });
+		new LoggerService({ adapter: log.adapter }).info("json", value);
+		const json = JSON.stringify(log.records[0]?.args?.[0]);
+		expect(invoked).toBe(false);
+		expect(json).not.toContain("private-token");
+		expect(json).not.toContain("reintroduced-secret");
+		expect(json).toContain("[Unsupported]");
+	});
+
 	it("fails closed for error-like getters, Error subclasses, and proxies", async () => {
 		class UnsafeError extends Error {
 			get name(): never {
@@ -133,7 +151,7 @@ describe("logger structured-field redaction", () => {
 		const emitted: any[] = [];
 		const logger = new LoggerService({
 			adapter: log.adapter,
-			redact: ["map.customerEmail", "url.customerEmail"],
+			redact: ["map.customerEmail", "url.customerEmail", "bytes.1"],
 		});
 		await runWithContext(
 			{
@@ -171,7 +189,7 @@ describe("logger structured-field redaction", () => {
 				],
 			},
 			set: { type: "Set", values: ["value"] },
-			bytes: { type: "TypedArray", values: [1, 2, 3] },
+			bytes: { type: "TypedArray", values: [1, "[Redacted]", 3] },
 		});
 		expect(emitted[0].attributes).toEqual(diagnostics);
 	});
@@ -200,7 +218,26 @@ describe("logger structured-field redaction", () => {
 			["TypeError", new TypeError("private")],
 			["URIError", new URIError("private")],
 			["AggregateError", new AggregateError([], "private")],
+			["DOMException", new DOMException("private")],
+			["WebAssembly.CompileError", new WebAssembly.CompileError("private")],
+			["WebAssembly.LinkError", new WebAssembly.LinkError("private")],
+			["WebAssembly.RuntimeError", new WebAssembly.RuntimeError("private")],
 		];
+		const SuppressedErrorConstructor = (
+			globalThis as unknown as {
+				SuppressedError?: new (
+					error: unknown,
+					suppressed: unknown,
+					message?: string,
+				) => Error;
+			}
+		).SuppressedError;
+		if (SuppressedErrorConstructor) {
+			errorCases.push([
+				"SuppressedError",
+				new SuppressedErrorConstructor(null, null, "private"),
+			]);
+		}
 		const log = createCapturingLogger({ captureMessages: false });
 		new LoggerService({ adapter: log.adapter }).info("matrix", {
 			map: new Map([
@@ -211,7 +248,7 @@ describe("logger structured-field redaction", () => {
 		});
 		const record = log.records[0]?.args?.[0] as Record<string, any>;
 		expect(record.map.entries).toEqual([
-			[{ token: "[Redacted]", toString: hostileKey.toString }, "safe"],
+			[{ token: "[Redacted]", toString: "[Unsupported]" }, "safe"],
 			["[Unserializable]", "safe"],
 		]);
 		expect(record.errors).toEqual(

--- a/packages/questpie/test/utils/capturing-logger.ts
+++ b/packages/questpie/test/utils/capturing-logger.ts
@@ -1,0 +1,45 @@
+import type { LoggerAdapter } from "../../src/server/modules/core/integrated/logger/types.js";
+
+export interface CapturedLogRecord {
+	level: "debug" | "info" | "warn" | "error";
+	message?: string;
+	args?: unknown[];
+}
+
+export interface CapturingLoggerOptions {
+	captureArgs?: boolean;
+	captureChildBindings?: boolean;
+	captureMessages?: boolean;
+}
+
+export function createCapturingLogger(options: CapturingLoggerOptions = {}) {
+	const {
+		captureArgs = true,
+		captureChildBindings = true,
+		captureMessages = true,
+	} = options;
+	const records: CapturedLogRecord[] = [];
+	const childBindings: Array<Record<string, unknown>> = [];
+	const capture = (
+		level: CapturedLogRecord["level"],
+		message: string,
+		args: unknown[],
+	) => {
+		records.push({
+			level,
+			...(captureMessages ? { message } : {}),
+			...(captureArgs ? { args } : {}),
+		});
+	};
+	const adapter: LoggerAdapter = {
+		debug: (message, ...args) => capture("debug", message, args),
+		info: (message, ...args) => capture("info", message, args),
+		warn: (message, ...args) => capture("warn", message, args),
+		error: (message, ...args) => capture("error", message, args),
+		child: (bindings) => {
+			if (captureChildBindings) childBindings.push(bindings);
+			return adapter;
+		},
+	};
+	return { adapter, childBindings, records };
+}

--- a/scripts/any-census.json
+++ b/scripts/any-census.json
@@ -56,7 +56,7 @@
 			"@ts-expect-error": 0
 		},
 		"questpie": {
-			": any": 542,
+			": any": 540,
 			"as any": 462,
 			"as unknown as": 49,
 			"@ts-expect-error": 0

--- a/skills/questpie/AGENTS.md
+++ b/skills/questpie/AGENTS.md
@@ -7248,6 +7248,13 @@ arguments redact common credential keys and framework-serialized `Error`
 messages/stacks before both sinks. Message strings are not inspected; keep them
 stable and place request data in structured fields.
 
+The logger first constructs one effective record from child bindings, caller
+fields, and request/trace/span context, then redacts and canonicalizes it once
+for both Pino and OTLP. Unsupported values, cycles, and non-finite numbers use
+explicit markers. Date, URL, Map, Set, and TypedArray values use tagged inert
+records; URL userinfo and fragments are removed. OTLP logs use recursive
+AnyValue attributes, independently from scalar span/metric attributes.
+
 **Propagation:** an inbound `traceparent` is continued with the remote span as
 parent, so a distributed waterfall stays connected. Only the root reads headers.
 

--- a/skills/questpie/AGENTS.md
+++ b/skills/questpie/AGENTS.md
@@ -7235,11 +7235,18 @@ semconv attributes). Rate is its count, errors are that count sliced by
 `http.response.status_code`. Do not add parallel counters; they duplicate the
 same series and drift.
 
-**Logs:** Pino output is untouched; records gain `trace_id`/`span_id` from the
-active span (snake_case — those are the keys backends join on) and, with an
-`otlpEndpoint`, are exported on the OTel logs signal too. The existing camelCase
+**Logs:** Pino remains the primary output; records gain `trace_id`/`span_id`
+from the active span (snake_case — those are the keys backends join on) and,
+with an `otlpEndpoint`, are exported on the OTel logs signal too. The existing camelCase
 `traceId` is a different value: the framework's correlation id from the inbound
 `traceparent`/`x-request-id`, not the span's.
+
+Inbound request/trace ids are accepted only as bounded safe identifiers; W3C
+`traceparent` must be structurally valid and use non-zero trace and parent ids.
+Invalid supplied values are replaced rather than reflected. Structured log
+arguments redact common credential keys and framework-serialized `Error`
+messages/stacks before both sinks. Message strings are not inspected; keep them
+stable and place request data in structured fields.
 
 **Propagation:** an inbound `traceparent` is continued with the remote span as
 parent, so a distributed waterfall stays connected. Only the root reads headers.
@@ -8471,6 +8478,12 @@ logger.info("Appointment created", {
 	barberId: "def",
 });
 ```
+
+QUESTPIE recursively redacts common credential keys and `Error` messages/stacks
+from structured log arguments before both Pino output and the observability tee.
+Add application-specific structured paths with `logger.redact`. Message strings
+are caller-owned and are not inspected, so never interpolate credentials or
+untrusted request data into the message.
 
 ## OpenAPI
 

--- a/skills/questpie/AGENTS.md
+++ b/skills/questpie/AGENTS.md
@@ -7254,6 +7254,8 @@ for both Pino and OTLP. Unsupported values, cycles, and non-finite numbers use
 explicit markers. Date, URL, Map, Set, and TypedArray values use tagged inert
 records; URL userinfo and fragments are removed. OTLP logs use recursive
 AnyValue attributes, independently from scalar span/metric attributes.
+Configured paths may target tagged fields such as `diagnostic.type`; the
+framework applies them before both sinks rather than running a second Pino pass.
 
 **Propagation:** an inbound `traceparent` is continued with the remote span as
 parent, so a distributed waterfall stays connected. Only the root reads headers.

--- a/skills/questpie/references/infrastructure-adapters.md
+++ b/skills/questpie/references/infrastructure-adapters.md
@@ -652,6 +652,12 @@ logger.info("Appointment created", {
 });
 ```
 
+QUESTPIE recursively redacts common credential keys and `Error` messages/stacks
+from structured log arguments before both Pino output and the observability tee.
+Add application-specific structured paths with `logger.redact`. Message strings
+are caller-owned and are not inspected, so never interpolate credentials or
+untrusted request data into the message.
+
 ## OpenAPI
 
 Auto-generates OpenAPI 3.1 spec from your schema.

--- a/skills/questpie/references/production.md
+++ b/skills/questpie/references/production.md
@@ -285,11 +285,18 @@ semconv attributes). Rate is its count, errors are that count sliced by
 `http.response.status_code`. Do not add parallel counters; they duplicate the
 same series and drift.
 
-**Logs:** Pino output is untouched; records gain `trace_id`/`span_id` from the
-active span (snake_case — those are the keys backends join on) and, with an
-`otlpEndpoint`, are exported on the OTel logs signal too. The existing camelCase
+**Logs:** Pino remains the primary output; records gain `trace_id`/`span_id`
+from the active span (snake_case — those are the keys backends join on) and,
+with an `otlpEndpoint`, are exported on the OTel logs signal too. The existing camelCase
 `traceId` is a different value: the framework's correlation id from the inbound
 `traceparent`/`x-request-id`, not the span's.
+
+Inbound request/trace ids are accepted only as bounded safe identifiers; W3C
+`traceparent` must be structurally valid and use non-zero trace and parent ids.
+Invalid supplied values are replaced rather than reflected. Structured log
+arguments redact common credential keys and framework-serialized `Error`
+messages/stacks before both sinks. Message strings are not inspected; keep them
+stable and place request data in structured fields.
 
 **Propagation:** an inbound `traceparent` is continued with the remote span as
 parent, so a distributed waterfall stays connected. Only the root reads headers.

--- a/skills/questpie/references/production.md
+++ b/skills/questpie/references/production.md
@@ -304,6 +304,8 @@ for both Pino and OTLP. Unsupported values, cycles, and non-finite numbers use
 explicit markers. Date, URL, Map, Set, and TypedArray values use tagged inert
 records; URL userinfo and fragments are removed. OTLP logs use recursive
 AnyValue attributes, independently from scalar span/metric attributes.
+Configured paths may target tagged fields such as `diagnostic.type`; the
+framework applies them before both sinks rather than running a second Pino pass.
 
 **Propagation:** an inbound `traceparent` is continued with the remote span as
 parent, so a distributed waterfall stays connected. Only the root reads headers.

--- a/skills/questpie/references/production.md
+++ b/skills/questpie/references/production.md
@@ -298,6 +298,13 @@ arguments redact common credential keys and framework-serialized `Error`
 messages/stacks before both sinks. Message strings are not inspected; keep them
 stable and place request data in structured fields.
 
+The logger first constructs one effective record from child bindings, caller
+fields, and request/trace/span context, then redacts and canonicalizes it once
+for both Pino and OTLP. Unsupported values, cycles, and non-finite numbers use
+explicit markers. Date, URL, Map, Set, and TypedArray values use tagged inert
+records; URL userinfo and fragments are removed. OTLP logs use recursive
+AnyValue attributes, independently from scalar span/metric attributes.
+
 **Propagation:** an inbound `traceparent` is continued with the remote span as
 parent, so a distributed waterfall stays connected. Only the root reads headers.
 


### PR DESCRIPTION
## Summary\n- build one final effective structured record from child bindings, caller fields, root errors, and request/trace/span context\n- apply the configured whole-field/path policy and inert canonicalization once, then send the same safe record to Pino/custom adapters and OTLP\n- preserve the logger adapter contract by always consuming the first non-array object after its guarded structured merge\n- prevent Pino from applying a second redaction pass and use an identity err serializer for the already-canonical Error tree\n- give OTLP logs an honest recursive AnyValue contract while keeping span and metric attributes scalar-only\n- validate bounded request/trace identifiers and forward only valid W3C traceparent carriers\n- document the canonical schema and migration contract in docs, source skill, generated skill, and changeset\n\n## Verification\n- rebased cleanly onto origin/main 74b9a6d3 after PR #255\n- focused post-rebase regression suite: 47/47 green\n- real Pino subprocess plus actual OTel InMemoryLogRecordExporter parity proof: green\n- questpie, observability, and admin typechecks: green\n- questpie, observability, and docs builds from the pre-rebase seal: green\n- repository Oxfmt and diff check: green\n- authoritative any-census: green; QUESTPIE colon-any ratchet decreases from 542 to 540\n- PR is reported MERGEABLE by GitHub; required CI is queued\n\n## Canonical contract\n- output is an inert tree of primitives, arrays, and null-prototype records\n- unsupported, circular, and non-finite values use explicit markers\n- Date, URL, Map, Set, and TypedArray values use tagged records\n- URL userinfo and fragments are removed; default and configured query paths are redacted\n- configured paths may address generated tagged fields and are applied before both sinks\n- structured OTLP log attributes retain recursive AnyValue values instead of using the scalar span/metric attribute type\n\n## Review fixes\n- final effective record is constructed before one shared redaction/canonicalization pass\n- adapter/Pino and OTLP receive the same canonical fields, including child and request context\n- structured collisions, empty objects, and unreadable proxies are consumed without leaking a second argument\n- Pino downstream redaction is disabled and canonical err records are serialized unchanged\n- descriptor-safe custom/class, Error/ErrorLike, accessor, Error subclass, and Proxy handling\n- caller hooks, coercion, getters, and toJSON are not executed\n- alias-specific configured paths, cycles, non-finite values, Map keys, URL query paths, typed arrays, and trusted runtime Error subtypes are covered adversarially\n- invalid traceparent omitted from observability carrier\n- admin action error fixture supplies the mandatory structured logger boundary and proves stale conflicts are not masked\n- PR #255 CRUD logger-context fallback is preserved without semantic overlap\n- generated skill output remains isolated in mechanical commits\n\n## Deferred intentionally\n- console boundaries without explicit logger ownership\n- arbitrary caller message-string inspection\n\n## Review\nReady for narrow final Standards and Spec seals at 25eab6a7. Do not merge before both are clean and required CI passes.