### PR TITLE
fix(release): add observability to fixed version train

### DIFF
--- a/.changeset/align-observability-fixed.md
+++ b/.changeset/align-observability-fixed.md
@@ -1,4 +1,0 @@
----
----
-
-Record the one-time `@questpie/observability` version alignment with the QUESTPIE fixed release train. The package version and changelog are release metadata in this correction PR, so this changeset intentionally schedules no second version bump.

--- a/.changeset/align-observability-fixed.md
+++ b/.changeset/align-observability-fixed.md
@@ -1,0 +1,4 @@
+---
+---
+
+Record the one-time `@questpie/observability` version alignment with the QUESTPIE fixed release train. The package version and changelog are release metadata in this correction PR, so this changeset intentionally schedules no second version bump.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -14,6 +14,7 @@
 			"@questpie/hono",
 			"@questpie/mcp",
 			"@questpie/next",
+			"@questpie/observability",
 			"@questpie/openapi",
 			"@questpie/sandbox",
 			"@questpie/tanstack-db",

--- a/bun.lock
+++ b/bun.lock
@@ -389,7 +389,7 @@
     },
     "packages/observability": {
       "name": "@questpie/observability",
-      "version": "3.18.1",
+      "version": "3.27.0",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/api-logs": "^0.221.0",

--- a/packages/observability/CHANGELOG.md
+++ b/packages/observability/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @questpie/observability
 
+## 3.27.0
+
+### Minor Changes
+
+- Align `@questpie/observability` with the QUESTPIE `3.27.0` fixed release train. This is a version-alignment release only; its runtime code is identical to `3.18.1`.
+
 ## 3.18.1
 
 ### Patch Changes

--- a/packages/observability/package.json
+++ b/packages/observability/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@questpie/observability",
-	"version": "3.18.1",
+	"version": "3.27.0",
 	"description": "OpenTelemetry adapter for QUESTPIE — traces and metrics via OTLP",
 	"license": "MIT",
 	"repository": {

--- a/scripts/publish-manifest.test.ts
+++ b/scripts/publish-manifest.test.ts
@@ -7,6 +7,7 @@ import elysiaPackageJson from "../packages/elysia/package.json";
 import honoPackageJson from "../packages/hono/package.json";
 import mcpPackageJson from "../packages/mcp/package.json";
 import nextPackageJson from "../packages/next/package.json";
+import observabilityPackageJson from "../packages/observability/package.json";
 import openApiPackageJson from "../packages/openapi/package.json";
 import questpiePackageJson from "../packages/questpie/package.json";
 import sandboxPackageJson from "../packages/sandbox/package.json";
@@ -78,6 +79,8 @@ describe("publish manifest workspace dependencies", () => {
 			questpie: "^3.17.0",
 		});
 		expect(adminPackageJson.version).toBe(questpiePackageJson.version);
+		expect(observabilityPackageJson.version).toBe(questpiePackageJson.version);
+		expect(changesetConfig.fixed[0]).toContain(observabilityPackageJson.name);
 		expect(
 			changesetConfig.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH
 				.onlyUpdatePeerDependentsWhenOutOfRange,


### PR DESCRIPTION
## What changed

- Add `@questpie/observability` to the QUESTPIE Changesets fixed group.
- Add a regression test requiring observability to remain in the fixed group and share `questpie`'s version.
- One-time align the already-published observability line from `3.18.1` to the current train version `3.27.0`.
- Record the alignment in its changelog and lockfile. Runtime package code is unchanged from `3.18.1`.

## Why this is a manual alignment release

A normal patch changeset after joining the fixed group would bump all fourteen packages to `3.27.1`. This PR instead fills the missing `@questpie/observability@3.27.0` slot without republishing the thirteen packages already at `3.27.0`. It intentionally contains no changeset because the version, changelog and lockfile are already the final release metadata. Changesets Action calls the custom publisher only when no changesets remain; an empty changeset would suppress both release-PR creation and publishing.

## Proof

- Changesets release plan: `[]`
- Publish dry-run: skips every existing package and validates only `@questpie/observability@3.27.0`
- Observability typecheck + build
- Publish-manifest contract: 4/4
- Audit, size budget, any census, format, lint and diff checks

## Release procedure

After merge, the release workflow directly invokes the registry-aware custom publisher. It publishes only observability `3.27.0` and creates only its package GitHub release. Future releases version all fourteen fixed packages together.