### PR TITLE
test(realtime): stabilize retry timing assertion

### DIFF
--- a/packages/questpie/test/client/sse-connection-manager.test.ts
+++ b/packages/questpie/test/client/sse-connection-manager.test.ts
@@ -69,6 +69,7 @@ function registerChannel(
 describe("SSE connection manager failure classification", () => {
 	test("backs off and retries an initial transport failure without a terminal resource error", async () => {
 		let requests = 0;
+		const requestStartedAt: number[] = [];
 		const controllers: ReadableStreamDefaultController<Uint8Array>[] = [];
 		const errors: Error[] = [];
 		const epochEnds: Error[] = [];
@@ -77,6 +78,7 @@ describe("SSE connection manager failure classification", () => {
 			withCredentials: true,
 			fetcher: async (_input, init) => {
 				requests += 1;
+				requestStartedAt.push(performance.now());
 				if (requests === 1) throw new Error("socket unavailable");
 				return openStream(requests, init?.signal, controllers);
 			},
@@ -87,12 +89,14 @@ describe("SSE connection manager failure classification", () => {
 		});
 		const release = registerChannel(manager, "channel:news", errors, epochEnds);
 
-		await waitFor(() => requests === 1);
-		await Bun.sleep(10);
-		expect(requests).toBe(1);
-		expect(errors).toEqual([]);
 		await waitFor(() => controllers.length === 1);
 		expect(requests).toBe(2);
+		// The configured retry delay is 20 ms. A positive lower bound remains
+		// valid when a loaded event loop resumes the test after that deadline.
+		expect(requestStartedAt[1]! - requestStartedAt[0]!).toBeGreaterThanOrEqual(
+			10,
+		);
+		expect(errors).toEqual([]);
 		expect(epochEnds.map((error) => error.message)).toEqual([
 			"socket unavailable",
 		]);

--- a/packages/questpie/test/client/sse-connection-manager.test.ts
+++ b/packages/questpie/test/client/sse-connection-manager.test.ts
@@ -91,10 +91,11 @@ describe("SSE connection manager failure classification", () => {
 
 		await waitFor(() => controllers.length === 1);
 		expect(requests).toBe(2);
-		// The configured retry delay is 20 ms. A positive lower bound remains
-		// valid when a loaded event loop resumes the test after that deadline.
+		// The configured retry delay is 20 ms. Allow 2 ms for monotonic-clock
+		// precision while keeping the assertion safe when a loaded event loop
+		// resumes the test after that deadline.
 		expect(requestStartedAt[1]! - requestStartedAt[0]!).toBeGreaterThanOrEqual(
-			10,
+			18,
 		);
 		expect(errors).toEqual([]);
 		expect(epochEnds.map((error) => error.message)).toEqual([


### PR DESCRIPTION
## Summary

- replace the flaky pre-deadline `Bun.sleep(10)` assertion with request-attempt timestamps
- assert a positive lower bound for the configured deterministic 20 ms retry
- preserve successful retry, epoch-end, terminal-error, and release cleanup coverage
- leave product retry/backoff behavior unchanged

## Verification

- `bun test packages/questpie/test/client/sse-connection-manager.test.ts`
- focused retry test: 800 iterations at P32
- `bun run --cwd packages/questpie check-types`
- `bun run format:check`
- `git diff --check`

Test-only change; no changeset.