### PR TITLE
chore: eliminate non-admin governed lint debt

### DIFF
--- a/.changeset/calm-lint-boundaries.md
+++ b/.changeset/calm-lint-boundaries.md
@@ -1,0 +1,9 @@
+---
+"questpie": patch
+"@questpie/openapi": patch
+"@questpie/workflows": patch
+---
+
+Remove unused private implementation and test scaffolding without changing public signatures.
+
+No migration is required.

--- a/.changeset/preserve-wrapped-error-causes.md
+++ b/.changeset/preserve-wrapped-error-causes.md
@@ -1,0 +1,8 @@
+---
+"questpie": patch
+"@questpie/sandbox": patch
+---
+
+Preserve caught errors as `cause` when the CLI or sandbox fetch bridge wraps them.
+
+No migration is required.

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -9,6 +9,9 @@
 		"typescript/no-explicit-any": "off",
 		"jsx-a11y/prefer-tag-over-role": "off",
 		"react/react-in-jsx-scope": "off",
+		// Leading underscores are the repository convention for internal members
+		// such as `_state` and `_pendingRelations`.
+		"eslint/no-underscore-dangle": "off",
 		"eslint/no-unused-vars": "warn",
 		"eslint/no-shadow": "off",
 		"unicorn/consistent-function-scoping": "off",

--- a/packages/openapi/src/generator/search.ts
+++ b/packages/openapi/src/generator/search.ts
@@ -3,7 +3,7 @@
  */
 
 import type { OpenApiConfig, PathOperation } from "../types.js";
-import { jsonRequestBody, jsonResponse, ref } from "./schemas.js";
+import { jsonRequestBody, jsonResponse } from "./schemas.js";
 
 /**
  * Generate OpenAPI paths for search endpoints.

--- a/packages/questpie/src/cli/codegen/template.ts
+++ b/packages/questpie/src/cli/codegen/template.ts
@@ -107,7 +107,6 @@ export function generateTemplate(options: TemplateOptions): TemplateResult {
 		appInstanceId = "questpie-app",
 		discovered,
 		categories,
-		singletonFactories,
 		extraImports,
 		extraTypeDeclarations,
 		extraRuntimeCode,
@@ -577,7 +576,7 @@ export function generateTemplate(options: TemplateOptions): TemplateResult {
 			lines.push('import type { ExtractModuleProp } from "questpie/types";');
 			lines.push("");
 
-			for (const { singleName, registryKey } of tildeKeys) {
+			for (const { singleName, registryKey: _registryKey } of tildeKeys) {
 				const userFile = discovered.singles.get(singleName);
 				const typeName = `_AllModule${capitalize(singleName)}`;
 				// Exported — consumed by the L2 `Registry` interface (`~fieldTypes`).
@@ -1726,7 +1725,7 @@ function sectionComment(label: string): string {
  * Used to separate "Core Singles" from "Plugin Singles" in generated comments.
  */
 function getCoreSingleKeys(
-	allDecls: Map<string, CategoryDeclaration>,
+	_allDecls: Map<string, CategoryDeclaration>,
 ): Set<string> {
 	// Core singles are those discovered by any plugin that also declares categories.
 	// In practice, this is the core plugin which declares modules, locale, hooks, etc.
@@ -1851,7 +1850,7 @@ function emitRouteTypeInterface(
  */
 function collectTildeRegistryKeys(
 	discoverPatterns: Record<string, DiscoverPattern> | undefined,
-	singles: Map<string, DiscoveredFile>,
+	_singles: Map<string, DiscoveredFile>,
 ): Array<{ singleName: string; registryKey: string }> {
 	if (!discoverPatterns) return [];
 	const result: Array<{ singleName: string; registryKey: string }> = [];

--- a/packages/questpie/src/cli/commands/codegen.ts
+++ b/packages/questpie/src/cli/commands/codegen.ts
@@ -725,7 +725,7 @@ async function watchSingleTarget(
 	configPath: string,
 	plugins: CodegenPlugin[],
 	moduleOpt: { name: string; outputFile?: string },
-	options: DevOptions,
+	_options: DevOptions,
 ): Promise<void> {
 	const outDir = join(rootDir, ".generated");
 
@@ -850,8 +850,6 @@ async function watchPackageModules(
 	options: DevOptions,
 ): Promise<void> {
 	const modulesDir = resolve(configRootDir, pkgConfig.modulesDir);
-	const prefix = pkgConfig.modulePrefix ?? "questpie";
-	const plugins = Array.isArray(pkgConfig.plugins) ? pkgConfig.plugins : [];
 
 	console.log(`\nWatching ${pkgConfig.modulesDir}/ for file changes...`);
 	console.log("  (Press Ctrl+C to stop)\n");

--- a/packages/questpie/src/cli/commands/generate.ts
+++ b/packages/questpie/src/cli/commands/generate.ts
@@ -19,7 +19,6 @@ function mockStdinForNonInteractive(): () => void {
 	const originalIsTTY = process.stdin.isTTY;
 	const originalSetRawMode = (process.stdin as any).setRawMode;
 
-	const buffer = "";
 	let promptCount = 0;
 
 	// Create a readable stream that provides Enter keypresses on demand
@@ -36,7 +35,7 @@ function mockStdinForNonInteractive(): () => void {
 	}) as any;
 
 	mockStream.isTTY = true;
-	mockStream.setRawMode = (mode: boolean) => {
+	mockStream.setRawMode = (_mode: boolean) => {
 		return mockStream;
 	};
 

--- a/packages/questpie/src/cli/config.ts
+++ b/packages/questpie/src/cli/config.ts
@@ -188,6 +188,7 @@ export async function loadQuestpieConfig(
 					`Could not load generated app at ${generatedPath}: ${reason}\n` +
 					`Run \`questpie generate\` first to create .generated/index.ts,\n` +
 					`or point --config to a file that exports { app: QuestpieInstance }.`,
+				{ cause: error },
 			);
 		}
 	}

--- a/packages/questpie/src/client/index.ts
+++ b/packages/questpie/src/client/index.ts
@@ -58,7 +58,6 @@ import { createChannelsAPI, type ChannelsClient } from "./channels/index.js";
 // pulls the whole 164 KB client CRDT implementation into every bundle — see
 // ./crdt-host.ts for the measurement.
 import { CRDT_CLIENT_HOST, type CrdtClientHostHandle } from "./crdt-host.js";
-import type { CrdtClientRuntimeConfig } from "./crdt/types.js";
 import {
 	buildCollectionTopic,
 	buildGlobalTopic,

--- a/packages/questpie/src/server/collection/builder/collection.ts
+++ b/packages/questpie/src/server/collection/builder/collection.ts
@@ -11,16 +11,13 @@ import { sql } from "drizzle-orm";
 import type { PgColumn, PgTable } from "drizzle-orm/pg-core";
 import {
 	bigint,
-	bigserial,
 	char,
 	index,
 	integer,
 	jsonb,
 	pgSchema,
 	pgTable,
-	serial,
 	smallint,
-	smallserial,
 	text,
 	uniqueIndex,
 	uuid,
@@ -37,14 +34,10 @@ import type {
 	InferSQLType,
 	InferTableWithColumns,
 	InferVersionedTableWithColumns,
-	LocalizedTableName,
-	RelationConfig,
-	RelationType,
 	TitleExpression,
 } from "#questpie/server/collection/builder/types.js";
 import { createCollectionValidationSchemas } from "#questpie/server/collection/builder/validation-helpers.js";
 import { CRUDGenerator } from "#questpie/server/collection/crud/index.js";
-import { getColumn } from "#questpie/server/collection/crud/shared/field-resolver.js";
 import type {
 	CRUD,
 	ExtractIdType,
@@ -99,14 +92,6 @@ import type {
 	ExtractMainFields,
 	ExtractVirtualFields,
 } from "#questpie/server/fields/types.js";
-
-/**
- * Extract input types from field definitions.
- * Maps each field to its input type from $types.input.
- */
-type ExtractInputTypes<TFieldDefs extends Record<string, any>> = {
-	[K in keyof TFieldDefs]: FieldInput<TFieldDefs[K]>;
-};
 
 type FieldInput<T> =
 	// V2: Field<TState> — extract input from accumulated state

--- a/packages/questpie/src/server/collection/builder/field-schema-builder.ts
+++ b/packages/questpie/src/server/collection/builder/field-schema-builder.ts
@@ -16,7 +16,6 @@ import { z } from "zod";
 
 import type { FieldState } from "#questpie/server/fields/field-class-types.js";
 import type { Field } from "#questpie/server/fields/field-class.js";
-import type { RelationFieldMetadata } from "#questpie/server/fields/types.js";
 
 // ============================================================================
 // Schema Building
@@ -88,7 +87,6 @@ export function extendSchemaWithNestedMutations(
 	for (const [fieldName, fieldDef] of Object.entries(fieldDefinitions)) {
 		const rawMetadata = fieldDef.getMetadata();
 		if (rawMetadata.type !== "relation") continue;
-		const metadata = rawMetadata as RelationFieldMetadata;
 
 		// Create a flexible schema that accepts nested mutations
 		const nestedMutationSchema = z

--- a/packages/questpie/src/server/collection/crud/query-builders/select-builder.ts
+++ b/packages/questpie/src/server/collection/crud/query-builders/select-builder.ts
@@ -93,7 +93,6 @@ export function buildSelectObject(
 		i18nCurrentTable,
 		i18nFallbackTable,
 		getVirtualsWithAliases,
-		getTitle,
 	} = options;
 
 	const select: Record<string, any> = {
@@ -284,7 +283,6 @@ export function buildVersionsSelectObject(
 		i18nVersionsFallbackTable,
 		state,
 		getVirtualsForVersionsWithAliases,
-		getTitleForVersions,
 	} = options;
 
 	if (!versionsTable) return {};

--- a/packages/questpie/src/server/collection/crud/query-builders/where-builder.ts
+++ b/packages/questpie/src/server/collection/crud/query-builders/where-builder.ts
@@ -624,7 +624,7 @@ export function buildRelationWhereClause(
 	relationValue: any,
 	options: BuildRelationWhereOptions,
 ): SQL | undefined {
-	const { app, parentTable, context } = options;
+	const { app, context: _context } = options;
 
 	if (!app) return undefined;
 
@@ -739,7 +739,7 @@ export function buildBelongsToExistsClause(
 	relationWhere: Where | undefined,
 	options: BuildRelationWhereOptions,
 ): SQL | undefined {
-	const { app, parentTable, parentState, context } = options;
+	const { app, parentTable, context } = options;
 
 	// Support both `field: string` (singular) and `fields: PgColumn[]` (array) formats
 	const hasFieldConfig =

--- a/packages/questpie/src/server/collection/crud/relation-mutations/cascade-delete.ts
+++ b/packages/questpie/src/server/collection/crud/relation-mutations/cascade-delete.ts
@@ -7,10 +7,7 @@
 
 import type { RelationConfig } from "#questpie/server/collection/builder/types.js";
 import type { resolveFieldKey as ResolveFieldKeyFn } from "#questpie/server/collection/crud/shared/field-resolver.js";
-import type {
-	CRUD,
-	CRUDContext,
-} from "#questpie/server/collection/crud/types.js";
+import type { CRUDContext } from "#questpie/server/collection/crud/types.js";
 import type { Questpie } from "#questpie/server/config/questpie.js";
 import { ApiError } from "#questpie/server/errors/base.js";
 

--- a/packages/questpie/src/server/collection/crud/relation-mutations/nested-operations.ts
+++ b/packages/questpie/src/server/collection/crud/relation-mutations/nested-operations.ts
@@ -264,7 +264,7 @@ export function extractBelongsToConnectValues(
 		}
 
 		// Remove connect from operations, keep create/connectOrCreate for later processing
-		const { connect, ...restOperations } = operations;
+		const { connect: _connect, ...restOperations } = operations;
 		if (Object.keys(restOperations).length === 0) {
 			delete remainingRelations[relationName];
 		} else {

--- a/packages/questpie/src/server/collection/crud/shared/access-control.ts
+++ b/packages/questpie/src/server/collection/crud/shared/access-control.ts
@@ -8,7 +8,6 @@
 import type {
 	AccessContext,
 	AccessWhere,
-	CollectionAccess,
 } from "#questpie/server/collection/builder/types.js";
 import type { CRUDContext } from "#questpie/server/collection/crud/types.js";
 import { extractAppServices } from "#questpie/server/config/app-context.js";
@@ -18,7 +17,7 @@ import type {
 	FieldAccessContext,
 } from "#questpie/server/fields/types.js";
 
-import { getDb, normalizeContext } from "./context.js";
+import { normalizeContext } from "./context.js";
 
 /** Internal, non-JSON marker for access already evaluated before CRUD hooks. */
 export const PRECHECKED_READ_ACCESS = Symbol("questpie.precheckedReadAccess");

--- a/packages/questpie/src/server/collection/crud/shared/field-extraction.ts
+++ b/packages/questpie/src/server/collection/crud/shared/field-extraction.ts
@@ -4,10 +4,7 @@
  * Runtime helpers to extract field information from Field state.
  */
 
-import type {
-	FieldRuntimeState,
-	FieldState,
-} from "#questpie/server/fields/field-class-types.js";
+import type { FieldState } from "#questpie/server/fields/field-class-types.js";
 import type { Field } from "#questpie/server/fields/field-class.js";
 
 /**

--- a/packages/questpie/src/server/collection/crud/types.ts
+++ b/packages/questpie/src/server/collection/crud/types.ts
@@ -8,10 +8,7 @@ import type {
 	RelationConfig,
 	UploadOptions,
 } from "#questpie/server/collection/builder/types.js";
-import type {
-	BaseRequestContext,
-	RequestContext,
-} from "#questpie/server/config/context.js";
+import type { BaseRequestContext } from "#questpie/server/config/context.js";
 import type { FieldState } from "#questpie/server/fields/field-class-types.js";
 import type {
 	FieldDefinitionsWithSystem,
@@ -25,7 +22,6 @@ import type {
 	CollectionRelations,
 	CollectionSelect as CollectionSelectFromInfer,
 	CollectionState,
-	CollectionUpdate as CollectionUpdateFromInfer,
 	ExtractRelationApp,
 	ExtractRelationCollection,
 	ExtractRelationInsert,
@@ -290,89 +286,6 @@ export type WhereOperators<T> = T extends { getOperators: () => any }
  */
 type RelationValue<T> = T extends (infer U)[] ? U : T;
 
-type RelationTargetNameFromConfig<TConfig> = TConfig extends {
-	to: infer TTo;
-}
-	? TTo extends string
-		? TTo
-		: TTo extends () => { name: infer TName extends string }
-			? TName
-			: TTo extends Record<string, infer TValue>
-				?
-						| (TValue extends string
-								? TValue
-								: TValue extends () => {
-											name: infer TObjectName extends string;
-									  }
-									? TObjectName
-									: never)
-						| (keyof TTo & string)
-				: never
-	: never;
-
-type InferRelationKindFromConfig<TConfig> = TConfig extends {
-	morphName: string;
-}
-	? "many"
-	: TConfig extends { hasMany: true }
-		? TConfig extends { through: any }
-			? "manyToMany"
-			: "many"
-		: "one";
-
-type RelationSelectFromConfig<TConfig, TApp> =
-	RelationTargetNameFromConfig<TConfig> extends infer TTarget
-		? TTarget extends string
-			? CollectionSelect<GetCollection<AppCollections<TApp>, TTarget>, TApp>
-			: never
-		: never;
-
-type RelationSelectFromConfigWithKind<TConfig, TApp> =
-	InferRelationKindFromConfig<TConfig> extends "many" | "manyToMany"
-		? RelationSelectFromConfig<TConfig, TApp>[]
-		: RelationSelectFromConfig<TConfig, TApp>;
-
-type BlockNodeFromRegistry<TBlocks> = {
-	id: string;
-	type: Extract<keyof TBlocks, string>;
-	children?: BlockNodeFromRegistry<TBlocks>[];
-};
-
-type BlockValuesFromDefinition<TBlock, TApp> = TBlock extends {
-	state: { fields: infer TFields };
-}
-	? TFields extends Record<string, AnyFieldDefinition>
-		? {
-				[K in keyof TFields]: FieldSelect<TFields[K], TApp>;
-			}
-		: Record<string, {}>
-	: Record<string, {}>;
-
-type BlockValuesUnion<TBlocks, TApp> =
-	TBlocks extends Record<string, any>
-		? BlockValuesFromDefinition<TBlocks[keyof TBlocks], TApp>
-		: Record<string, {}>;
-
-type BlocksDocumentBase = {
-	_tree: Array<{ id: string; type: string; children?: any[] }>;
-	_values: Record<string, Record<string, {}>>;
-	_data?: Record<string, Record<string, {}>>;
-};
-
-type BlocksSelectFromRegistry<TBlocks, TApp> =
-	TBlocks extends Record<string, any>
-		? {
-				_tree: BlockNodeFromRegistry<TBlocks>[];
-				_values: Record<string, BlockValuesUnion<TBlocks, TApp>>;
-				_data?: Record<string, Record<string, {}>>;
-			}
-		: BlocksDocumentBase;
-
-type BlocksSelectFromApp<TApp> = BlocksSelectFromRegistry<
-	TApp extends { blocks?: infer TBlocks } ? TBlocks : undefined,
-	TApp
->;
-
 /**
  * Build CollectionSelect purely from field definitions (v2).
  *
@@ -455,42 +368,6 @@ type ResolveRelationsDeepFromApp<
 
 export type CollectionRelationsFromApp<TCollection, TApp> =
 	ResolveRelationsDeepFromApp<CollectionRelationsFor<TCollection>, TApp>;
-
-type RelationTargetCollectionFromConfig<TConfig, TApp> =
-	RelationTargetNameFromConfig<TConfig> extends infer TTarget
-		? TTarget extends string
-			? GetCollection<AppCollections<TApp>, TTarget>
-			: never
-		: never;
-
-/**
- * Resolve CollectionWherePlaceholder brands in a where operator map.
- *
- * FieldWhere produces `{ some?: CollectionWherePlaceholder; eq?: string; ... }`.
- * This type walks each property: if the value extends CollectionWherePlaceholder,
- * replace it with `Where<TargetCollection, TApp>`. Otherwise pass through.
- *
- * The field's operators are the source of truth for WHAT operators exist.
- * This type resolves the cross-collection types they couldn't express.
- */
-type ResolveWherePlaceholders<
-	TWhereShape,
-	TConfig,
-	TApp,
-	Depth extends unknown[] = DefaultWhereDepth,
-> = {
-	[K in keyof TWhereShape]?: NonNullable<
-		TWhereShape[K]
-	> extends CollectionWherePlaceholder
-		? Depth extends []
-			? never
-			: WhereFromCollection<
-					RelationTargetCollectionFromConfig<TConfig, TApp>,
-					TApp,
-					DecrementDepth<Depth>
-				>
-		: TWhereShape[K];
-};
 
 type RelationWhereFromTarget<
 	TTo extends string,

--- a/packages/questpie/src/server/fields/derive-schema.ts
+++ b/packages/questpie/src/server/fields/derive-schema.ts
@@ -140,8 +140,9 @@ function applyRefinements(schema: ZodType, state: FieldRuntimeState): ZodType {
 		if (state.positive) s = s.positive();
 		if (state.int) s = s.int();
 		if (state.step !== undefined) {
-			s = s.refine((v) => v % state.step! === 0, {
-				message: `Must be a multiple of ${state.step}`,
+			const step = state.step;
+			s = s.refine((v) => v % step === 0, {
+				message: `Must be a multiple of ${step}`,
 			}) as any;
 		}
 		return s;

--- a/packages/questpie/src/server/fields/field-class.ts
+++ b/packages/questpie/src/server/fields/field-class.ts
@@ -39,7 +39,6 @@ import type {
 	FieldLocation,
 	FieldMetadata,
 	FieldMetadataBase,
-	ReferentialAction,
 } from "./types.js";
 
 // ============================================================================

--- a/packages/questpie/src/server/fields/field-types.ts
+++ b/packages/questpie/src/server/fields/field-types.ts
@@ -18,7 +18,6 @@ import type {
 	UploadOptions,
 } from "#questpie/server/collection/builder/types.js";
 import type { FieldState } from "#questpie/server/fields/field-class-types.js";
-import type { Field } from "#questpie/server/fields/field-class.js";
 import type {
 	ArrayWhereInput,
 	ElementWhereValueOf,

--- a/packages/questpie/src/server/fields/operators/builtin.ts
+++ b/packages/questpie/src/server/fields/operators/builtin.ts
@@ -310,16 +310,16 @@ export const emailOps = extendOperatorSet(stringOps, {
 	},
 	jsonbOverrides: {
 		domain: operator<string, unknown>((col, value, ctx) => {
-			return sql`${jsonbPathRef(col, ctx.jsonbPath, false)} ILIKE ${"%" + "@" + value}`;
+			return sql`${jsonbPathRef(col, ctx.jsonbPath, false)} ILIKE ${`%@${value}`}`;
 		}),
 		domainIn: operator<string[], unknown>((col, values, ctx) => {
 			if (values.length === 0) return sql`FALSE`;
 			if (values.length === 1)
-				return sql`${jsonbPathRef(col, ctx.jsonbPath, false)} ILIKE ${"%" + "@" + values[0]}`;
+				return sql`${jsonbPathRef(col, ctx.jsonbPath, false)} ILIKE ${`%@${values[0]}`}`;
 			return sql`(${sql.join(
 				values.map(
 					(d) =>
-						sql`${jsonbPathRef(col, ctx.jsonbPath, false)} ILIKE ${"%" + "@" + d}`,
+						sql`${jsonbPathRef(col, ctx.jsonbPath, false)} ILIKE ${`%@${d}`}`,
 				),
 				sql` OR `,
 			)})`;

--- a/packages/questpie/src/server/fields/operators/types.ts
+++ b/packages/questpie/src/server/fields/operators/types.ts
@@ -6,15 +6,9 @@
  * enabling auto-derivation of JSONB operators from column operators.
  */
 
-import type { SQL } from "drizzle-orm";
 import type { AnyPgColumn } from "drizzle-orm/pg-core";
 
-import type {
-	ContextualOperators,
-	OperatorFn,
-	OperatorMap,
-	QueryContext,
-} from "../types.js";
+import type { ContextualOperators, OperatorMap } from "../types.js";
 
 // ============================================================================
 // JSONB Cast Strategies

--- a/packages/questpie/src/server/fields/types.ts
+++ b/packages/questpie/src/server/fields/types.ts
@@ -11,7 +11,6 @@
 
 import type { SQL } from "drizzle-orm";
 import type { AnyPgColumn } from "drizzle-orm/pg-core";
-import type { ZodType } from "zod";
 
 import type { Principal } from "#questpie/server/config/context.js";
 import type { AuthorityActor } from "#questpie/server/modules/core/integrated/crdt/authority.js";

--- a/packages/questpie/src/server/global/builder/global-builder.ts
+++ b/packages/questpie/src/server/global/builder/global-builder.ts
@@ -419,7 +419,7 @@ export class GlobalBuilder<TState extends GlobalBuilderState> {
 		metadata: RelationFieldMetadata,
 		columns: Record<string, any>,
 	): RelationConfig | null {
-		const { relationType, foreignKey, _toConfig, _throughConfig } = metadata;
+		const { relationType, _toConfig, _throughConfig } = metadata;
 		let { targetCollection, through } = metadata;
 
 		// Resolve deferred callbacks now (all collections should be defined by build time)

--- a/packages/questpie/src/server/global/builder/global.ts
+++ b/packages/questpie/src/server/global/builder/global.ts
@@ -664,7 +664,7 @@ export class Global<TState extends GlobalBuilderState> {
 	getMeta(): GlobalMeta {
 		const fieldDefinitions = this.state.fieldDefinitions || {};
 		const fields = Object.entries(fieldDefinitions).map(
-			([name, def]: [string, any]) => ({
+			([name, _def]: [string, any]) => ({
 				name,
 				localized: this.state.localized.includes(name as any),
 				virtual: name in this.state.virtuals,

--- a/packages/questpie/src/server/global/introspection.ts
+++ b/packages/questpie/src/server/global/introspection.ts
@@ -31,7 +31,6 @@ import type {
 } from "#questpie/server/fields/types.js";
 import type { Global } from "#questpie/server/global/builder/global.js";
 import type {
-	GlobalAccess,
 	GlobalAccessContext,
 	GlobalAccessRule,
 	GlobalBuilderState,

--- a/packages/questpie/src/server/migration/operation-snapshot.ts
+++ b/packages/questpie/src/server/migration/operation-snapshot.ts
@@ -1,6 +1,6 @@
 import type { generateDrizzleJson } from "drizzle-kit/api-postgres";
 
-import type { OperationSnapshot, SnapshotOperation } from "./types.js";
+import type { SnapshotOperation } from "./types.js";
 
 // Infer snapshot type from drizzle-kit API
 type DrizzleSnapshotJSON = Awaited<ReturnType<typeof generateDrizzleJson>>;
@@ -46,7 +46,7 @@ export class OperationSnapshotManager {
 		}
 
 		// Check for removed entities
-		for (const [key, oldEntity] of oldDdlMap) {
+		for (const [key, _oldEntity] of oldDdlMap) {
 			if (!newDdlMap.has(key)) {
 				operations.push({
 					type: "remove",

--- a/packages/questpie/src/server/migration/runner.ts
+++ b/packages/questpie/src/server/migration/runner.ts
@@ -256,6 +256,7 @@ export class MigrationRunner {
 		}
 
 		// Get all migrations after target (reverse order)
+		// oxlint-disable-next-line unicorn/no-array-reverse -- slice() already isolates the input and ES2023 toReversed is outside the supported target.
 		const toRollback = executed.slice(targetIndex).reverse();
 
 		this.log(

--- a/packages/questpie/src/server/modules/core/fields/select.ts
+++ b/packages/questpie/src/server/modules/core/fields/select.ts
@@ -12,10 +12,7 @@ import type { DefaultFieldState } from "../../../fields/field-class-types.js";
 import { field, Field } from "../../../fields/field-class.js";
 import { fieldType, wrapFieldComplete } from "../../../fields/field-type.js";
 import type { FieldWithMethods } from "../../../fields/field-with-methods.js";
-import {
-	selectMultiOps,
-	selectSingleOps,
-} from "../../../fields/operators/builtin.js";
+import { selectSingleOps } from "../../../fields/operators/builtin.js";
 import type { ScalarWhereInput } from "../../../fields/operators/builtin.js";
 import type { OptionsConfig } from "../../../fields/reactive.js";
 import type { SelectFieldMetadata } from "../../../fields/types.js";

--- a/packages/questpie/src/server/modules/core/fields/upload.ts
+++ b/packages/questpie/src/server/modules/core/fields/upload.ts
@@ -17,10 +17,7 @@ import {
 	multipleOps,
 	toManyOps,
 } from "../../../fields/operators/builtin.js";
-import type {
-	ReferentialAction,
-	RelationFieldMetadata,
-} from "../../../fields/types.js";
+import type { RelationFieldMetadata } from "../../../fields/types.js";
 
 declare global {
 	namespace Questpie {

--- a/packages/questpie/src/server/modules/core/integrated/queue/service.ts
+++ b/packages/questpie/src/server/modules/core/integrated/queue/service.ts
@@ -369,7 +369,11 @@ export function createQueueClient<
 				);
 			}
 
-			const { cron, startAfter, ...scheduleOptions } = jobDef.options ?? {};
+			const {
+				cron: _cron,
+				startAfter: _startAfter,
+				...scheduleOptions
+			} = jobDef.options ?? {};
 			await adapter.schedule(
 				jobDef.name,
 				jobDef.options.cron,

--- a/packages/questpie/src/server/routes/route-matcher.ts
+++ b/packages/questpie/src/server/routes/route-matcher.ts
@@ -189,7 +189,7 @@ export function compileMatcher<T>(
 	// Per-method collision: same pattern + same method = collision
 	const patternMethodMap = new Map<string, Map<string, string>>();
 
-	for (const [pattern, method] of entries) {
+	for (const [pattern, _method] of entries) {
 		const key = specificityKey(pattern);
 		let methodMap = patternMethodMap.get(key);
 		if (!methodMap) {

--- a/packages/questpie/test/cli/config.test.ts
+++ b/packages/questpie/test/cli/config.test.ts
@@ -60,4 +60,28 @@ describe("loadQuestpieConfig", () => {
 		expect((config.app as any).config.source).toBe("generated");
 		expect(config.cli?.migrations?.directory).toBe("./custom-migrations");
 	});
+
+	it("preserves the generated module load error as the cause", async () => {
+		const rootDir = await createTempProject();
+		const configPath = join(rootDir, "questpie.config.ts");
+
+		await writeFile(
+			configPath,
+			`export default { app: { url: "http://localhost:3000" } };\n`,
+			"utf-8",
+		);
+
+		try {
+			await loadQuestpieConfig(configPath);
+			expect.unreachable("config loading should fail without generated output");
+		} catch (error) {
+			expect(error).toBeInstanceOf(Error);
+			if (!(error instanceof Error)) return;
+			expect(error.message).toContain("Could not load generated app");
+			const cause = error.cause;
+			expect(cause).toMatchObject({
+				message: expect.stringContaining(".generated/index.ts"),
+			});
+		}
+	});
 });

--- a/packages/questpie/test/codegen/template.test.ts
+++ b/packages/questpie/test/codegen/template.test.ts
@@ -37,7 +37,6 @@ function generateTemplate(
 import type {
 	CategoryDeclaration,
 	CodegenPlugin,
-	CodegenResult,
 	CrossTargetValidator,
 	DiscoveredFile,
 	DiscoveryResult,
@@ -1469,7 +1468,7 @@ describe("generateTemplate — factory re-exports", () => {
 
 describe("runAllTargets", () => {
 	it("generates the server target by default (single target)", async () => {
-		const { mkdtemp, writeFile, mkdir } = await import("node:fs/promises");
+		const { mkdtemp, writeFile } = await import("node:fs/promises");
 		const { tmpdir } = await import("node:os");
 		const { join } = await import("node:path");
 
@@ -1707,7 +1706,7 @@ describe("runAllTargets", () => {
 							extractFromModules: false,
 						},
 					},
-					generate: async ({ target, discovered }) => {
+					generate: async ({ target: _target, discovered }) => {
 						const blocks = discovered.categories.get("blocks");
 						const lines = [
 							"// Generated admin client config",
@@ -1791,41 +1790,6 @@ describe("runAllTargets", () => {
 
 describe("cross-target projection validators", () => {
 	/**
-	 * Helper: create a minimal CodegenResult with specified category files.
-	 */
-	function makeFakeResult(
-		targetId: string,
-		categories: Record<string, string[]>,
-	): CodegenResult {
-		const catMap = new Map<string, Map<string, DiscoveredFile>>();
-		for (const [catName, keys] of Object.entries(categories)) {
-			const fileMap = new Map<string, DiscoveredFile>();
-			for (const key of keys) {
-				fileMap.set(
-					key,
-					makeFile(key, {
-						varName: `_${catName}_${key}`,
-						importPath: `../${catName}/${key}`,
-						exportType: "default",
-					}),
-				);
-			}
-			catMap.set(catName, fileMap);
-		}
-
-		return {
-			targetId,
-			code: "// fake",
-			outputPath: `/fake/.generated/${targetId}.ts`,
-			discovered: {
-				categories: catMap,
-				singles: new Map(),
-				spreads: new Map(),
-			},
-		};
-	}
-
-	/**
 	 * Simple projection validator for testing — checks that server "blocks"
 	 * keys all exist in admin-client "blocks" keys.
 	 */
@@ -1842,7 +1806,7 @@ describe("cross-target projection validators", () => {
 		if (!serverBlocks) return [];
 		const clientKeys = new Set(clientBlocks?.keys() ?? []);
 
-		for (const [key, file] of serverBlocks) {
+		for (const key of serverBlocks.keys()) {
 			if (!clientKeys.has(key)) {
 				errors.push({
 					severity: "error",
@@ -2112,7 +2076,7 @@ describe("cross-target projection validators", () => {
 	});
 
 	it("skips validation when one target is missing", async () => {
-		const { mkdtemp, writeFile, mkdir } = await import("node:fs/promises");
+		const { mkdtemp, writeFile } = await import("node:fs/promises");
 		const { tmpdir } = await import("node:os");
 		const { join } = await import("node:path");
 
@@ -2158,7 +2122,7 @@ describe("cross-target projection validators", () => {
 	});
 
 	it("aggregates validators from multiple plugins", async () => {
-		const { mkdtemp, writeFile, mkdir } = await import("node:fs/promises");
+		const { mkdtemp, writeFile } = await import("node:fs/promises");
 		const { tmpdir } = await import("node:os");
 		const { join } = await import("node:path");
 

--- a/packages/questpie/test/collection/collection-hooks.test.ts
+++ b/packages/questpie/test/collection/collection-hooks.test.ts
@@ -5,7 +5,6 @@ import { z } from "zod";
 import { collection, job } from "../../src/exports/index.js";
 import { isNullish } from "../../src/shared/utils/data-utils.js";
 import { buildMockApp } from "../utils/mocks/mock-app-builder";
-import { createTestContext } from "../utils/test-context";
 import { runTestDbMigrations } from "../utils/test-db";
 
 const articleCreatedJob = job({

--- a/packages/questpie/test/collection/introspection.test.ts
+++ b/packages/questpie/test/collection/introspection.test.ts
@@ -21,9 +21,7 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 
 import { collection } from "../../src/exports/index.js";
 import {
-	type CollectionSchema,
 	extractFormReactiveConfigs,
-	type FieldSchema,
 	introspectCollection,
 	introspectCollections,
 } from "../../src/server/collection/introspection.js";

--- a/packages/questpie/test/collection/nested-operations.test.ts
+++ b/packages/questpie/test/collection/nested-operations.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+
+import type { RelationConfig } from "../../src/server/collection/builder/types.js";
+import { extractBelongsToConnectValues } from "../../src/server/collection/crud/relation-mutations/nested-operations.js";
+
+const belongsToRelation = {
+	type: "one",
+	fields: [{ name: "authorId" }],
+} as unknown as RelationConfig;
+
+const resolveFieldKey = (_state: unknown, field: { name?: string }) =>
+	field.name;
+
+describe("extractBelongsToConnectValues", () => {
+	test("extracts a connect value and removes the consumed relation operation", () => {
+		const result = extractBelongsToConnectValues(
+			{},
+			{ author: { connect: { id: "author-1" } } },
+			{ author: belongsToRelation },
+			resolveFieldKey as never,
+			{},
+			{},
+		);
+
+		expect(result.regularFields).toEqual({ authorId: "author-1" });
+		expect(result.nestedRelations).toEqual({});
+	});
+
+	test("removes connect while preserving mixed operations for later processing", () => {
+		const create = { name: "New author" };
+		const connectOrCreate = {
+			where: { email: "author@example.com" },
+			create,
+		};
+		const result = extractBelongsToConnectValues(
+			{},
+			{
+				author: {
+					connect: { id: "author-1" },
+					create,
+					connectOrCreate,
+				},
+			},
+			{ author: belongsToRelation },
+			resolveFieldKey as never,
+			{},
+			{},
+		);
+
+		expect(result.regularFields).toEqual({ authorId: "author-1" });
+		expect(result.nestedRelations).toEqual({
+			author: { create, connectOrCreate },
+		});
+	});
+});

--- a/packages/questpie/test/collection/type-safe-hooks.test.ts
+++ b/packages/questpie/test/collection/type-safe-hooks.test.ts
@@ -88,7 +88,7 @@ describe("Type-Safe Hooks", () => {
 			}))
 			.hooks({
 				// beforeValidate: original is NOT available (type is never)
-				beforeValidate: async ({ data, operation, original }) => {
+				beforeValidate: async ({ data, operation, original: _original }) => {
 					// original is type 'never', cannot be used
 					if (operation === "create") {
 						expectTypeOf(data).toMatchTypeOf<{
@@ -102,7 +102,7 @@ describe("Type-Safe Hooks", () => {
 					}
 				},
 				// beforeChange: original is NOT available (type is never)
-				beforeChange: async ({ data, original }) => {
+				beforeChange: async ({ data, original: _original }) => {
 					// original is type 'never', cannot be used
 					if (!data.bio) {
 						data.bio = "No bio";
@@ -169,7 +169,7 @@ describe("Type-Safe Hooks", () => {
 					}
 				},
 				// beforeDelete: original is NOT available (type is never)
-				beforeDelete: async ({ data, original }) => {
+				beforeDelete: async ({ data, original: _original }) => {
 					// original is type 'never', cannot be used
 					expectTypeOf(data).toMatchTypeOf<{
 						id: string;
@@ -182,7 +182,7 @@ describe("Type-Safe Hooks", () => {
 					}>();
 				},
 				// afterDelete: original is NOT available (type is never)
-				afterDelete: async ({ data, original }) => {
+				afterDelete: async ({ data, original: _original }) => {
 					// original is type 'never', cannot be used
 					expectTypeOf(data).toMatchTypeOf<{
 						id: string;
@@ -205,7 +205,7 @@ describe("Type-Safe Hooks", () => {
 				title: f.textarea().required(),
 			}))
 			.hooks({
-				beforeOperation: async ({ data, operation, original }) => {
+				beforeOperation: async ({ data, operation, original: _original }) => {
 					// original is type 'never', cannot be used
 
 					// data type depends on operation

--- a/packages/questpie/test/crdt/sync/store.test.ts
+++ b/packages/questpie/test/crdt/sync/store.test.ts
@@ -35,7 +35,6 @@ import {
 	questpieCrdtSessionGrantTable,
 	questpieCrdtSessionTable,
 	questpieCrdtSnapshotManifestTable,
-	questpieCrdtSnapshotTable,
 	questpieCrdtSubjectAdmissionTable,
 	questpieCrdtSubjectTable,
 	questpieCrdtTables,

--- a/packages/questpie/test/fields/field-with-methods.test.ts
+++ b/packages/questpie/test/fields/field-with-methods.test.ts
@@ -9,12 +9,8 @@ import { describe, expect, it } from "bun:test";
 import { varchar } from "drizzle-orm/pg-core";
 import { z } from "zod";
 
-import { Field, field } from "../../src/server/fields/field-class.js";
-import {
-	fieldType,
-	wrapFieldComplete,
-} from "../../src/server/fields/field-type.js";
-import type { FieldWithMethods } from "../../src/server/fields/field-with-methods.js";
+import { Field } from "../../src/server/fields/field-class.js";
+import { fieldType } from "../../src/server/fields/field-type.js";
 import { stringOps } from "../../src/server/fields/operators/builtin.js";
 
 // ============================================================================

--- a/packages/questpie/test/fields/tstate-inference.test.ts
+++ b/packages/questpie/test/fields/tstate-inference.test.ts
@@ -163,8 +163,8 @@ describe("Collection Type Inference", () => {
 
 		// Test that we can use the types
 		type PostState = typeof posts.state;
-		type PostSelect = CollectionSelect<PostState>;
-		type PostInsert = CollectionInsert<PostState>;
+		type _PostSelect = CollectionSelect<PostState>;
+		type _PostInsert = CollectionInsert<PostState>;
 
 		// Type checking only - runtime test
 		expect(posts.state.fieldDefinitions).toBeDefined();

--- a/packages/questpie/test/fields/tstate-types.test.ts
+++ b/packages/questpie/test/fields/tstate-types.test.ts
@@ -42,20 +42,20 @@ describe("TState Type Inference (compile-time only)", () => {
 		const _countVirtual: CountState["virtual"] = true;
 
 		// Input type extraction
-		type TitleInput = ExtractInputType<TitleState>; // string (required, no default)
-		type ContentInput = ExtractInputType<ContentState>; // string | null | undefined (nullable)
-		type ExcerptInput = ExtractInputType<ExcerptState>; // never (virtual, no input)
-		type CountInput = ExtractInputType<CountState>; // never (virtual, no input)
+		type _TitleInput = ExtractInputType<TitleState>; // string (required, no default)
+		type _ContentInput = ExtractInputType<ContentState>; // string | null | undefined (nullable)
+		type _ExcerptInput = ExtractInputType<ExcerptState>; // never (virtual, no input)
+		type _CountInput = ExtractInputType<CountState>; // never (virtual, no input)
 
 		// Output type extraction
-		type TitleOutput = ExtractSelectType<TitleState>; // string (notNull)
-		type ContentOutput = ExtractSelectType<ContentState>; // string | null
-		type ExcerptOutput = ExtractSelectType<ExcerptState>; // string | null
-		type CountOutput = ExtractSelectType<CountState>; // number | null
+		type _TitleOutput = ExtractSelectType<TitleState>; // string (notNull)
+		type _ContentOutput = ExtractSelectType<ContentState>; // string | null
+		type _ExcerptOutput = ExtractSelectType<ExcerptState>; // string | null
+		type _CountOutput = ExtractSelectType<CountState>; // number | null
 
 		// Column types
-		type TitleColumn = TitleState["column"]; // PgVarchar (not null)
-		type ExcerptColumn = ExcerptState["column"]; // null (virtual)
+		type _TitleColumn = TitleState["column"]; // PgVarchar (not null)
+		type _ExcerptColumn = ExcerptState["column"]; // null (virtual)
 
 		// Runtime assertions (just to have something to execute)
 		expect(titleField.getLocation()).toBe("main");
@@ -67,27 +67,27 @@ describe("TState Type Inference (compile-time only)", () => {
 	test("input variations are correctly inferred", () => {
 		// required: true
 		const requiredField = f.text().required();
-		type RequiredInput = (typeof requiredField._)["input"];
+		type _RequiredInput = (typeof requiredField._)["input"];
 		// RequiredInput narrows to true (notNull means input is required)
 
 		// default value
 		const defaultField = f.text().default("untitled");
-		type DefaultHasDefault = (typeof defaultField._)["hasDefault"];
+		type _DefaultHasDefault = (typeof defaultField._)["hasDefault"];
 		// DefaultHasDefault narrows to true
 
 		// input: false
 		const noInputField = f.text().inputFalse();
-		type NoInputFlag = (typeof noInputField._)["input"];
+		type _NoInputFlag = (typeof noInputField._)["input"];
 		// NoInputFlag narrows to false
 
 		// input: "optional"
 		const optionalField = f.text().inputOptional();
-		type OptionalInputFlag = (typeof optionalField._)["input"];
+		type _OptionalInputFlag = (typeof optionalField._)["input"];
 		// OptionalInputFlag narrows to "optional"
 
 		// virtual + input: true
 		const virtualWithInput = f.text().virtual().inputTrue();
-		type VirtualWithInputFlag = (typeof virtualWithInput._)["input"];
+		type _VirtualWithInputFlag = (typeof virtualWithInput._)["input"];
 		// VirtualWithInputFlag narrows to true
 
 		expect(requiredField._state.notNull).toBe(true);
@@ -100,19 +100,19 @@ describe("TState Type Inference (compile-time only)", () => {
 	test("output variations are correctly inferred", () => {
 		// default
 		const normalField = f.text();
-		type NormalOutput = (typeof normalField._)["output"];
+		type _NormalOutput = (typeof normalField._)["output"];
 		// NormalOutput is true (default)
 
 		// output: false
 		const hiddenField = f.text().outputFalse();
-		type HiddenOutput = (typeof hiddenField._)["output"];
+		type _HiddenOutput = (typeof hiddenField._)["output"];
 		// HiddenOutput is false
 
 		// access.read function
 		const restrictedField = f
 			.text()
 			.access({ read: (ctx: any) => (ctx.user as any)?.role === "admin" });
-		type RestrictedOutput = (typeof restrictedField._)["output"];
+		type _RestrictedOutput = (typeof restrictedField._)["output"];
 		// RestrictedOutput is still true (access doesn't change type-level output)
 
 		expect(normalField._state.output).toBe(true);

--- a/packages/questpie/test/fields/v2/field.test.ts
+++ b/packages/questpie/test/fields/v2/field.test.ts
@@ -6,24 +6,12 @@
 
 import { describe, expect, it } from "bun:test";
 
-import {
-	integer,
-	boolean as pgBoolean,
-	text as pgText,
-	varchar,
-} from "drizzle-orm/pg-core";
+import { varchar } from "drizzle-orm/pg-core";
 import { z } from "zod";
 
-import type {
-	DefaultFieldState,
-	FieldRuntimeState,
-} from "#questpie/server/fields/field-class-types.js";
+import type { DefaultFieldState } from "#questpie/server/fields/field-class-types.js";
 import { Field, field } from "#questpie/server/fields/field-class.js";
-import {
-	booleanOps,
-	numberOps,
-	stringOps,
-} from "#questpie/server/fields/operators/builtin.js";
+import { stringOps } from "#questpie/server/fields/operators/builtin.js";
 import { resolveContextualOperators } from "#questpie/server/fields/operators/resolve.js";
 import { json } from "#questpie/server/modules/core/fields/json.js";
 
@@ -45,22 +33,6 @@ function createTestTextField(maxLength = 255) {
 		output: true,
 		isArray: false,
 		maxLength,
-	});
-}
-
-function createTestNumberField() {
-	return field<DefaultFieldState & { type: "number"; data: number }>({
-		type: "number",
-		columnFactory: (name) => integer(name),
-		schemaFactory: () => z.number(),
-		operatorSet: numberOps,
-		notNull: false,
-		hasDefault: false,
-		localized: false,
-		virtual: false,
-		input: true,
-		output: true,
-		isArray: false,
 	});
 }
 

--- a/packages/questpie/test/routes/route-matcher.test.ts
+++ b/packages/questpie/test/routes/route-matcher.test.ts
@@ -251,9 +251,9 @@ describe("Route Matcher — Collision Detection", () => {
 
 describe("Route Matcher — Edge Cases", () => {
 	it("handles root path", () => {
-		const m = compileMatcher(routes(["", "root-handler"]));
 		// Empty pattern = zero segments = matches empty path
 		// This is a degenerate case; root typically handled separately
+		expect(() => compileMatcher(routes(["", "root-handler"]))).not.toThrow();
 	});
 
 	it("handles trailing slash normalization", () => {

--- a/packages/questpie/test/search/search-adapter.test.ts
+++ b/packages/questpie/test/search/search-adapter.test.ts
@@ -8,7 +8,6 @@ import {
 	type PostgresSearchAdapter,
 } from "../../src/server/modules/core/integrated/search/adapters/postgres.js";
 import { buildMockApp } from "../utils/mocks/mock-app-builder";
-import { createTestContext } from "../utils/test-context";
 import { runTestDbMigrations } from "../utils/test-db";
 
 // ============================================================================

--- a/packages/questpie/test/search/search-schema-integration.test.ts
+++ b/packages/questpie/test/search/search-schema-integration.test.ts
@@ -1,10 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 
 import { collection } from "../../src/exports/index.js";
-import {
-	createPgVectorSearchAdapter,
-	type PgVectorSearchAdapter,
-} from "../../src/server/modules/core/integrated/search/adapters/pgvector.js";
+import { createPgVectorSearchAdapter } from "../../src/server/modules/core/integrated/search/adapters/pgvector.js";
 import { createPostgresSearchAdapter } from "../../src/server/modules/core/integrated/search/adapters/postgres.js";
 import { buildMockApp } from "../utils/mocks/mock-app-builder";
 

--- a/packages/questpie/test/types/__fullapp__/service-ctx-cycle.test-d.ts
+++ b/packages/questpie/test/types/__fullapp__/service-ctx-cycle.test-d.ts
@@ -34,7 +34,6 @@ import type { NoAny } from "../_assert.js";
 import type { Equal, Expect, HasKey } from "../type-test-utils.js";
 import type { AppServices } from "./.generated/index.js";
 import { analyticsService } from "./services/analytics.js";
-import { reportingService } from "./services/reporting.js";
 
 // ── (a) The composed services fold resolves (no TS2456 degradation) ─────────
 // AppServices must carry BOTH the inferred-return cycle-trigger (`analytics`)

--- a/packages/questpie/test/types/clusters/CL-03-globals-parity.test-d.ts
+++ b/packages/questpie/test/types/clusters/CL-03-globals-parity.test-d.ts
@@ -53,7 +53,6 @@ import type {
 	HasKey,
 	IsArrayType,
 	IsNever,
-	IsUnknown,
 	NoNever,
 	NoStringIndex,
 	NoUnknown,

--- a/packages/questpie/test/types/clusters/CL-04-jobctx-module-collections.test-d.ts
+++ b/packages/questpie/test/types/clusters/CL-04-jobctx-module-collections.test-d.ts
@@ -76,10 +76,8 @@ import type {
 	Equal,
 	Expect,
 	HasKey,
-	IsAny,
 	IsNever,
 	IsEmptyObject,
-	Not,
 	NoAny,
 } from "../_assert.js";
 import type { App, Collections, QuestpieApp } from "../_fixtures.js";

--- a/packages/questpie/test/types/clusters/CRUD-create-input-output.test-d.ts
+++ b/packages/questpie/test/types/clusters/CRUD-create-input-output.test-d.ts
@@ -70,7 +70,6 @@ type StarterModule = {
 	name: "starter";
 	collections: { user: typeof starterUser; account: typeof starterAccount };
 };
-declare const starterModule: StarterModule;
 
 /**
  * Admin re-declares `user` = collection("user").merge(starter.user).<more config>.
@@ -101,7 +100,6 @@ type AdminModule = {
 	modules: readonly [StarterModule];
 	collections: { user: typeof adminUser; admin_locks: typeof adminLocks };
 };
-declare const adminModule: AdminModule;
 
 /** Top-level module tuple (what `_modules` is). */
 type Mods = readonly [AdminModule];

--- a/packages/questpie/test/types/crud-deep-typesafety.test-d.ts
+++ b/packages/questpie/test/types/crud-deep-typesafety.test-d.ts
@@ -25,7 +25,6 @@ import type {
 	CollectionRelationsFromApp,
 	CollectionSelect as CollectionSelectFromApp,
 	CreateInput,
-	CreateInputBase,
 	FindOptions,
 	UpdateInput,
 	Where as WhereType,
@@ -459,7 +458,7 @@ type ArticleFindOpts_Infer = FindOptions<typeof articles, TAppManual>;
 type ArticleFindOpts_Manual = FindOptions<typeof articles, TAppManual>;
 
 type ArticleWith_Infer = NonNullable<ArticleFindOpts_Infer["with"]>;
-type ArticleWith_Manual = NonNullable<ArticleFindOpts_Manual["with"]>;
+type _ArticleWith_Manual = NonNullable<ArticleFindOpts_Manual["with"]>;
 
 // --- Available relation keys ---
 type _inferWithHasAuthor = Expect<

--- a/packages/questpie/test/types/crud-types.test-d.ts
+++ b/packages/questpie/test/types/crud-types.test-d.ts
@@ -40,7 +40,7 @@ const postsCollection = collection("posts").fields(({ f }) => ({
 }));
 
 type PostSelect = typeof postsCollection.$infer.select;
-type PostInsert = typeof postsCollection.$infer.insert;
+type _PostInsert = typeof postsCollection.$infer.insert;
 
 // ============================================================================
 // WhereOperators tests

--- a/packages/questpie/test/types/functions-jobs.test-d.ts
+++ b/packages/questpie/test/types/functions-jobs.test-d.ts
@@ -17,7 +17,6 @@ import type {
 	JsonRouteDefinition,
 	RouteParamsFromKey,
 	RawRouteDefinition,
-	RouteDefinition,
 	RouteWithParams,
 } from "#questpie/server/routes/types.js";
 import { isJsonRoute, isRawRoute } from "#questpie/server/routes/types.js";
@@ -30,13 +29,7 @@ declare module "#questpie/server/config/app-context.js" {
 	}
 }
 
-import type {
-	Equal,
-	Expect,
-	Extends,
-	HasKey,
-	IsNever,
-} from "./type-test-utils.js";
+import type { Equal, Expect, Extends, HasKey } from "./type-test-utils.js";
 
 // ============================================================================
 // route() - JSON route type tests
@@ -88,7 +81,7 @@ const validateRoute = route()
 			errors: z.array(z.string()),
 		}),
 	)
-	.handler(async ({ input }) => {
+	.handler(async ({ input: _input }) => {
 		return { valid: true, errors: [] };
 	});
 
@@ -98,17 +91,16 @@ type _validateHasOutputSchema = Expect<
 >;
 
 // Route with session context
-const protectedRoute = route()
+const _protectedRoute = route()
 	.post()
 	.schema(z.object({ action: z.string() }))
-	.handler(async ({ input, session }) => {
-		// session should be available
-		const userId = session?.user?.id;
-		return { success: true, userId };
+	.handler(async ({ input: _input, session }) => {
+		const _userId = session?.user?.id;
+		return { success: true, userId: _userId };
 	});
 
 // Complex input schema should preserve nested types
-const complexRoute = route()
+const _complexRoute = route()
 	.post()
 	.schema(
 		z.object({
@@ -125,9 +117,8 @@ const complexRoute = route()
 		}),
 	)
 	.handler(async ({ input }) => {
-		// All nested types should be inferred
-		const theme = input.user.preferences.theme; // "light" | "dark"
-		const tags = input.tags; // string[]
+		const _theme = input.user.preferences.theme;
+		const _tags = input.tags;
 		return { processed: true };
 	});
 
@@ -147,7 +138,7 @@ type _getRouteHasMethod = Expect<Equal<HasKey<GetRouteType, "method">, true>>;
 const rawRoute = route()
 	.post()
 	.raw()
-	.handler(async ({ request }) => {
+	.handler(async ({ request: _request }) => {
 		return new Response("ok");
 	});
 
@@ -211,10 +202,10 @@ const sendEmailJob = job({
 		subject: z.string(),
 		body: z.string(),
 	}),
-	handler: async ({ payload }) => {
+	handler: async ({ payload: _payload }) => {
 		// payload should have correct types
-		const to: string = payload.to;
-		const subject: string = payload.subject;
+		const _to: string = _payload.to;
+		const _subject: string = _payload.subject;
 	},
 });
 
@@ -235,7 +226,7 @@ const processImageJob = job({
 		),
 	}),
 	handler: async ({ payload }) => {
-		const imageId: string = payload.imageId;
+		const _imageId: string = payload.imageId;
 		const ops = payload.operations;
 		return { processed: true, operationCount: ops.length };
 	},
@@ -250,7 +241,7 @@ type _processImageIsJobDef = Expect<
 const calculateJob = job({
 	name: "calculate-stats",
 	schema: z.object({ datasetId: z.string() }),
-	handler: async ({ payload }) => {
+	handler: async ({ payload: _payload }) => {
 		return {
 			mean: 0,
 			median: 0,
@@ -271,35 +262,26 @@ type _calculateHasHandler = Expect<
 >;
 
 // Job with app in handler context
-const notifyJob = job({
+const _notifyJob = job({
 	name: "notify-users",
-	schema: z.object({
-		userIds: z.array(z.string()),
-		message: z.string(),
-	}),
-	handler: async ({ payload, db }) => {
-		// db should be available for accessing database
+	schema: z.object({ userIds: z.array(z.string()), message: z.string() }),
+	handler: async ({ payload, db: _db }) => {
 		const users = payload.userIds;
 		return { notified: users.length };
 	},
 });
 
 // Job with optional fields in schema
-const syncJob = job({
+const _syncJob = job({
 	name: "sync-data",
 	schema: z.object({
 		source: z.string(),
 		destination: z.string(),
-		options: z
-			.object({
-				force: z.boolean(),
-				dryRun: z.boolean(),
-			})
-			.optional(),
+		options: z.object({ force: z.boolean(), dryRun: z.boolean() }).optional(),
 	}),
 	handler: async ({ payload }) => {
-		const force = payload.options?.force;
-		const dryRun = payload.options?.dryRun;
+		const _force = payload.options?.force;
+		const _dryRun = payload.options?.dryRun;
 		return { synced: true };
 	},
 });
@@ -309,17 +291,16 @@ const syncJob = job({
 // ============================================================================
 
 // Void return in job handler
-const logJob = job({
+const _logJob = job({
 	name: "log-event",
 	schema: z.object({ event: z.string() }),
 	handler: async ({ payload }) => {
-		// No return - void
 		console.log(payload.event);
 	},
 });
 
 // Union types in schema
-const actionRoute = route()
+const _actionRoute = route()
 	.post()
 	.schema(
 		z.object({
@@ -337,7 +318,7 @@ const actionRoute = route()
 	});
 
 // Discriminated unions
-const webhookJob = job({
+const _webhookJob = job({
 	name: "process-webhook",
 	schema: z.discriminatedUnion("type", [
 		z.object({
@@ -360,7 +341,7 @@ const webhookJob = job({
 });
 
 // Nullable schema fields
-const updateRoute = route()
+const _updateRoute = route()
 	.post()
 	.schema(
 		z.object({
@@ -370,8 +351,8 @@ const updateRoute = route()
 		}),
 	)
 	.handler(async ({ input }) => {
-		const name: string | null = input.name;
-		const desc: string | null | undefined = input.description;
+		const _name: string | null = input.name;
+		const _desc: string | null | undefined = input.description;
 		return { updated: true };
 	});
 
@@ -397,7 +378,7 @@ type _testRouteHasBrand = Expect<Equal<HasKey<TestRouteType, "__brand">, true>>;
 const testJob = job({
 	name: "test-job",
 	schema: z.object({ data: z.string() }),
-	handler: async ({ payload }) => {},
+	handler: async ({ payload: _payload }) => {},
 });
 
 type TestJobType = typeof testJob;

--- a/packages/questpie/test/types/global-builder.test-d.ts
+++ b/packages/questpie/test/types/global-builder.test-d.ts
@@ -8,7 +8,6 @@
  * Run with: tsc --noEmit
  */
 
-import { sql } from "drizzle-orm";
 import { boolean, integer, jsonb, text, varchar } from "drizzle-orm/pg-core";
 
 import type { GlobalBuilder } from "#questpie/server/global/builder/global-builder.js";
@@ -108,14 +107,13 @@ type _maintenanceOptional = Expect<
 // ============================================================================
 
 // Hooks should type data correctly
-const hooksSettings = global("settings")
+const _hooksSettings = global("settings")
 	.fields({
 		siteName: text("site_name").notNull(),
 		maintenanceMode: boolean("maintenance_mode"),
 	})
 	.hooks({
 		afterChange: async ({ data }) => {
-			// data should be select type
 			const _id: string = data.id;
 			const _siteName: string = data.siteName;
 		},
@@ -126,20 +124,14 @@ const hooksSettings = global("settings")
 // ============================================================================
 
 // Access should type context with session
-const accessSettings = global("settings")
+const _accessSettings = global("settings")
 	.fields({
 		siteName: text("site_name"),
 		adminOnly: boolean("admin_only"),
 	})
 	.access({
-		read: ({ session }) => {
-			// Anyone can read
-			return true;
-		},
-		update: ({ session }) => {
-			// Only authenticated users can update
-			return !!session?.user;
-		},
+		read: ({ session: _session }) => true,
+		update: ({ session }) => !!session?.user,
 	});
 
 // ============================================================================
@@ -158,7 +150,7 @@ const complexSettings = global("site_settings")
 		}>(),
 	})
 	.hooks({
-		beforeChange: async ({ data }) => {
+		beforeChange: async ({ data: _data }) => {
 			// Can access data fields
 		},
 	})

--- a/packages/questpie/test/types/shared-type-utils.test-d.ts
+++ b/packages/questpie/test/types/shared-type-utils.test-d.ts
@@ -22,7 +22,6 @@ import type {
 	GlobalUpdate,
 	Prettify,
 	RelationShape,
-	ResolveRelations,
 } from "#questpie/shared/type-utils.js";
 
 import type {

--- a/packages/questpie/test/types/unified-api-types.test-d.ts
+++ b/packages/questpie/test/types/unified-api-types.test-d.ts
@@ -894,7 +894,7 @@ type _authorResultExactEmail = Expect<Equal<AuthorInResult["email"], string>>;
 // ============================================================================
 
 // --- Top-level: title operators are concrete ---
-type PostsWhereTitle = NonNullable<PostsWhereCheck["title"]>;
+type _PostsWhereTitle = NonNullable<PostsWhereCheck["title"]>;
 // title should accept string directly or operator object with string operators
 const _whereTitleContains: PostsWhereCheck = { title: { contains: "hello" } };
 const _whereTitleStartsWith: PostsWhereCheck = {

--- a/packages/questpie/test/unit/mailer/email-template.test.ts
+++ b/packages/questpie/test/unit/mailer/email-template.test.ts
@@ -4,11 +4,9 @@ import { z } from "zod";
 
 import {
 	email,
-	type EmailTemplateDefinition,
 	type InferEmailTemplateInput,
 	type InferEmailTemplateContext,
 	type EmailResult,
-	type EmailHandlerArgs,
 } from "../../../src/server/modules/core/integrated/mailer/template.js";
 
 describe("email() factory", () => {

--- a/packages/questpie/test/unit/services/namespace-projection.test.ts
+++ b/packages/questpie/test/unit/services/namespace-projection.test.ts
@@ -7,12 +7,11 @@
  * 3. extractAppServices includes scoped null-namespace services at top level
  * 4. Singleton null-namespace services work as before
  */
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 
 import { collection, service } from "../../../src/exports/index.js";
 import { extractAppServices } from "../../../src/server/config/app-context.js";
 import { buildMockApp } from "../../utils/mocks/mock-app-builder";
-import { createTestContext } from "../../utils/test-context";
 import { runTestDbMigrations } from "../../utils/test-db";
 
 describe("Namespace + Lifecycle Projection (QUE-260)", () => {

--- a/packages/questpie/test/units/queue-runtime.test.ts
+++ b/packages/questpie/test/units/queue-runtime.test.ts
@@ -342,6 +342,42 @@ describe("queue runtime api", () => {
 		expect(adapter.getScheduledJob("internal-b")?.cron).toBe("0 * * * *");
 	});
 
+	test("registerSchedules passes cron once and omits publish-only timing options", async () => {
+		const adapter = new MockQueueAdapter();
+		const queue = createQueueClient(
+			{
+				notify: {
+					name: "notify",
+					schema: z.object({}).passthrough(),
+					handler: async () => {},
+					options: {
+						cron: "0 * * * *",
+						startAfter: 30,
+						retryLimit: 4,
+					},
+				},
+			},
+			adapter,
+			{
+				createContext: async () => ({ db: {} }),
+				getApp: () => ({ name: "app" }),
+			},
+		);
+
+		await queue.registerSchedules();
+
+		expect(adapter.getScheduledJob("notify")).toMatchObject({
+			cron: "0 * * * *",
+			options: { retryLimit: 4 },
+		});
+		expect(adapter.getScheduledJob("notify")?.options).not.toHaveProperty(
+			"cron",
+		);
+		expect(adapter.getScheduledJob("notify")?.options).not.toHaveProperty(
+			"startAfter",
+		);
+	});
+
 	test("queue exposes literal job name aliases", async () => {
 		const adapter = new MockQueueAdapter();
 		const queue = createQueueClient(

--- a/packages/questpie/test/utils/test-migrations.ts
+++ b/packages/questpie/test/utils/test-migrations.ts
@@ -111,7 +111,7 @@ export async function setupTestMigrations(
 	// Generate migrations for each collection
 	const collectionMigrations: Migration[] = [];
 
-	for (const collection of collections) {
+	for (const _collection of collections) {
 		// For testing, we still need to use manual DDL
 		// But in the future, we can use Drizzle Kit to generate SQL
 		// For now, this is a placeholder that documents the approach

--- a/packages/sandbox/src/guest-bindings.ts
+++ b/packages/sandbox/src/guest-bindings.ts
@@ -23,6 +23,23 @@
 /** Transport: send one binding RPC, resolve with its brokered value or reject. */
 export type HostCall = (method: string, args: unknown) => Promise<unknown>;
 
+/** Relay brokered fetch and retain a rejected host call as the fetch error cause. */
+export async function callBrokeredFetch<T>(
+	hostCall: HostCall,
+	request: unknown,
+): Promise<T> {
+	try {
+		return (await hostCall("http.fetch", request)) as T;
+	} catch (error) {
+		throw new TypeError(
+			error instanceof Error ? error.message : String(error),
+			{
+				cause: error,
+			},
+		);
+	}
+}
+
 /**
  * Per-collection access surface. Reads (`find`/`findOne`) are always available;
  * writes (`create`/`update`/`delete`) are dispatched ONLY where the host wires a

--- a/packages/sandbox/src/guest-entry.ts
+++ b/packages/sandbox/src/guest-entry.ts
@@ -40,7 +40,7 @@
 
 import nodeProcess from "node:process";
 
-import { buildGuestBindings } from "./guest-bindings.ts";
+import { buildGuestBindings, callBrokeredFetch } from "./guest-bindings.ts";
 
 /** Marker so the supervisor can pick the result line out of guest stdout noise. */
 const RESULT_MARKER = "__QP_SANDBOX_RESULT__";
@@ -336,6 +336,7 @@ function installFetchShim(
 		} catch (e) {
 			throw new TypeError(
 				`Failed to construct fetch request: ${e instanceof Error ? e.message : String(e)}`,
+				{ cause: e },
 			);
 		}
 
@@ -367,12 +368,7 @@ function installFetchShim(
 		// Relay over the existing stdio RPC channel. A structured broker error
 		// (network failure / blocked target / oversize) arrives as a rejected
 		// hostCall — surface it as a fetch-like TypeError, NOT a fake 5xx Response.
-		let value: HttpFetchResponse;
-		try {
-			value = (await hostCall("http.fetch", request)) as HttpFetchResponse;
-		} catch (e) {
-			throw new TypeError(e instanceof Error ? e.message : String(e));
-		}
+		const value = await callBrokeredFetch<HttpFetchResponse>(hostCall, request);
 
 		const status = typeof value?.status === "number" ? value.status : 0;
 		const body = value?.bodyBase64

--- a/packages/sandbox/src/guest-runtime-source.ts
+++ b/packages/sandbox/src/guest-runtime-source.ts
@@ -1,5 +1,5 @@
 const GUEST_BINDINGS_IMPORT =
-	'import { buildGuestBindings } from "./guest-bindings.ts";';
+	'import { buildGuestBindings, callBrokeredFetch } from "./guest-bindings.ts";';
 const HTTP_BODY_CAP_MARKER = "__QP_HTTP_FETCH_BODY_CAP_BYTES__";
 
 /** Inline the trusted dependency so the guest entry needs no host path/socket. */

--- a/packages/sandbox/test/bindings-e2e.test.ts
+++ b/packages/sandbox/test/bindings-e2e.test.ts
@@ -676,7 +676,11 @@ function guestFetchSource(url: string, init?: string): string {
 				text,
 			};
 		} catch (e) {
-			return { fetched: false, message: String(e && e.message || e) };
+			return {
+				fetched: false,
+				message: String(e && e.message || e),
+				causeMessage: String(e && e.cause && e.cause.message || e && e.cause || ""),
+			};
 		}
 	}`;
 }
@@ -690,6 +694,7 @@ interface GuestFetchOut {
 	fromBroker?: string | null;
 	text?: string;
 	message?: string;
+	causeMessage?: string;
 }
 
 async function runGuestFetch(
@@ -743,6 +748,13 @@ describe.if(!!denoPath)(
 			expect(originSeen[0]?.host).toBe(`${ALLOWED_HOST}:${originPort}`);
 			expect(originSeen[0]?.method).toBe("POST");
 			expect(originSeen[0]?.body).toBe("ping");
+		}, 20_000);
+
+		it("preserves request construction failures as the fetch error cause", async () => {
+			const out = await runGuestFetch({ net: [] }, "http://[");
+			expect(out.fetched).toBe(false);
+			expect(out.message).toStartWith("Failed to construct fetch request:");
+			expect(out.causeMessage).not.toBe("");
 		}, 20_000);
 
 		// ── ★ THE REBIND ACCEPTANCE — the headline regression. ──

--- a/packages/sandbox/test/guest-bindings.test.ts
+++ b/packages/sandbox/test/guest-bindings.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "bun:test";
 
-import { buildGuestBindings } from "../src/guest-bindings.js";
+import {
+	buildGuestBindings,
+	callBrokeredFetch,
+} from "../src/guest-bindings.js";
 
 // ──────────────────────────────────────────────────────────────────────────
 // The guest bindings proxy is pure wire-shaping over an injected `hostCall`.
@@ -245,5 +248,20 @@ describe("error propagation: a rejecting hostCall rejects the proxied call", () 
 		await expect(
 			q.store.posts.create({ key: "k1", data: { v: 1 } }),
 		).rejects.toBe(denied);
+	});
+
+	it("brokered fetch wraps a rejected hostCall and preserves its cause", async () => {
+		const denied = new Error("sandbox binding operation failed");
+		const { hostCall } = rejector(denied);
+
+		try {
+			await callBrokeredFetch(hostCall, { url: "https://example.com" });
+			expect.unreachable("brokered fetch should reject");
+		} catch (error) {
+			expect(error).toBeInstanceOf(TypeError);
+			if (!(error instanceof TypeError)) return;
+			expect(error.message).toBe(denied.message);
+			expect(error.cause).toBe(denied);
+		}
 	});
 });

--- a/packages/sandbox/test/guest-runtime-source.test.ts
+++ b/packages/sandbox/test/guest-runtime-source.test.ts
@@ -8,7 +8,7 @@ import {
 describe("guest runtime source transport", () => {
 	it("inlines trusted bindings without a host path or network import", () => {
 		const bundled = bundleGuestRuntimeSource(
-			'import { buildGuestBindings } from "./guest-bindings.ts";\nconst cap = __QP_HTTP_FETCH_BODY_CAP_BYTES__;\nexport default buildGuestBindings;',
+			'import { buildGuestBindings, callBrokeredFetch } from "./guest-bindings.ts";\nconst cap = __QP_HTTP_FETCH_BODY_CAP_BYTES__;\nexport default buildGuestBindings;',
 			"export function buildGuestBindings() { return 'ready'; }",
 			123,
 		);

--- a/packages/workflows/src/server/engine/compensation.ts
+++ b/packages/workflows/src/server/engine/compensation.ts
@@ -96,6 +96,7 @@ export async function runCompensations(
 	};
 
 	// Run in reverse order (LIFO — last completed step compensates first)
+	// oxlint-disable-next-line unicorn/no-array-reverse -- the spread already isolates the input and ES2023 toReversed is outside the supported target.
 	const reversed = [...compensations].reverse();
 
 	for (const entry of reversed) {

--- a/packages/workflows/src/server/engine/cron.ts
+++ b/packages/workflows/src/server/engine/cron.ts
@@ -167,7 +167,7 @@ export function cronFiredInWindow(
 	const fields = parseCron(expression);
 
 	// Iterate each minute in the window
-	const current = new Date(windowStart);
+	let current = new Date(windowStart);
 	// Floor to the start of the minute
 	current.setSeconds(0, 0);
 
@@ -181,7 +181,9 @@ export function cronFiredInWindow(
 		) {
 			return true;
 		}
-		current.setMinutes(current.getMinutes() + 1);
+		const next = new Date(current);
+		next.setMinutes(next.getMinutes() + 1);
+		current = next;
 	}
 
 	return false;

--- a/packages/workflows/src/server/modules/workflows/jobs/wf-execute.ts
+++ b/packages/workflows/src/server/modules/workflows/jobs/wf-execute.ts
@@ -204,7 +204,7 @@ export const wfExecuteJob = job({
 						}
 						return null;
 					},
-					async findWaitingSteps(eventName, matchData) {
+					async findWaitingSteps(eventName, _matchData) {
 						const result = await stepsCrud.find(
 							{
 								where: {

--- a/packages/workflows/test/client/client.test.ts
+++ b/packages/workflows/test/client/client.test.ts
@@ -191,7 +191,7 @@ describe("createWorkflowClient", () => {
 			});
 			const client = createWorkflowClient({ "timed-wf": timedWorkflow }, deps);
 
-			const result = await client.trigger("timed-wf", { taskId: "t1" });
+			const _result = await client.trigger("timed-wf", { taskId: "t1" });
 			const instance = instanceStore.values().next().value;
 
 			expect(instance).toBeDefined();

--- a/packages/workflows/test/engine/step-events.test.ts
+++ b/packages/workflows/test/engine/step-events.test.ts
@@ -91,7 +91,7 @@ describe("step.sendEvent", () => {
 	it("dispatches event and persists step as completed", async () => {
 		const { persistence: eventPersistence, store } =
 			createMockEventPersistence();
-		const { fn: resumeWaiter, calls: resumeCalls } = createMockResumeWaiter();
+		const { fn: resumeWaiter } = createMockResumeWaiter();
 
 		const { ctx, log } = createTestStepContext({
 			eventPersistence,
@@ -270,7 +270,7 @@ describe("step.run with timeout", () => {
 	});
 
 	it("step.run with opts but no timeout works normally", async () => {
-		const { ctx, log } = createTestStepContext();
+		const { ctx } = createTestStepContext();
 		const compensateCalls: any[] = [];
 
 		const result = await ctx.run(

--- a/scripts/any-census.json
+++ b/scripts/any-census.json
@@ -56,7 +56,7 @@
 			"@ts-expect-error": 0
 		},
 		"questpie": {
-			": any": 540,
+			": any": 538,
 			"as any": 462,
 			"as unknown as": 49,
 			"@ts-expect-error": 0

--- a/scripts/audit-gate.ts
+++ b/scripts/audit-gate.ts
@@ -42,7 +42,7 @@ if (!stdout.trim()) {
 let advisories: Record<string, Advisory[]>;
 try {
 	advisories = JSON.parse(stdout);
-} catch (err) {
+} catch {
 	console.error("Could not parse `bun audit --json` output:");
 	console.error(stdout);
 	console.error(proc.stderr.toString());

--- a/scripts/lint-census.json
+++ b/scripts/lint-census.json
@@ -1,5 +1,5 @@
 {
-	"$comment": "oxlint WARNING counts per package per rule. Errors are gated separately by the Lint & Format job. Regenerate with `bun run scripts/lint-census.ts --update` and review the diff. Ratchet: any per-rule increase fails CI. NOTE: no-underscore-dangle dominates this baseline and is largely a house convention (_state, _pendingRelations) rather than debt — configuring or dropping that rule is a better fix than burning it down. See the script header.",
+	"$comment": "oxlint WARNING counts per package per rule. Errors are gated separately by the Lint & Format job. Regenerate with `bun run scripts/lint-census.ts --update` and review the diff. Ratchet: any per-rule increase fails CI.",
 	"packages": {
 		"admin": {
 			"eslint(no-unused-vars)": 150,
@@ -14,31 +14,15 @@
 		"mcp": {},
 		"next": {},
 		"observability": {},
-		"openapi": {
-			"eslint(no-unused-vars)": 1
-		},
-		"questpie": {
-			"eslint(no-unused-vars)": 148,
-			"eslint(no-useless-concat)": 3,
-			"eslint(preserve-caught-error)": 1,
-			"typescript(no-confusing-non-null-assertion)": 1,
-			"unicorn(no-array-reverse)": 2
-		},
-		"sandbox": {
-			"eslint(preserve-caught-error)": 2
-		},
-		"scripts": {
-			"eslint(no-unused-vars)": 1
-		},
+		"openapi": {},
+		"questpie": {},
+		"sandbox": {},
+		"scripts": {},
 		"tanstack-db": {},
 		"tanstack-query": {},
 		"testing": {},
 		"tokens": {},
 		"vite-plugin-iconify": {},
-		"workflows": {
-			"eslint(no-unmodified-loop-condition)": 2,
-			"eslint(no-unused-vars)": 4,
-			"unicorn(no-array-reverse)": 1
-		}
+		"workflows": {}
 	}
 }

--- a/scripts/lint-census.ts
+++ b/scripts/lint-census.ts
@@ -7,25 +7,9 @@
  * scripts/any-census.ts: freeze the counts, fail on an increase, burn down over
  * time.
  *
- * ONE RULE IS DELIBERATELY NOT GOVERNED — see IGNORED_RULES below. At the time
- * this was written 1114 of 1443 warnings, 77%, were
- * `eslint(no-underscore-dangle)`, 980 of them in `questpie` alone. This
- * codebase uses a leading underscore as a deliberate convention for internal
- * members — `_state`, `_pendingRelations`, `_internalRelatedTable`,
- * `_getVirtuals` — so those are not debt, they are a preset rule disagreeing
- * with a house style.
- *
- * Ratcheting them would make adding one more `_internal` field, i.e. following
- * the project's own convention, fail CI. The developer's options would then be
- * to pad the baseline or to rename against the style, and the third option —
- * disabling the gate — is exactly how the 85 lint errors accumulated while that
- * job sat commented out. A gate that fights the codebase loses.
- *
- * Excluding it here rather than editing .oxlintrc.json keeps the decision
- * inside this script: the warnings still appear in lint output, unchanged, and
- * whether to configure or drop the rule stays the owner's call. What remains
- * governed is 329 warnings — admin 160, questpie 158, the rest in single
- * digits — dominated by `no-unused-vars`, which is real debt.
+ * `eslint/no-underscore-dangle` is disabled in the root Oxlint config because
+ * leading underscores are the repository's documented house convention for
+ * internal members. Every warning emitted here is therefore governed debt.
  *
  * Usage:
  *   bun run scripts/lint-census.ts            # check against baseline
@@ -50,16 +34,6 @@ type Diagnostic = {
 	code?: string;
 	severity?: string;
 	filename?: string;
-};
-
-/**
- * Rules whose warnings are counted but never ratcheted. Entries need a reason
- * that says why the rule is wrong for THIS codebase, not why the warnings are
- * inconvenient.
- */
-const IGNORED_RULES: Record<string, string> = {
-	"eslint(no-underscore-dangle)":
-		"leading underscore is the house convention for internal members (_state, _pendingRelations, _internalRelatedTable); ratcheting it would fail CI for following the project's own style",
 };
 
 /** Discovered, never hand-listed — a new package shows up and must be baselined. */
@@ -105,16 +79,11 @@ const current: Record<string, Record<string, number>> = {};
 for (const name of [...packageDirs(), "scripts"]) current[name] = {};
 
 let unattributed = 0;
-let ignored = 0;
 for (const d of diagnostics) {
 	// Errors are already gated by the Lint & Format job; this census is the
 	// warning backlog it deliberately leaves ungated.
 	if (d.severity !== "warning") continue;
 	const code = d.code ?? "unknown";
-	if (code in IGNORED_RULES) {
-		ignored += 1;
-		continue;
-	}
 	const owner = d.filename ? ownerOf(d.filename) : null;
 	if (!owner || !(owner in current)) {
 		unattributed += 1;
@@ -158,11 +127,6 @@ const grand = owners.reduce(
 	0,
 );
 console.log(`\n  total ${grand}`);
-if (ignored > 0) {
-	console.log(
-		`  (${ignored} not governed: ${Object.keys(IGNORED_RULES).join(", ")})`,
-	);
-}
 if (unattributed > 0) {
 	console.log(`  (${unattributed} warnings outside packages/ and scripts/)`);
 }
@@ -184,7 +148,7 @@ if (wantUpdate) {
 
 	const next: Baseline = {
 		$comment:
-			"oxlint WARNING counts per package per rule. Errors are gated separately by the Lint & Format job. Regenerate with `bun run scripts/lint-census.ts --update` and review the diff. Ratchet: any per-rule increase fails CI. NOTE: no-underscore-dangle dominates this baseline and is largely a house convention (_state, _pendingRelations) rather than debt — configuring or dropping that rule is a better fix than burning it down. See the script header.",
+			"oxlint WARNING counts per package per rule. Errors are gated separately by the Lint & Format job. Regenerate with `bun run scripts/lint-census.ts --update` and review the diff. Ratchet: any per-rule increase fails CI.",
 		packages: sorted,
 	};
 	writeFileSync(BASELINE_PATH, `${JSON.stringify(next, null, "\t")}\n`);


### PR DESCRIPTION
## Summary

- encode the existing leading-underscore convention and remove 1078 ungoverned false positives
- eliminate all 160 governed non-admin warnings while leaving `packages/admin/**` untouched at 158 warnings
- preserve public callback signatures and existing type assertions
- retain nested-connect and queue-scheduling semantics with intentional underscore bindings
- preserve wrapped CLI and sandbox errors as `cause`, including direct rejecting-`hostCall` coverage
- ratchet lint/any censuses and add patch changesets

## Why this spans packages

This is one governed Oxlint rule-family campaign, not a collection of feature refactors. The same warning families were cleared across non-admin packages so the shared census can move from 160 to zero in one atomic ratchet. Admin hygiene remains a separate lane.

The commits remain mechanically reviewable:

1. encode the underscore convention
2. clear non-admin source warnings
3. make non-admin test fixtures intentional and prove preserved semantics
4. ratchet censuses and record the mechanical release note
5. isolate the `Error.cause` behavior, its direct tests, and its own changeset

## Measured result

- governed lint: 318 → 158
- non-admin governed lint: 160 → 0
- admin governed lint: 158 → 158
- `questpie` `: any`: 540 → 538; all other any baselines unchanged
- unreachable modules: 0 → 0

## Review regressions

- connect-only extraction removes the consumed relation; mixed connect/create/connectOrCreate retains later operations
- cron is passed once to the queue adapter and neither cron nor startAfter leaks into schedule options
- the root route matcher edge-case test again invokes the compiler and asserts the result
- sandbox tests assert both malformed-Request cause and direct broker hostCall rejection cause identity

## Verification

- `bun run lint`
- `bun run scripts/audit-gate.ts`
- `bun run check-types`
- `bunx turbo run build --filter=./packages/*`
- `bun run format:check`
- `git diff --check`
- focused QUESTPIE semantic suites: 51/51
- sandbox runtime/bindings suites: 39/39

## Scope note

The root build currently fails outside this diff in `tanstack-barbershop-example#build`: SSR import protection rejects `src/questpie/server/env.ts` importing `./env.client` because it resolves to the denied `**/*.client.*` pattern. This lint-only PR does not alter that example architecture. Full root Build remains visible in PR CI.

No migration is required.