### PR TITLE
fix(client): honor typed raw route responses

### DIFF
--- a/.changeset/fuzzy-taxis-return.md
+++ b/.changeset/fuzzy-taxis-return.md
@@ -1,0 +1,5 @@
+---
+"questpie": patch
+---
+
+Pass request options through registered typed raw route callers and return the untouched response. The typed method leaf now owns the HTTP method.

--- a/apps/docs/content/docs/code/routes.mdx
+++ b/apps/docs/content/docs/code/routes.mdx
@@ -94,6 +94,32 @@ fine.
 nothing asked for JSON. `.schema()` and `.outputSchema()` turn JSON mode on.
 `.raw()` turns it off and drops any schema you set. The last of the two wins.
 
+### Call a raw route
+
+Raw route definitions are types, so a browser client must register the runtime
+keys it wants to call as raw. A typed app rejects JSON routes or the wrong
+method:
+
+```ts
+export const client = createClient<AppConfig>({
+	baseURL: window.location.origin,
+	basePath: "/api",
+	rawRoutes: {
+		"workMachines/enrollmentExchange:POST": true,
+	},
+});
+
+const response = await client.routes.workMachines.enrollmentExchange.post({
+	body: new URLSearchParams({ code }),
+	credentials: "include",
+	redirect: "manual",
+});
+```
+
+The caller accepts `RequestInit` except `method`. The typed method leaf owns the
+method. It returns the original `Response`, including redirects and error
+responses, without JSON parsing.
+
 ## The file name is the URL
 
 | File                            | Client method                      | HTTP                       |

--- a/apps/docs/content/docs/code/routes.mdx
+++ b/apps/docs/content/docs/code/routes.mdx
@@ -96,9 +96,11 @@ nothing asked for JSON. `.schema()` and `.outputSchema()` turn JSON mode on.
 
 ### Call a raw route
 
-Raw route definitions are types, so a browser client must register the runtime
-keys it wants to call as raw. A typed app rejects JSON routes or the wrong
-method:
+Raw route definitions are types, so a browser client must register every known
+raw runtime key. A typed app rejects missing keys, JSON routes, and wrong
+methods. Erased framework definitions with no safe method literal stay on their
+legacy unregistered surface; they do not create false registrations or promise
+raw response semantics:
 
 ```ts
 export const client = createClient<AppConfig>({

--- a/packages/admin/src/client/create-admin-client.ts
+++ b/packages/admin/src/client/create-admin-client.ts
@@ -21,7 +21,7 @@ import {
 import { withAdminRequestHeader } from "../shared/preview-utils.js";
 
 export function createAdminClient<TApp extends QuestpieApp>(
-	config: QuestpieClientConfig,
+	config: QuestpieClientConfig<TApp>,
 ): QuestpieClient<TApp> {
 	return createClient<TApp>({
 		...config,

--- a/packages/elysia/src/client.ts
+++ b/packages/elysia/src/client.ts
@@ -6,12 +6,13 @@ import {
 	type GetAuthHeaders,
 	type QuestpieApp,
 	type QuestpieClient,
+	type QuestpieRouteClientConfig,
 } from "questpie/client";
 
 /**
  * Elysia client configuration
  */
-export type ElysiaClientConfig = {
+export type ElysiaClientConfig<TApp extends QuestpieApp = QuestpieApp> = {
 	/**
 	 * Server URL (domain with optional port, no protocol needed for Eden)
 	 * @example 'localhost:3000'
@@ -44,7 +45,7 @@ export type ElysiaClientConfig = {
 	/**
 	 * Optional collaborative-document client runtime.
 	 */
-};
+} & QuestpieRouteClientConfig<TApp>;
 
 /**
  * Create a unified client that combines QUESTPIE CRUD operations
@@ -69,20 +70,14 @@ export type ElysiaClientConfig = {
 export function createClientFromEden<
 	TApp extends Elysia<any, any, any, any, any, any, any> = any,
 	TQP extends QuestpieApp = any,
->(config: ElysiaClientConfig): QuestpieClient<TQP> & Treaty.Create<TApp> {
+>(config: ElysiaClientConfig<TQP>): QuestpieClient<TQP> & Treaty.Create<TApp> {
 	// Determine baseURL with protocol for app client
 	const baseURL = config.server.startsWith("http")
 		? config.server
 		: `http://${config.server}`;
 
 	// Create QUESTPIE client for CRUD operations
-	const qpClient = createClient<TQP>({
-		baseURL,
-		fetch: config.fetch,
-		basePath: config.basePath,
-		headers: config.headers,
-		getAuthHeaders: config.getAuthHeaders,
-	});
+	const qpClient = createClient<TQP>({ ...config, baseURL });
 
 	// Create Eden Treaty client for custom routes
 	const edenClient = treaty<TApp>(config.server, {
@@ -95,5 +90,6 @@ export function createClientFromEden<
 		...edenClient,
 		collections: qpClient.collections,
 		globals: qpClient.globals,
+		routes: qpClient.routes,
 	} as QuestpieClient<TQP> & Treaty.Create<TApp>;
 }

--- a/packages/hono/src/client.ts
+++ b/packages/hono/src/client.ts
@@ -1,40 +1,22 @@
 import type { Hono } from "hono";
 import type { ClientRequestOptions } from "hono/client";
 import { hc } from "hono/client";
-import { createClient, type QuestpieApp } from "questpie/client";
+import {
+	createClient,
+	type QuestpieApp,
+	type QuestpieClientConfig,
+} from "questpie/client";
 
 /**
  * Hono client configuration
  */
-export type HonoClientConfig = {
-	/**
-	 * Base URL of the API
-	 * @example 'http://localhost:3000'
-	 */
-	baseURL: string;
-
-	/**
-	 * Custom fetch implementation
-	 * @default globalThis.fetch
-	 */
-	fetch?: typeof fetch;
-
-	/**
-	 * Base path for routes
-	 * @default '/'
-	 */
-	basePath?: string;
-
-	/**
-	 * Default headers to include in all requests
-	 */
-	headers?: Record<string, string>;
-
-	/**
-	 * Hono client options
-	 */
-	honoOptions?: ClientRequestOptions;
-};
+export type HonoClientConfig<TApp extends QuestpieApp = QuestpieApp> =
+	QuestpieClientConfig<TApp> & {
+		/**
+		 * Hono client options
+		 */
+		honoOptions?: ClientRequestOptions;
+	};
 
 /**
  * Create a unified client that combines QUESTPIE CRUD operations
@@ -61,15 +43,10 @@ export function createClientFromHono<
 	THono extends Hono<any, any, any>,
 	TApp extends QuestpieApp,
 >(
-	config: HonoClientConfig,
+	config: HonoClientConfig<TApp>,
 ): ReturnType<typeof hc<THono>> & ReturnType<typeof createClient<TApp>> {
 	// Create QUESTPIE client for CRUD operations
-	const qpClient = createClient<TApp>({
-		baseURL: config.baseURL,
-		fetch: config.fetch,
-		basePath: config.basePath,
-		headers: config.headers,
-	});
+	const qpClient = createClient<TApp>(config);
 
 	// Create Hono RPC client for custom routes
 	const honoClient = hc<THono>(config.baseURL, {
@@ -78,11 +55,14 @@ export function createClientFromHono<
 		...config.honoOptions,
 	});
 
-	// Merge both clients
-	(honoClient as typeof honoClient & typeof qpClient).collections =
-		qpClient.collections;
-	(honoClient as typeof honoClient & typeof qpClient).globals =
-		qpClient.globals;
-
-	return honoClient as typeof honoClient & typeof qpClient;
+	// Hono's client is itself a Proxy and ignores properties assigned to it.
+	// Resolve QUESTPIE surfaces before forwarding all other reads to Hono.
+	return new Proxy(honoClient as object, {
+		get(target, property, receiver) {
+			if (property === "collections") return qpClient.collections;
+			if (property === "globals") return qpClient.globals;
+			if (property === "routes") return qpClient.routes;
+			return Reflect.get(target, property, receiver);
+		},
+	}) as typeof honoClient & typeof qpClient;
 }

--- a/packages/hono/test/client.test.ts
+++ b/packages/hono/test/client.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+
+import type { RawRouteDefinition } from "questpie/server";
+
+import { createClientFromHono } from "../src/client.js";
+
+type DownloadRoute = Omit<RawRouteDefinition, "method"> & {
+	readonly method: "GET";
+};
+
+type RawRouteApp = {
+	collections: {};
+	routes: { download: DownloadRoute };
+};
+
+describe("Hono unified client", () => {
+	test("forwards QUESTPIE raw routes through the outer client", async () => {
+		const response = new Response("download");
+		let receivedUrl = "";
+		let receivedInit: RequestInit | undefined;
+		const client = createClientFromHono<any, RawRouteApp>({
+			baseURL: "https://example.test",
+			rawRoutes: { "download:GET": true },
+			fetch: async (input, init) => {
+				receivedUrl = String(input);
+				receivedInit = init;
+				return response;
+			},
+		});
+
+		const result = await client.routes.download.get({ redirect: "manual" });
+
+		expect(result).toBe(response);
+		expect(receivedUrl).toBe("https://example.test/download");
+		expect(receivedInit?.method).toBe("GET");
+		expect(receivedInit?.redirect).toBe("manual");
+	});
+});

--- a/packages/questpie/src/client/index.ts
+++ b/packages/questpie/src/client/index.ts
@@ -258,7 +258,40 @@ export class QuestpieClientError extends Error {
 /**
  * Client configuration
  */
-export type QuestpieClientConfig = {
+type RawRouteRegistrationKeys<TRoutes> = string extends keyof TRoutes
+	? string
+	: {
+			[K in keyof TRoutes & string]: K extends `${string}[${string}`
+				? never
+				: TRoutes[K] extends {
+							mode: "raw";
+							method: infer TMethod;
+					  }
+					? HttpMethod extends TMethod
+						? never
+						: K extends `${string}:${string}`
+							? K
+							: `${K}:${Extract<TMethod, HttpMethod>}`
+					: never;
+		}[keyof TRoutes & string];
+
+type RawRouteRegistration<TApp extends QuestpieApp> =
+	string extends RawRouteRegistrationKeys<NonNullable<TApp["routes"]>>
+		? { rawRoutes?: Readonly<Record<string, true>> }
+		: [RawRouteRegistrationKeys<NonNullable<TApp["routes"]>>] extends [never]
+			? { rawRoutes?: undefined }
+			: {
+					rawRoutes?: {
+						readonly [K in RawRouteRegistrationKeys<
+							NonNullable<TApp["routes"]>
+						>]?: true;
+					};
+				};
+
+export type QuestpieRouteClientConfig<TApp extends QuestpieApp = QuestpieApp> =
+	RawRouteRegistration<TApp>;
+
+export type QuestpieClientConfig<TApp extends QuestpieApp = QuestpieApp> = {
 	/**
 	 * Base URL of the app API
 	 * @example 'http://localhost:3000'
@@ -299,7 +332,7 @@ export type QuestpieClientConfig = {
 	 * @default true
 	 */
 	useSuperJSON?: boolean;
-};
+} & QuestpieRouteClientConfig<TApp>;
 
 /**
  * Caller for a JSON route — sends input, returns typed output.
@@ -1186,10 +1219,7 @@ type SearchAPI = {
 /**
  * Options for calling a custom route.
  */
-type RouteCallOptions = Omit<RequestInit, "method"> & {
-	/** HTTP method override. If omitted, uses the route's declared method or GET. */
-	method?: string;
-};
+type RouteCallOptions = Omit<RequestInit, "method">;
 
 /**
  * Questpie Client
@@ -1261,7 +1291,7 @@ export type QuestpieClient<in out TApp extends QuestpieApp> = {
  * ```
  */
 export function createClient<TApp extends QuestpieApp>(
-	config: QuestpieClientConfig,
+	config: QuestpieClientConfig<TApp>,
 ): QuestpieClient<TApp> {
 	// Bind the default fetch: realtime/channels store this and invoke it as a
 	// method (`this.fetcher(...)`), and browsers throw "Illegal invocation"
@@ -1382,6 +1412,28 @@ export function createClient<TApp extends QuestpieApp>(
 		options: QuestpieRequestInit = {},
 	): Promise<any> {
 		return (await requestWithMeta(path, options)).data;
+	}
+
+	const rawRoutePaths = new Set(Object.keys(config.rawRoutes ?? {}));
+
+	async function rawRouteRequest(
+		path: string,
+		method: string,
+		options: RouteCallOptions,
+	): Promise<Response> {
+		const authHeaders = await config.getAuthHeaders?.();
+		const headers = new Headers(defaultHeaders);
+		new Headers(options.headers).forEach((value, key) =>
+			headers.set(key, value),
+		);
+		new Headers(authHeaders).forEach((value, key) => headers.set(key, value));
+
+		return fetcher(`${config.baseURL}${path}`, {
+			...options,
+			method,
+			headers,
+			credentials: options.credentials ?? "include",
+		});
 	}
 
 	async function mutationRequest(
@@ -2147,9 +2199,21 @@ export function createClient<TApp extends QuestpieApp>(
 
 				// HTTP method names at leaf → method-specific caller
 				const methodUpper = prop.toUpperCase();
-				if (["GET", "POST", "PUT", "DELETE", "PATCH"].includes(methodUpper)) {
+				if (
+					["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"].includes(
+						methodUpper,
+					)
+				) {
 					return async (input?: any) => {
 						const path = segments.map(camelToKebab).join("/");
+						const routeKey = `${segments.join("/")}:${methodUpper}`;
+						if (rawRoutePaths.has(routeKey)) {
+							return rawRouteRequest(
+								`${apiBasePath}/${path}`,
+								methodUpper,
+								input ?? {},
+							);
+						}
 						if (methodUpper === "GET" && input) {
 							const queryString = stringifyQuery(input);
 							return request(

--- a/packages/questpie/src/client/index.ts
+++ b/packages/questpie/src/client/index.ts
@@ -281,10 +281,10 @@ type RawRouteRegistration<TApp extends QuestpieApp> =
 		: [RawRouteRegistrationKeys<NonNullable<TApp["routes"]>>] extends [never]
 			? { rawRoutes?: undefined }
 			: {
-					rawRoutes?: {
+					rawRoutes: {
 						readonly [K in RawRouteRegistrationKeys<
 							NonNullable<TApp["routes"]>
-						>]?: true;
+						>]: true;
 					};
 				};
 
@@ -408,8 +408,10 @@ type RouteMethodCallers<TDef> = TDef extends { method: infer TMethod }
 type RouteCallerFromDef<TDef> =
 	TDef extends JsonRouteDefinition<any, any>
 		? JsonRouteCaller<TDef>
-		: TDef extends RawRouteDefinition
-			? RawRouteCaller
+		: TDef extends RawRouteDefinition<any, infer TMethod>
+			? HttpMethod extends TMethod
+				? (input?: any) => Promise<any>
+				: RawRouteCaller
 			: (input?: any) => Promise<any>;
 
 /**
@@ -1414,28 +1416,6 @@ export function createClient<TApp extends QuestpieApp>(
 		return (await requestWithMeta(path, options)).data;
 	}
 
-	const rawRoutePaths = new Set(Object.keys(config.rawRoutes ?? {}));
-
-	async function rawRouteRequest(
-		path: string,
-		method: string,
-		options: RouteCallOptions,
-	): Promise<Response> {
-		const authHeaders = await config.getAuthHeaders?.();
-		const headers = new Headers(defaultHeaders);
-		new Headers(options.headers).forEach((value, key) =>
-			headers.set(key, value),
-		);
-		new Headers(authHeaders).forEach((value, key) => headers.set(key, value));
-
-		return fetcher(`${config.baseURL}${path}`, {
-			...options,
-			method,
-			headers,
-			credentials: options.credentials ?? "include",
-		});
-	}
-
 	async function mutationRequest(
 		path: string,
 		options: QuestpieRequestInit,
@@ -2182,8 +2162,8 @@ export function createClient<TApp extends QuestpieApp>(
 	 * Segment names are converted from camelCase to kebab-case for URLs.
 	 */
 	const createRouteProxy = (segments: string[]): any => {
+		const path = segments.map(camelToKebab).join("/");
 		const callable = async (input?: any) => {
-			const path = segments.map(camelToKebab).join("/");
 			return request(`${apiBasePath}/${path}`, {
 				method: "POST",
 				json: input,
@@ -2193,28 +2173,28 @@ export function createClient<TApp extends QuestpieApp>(
 		return new Proxy(callable, {
 			get(_, prop) {
 				if (prop === "then") return undefined;
-				if (prop === "url")
-					return `${config.baseURL}${apiBasePath}/${segments.map(camelToKebab).join("/")}`;
+				if (prop === "url") return `${config.baseURL}${apiBasePath}/${path}`;
 				if (typeof prop !== "string") return undefined;
 
 				// HTTP method names at leaf → method-specific caller
-				const methodUpper = prop.toUpperCase();
-				if (
-					["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"].includes(
-						methodUpper,
-					)
-				) {
+				const method = prop.toUpperCase();
+				if (/^(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS)$/.test(method)) {
 					return async (input?: any) => {
-						const path = segments.map(camelToKebab).join("/");
-						const routeKey = `${segments.join("/")}:${methodUpper}`;
-						if (rawRoutePaths.has(routeKey)) {
-							return rawRouteRequest(
-								`${apiBasePath}/${path}`,
-								methodUpper,
+						if (
+							(
+								config.rawRoutes as Readonly<Record<string, true>> | undefined
+							)?.[`${segments.join("/")}:${method}`]
+						) {
+							return (await import("./raw-route.js")).callRawRoute(
+								fetcher,
+								`${config.baseURL}${apiBasePath}/${path}`,
+								method,
 								input ?? {},
+								defaultHeaders,
+								config.getAuthHeaders,
 							);
 						}
-						if (methodUpper === "GET" && input) {
+						if (method === "GET" && input) {
 							const queryString = stringifyQuery(input);
 							return request(
 								`${apiBasePath}/${path}${queryString ? `?${queryString}` : ""}`,
@@ -2222,7 +2202,7 @@ export function createClient<TApp extends QuestpieApp>(
 							);
 						}
 						return request(`${apiBasePath}/${path}`, {
-							method: methodUpper,
+							method,
 							json: input,
 						});
 					};
@@ -2230,14 +2210,6 @@ export function createClient<TApp extends QuestpieApp>(
 
 				// Otherwise, deeper nesting
 				return createRouteProxy([...segments, prop]);
-			},
-			apply(_, __, args: unknown[]) {
-				const input = args[0];
-				const path = segments.map(camelToKebab).join("/");
-				return request(`${apiBasePath}/${path}`, {
-					method: "POST",
-					json: input,
-				});
 			},
 		});
 	};

--- a/packages/questpie/src/client/index.ts
+++ b/packages/questpie/src/client/index.ts
@@ -410,7 +410,7 @@ type RouteCallerFromDef<TDef> =
 		? JsonRouteCaller<TDef>
 		: TDef extends RawRouteDefinition<any, infer TMethod>
 			? HttpMethod extends TMethod
-				? (input?: any) => Promise<any>
+				? (input?: unknown) => Promise<unknown>
 				: RawRouteCaller
 			: (input?: any) => Promise<any>;
 

--- a/packages/questpie/src/client/raw-route.ts
+++ b/packages/questpie/src/client/raw-route.ts
@@ -1,0 +1,23 @@
+import type { GetAuthHeaders } from "./auth.js";
+
+/** Execute a raw route without adding the JSON wire contract. */
+export async function callRawRoute(
+	fetcher: typeof fetch,
+	url: string,
+	method: string,
+	options: Omit<RequestInit, "method">,
+	defaultHeaders: Record<string, string>,
+	getAuthHeaders?: GetAuthHeaders,
+): Promise<Response> {
+	const headers = new Headers(defaultHeaders);
+	for (const source of [options.headers, await getAuthHeaders?.()]) {
+		new Headers(source).forEach((value, key) => headers.set(key, value));
+	}
+
+	return fetcher(url, {
+		...options,
+		method,
+		headers,
+		credentials: options.credentials ?? "include",
+	});
+}

--- a/packages/questpie/src/server/routes/route-builder.ts
+++ b/packages/questpie/src/server/routes/route-builder.ts
@@ -36,6 +36,8 @@ import type {
 
 type NoMethod = { __method: false };
 type HasMethod<M extends HttpMethod = HttpMethod> = { __method: M };
+type MethodOf<TMethod> =
+	TMethod extends HasMethod<infer TMethodValue> ? TMethodValue : "POST";
 
 type NoMode = { __mode: false };
 type JsonMode = { __mode: "json" };
@@ -293,7 +295,7 @@ export class RouteBuilder<
 							args: RawRouteHandlerArgs<TParams>,
 						) => Response | Promise<Response>,
 	): TMode extends RawMode
-		? RawRouteDefinition<TParams>
+		? RawRouteDefinition<TParams, MethodOf<_TMethod>>
 		: TSchema extends HasSchema<infer TInput>
 			? JsonRouteDefinition<
 					TInput,
@@ -307,8 +309,8 @@ export class RouteBuilder<
 						TOutput extends HasOutput<infer O> ? O : unknown,
 						TParams
 					>
-				: RawRouteDefinition<TParams> {
-		const method = this._config.method ?? "POST";
+				: RawRouteDefinition<TParams, MethodOf<_TMethod>> {
+		const method = (this._config.method ?? "POST") as MethodOf<_TMethod>;
 
 		if (this._config.mode === "json" || this._config.schema) {
 			// JSON route
@@ -326,7 +328,7 @@ export class RouteBuilder<
 		}
 
 		// Raw route (default)
-		const def: RawRouteDefinition<TParams> = {
+		const def: RawRouteDefinition<TParams, MethodOf<_TMethod>> = {
 			__brand: "route",
 			mode: "raw",
 			method,

--- a/packages/questpie/src/server/routes/types.ts
+++ b/packages/questpie/src/server/routes/types.ts
@@ -167,10 +167,11 @@ export type JsonRouteDefinition<
  */
 export type RawRouteDefinition<
 	TParams extends JsonRouteParams = JsonRouteParams,
+	TMethod extends HttpMethod = HttpMethod,
 > = {
 	readonly __brand: "route";
 	readonly mode: "raw";
-	readonly method: HttpMethod;
+	readonly method: TMethod;
 	readonly access?: RouteAccess;
 	readonly meta?: RouteMeta;
 	readonly handler: (
@@ -240,8 +241,8 @@ export type RouteWithParams<
 		// wholesale: codegen-erased handlers (`(args: unknown) => unknown`)
 		// would otherwise poison the inferred `TOutput` with `unknown`.
 		JsonRouteDefinition<InferRouteInput<TDef>, InferRouteOutput<TDef>, TParams>
-	: TDef extends { mode: "raw" }
-		? RawRouteDefinition<TParams>
+	: TDef extends { mode: "raw"; method: infer TMethod }
+		? RawRouteDefinition<TParams, Extract<TMethod, HttpMethod>>
 		: TDef;
 
 // ============================================================================

--- a/packages/questpie/test/client/client-raw-routes.test.ts
+++ b/packages/questpie/test/client/client-raw-routes.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test } from "bun:test";
+
+import { createClient } from "../../src/client/index.js";
+import type { RawRouteDefinition } from "../../src/server/routes/types.js";
+
+type EnrollmentExchangeRoute = Omit<RawRouteDefinition, "method"> & {
+	readonly method: "POST";
+};
+
+type RawRoutesApp = {
+	collections: {};
+	routes: {
+		"workMachines/enrollmentExchange": EnrollmentExchangeRoute;
+	};
+};
+
+describe("typed raw route client", () => {
+	test("passes request options through and returns the untouched Response", async () => {
+		const controller = new AbortController();
+		const response = new Response(null, {
+			status: 204,
+			headers: { "x-enrollment": "accepted" },
+		});
+		let receivedUrl = "";
+		let receivedInit: RequestInit | undefined;
+
+		const client = createClient<RawRoutesApp>({
+			baseURL: "https://autopilot.example",
+			basePath: "/api",
+			rawRoutes: { "workMachines/enrollmentExchange:POST": true },
+			headers: {
+				"x-default": "default",
+				authorization: "Bearer stale",
+			},
+			getAuthHeaders: () => ({ authorization: "Bearer current" }),
+			fetch: async (input, init) => {
+				receivedUrl = String(input);
+				receivedInit = init;
+				return response;
+			},
+		});
+		const body = new URLSearchParams({ code: "fragment-code" });
+
+		const result = await client.routes.workMachines.enrollmentExchange.post({
+			body,
+			credentials: "same-origin",
+			headers: {
+				"content-type": "application/x-www-form-urlencoded;charset=UTF-8",
+				"x-request": "enrollment",
+			},
+			redirect: "manual",
+			signal: controller.signal,
+		});
+
+		expect(result).toBe(response);
+		expect(receivedUrl).toBe(
+			"https://autopilot.example/api/work-machines/enrollment-exchange",
+		);
+		expect(receivedInit?.method).toBe("POST");
+		expect(receivedInit?.body).toBe(body);
+		expect(receivedInit?.credentials).toBe("same-origin");
+		expect(receivedInit?.redirect).toBe("manual");
+		expect(receivedInit?.signal).toBe(controller.signal);
+
+		const headers = new Headers(receivedInit?.headers);
+		expect(headers.get("authorization")).toBe("Bearer current");
+		expect(headers.get("x-default")).toBe("default");
+		expect(headers.get("x-request")).toBe("enrollment");
+		expect(headers.get("content-type")).toBe(
+			"application/x-www-form-urlencoded;charset=UTF-8",
+		);
+		expect(headers.has("x-superjson")).toBe(false);
+	});
+
+	test("supports omitted options and returns non-success responses", async () => {
+		const redirect = new Response(null, { status: 302 });
+		const forbidden = new Response("denied", { status: 403 });
+		const responses = [redirect, forbidden];
+		const client = createClient<RawRoutesApp>({
+			baseURL: "https://autopilot.example",
+			rawRoutes: { "workMachines/enrollmentExchange:POST": true },
+			fetch: async () => responses.shift()!,
+		});
+
+		expect(await client.routes.workMachines.enrollmentExchange.post()).toBe(
+			redirect,
+		);
+		expect(await client.routes.workMachines.enrollmentExchange.post({})).toBe(
+			forbidden,
+		);
+	});
+
+	test("keeps RequestInit-shaped JSON input on the SuperJSON path", async () => {
+		let received: RequestInit | undefined;
+		const client = createClient<any>({
+			baseURL: "https://autopilot.example",
+			fetch: async (_input, init) => {
+				received = init;
+				return Response.json({ ok: true });
+			},
+		});
+
+		await client.routes.messages.send.post({
+			body: "hello",
+			mode: "draft",
+		});
+
+		expect(received?.body).not.toBe("hello");
+		expect(String(received?.body)).toContain("hello");
+		expect(String(received?.body)).toContain("draft");
+		expect(new Headers(received?.headers).get("x-superjson")).toBe("1");
+	});
+
+	test("keeps a same-path JSON method separate from a raw method", async () => {
+		const rawResponse = new Response("download");
+		const requests: RequestInit[] = [];
+		const client = createClient<any>({
+			baseURL: "https://autopilot.example",
+			rawRoutes: { "report:GET": true },
+			fetch: async (_input, init) => {
+				requests.push(init ?? {});
+				return requests.length === 1
+					? rawResponse
+					: Response.json({ total: 1 });
+			},
+		});
+
+		expect(await client.routes.report.get()).toBe(rawResponse);
+		expect(await client.routes.report.post({ mode: "week" })).toEqual({
+			total: 1,
+		});
+		expect(requests[0]?.method).toBe("GET");
+		expect(new Headers(requests[1]?.headers).get("x-superjson")).toBe("1");
+	});
+});

--- a/packages/questpie/test/types/routes-rpc-client.test-d.ts
+++ b/packages/questpie/test/types/routes-rpc-client.test-d.ts
@@ -30,7 +30,7 @@ declare module "#questpie/server/config/app-context.js" {
 
 import { z } from "zod";
 
-import type { QuestpieClient } from "#questpie/client/index.js";
+import { createClient, type QuestpieClient } from "#questpie/client/index.js";
 import { collection } from "#questpie/server/collection/builder/collection-builder.js";
 import { route } from "#questpie/server/routes/define-route.js";
 import type {
@@ -213,7 +213,7 @@ type MockRoutes = {
 	getSlots: typeof echoRoute;
 	"admin/stats": typeof statsRoute;
 	"admin/users:GET": typeof adminUsersGetRoute;
-	download: RawRouteDefinition;
+	download: typeof rawRoute;
 };
 
 type ClientApp = {
@@ -253,6 +253,39 @@ type _usersGetOutput = Expect<
 type _downloadOutput = Expect<
 	Equal<Awaited<ReturnType<typeof client.routes.download.get>>, Response>
 >;
+client.routes.download.get({ redirect: "manual" });
+// @ts-expect-error the typed method leaf owns the HTTP method
+client.routes.download.get({ method: "POST" });
+// @ts-expect-error raw route exposes only its declared GET leaf
+void client.routes.download.post;
+createClient<ClientApp>({
+	baseURL: "https://example.test",
+	rawRoutes: { "download:GET": true },
+});
+createClient<ClientApp>({ baseURL: "https://example.test" });
+createClient<ClientApp>({
+	baseURL: "https://example.test",
+	// @ts-expect-error JSON route keys cannot be registered as raw
+	rawRoutes: { "admin/stats": true },
+});
+createClient<ClientApp>({
+	baseURL: "https://example.test",
+	// @ts-expect-error raw registration method must match the route definition
+	rawRoutes: { "download:POST": true },
+});
+
+type WideRawRouteApp = {
+	collections: {};
+	routes: { openapi: RawRouteDefinition };
+};
+
+// Erased framework route definitions do not demand every possible method key.
+createClient<WideRawRouteApp>({ baseURL: "https://example.test" });
+createClient<WideRawRouteApp>({
+	baseURL: "https://example.test",
+	// @ts-expect-error a wide method definition cannot be safely registered as raw
+	rawRoutes: { "openapi:GET": true },
+});
 
 // Phantom route names are compile errors (no index-signature poisoning)
 // @ts-expect-error unknown route name must not typecheck

--- a/packages/questpie/test/types/routes-rpc-client.test-d.ts
+++ b/packages/questpie/test/types/routes-rpc-client.test-d.ts
@@ -262,6 +262,7 @@ createClient<ClientApp>({
 	baseURL: "https://example.test",
 	rawRoutes: { "download:GET": true },
 });
+// @ts-expect-error known raw routes must register their runtime keys
 createClient<ClientApp>({ baseURL: "https://example.test" });
 createClient<ClientApp>({
 	baseURL: "https://example.test",
@@ -281,6 +282,10 @@ type WideRawRouteApp = {
 
 // Erased framework route definitions do not demand every possible method key.
 createClient<WideRawRouteApp>({ baseURL: "https://example.test" });
+declare const wideRawClient: QuestpieClient<WideRawRouteApp>;
+type _wideRawDoesNotPromiseResponse = Expect<
+	IsAny<Awaited<ReturnType<typeof wideRawClient.routes.openapi.get>>>
+>;
 createClient<WideRawRouteApp>({
 	baseURL: "https://example.test",
 	// @ts-expect-error a wide method definition cannot be safely registered as raw

--- a/packages/questpie/test/types/routes-rpc-client.test-d.ts
+++ b/packages/questpie/test/types/routes-rpc-client.test-d.ts
@@ -284,7 +284,7 @@ type WideRawRouteApp = {
 createClient<WideRawRouteApp>({ baseURL: "https://example.test" });
 declare const wideRawClient: QuestpieClient<WideRawRouteApp>;
 type _wideRawDoesNotPromiseResponse = Expect<
-	IsAny<Awaited<ReturnType<typeof wideRawClient.routes.openapi.get>>>
+	IsUnknown<Awaited<ReturnType<typeof wideRawClient.routes.openapi.get>>>
 >;
 createClient<WideRawRouteApp>({
 	baseURL: "https://example.test",


### PR DESCRIPTION
## Summary
- preserve raw route method literals and opt typed raw callers into an explicit runtime manifest
- pass RequestInit options through without a method override and return the exact Response
- keep JSON routes on SuperJSON and forward unified Hono/Elysia route clients correctly
- document the public raw route client contract and add a patch changeset

## Verification
- `bun test packages/questpie/test`: 3115 pass, 65 skip, 0 fail
- `bun run --cwd packages/questpie check-types`
- `bun run --cwd packages/hono check-types`
- `bun run --cwd packages/elysia check-types`
- `bun run --cwd packages/admin check-types`
- `bun run format:check`
- `bun run lint`
- `git diff --check`
- Hono composition tests: 4 pass on isolated retry
- City Portal and Toy Factory example typechecks pass; Barbershop reaches only its pre-existing missing iconify dependency

## Audit
Claude Opus 5 medium ran read-only. Its exhaustive-manifest, wide-method, and Hono proxy findings are resolved in this patch.

Agent Board verify repeated the four short gates successfully. Its full-suite wrapper timed out with exit 124 because the suite takes 13m46s; the identical direct command completed with zero failures as listed above.