### PR TITLE
fix(oauth): preserve mounted discovery issuer

### DIFF
--- a/.changeset/fair-dodos-discover.md
+++ b/.changeset/fair-dodos-discover.md
@@ -1,0 +1,6 @@
+---
+"questpie": patch
+"@questpie/hono": patch
+---
+
+Advertise the exact mounted OAuth issuer in MCP protected-resource metadata, and return a real 404 from unmatched Hono mounts so standards-based discovery can continue to its supported fallback endpoint.

--- a/packages/hono/src/server.ts
+++ b/packages/hono/src/server.ts
@@ -101,7 +101,7 @@ export function questpieHono<TQuestpie = Questpie<any>>(
 	const honoApp = new Hono<{
 		Variables: QuestpieVariables<TQuestpie>;
 	}>()
-		.notFound((context) => context.res)
+		.notFound((context) => context.body(null, 404))
 		.use("*", async (c, next) => {
 			const storedContext = adapterContexts.get(c.req.raw);
 			const hasCompatibilityContext = storedContext?.app === app;

--- a/packages/hono/test/server-composition.test.ts
+++ b/packages/hono/test/server-composition.test.ts
@@ -356,6 +356,10 @@ describe("hono adapter composition", () => {
 		);
 		expect(explicitResponse.status).toBe(200);
 		expect(await explicitResponse.text()).toBe("pong");
+		const outsideResponse = await explicitBasePath.request(
+			"http://localhost/.well-known/oauth-authorization-server/api/auth",
+		);
+		expect(outsideResponse.status).toBe(404);
 
 		const rootResponse = await rootMount.request("http://localhost/ping");
 		expect(rootResponse.status).toBe(200);

--- a/packages/mcp/test/oauth-mcp-e2e.test.ts
+++ b/packages/mcp/test/oauth-mcp-e2e.test.ts
@@ -40,6 +40,7 @@ import { describe, expect, it } from "bun:test";
 import { createHash, randomBytes } from "node:crypto";
 
 import { oauthProvider } from "@better-auth/oauth-provider";
+import { discoverOAuthServerInfo } from "@modelcontextprotocol/sdk/client/auth.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -418,6 +419,90 @@ describe("MO13 end-to-end OAuth MCP flow + system mode", () => {
 	}
 
 	// ── (a) external client: a REAL token is issued and threads through /mcp ──
+
+	it("discovers the mounted authorization server from the MCP challenge", async () => {
+		const { cleanup } = await setupApp();
+		try {
+			const unauthorized = await fetch(`${ORIGIN}/api/mcp`, {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({
+					jsonrpc: "2.0",
+					id: 1,
+					method: "initialize",
+					params: {
+						protocolVersion: "2025-06-18",
+						capabilities: {},
+						clientInfo: { name: "MO13 discovery", version: "1.0.0" },
+					},
+				}),
+			});
+			expect(unauthorized.status).toBe(401);
+			const challenge = unauthorized.headers.get("www-authenticate") ?? "";
+			const resourceMetadataUrl = challenge.match(
+				/resource_metadata="([^"]+)"/,
+			)?.[1];
+			expect(resourceMetadataUrl).toBe(
+				`${ORIGIN}/api/.well-known/oauth-protected-resource`,
+			);
+			const resourceMetadataResponse = await fetch(resourceMetadataUrl!);
+			expect(resourceMetadataResponse.status).toBe(200);
+			const resourceMetadata = await resourceMetadataResponse.json();
+			expect(resourceMetadata.authorization_servers).toEqual([
+				`${ORIGIN}/api/auth`,
+			]);
+			const poisonedMetadataResponse = await fetch(resourceMetadataUrl!, {
+				headers: {
+					host: "attacker.invalid",
+					"x-forwarded-host": "attacker.invalid",
+					"x-forwarded-proto": "https",
+				},
+			});
+			expect(poisonedMetadataResponse.status).toBe(200);
+			expect(
+				(await poisonedMetadataResponse.json()).authorization_servers,
+			).toEqual([`${ORIGIN}/api/auth`]);
+			const poisonedAuthorizationServerResponse = await fetch(
+				`${ORIGIN}/api/.well-known/oauth-authorization-server`,
+				{
+					headers: {
+						host: "attacker.invalid",
+						"x-forwarded-host": "attacker.invalid",
+						"x-forwarded-proto": "https",
+					},
+				},
+			);
+			expect(poisonedAuthorizationServerResponse.status).toBe(200);
+			const poisonedAuthorizationServer =
+				await poisonedAuthorizationServerResponse.json();
+			expect(poisonedAuthorizationServer).toMatchObject({
+				issuer: `${ORIGIN}/api/auth`,
+				authorization_endpoint: `${ORIGIN}/api/auth/oauth2/authorize`,
+				token_endpoint: `${ORIGIN}/api/auth/oauth2/token`,
+				jwks_uri: `${ORIGIN}/api/auth/jwks`,
+			});
+			expect(JSON.stringify(poisonedAuthorizationServer)).not.toContain(
+				"attacker.invalid",
+			);
+			const oidcMetadataResponse = await fetch(
+				`${ORIGIN}/api/auth/.well-known/openid-configuration`,
+			);
+			expect(oidcMetadataResponse.status).toBe(200);
+			expect((await oidcMetadataResponse.json()).issuer).toBe(
+				`${ORIGIN}/api/auth`,
+			);
+
+			const discovered = await discoverOAuthServerInfo(MCP_AUD, {
+				resourceMetadataUrl,
+			});
+			expect(discovered.authorizationServerUrl).toBe(`${ORIGIN}/api/auth`);
+			expect(discovered.authorizationServerMetadata?.issuer).toBe(
+				`${ORIGIN}/api/auth`,
+			);
+		} finally {
+			await cleanup();
+		}
+	});
 
 	it("issues a real app-issued JWT via DCR + authorize + consent + token and resolves it to an oauth principal on POST /mcp", async () => {
 		const { auth, cookie, cleanup } = await setupApp();

--- a/packages/questpie/src/server/modules/core/routes/.well-known/_metadata.ts
+++ b/packages/questpie/src/server/modules/core/routes/.well-known/_metadata.ts
@@ -20,7 +20,10 @@
 
 import { oauthProviderResourceClient } from "@better-auth/oauth-provider/resource-client";
 
-import { mcpAudienceForApp } from "#questpie/server/adapters/utils/oauth-principal.js";
+import {
+	mcpAudienceForApp,
+	oauthIssuerForAuth,
+} from "#questpie/server/adapters/utils/oauth-principal.js";
 import type { Questpie } from "#questpie/server/config/questpie.js";
 import type { QuestpieConfig } from "#questpie/server/config/types.js";
 import { ApiError } from "#questpie/server/errors/index.js";
@@ -94,9 +97,11 @@ export async function oauthAuthorizationServerMetadata(
  * `GET /.well-known/oauth-protected-resource` — Protected Resource metadata
  * (RFC 9728). The authorization server does not publish this itself, so we build
  * it via the resource client. `resource` is the MCP endpoint URL (the RFC 8707
- * `aud` MO2 binds tokens to and MO6 verifies against), and `authorization_servers`
- * is auto-derived by the provider to point at this app's AS metadata document —
- * so a client that hits this endpoint discovers where to run the OAuth flow.
+ * `aud` MO2 binds tokens to and MO6 verifies against). The provider resource
+ * client derives `authorization_servers` from JWT configuration, which can lose
+ * the mounted auth path. Replace it with the exact statically configured token
+ * issuer so an untrusted request host cannot influence discovery and an MCP
+ * client discovers the same server that issues and verifies the token.
  */
 export async function oauthProtectedResourceMetadata(
 	app: Questpie<QuestpieConfig>,
@@ -104,11 +109,21 @@ export async function oauthProtectedResourceMetadata(
 ): Promise<Response> {
 	const auth = requireAuth(app, request);
 	if (auth instanceof Response) return auth;
+	const issuer = await oauthIssuerForAuth(app.auth);
+	if (!issuer) {
+		return handleError(ApiError.internal("OAuth issuer is unavailable"), {
+			request,
+			app,
+		});
+	}
 	const resourceClient = oauthProviderResourceClient(app.auth);
 	const metadata = await resourceClient
 		.getActions()
 		.getProtectedResourceMetadata({ resource: mcpAudienceForApp(app) });
-	return Response.json(metadata);
+	return Response.json({
+		...metadata,
+		authorization_servers: [issuer],
+	});
 }
 
 /**

--- a/packages/questpie/test/integration/oauth-discovery-routes.test.ts
+++ b/packages/questpie/test/integration/oauth-discovery-routes.test.ts
@@ -46,7 +46,7 @@ const STUB_JWKS = {
 
 /** AS metadata `api.getOAuthServerConfig` returns (asResponse: false → data). */
 const STUB_AS_METADATA = {
-	issuer: BASE_URL,
+	issuer: `${BASE_URL}/api/auth`,
 	authorization_endpoint: `${BASE_URL}/api/auth/oauth2/authorize`,
 	token_endpoint: `${BASE_URL}/api/auth/oauth2/token`,
 	jwks_uri: `${BASE_URL}/api/auth/jwks`,
@@ -82,7 +82,7 @@ function makeStubAuth() {
 				if (name === "jwt")
 					return {
 						options: {
-							jwt: { issuer: BASE_URL },
+							jwt: { issuer: STUB_AS_METADATA.issuer },
 							jwks: { jwksPath: "/jwks" },
 						},
 					};
@@ -114,7 +114,7 @@ describe("root OAuth / MCP discovery routes", () => {
 		// path round-trip works.
 		expect(response!.status).toBe(200);
 		const body = await response!.json();
-		expect(body.issuer).toBe(BASE_URL);
+		expect(body.issuer).toBe(STUB_AS_METADATA.issuer);
 		expect(body.authorization_endpoint).toBe(
 			STUB_AS_METADATA.authorization_endpoint,
 		);
@@ -130,11 +130,9 @@ describe("root OAuth / MCP discovery routes", () => {
 		const body = await response!.json();
 		// resource = the RFC 8707 aud MO2 binds tokens to / MO6 verifies.
 		expect(body.resource).toBe(MCP_AUDIENCE);
-		// authorization_servers is auto-derived by the provider to point at this
-		// app's AS (issuer). MCP clients follow it to run the flow (MO9).
-		expect(Array.isArray(body.authorization_servers)).toBe(true);
-		expect(body.authorization_servers.length).toBeGreaterThanOrEqual(1);
-		expect(body.authorization_servers[0]).toContain(BASE_URL);
+		// The resource client loses mounted auth paths when it derives this value.
+		// The proxy must publish the exact provider issuer instead.
+		expect(body.authorization_servers).toEqual([STUB_AS_METADATA.issuer]);
 	});
 
 	test("GET /jwks returns the key set (proxied from the auth basePath)", async () => {


### PR DESCRIPTION
## Summary

- publish the exact statically configured OAuth token issuer in RFC 9728 protected-resource metadata instead of losing the mounted auth path
- return a real 404 for unmatched Hono mounts so standards-aware MCP clients can continue to the supported OIDC discovery fallback
- cover the real `/api` Hono mount with the official MCP SDK, including hostile Host and X-Forwarded-Host requests
- add patch changesets for `questpie` and `@questpie/hono`

## Why

`questpie@3.27.0` served the MCP protected-resource document under the correct `/api` mount, but advertised the bare origin as `authorization_servers`. The official MCP SDK then could not discover the mounted issuer at `/api/auth`. Production OAuth endpoints and token verification were healthy; discovery was the missing link.

QUESTPIE always pins Better Auth `baseURL` to `app.config.app.url`. The fix reuses the existing `oauthIssuerForAuth` derivation, so request Host headers cannot influence either the resource metadata or the authorization metadata.

Strict origin-root RFC aliases remain deployment composition because an API handler cannot own paths outside its mount. The package proof covers the supported MCP SDK/OIDC fallback and both root/non-root handler behavior.

## Verification

- `bun test packages/mcp/test/oauth-mcp-e2e.test.ts packages/questpie/test/integration/oauth-discovery-routes.test.ts packages/hono/test/server-composition.test.ts` — 15 passed
- `bun run --cwd packages/questpie check-types`
- `bun run --cwd packages/hono check-types`
- `bun run --cwd packages/mcp check-types`
- scoped Oxfmt/Oxlint
- `git diff --check`
- two read-only Claude Opus 5 adversarial reviews; request-host and second-hop poisoning concerns are covered by static baseURL ownership plus negative tests
