### PR TITLE
fix(codegen): preserve public module route types

### DIFF
--- a/.changeset/bright-routes-remember.md
+++ b/.changeset/bright-routes-remember.md
@@ -1,0 +1,5 @@
+---
+"questpie": patch
+---
+
+Preserve exact generated custom route types when an app includes modules exposed through the public module definition type.

--- a/packages/questpie/src/server/config/codegen-type-utils.ts
+++ b/packages/questpie/src/server/config/codegen-type-utils.ts
@@ -150,23 +150,32 @@ type FoldModulePropOverride<
 	M,
 	K extends string,
 	State extends ModulePropFoldState<any, any>,
-> = [ValidatedModuleName<M>] extends [State["seen"]]
-	? [ValidatedModuleName<M>] extends [never]
-		? never
-		: State
-	: FoldModulePropArrOverride<
-				M extends { modules: infer Sub extends readonly any[] } ? Sub : [],
-				K,
-				ModulePropFoldState<
-					State["result"],
-					State["seen"] | ValidatedModuleName<M>
-				>
-		  > extends infer NestedState extends ModulePropFoldState<any, any>
+> = [ValidatedModuleName<M>] extends [never]
+	? FoldModulePropArrOverride<
+			M extends { modules: infer Sub extends readonly any[] } ? Sub : [],
+			K,
+			State
+		> extends infer NestedState extends ModulePropFoldState<any, any>
 		? ModulePropFoldState<
 				Override<NestedState["result"], ExtractDirectModuleProp<M, K>>,
 				NestedState["seen"]
 			>
-		: never;
+		: never
+	: [ValidatedModuleName<M>] extends [State["seen"]]
+		? State
+		: FoldModulePropArrOverride<
+					M extends { modules: infer Sub extends readonly any[] } ? Sub : [],
+					K,
+					ModulePropFoldState<
+						State["result"],
+						State["seen"] | ValidatedModuleName<M>
+					>
+			  > extends infer NestedState extends ModulePropFoldState<any, any>
+			? ModulePropFoldState<
+					Override<NestedState["result"], ExtractDirectModuleProp<M, K>>,
+					NestedState["seen"]
+				>
+			: never;
 
 type FoldModulePropArrOverride<
 	A extends readonly any[],
@@ -182,9 +191,11 @@ type FoldModulePropArrOverride<
  * names; runtime validation guarantees each such name identifies exactly one
  * object and rejects cycles and distinct objects sharing a name before code is
  * emitted. Under those preconditions, names are a sound type-level stand-in for
- * object identity and reproduce children-first, first-position dedupe. A module
- * whose name has widened to `string` produces `never` instead of silently using
- * structural equality as fake object identity.
+ * object identity and reproduce children-first, first-position dedupe. If a
+ * consumer exposes only the public `ModuleDefinition` type and widens the name
+ * to `string`, the fold keeps its available contributions but skips name-based
+ * dedupe for that module. This preserves exact root definitions without
+ * pretending that TypeScript can recover the lost object identity.
  *
  * TypeScript cannot observe JavaScript object identity or diagnose arbitrary
  * recursive object graphs. Do not use this helper on an unvalidated module tree.

--- a/packages/questpie/test/types/module-graph-diamond.test-d.ts
+++ b/packages/questpie/test/types/module-graph-diamond.test-d.ts
@@ -1,6 +1,7 @@
 import type {
 	ExtractModulePropArrOverride,
 	ExtractModulePropOverride,
+	ModuleDefinition,
 } from "questpie/types";
 
 import type { CodegenResolvedModulePropArr } from "#questpie/server/config/codegen-type-utils.js";
@@ -67,18 +68,30 @@ type _otherCategoryUsesTheSameOrderedFold = Expect<
 	Equal<DiamondJobs["digest"]["owner"], "left">
 >;
 
+type PublicModuleDefinition = (readonly ModuleDefinition[])[number];
+
+// A package can expose only the stable public module contract. Codegen has
+// already validated the runtime graph, so the widened definition must not
+// poison the generated aggregate with `never`.
+type _publicModuleDefinitionKeepsSafeAggregate = Expect<
+	Equal<
+		CodegenResolvedModulePropArr<readonly [PublicModuleDefinition], "globals">,
+		{}
+	>
+>;
+
 type WidenedNameModule = {
 	name: string;
 	globals: { settings: { owner: "widened" } };
 };
 
-// The internal fold is deliberately defined only for generated/const module
-// graphs. A widened name must not fall back to structural equality and pretend
-// that TypeScript can observe JavaScript object identity.
-type _widenedNameDoesNotClaimIdentitySemantics = Expect<
+// Codegen has already validated the runtime graph. A widened public module name
+// cannot participate in type-level identity dedupe, but its known contribution
+// must remain usable and must not poison later root definitions with `never`.
+type _widenedNameKeepsKnownContribution = Expect<
 	Equal<
 		CodegenResolvedModulePropArr<readonly [WidenedNameModule], "globals">,
-		never
+		{ settings: { owner: "widened" } }
 	>
 >;
 

--- a/packages/questpie/test/types/module-route-output-codegen.test-d.ts
+++ b/packages/questpie/test/types/module-route-output-codegen.test-d.ts
@@ -1,0 +1,65 @@
+/**
+ * Regression: generated user route outputs must stay exact when the app also
+ * consumes package modules whose route records are merged and overridden.
+ */
+
+import type { ModuleDefinition } from "questpie/types";
+import { z } from "zod";
+
+import type { CodegenResolvedModulePropArr } from "#questpie/server/config/codegen-type-utils.js";
+import starterModule from "#questpie/server/modules/starter/.generated/module.js";
+import { route } from "#questpie/server/routes/define-route.js";
+import type {
+	InferRouteOutput,
+	RouteParamsFromKey,
+	RouteWithParams,
+} from "#questpie/server/routes/types.js";
+import type { Override } from "#questpie/shared/type-utils.js";
+
+import { mcpModule } from "../../../mcp/src/server/modules/mcp/index.js";
+import { openApiModule } from "../../../openapi/src/server.js";
+import { workflowsModule } from "../../../workflows/src/server/modules/workflows/index.js";
+import type { Equal, Expect, IsUnknown, Not } from "./type-test-utils.js";
+
+const publicModules: readonly ModuleDefinition[] = [{ name: "public-module" }];
+const publicModule = publicModules[0]!;
+const modules = [
+	starterModule,
+	openApiModule,
+	workflowsModule,
+	mcpModule,
+	publicModule,
+] as const;
+
+const userRoute = route()
+	.post()
+	.schema(z.object({}))
+	.handler(() => ({ connectionId: "connection-1", enabled: true }));
+
+type RouteDefinitionWithoutHandler<T> = T extends { mode: "raw" }
+	? Omit<T, "handler"> & {
+			handler: (args: unknown) => Response | Promise<Response>;
+		}
+	: Omit<T, "handler"> & {
+			handler: (args: unknown) => unknown | Promise<unknown>;
+		};
+
+type ModuleRoutes = CodegenResolvedModulePropArr<typeof modules, "routes">;
+type AppRoutes = Override<
+	ModuleRoutes,
+	{
+		"account/externalAiConnection": RouteWithParams<
+			RouteDefinitionWithoutHandler<typeof userRoute>,
+			RouteParamsFromKey<"account/externalAiConnection">
+		>;
+	}
+>;
+
+type UserRouteOutput = InferRouteOutput<
+	AppRoutes["account/externalAiConnection"]
+>;
+
+type _userRouteOutputIsExact = Expect<
+	Equal<UserRouteOutput, { connectionId: string; enabled: boolean }>
+>;
+type _userRouteOutputIsNotUnknown = Expect<Not<IsUnknown<UserRouteOutput>>>;

--- a/packages/questpie/test/types/module-route-output-codegen.test-d.ts
+++ b/packages/questpie/test/types/module-route-output-codegen.test-d.ts
@@ -7,7 +7,6 @@ import type { ModuleDefinition } from "questpie/types";
 import { z } from "zod";
 
 import type { CodegenResolvedModulePropArr } from "#questpie/server/config/codegen-type-utils.js";
-import starterModule from "#questpie/server/modules/starter/.generated/module.js";
 import { route } from "#questpie/server/routes/define-route.js";
 import type {
 	InferRouteOutput,
@@ -16,11 +15,16 @@ import type {
 } from "#questpie/server/routes/types.js";
 import type { Override } from "#questpie/shared/type-utils.js";
 
-import { mcpModule } from "../../../mcp/src/server/modules/mcp/index.js";
-import { openApiModule } from "../../../openapi/src/server.js";
-import { workflowsModule } from "../../../workflows/src/server/modules/workflows/index.js";
 import type { Equal, Expect, IsUnknown, Not } from "./type-test-utils.js";
 
+// Keep this fixture small. Importing each package's full generated module type
+// here measures those large package graphs as test cost instead of exercising
+// the generic regression. The literal names preserve the production ordering
+// while the final value preserves the public ModuleDefinition[] boundary.
+const starterModule = { name: "questpie-starter" } as const;
+const openApiModule = { name: "questpie-openapi" } as const;
+const workflowsModule = { name: "questpie-workflows" } as const;
+const mcpModule = { name: "questpie-mcp" } as const;
 const publicModules: readonly ModuleDefinition[] = [{ name: "public-module" }];
 const publicModule = publicModules[0]!;
 const modules = [


### PR DESCRIPTION
## Summary

- preserve safe module contributions when a public ModuleDefinition widens the module name
- keep exact const tuple and diamond graph ordering unchanged
- prove generated-style custom route output inference with starter, OpenAPI, workflows, MCP, and a public module definition
- add a patch changeset

## Verification

- bun test ./packages/questpie/test/types/module-graph-diamond.test-d.ts ./packages/questpie/test/types/module-route-output-codegen.test-d.ts
- bun run --cwd packages/questpie check-types
- bun run --cwd packages/questpie build
- bun test ./packages/questpie/test/cli/binary.test.ts
- bun run check-types (27/27 tasks)
- bun run format:check
- bun run lint
- git diff --check

The full questpie suite ran 3,112 passing and 65 skipped tests. Its two packaged CLI shim tests initially failed because dist/cli.mjs was absent in the fresh worktree; both passed after the required package build.