### PR TITLE
feat(auth): add verified provider entry methods

### DIFF
--- a/.changeset/verified-provider-auth-entry-methods.md
+++ b/.changeset/verified-provider-auth-entry-methods.md
@@ -1,0 +1,5 @@
+---
+"questpie": minor
+---
+
+Add a server-owned Auth entry method configuration seam with verified social-email enforcement, a secret-free effective method catalog, implicit-link protection, disclosure-safe provider errors, and browser-only last-login-method support.

--- a/packages/questpie/src/exports/auth.ts
+++ b/packages/questpie/src/exports/auth.ts
@@ -3,6 +3,12 @@ export {
 	mergeAuthOptions,
 	type MergeAuthOptions,
 } from "#questpie/server/modules/core/integrated/auth/merge.js";
+export {
+	configureAuthEntryMethods,
+	type AuthEntryMethodsConfig,
+	type AuthEntryMethodsInput,
+	type PublicAuthEntryMethod,
+} from "#questpie/server/modules/core/integrated/auth/entry-methods.js";
 export * from "#questpie/server/modules/core/integrated/auth/types.js";
 export {
 	type AuthTransactionalQueueContext,

--- a/packages/questpie/src/server/modules/core/integrated/auth/entry-methods.ts
+++ b/packages/questpie/src/server/modules/core/integrated/auth/entry-methods.ts
@@ -1,0 +1,370 @@
+import {
+	APIError,
+	type BetterAuthOptions,
+	type BetterAuthPlugin,
+} from "better-auth";
+import { createAuthMiddleware, isAPIError } from "better-auth/api";
+import { lastLoginMethod } from "better-auth/plugins";
+import {
+	github,
+	google,
+	type GithubOptions,
+	type GoogleOptions,
+} from "better-auth/social-providers";
+
+import { mergeAuthOptions } from "./merge.js";
+
+export type PublicAuthEntryMethod =
+	| { id: "email"; kind: "credentials" }
+	| { id: "google" | "github"; kind: "social" };
+
+type ProviderCredentialPair = {
+	clientId: string;
+	clientSecret: string;
+};
+
+type GoogleAuthEntryOptions = Omit<GoogleOptions, "clientId" | "clientSecret"> &
+	ProviderCredentialPair;
+
+type GithubAuthEntryOptions = Omit<GithubOptions, "clientId" | "clientSecret"> &
+	ProviderCredentialPair;
+
+export type AuthEntryMethodsInput = {
+	authOptions?: Omit<BetterAuthOptions, "socialProviders"> & {
+		socialProviders?: never;
+	};
+	credentials: { enabled: boolean };
+	socialProviders?: {
+		google?: GoogleAuthEntryOptions;
+		github?: GithubAuthEntryOptions;
+	};
+	requireVerifiedProviderEmail: true;
+	lastLoginMethod?: {
+		enabledWhenMultiple: true;
+		storeInDatabase: false;
+		maxAgeSeconds?: number;
+	};
+};
+
+export type AuthEntryMethodsConfig = {
+	authOptions: BetterAuthOptions;
+	publicMethods: readonly PublicAuthEntryMethod[];
+};
+
+const SOCIAL_PROVIDER_ERROR_CODE = "social_provider_error";
+const SOCIAL_PROVIDER_ERROR_MESSAGE = "Social provider authentication failed";
+const UNSUPPORTED_SOCIAL_PLUGIN_IDS = new Set([
+	"generic-oauth",
+	"oauth-proxy",
+	"one-tap",
+]);
+
+function hasProviderError(params: URLSearchParams): boolean {
+	return params.has("error") || params.has("error_description");
+}
+
+function sanitizeProviderError(params: URLSearchParams): void {
+	params.set("error", SOCIAL_PROVIDER_ERROR_CODE);
+	params.delete("error_description");
+}
+
+function createSocialProviderErrorBoundary(
+	providerIds: readonly ("google" | "github")[],
+): BetterAuthPlugin {
+	const enabledProviders = new Set(providerIds);
+	return {
+		id: "questpie-auth-entry-methods",
+		async onRequest(request, context) {
+			const url = new URL(request.url);
+			const providerSegment = url.pathname.match(
+				/\/callback\/([^/]+)\/?$/,
+			)?.[1];
+			let providerId: string | undefined;
+			try {
+				providerId = providerSegment
+					? decodeURIComponent(providerSegment)
+					: undefined;
+			} catch {
+				return;
+			}
+			if (
+				(providerId !== "google" && providerId !== "github") ||
+				!enabledProviders.has(providerId)
+			) {
+				return;
+			}
+
+			const queryChanged = hasProviderError(url.searchParams);
+			if (queryChanged) {
+				context.logger.warn("Social provider callback rejected", {
+					providerId,
+					error: url.searchParams.get("error"),
+					errorDescription: url.searchParams.get("error_description"),
+				});
+				sanitizeProviderError(url.searchParams);
+			}
+			if (request.method === "GET") {
+				return queryChanged
+					? { request: new Request(url, request) }
+					: undefined;
+			}
+			if (request.method !== "POST") return;
+
+			const contentType = request.headers.get("content-type") ?? "";
+			if (contentType.includes("application/x-www-form-urlencoded")) {
+				const body = new URLSearchParams(await request.clone().text());
+				const bodyChanged = hasProviderError(body);
+				if (bodyChanged) sanitizeProviderError(body);
+				if (!queryChanged && !bodyChanged) return;
+				const headers = new Headers(request.headers);
+				headers.delete("content-length");
+				return {
+					request: new Request(url, {
+						method: "POST",
+						headers,
+						body,
+					}),
+				};
+			}
+			if (!contentType.includes("application/json")) {
+				return queryChanged
+					? { request: new Request(url, request) }
+					: undefined;
+			}
+
+			const body = await request
+				.clone()
+				.json()
+				.catch(() => null);
+			if (!body || typeof body !== "object" || Array.isArray(body)) {
+				return queryChanged
+					? { request: new Request(url, request) }
+					: undefined;
+			}
+			const record = body as Record<string, unknown>;
+			const bodyChanged = "error" in record || "error_description" in record;
+			if (bodyChanged) {
+				record.error = SOCIAL_PROVIDER_ERROR_CODE;
+				delete record.error_description;
+			}
+			if (!queryChanged && !bodyChanged) return;
+			const headers = new Headers(request.headers);
+			headers.delete("content-length");
+			return {
+				request: new Request(url, {
+					method: "POST",
+					headers,
+					body: JSON.stringify(record),
+				}),
+			};
+		},
+		hooks: {
+			after: [
+				{
+					matcher: (context) => context.path === "/sign-in/social",
+					handler: createAuthMiddleware(async (context) => {
+						if (!isAPIError(context.context.returned)) return;
+						throw new APIError("UNAUTHORIZED", {
+							code: SOCIAL_PROVIDER_ERROR_CODE,
+							message: SOCIAL_PROVIDER_ERROR_MESSAGE,
+						});
+					}),
+				},
+				{
+					matcher: (context) => context.path === "/callback/:id",
+					handler: createAuthMiddleware(async (context) => {
+						if (context.context.newSession) return;
+						const location = context.context.responseHeaders?.get("location");
+						if (!location) return;
+						const absolute = /^[a-z][a-z\d+.-]*:/i.test(location);
+						const redirect = new URL(location, context.context.baseURL);
+						if (!hasProviderError(redirect.searchParams)) return;
+						sanitizeProviderError(redirect.searchParams);
+						context.setHeader(
+							"location",
+							absolute
+								? redirect.toString()
+								: `${redirect.pathname}${redirect.search}${redirect.hash}`,
+						);
+					}),
+				},
+			],
+		},
+	};
+}
+
+function assertProviderCredentials(
+	providerId: "google" | "github",
+	options: Partial<ProviderCredentialPair>,
+): asserts options is ProviderCredentialPair {
+	if (
+		typeof options.clientId !== "string" ||
+		options.clientId.trim().length === 0 ||
+		typeof options.clientSecret !== "string" ||
+		options.clientSecret.trim().length === 0
+	) {
+		throw new TypeError(
+			`Auth entry provider "${providerId}" requires non-empty clientId and clientSecret values`,
+		);
+	}
+}
+
+function assertNoBypassEntryMethods(
+	authOptions: AuthEntryMethodsInput["authOptions"],
+): void {
+	const runtimeOptions = authOptions as BetterAuthOptions | undefined;
+	if (Object.keys(runtimeOptions?.socialProviders ?? {}).length > 0) {
+		throw new TypeError(
+			"Auth entry social providers must be configured through socialProviders",
+		);
+	}
+	const unsupportedPlugin = runtimeOptions?.plugins?.find((plugin) =>
+		UNSUPPORTED_SOCIAL_PLUGIN_IDS.has(plugin.id),
+	);
+	if (unsupportedPlugin) {
+		throw new TypeError(
+			`Auth entry plugin "${unsupportedPlugin.id}" is not supported by the verified provider catalog`,
+		);
+	}
+}
+
+function withVerifiedGoogleEmail(
+	options: GoogleAuthEntryOptions,
+): GoogleOptions {
+	const { mapProfileToUser, ...providerOptions } = options;
+	const provider = google(providerOptions);
+	return {
+		...options,
+		getUserInfo: async (tokens) => {
+			const result = await provider.getUserInfo(tokens);
+			if (
+				!result ||
+				result.user.emailVerified !== true ||
+				typeof result.user.id !== "string" ||
+				result.user.id.trim().length === 0 ||
+				typeof result.user.email !== "string" ||
+				result.user.email.trim().length === 0
+			) {
+				return null;
+			}
+			const mapped = await mapProfileToUser?.(result.data);
+			return {
+				data: result.data,
+				user: {
+					...result.user,
+					...mapped,
+					id: result.user.id.trim(),
+					email: result.user.email.trim(),
+					emailVerified: true,
+				},
+			};
+		},
+	};
+}
+
+function withVerifiedGithubEmail(
+	options: GithubAuthEntryOptions,
+): GithubOptions {
+	const { mapProfileToUser, ...providerOptions } = options;
+	const provider = github(providerOptions);
+	return {
+		...options,
+		getUserInfo: async (tokens) => {
+			const result = await provider.getUserInfo(tokens);
+			if (
+				!result ||
+				result.user.emailVerified !== true ||
+				typeof result.user.id !== "string" ||
+				result.user.id.trim().length === 0 ||
+				typeof result.user.email !== "string" ||
+				result.user.email.trim().length === 0
+			) {
+				return null;
+			}
+			const mapped = await mapProfileToUser?.(result.data);
+			return {
+				data: result.data,
+				user: {
+					...result.user,
+					...mapped,
+					id: result.user.id.trim(),
+					email: result.user.email.trim(),
+					emailVerified: true,
+				},
+			};
+		},
+	};
+}
+
+export function configureAuthEntryMethods(
+	input: AuthEntryMethodsInput,
+): AuthEntryMethodsConfig {
+	assertNoBypassEntryMethods(input.authOptions);
+	if (input.socialProviders?.google) {
+		assertProviderCredentials("google", input.socialProviders.google);
+	}
+	if (input.socialProviders?.github) {
+		assertProviderCredentials("github", input.socialProviders.github);
+	}
+
+	const publicMethods: PublicAuthEntryMethod[] = [];
+	if (input.credentials.enabled) {
+		publicMethods.push({ id: "email", kind: "credentials" });
+	}
+	if (input.socialProviders?.google) {
+		publicMethods.push({ id: "google", kind: "social" });
+	}
+	if (input.socialProviders?.github) {
+		publicMethods.push({ id: "github", kind: "social" });
+	}
+
+	const plugins: BetterAuthPlugin[] = [];
+	const socialMethodIds = publicMethods
+		.filter(
+			(method): method is Extract<PublicAuthEntryMethod, { kind: "social" }> =>
+				method.kind === "social",
+		)
+		.map(({ id }) => id);
+	if (socialMethodIds.length > 0) {
+		plugins.push(createSocialProviderErrorBoundary(socialMethodIds));
+	}
+	if (input.lastLoginMethod?.enabledWhenMultiple && publicMethods.length >= 2) {
+		plugins.push(
+			lastLoginMethod({
+				storeInDatabase: false,
+				...(input.lastLoginMethod.maxAgeSeconds === undefined
+					? {}
+					: { maxAge: input.lastLoginMethod.maxAgeSeconds }),
+			}),
+		);
+	}
+
+	const protectedOptions: BetterAuthOptions = {
+		emailAndPassword: { enabled: input.credentials.enabled },
+		account: {
+			accountLinking: {
+				disableImplicitLinking: true,
+			},
+		},
+		socialProviders: input.socialProviders
+			? {
+					...(input.socialProviders.google
+						? {
+								google: withVerifiedGoogleEmail(input.socialProviders.google),
+							}
+						: {}),
+					...(input.socialProviders.github
+						? {
+								github: withVerifiedGithubEmail(input.socialProviders.github),
+							}
+						: {}),
+				}
+			: undefined,
+		plugins: plugins.length > 0 ? plugins : undefined,
+	};
+
+	return {
+		authOptions: mergeAuthOptions(input.authOptions ?? {}, protectedOptions),
+		publicMethods,
+	};
+}

--- a/packages/questpie/src/server/modules/core/integrated/auth/entry-methods.ts
+++ b/packages/questpie/src/server/modules/core/integrated/auth/entry-methods.ts
@@ -88,12 +88,15 @@ function sanitizeProviderError(params: URLSearchParams): void {
 
 function markProviderErrorCallbackURL(
 	callbackURL: unknown,
+	configuredErrorURL: unknown,
 	baseURL: string,
 ): string {
 	const raw =
 		typeof callbackURL === "string" && callbackURL.length > 0
 			? callbackURL
-			: `${baseURL}/error`;
+			: typeof configuredErrorURL === "string" && configuredErrorURL.length > 0
+				? configuredErrorURL
+				: `${baseURL}/error`;
 	const absolute = /^[a-z][a-z\d+.-]*:/i.test(raw);
 	const url = new URL(raw, baseURL);
 	url.searchParams.set(SOCIAL_PROVIDER_ERROR_MARKER, "1");
@@ -208,6 +211,7 @@ function createSocialProviderErrorBoundary(
 						}
 						body.errorCallbackURL = markProviderErrorCallbackURL(
 							body.errorCallbackURL,
+							context.context.options.onAPIError?.errorURL,
 							context.context.baseURL,
 						);
 					}),

--- a/packages/questpie/src/server/modules/core/integrated/auth/entry-methods.ts
+++ b/packages/questpie/src/server/modules/core/integrated/auth/entry-methods.ts
@@ -23,14 +23,25 @@ type ProviderCredentialPair = {
 	clientSecret: string;
 };
 
-type GoogleAuthEntryOptions = Omit<GoogleOptions, "clientId" | "clientSecret"> &
+type GoogleAuthEntryOptions = Omit<
+	GoogleOptions,
+	"clientId" | "clientSecret" | "getUserInfo" | "verifyIdToken"
+> &
 	ProviderCredentialPair;
 
-type GithubAuthEntryOptions = Omit<GithubOptions, "clientId" | "clientSecret"> &
+type GithubAuthEntryOptions = Omit<
+	GithubOptions,
+	"clientId" | "clientSecret" | "getUserInfo"
+> &
 	ProviderCredentialPair;
+
+type ReviewedNonEntryPlugin = BetterAuthPlugin & {
+	id: "admin" | "bearer" | "jwt" | "oauth-provider" | "open-api";
+};
 
 export type AuthEntryMethodsInput = {
-	authOptions?: Omit<BetterAuthOptions, "socialProviders"> & {
+	authOptions?: Omit<BetterAuthOptions, "plugins" | "socialProviders"> & {
+		plugins?: ReviewedNonEntryPlugin[];
 		socialProviders?: never;
 	};
 	credentials: { enabled: boolean };
@@ -53,11 +64,18 @@ export type AuthEntryMethodsConfig = {
 
 const SOCIAL_PROVIDER_ERROR_CODE = "social_provider_error";
 const SOCIAL_PROVIDER_ERROR_MESSAGE = "Social provider authentication failed";
-const UNSUPPORTED_SOCIAL_PLUGIN_IDS = new Set([
-	"generic-oauth",
-	"oauth-proxy",
-	"one-tap",
+const SOCIAL_PROVIDER_ERROR_MARKER = "questpie_social_provider_error";
+const REVIEWED_NON_ENTRY_PLUGIN_IDS = new Set([
+	"admin",
+	"bearer",
+	"jwt",
+	"oauth-provider",
+	"open-api",
 ]);
+const SECURITY_SENSITIVE_PROVIDER_OPTIONS = {
+	google: ["getUserInfo", "verifyIdToken"],
+	github: ["getUserInfo"],
+} as const;
 
 function hasProviderError(params: URLSearchParams): boolean {
 	return params.has("error") || params.has("error_description");
@@ -66,6 +84,20 @@ function hasProviderError(params: URLSearchParams): boolean {
 function sanitizeProviderError(params: URLSearchParams): void {
 	params.set("error", SOCIAL_PROVIDER_ERROR_CODE);
 	params.delete("error_description");
+}
+
+function markProviderErrorCallbackURL(
+	callbackURL: unknown,
+	baseURL: string,
+): string {
+	const raw =
+		typeof callbackURL === "string" && callbackURL.length > 0
+			? callbackURL
+			: `${baseURL}/error`;
+	const absolute = /^[a-z][a-z\d+.-]*:/i.test(raw);
+	const url = new URL(raw, baseURL);
+	url.searchParams.set(SOCIAL_PROVIDER_ERROR_MARKER, "1");
+	return absolute ? url.toString() : `${url.pathname}${url.search}${url.hash}`;
 }
 
 function createSocialProviderErrorBoundary(
@@ -159,6 +191,28 @@ function createSocialProviderErrorBoundary(
 			};
 		},
 		hooks: {
+			before: [
+				{
+					matcher: (context) =>
+						context.path === "/sign-in/social" ||
+						context.path === "/link-social",
+					handler: createAuthMiddleware(async (context) => {
+						const body = context.body as Record<string, unknown> | undefined;
+						if (!body) return;
+						const providerId = body.provider;
+						if (
+							(providerId !== "google" && providerId !== "github") ||
+							!enabledProviders.has(providerId)
+						) {
+							return;
+						}
+						body.errorCallbackURL = markProviderErrorCallbackURL(
+							body.errorCallbackURL,
+							context.context.baseURL,
+						);
+					}),
+				},
+			],
 			after: [
 				{
 					matcher: (context) => context.path === "/sign-in/social",
@@ -173,12 +227,16 @@ function createSocialProviderErrorBoundary(
 				{
 					matcher: (context) => context.path === "/callback/:id",
 					handler: createAuthMiddleware(async (context) => {
-						if (context.context.newSession) return;
 						const location = context.context.responseHeaders?.get("location");
 						if (!location) return;
 						const absolute = /^[a-z][a-z\d+.-]*:/i.test(location);
 						const redirect = new URL(location, context.context.baseURL);
-						if (!hasProviderError(redirect.searchParams)) return;
+						if (
+							redirect.searchParams.get(SOCIAL_PROVIDER_ERROR_MARKER) !== "1"
+						) {
+							return;
+						}
+						redirect.searchParams.delete(SOCIAL_PROVIDER_ERROR_MARKER);
 						sanitizeProviderError(redirect.searchParams);
 						context.setHeader(
 							"location",
@@ -209,6 +267,19 @@ function assertProviderCredentials(
 	}
 }
 
+function assertNoProviderSecurityOverrides(
+	providerId: "google" | "github",
+	options: object,
+): void {
+	for (const option of SECURITY_SENSITIVE_PROVIDER_OPTIONS[providerId]) {
+		if (option in options) {
+			throw new TypeError(
+				`Auth entry provider "${providerId}" does not allow the "${option}" override`,
+			);
+		}
+	}
+}
+
 function assertNoBypassEntryMethods(
 	authOptions: AuthEntryMethodsInput["authOptions"],
 ): void {
@@ -218,12 +289,12 @@ function assertNoBypassEntryMethods(
 			"Auth entry social providers must be configured through socialProviders",
 		);
 	}
-	const unsupportedPlugin = runtimeOptions?.plugins?.find((plugin) =>
-		UNSUPPORTED_SOCIAL_PLUGIN_IDS.has(plugin.id),
+	const unsupportedPlugin = runtimeOptions?.plugins?.find(
+		(plugin) => !REVIEWED_NON_ENTRY_PLUGIN_IDS.has(plugin.id),
 	);
 	if (unsupportedPlugin) {
 		throw new TypeError(
-			`Auth entry plugin "${unsupportedPlugin.id}" is not supported by the verified provider catalog`,
+			`Auth entry plugin "${unsupportedPlugin.id}" is not in the reviewed non-entry allowlist`,
 		);
 	}
 }
@@ -237,11 +308,13 @@ function withVerifiedGoogleEmail(
 		...options,
 		getUserInfo: async (tokens) => {
 			const result = await provider.getUserInfo(tokens);
+			const providerId: unknown = result?.user.id;
 			if (
 				!result ||
 				result.user.emailVerified !== true ||
-				typeof result.user.id !== "string" ||
-				result.user.id.trim().length === 0 ||
+				(typeof providerId !== "string" && typeof providerId !== "number") ||
+				(typeof providerId === "number" && !Number.isFinite(providerId)) ||
+				String(providerId).trim().length === 0 ||
 				typeof result.user.email !== "string" ||
 				result.user.email.trim().length === 0
 			) {
@@ -253,7 +326,7 @@ function withVerifiedGoogleEmail(
 				user: {
 					...result.user,
 					...mapped,
-					id: result.user.id.trim(),
+					id: String(providerId).trim(),
 					email: result.user.email.trim(),
 					emailVerified: true,
 				},
@@ -271,11 +344,13 @@ function withVerifiedGithubEmail(
 		...options,
 		getUserInfo: async (tokens) => {
 			const result = await provider.getUserInfo(tokens);
+			const providerId: unknown = result?.user.id;
 			if (
 				!result ||
 				result.user.emailVerified !== true ||
-				typeof result.user.id !== "string" ||
-				result.user.id.trim().length === 0 ||
+				(typeof providerId !== "string" && typeof providerId !== "number") ||
+				(typeof providerId === "number" && !Number.isFinite(providerId)) ||
+				String(providerId).trim().length === 0 ||
 				typeof result.user.email !== "string" ||
 				result.user.email.trim().length === 0
 			) {
@@ -287,7 +362,7 @@ function withVerifiedGithubEmail(
 				user: {
 					...result.user,
 					...mapped,
-					id: result.user.id.trim(),
+					id: String(providerId).trim(),
 					email: result.user.email.trim(),
 					emailVerified: true,
 				},
@@ -302,9 +377,11 @@ export function configureAuthEntryMethods(
 	assertNoBypassEntryMethods(input.authOptions);
 	if (input.socialProviders?.google) {
 		assertProviderCredentials("google", input.socialProviders.google);
+		assertNoProviderSecurityOverrides("google", input.socialProviders.google);
 	}
 	if (input.socialProviders?.github) {
 		assertProviderCredentials("github", input.socialProviders.github);
+		assertNoProviderSecurityOverrides("github", input.socialProviders.github);
 	}
 
 	const publicMethods: PublicAuthEntryMethod[] = [];

--- a/packages/questpie/test/integration/auth-entry-methods.test.ts
+++ b/packages/questpie/test/integration/auth-entry-methods.test.ts
@@ -1143,6 +1143,57 @@ describe("configureAuthEntryMethods", () => {
 		expect(diagnostics.join("\n")).toContain("private-provider-detail");
 	});
 
+	it("uses the configured API error URL when social errorCallbackURL is omitted", async () => {
+		const configured = configureAuthEntryMethods({
+			authOptions: {
+				onAPIError: {
+					errorURL: "https://auth.example.test/custom-error",
+				},
+			},
+			credentials: { enabled: false },
+			socialProviders: {
+				google: {
+					clientId: "google-client",
+					clientSecret: "google-secret",
+				},
+			},
+			requireVerifiedProviderEmail: true,
+		});
+		const auth = createTestAuth(configured);
+		const startResponse = await auth.handler(
+			new Request("https://auth.example.test/api/auth/sign-in/social", {
+				method: "POST",
+				headers: jsonHeaders,
+				body: JSON.stringify({
+					provider: "google",
+					callbackURL: "https://auth.example.test/complete",
+					disableRedirect: true,
+				}),
+			}),
+		);
+		const startBody = (await startResponse.json()) as { url: string };
+		const state = new URL(startBody.url).searchParams.get("state") ?? "";
+		const cookie = startResponse.headers
+			.getSetCookie()
+			.map((value) => value.split(";", 1)[0])
+			.join("; ");
+		const response = await auth.handler(
+			new Request(
+				`https://auth.example.test/api/auth/callback/google?error=access_denied&error_description=private-provider-detail&state=${state}`,
+				{ headers: { cookie } },
+			),
+		);
+		const location = new URL(
+			response.headers.get("location") ?? "",
+			"https://auth.example.test",
+		);
+
+		expect(response.status).toBe(302);
+		expect(location.pathname).toBe("/custom-error");
+		expect(location.searchParams.get("error")).toBe("social_provider_error");
+		expect(location.searchParams.has("error_description")).toBe(false);
+	});
+
 	it("enables the browser-only last-method cookie only with multiple methods", async () => {
 		const multiple = configureAuthEntryMethods({
 			credentials: { enabled: true },

--- a/packages/questpie/test/integration/auth-entry-methods.test.ts
+++ b/packages/questpie/test/integration/auth-entry-methods.test.ts
@@ -1,0 +1,767 @@
+import { describe, expect, it } from "bun:test";
+
+import { APIError, betterAuth } from "better-auth";
+import { memoryAdapter, type MemoryDB } from "better-auth/adapters/memory";
+
+import {
+	configureAuthEntryMethods,
+	type AuthEntryMethodsInput,
+} from "../../src/exports/auth.js";
+
+const emptyDatabase = (): MemoryDB => ({
+	user: [],
+	account: [],
+	session: [],
+	verification: [],
+});
+
+const createTestAuth = (
+	configured: ReturnType<typeof configureAuthEntryMethods>,
+	database: MemoryDB = emptyDatabase(),
+) =>
+	betterAuth({
+		baseURL: "https://auth.example.test",
+		secret: "a-test-secret-long-enough-for-better-auth",
+		database: memoryAdapter(database),
+		trustedOrigins: ["https://auth.example.test"],
+		rateLimit: { enabled: false },
+		...configured.authOptions,
+	});
+
+const jsonHeaders = {
+	"content-type": "application/json",
+	origin: "https://auth.example.test",
+};
+
+const socialInput = (user: {
+	id: string;
+	name: string;
+	email?: string | null;
+	emailVerified: boolean;
+}): AuthEntryMethodsInput => ({
+	credentials: { enabled: false },
+	socialProviders: {
+		google: {
+			clientId: "google-client",
+			clientSecret: "google-secret",
+			verifyIdToken: async () => true,
+			getUserInfo: async () => ({ user, data: { privateProfile: true } }),
+		},
+	},
+	requireVerifiedProviderEmail: true,
+});
+
+const signInWithGoogleIdToken = (auth: ReturnType<typeof betterAuth>) =>
+	auth.handler(
+		new Request("https://auth.example.test/api/auth/sign-in/social", {
+			method: "POST",
+			headers: jsonHeaders,
+			body: JSON.stringify({
+				provider: "google",
+				idToken: {
+					token: "provider-id-token",
+					accessToken: "new-provider-access-token",
+				},
+			}),
+		}),
+	);
+
+async function beginSocialCallback(
+	auth: ReturnType<typeof betterAuth>,
+	provider: "google" | "github",
+	callbackURL = "https://auth.example.test/complete",
+) {
+	const response = await auth.handler(
+		new Request("https://auth.example.test/api/auth/sign-in/social", {
+			method: "POST",
+			headers: jsonHeaders,
+			body: JSON.stringify({
+				provider,
+				callbackURL,
+				errorCallbackURL: "https://auth.example.test/error",
+				disableRedirect: true,
+			}),
+		}),
+	);
+	const body = (await response.json()) as { url: string };
+	return {
+		state: new URL(body.url).searchParams.get("state") ?? "",
+		cookie: response.headers
+			.getSetCookie()
+			.map((value) => value.split(";", 1)[0])
+			.join("; "),
+	};
+}
+
+async function withFakeTokenExchange<T>(run: () => Promise<T>): Promise<T> {
+	const originalFetch = globalThis.fetch;
+	globalThis.fetch = async () =>
+		Response.json({
+			access_token: "provider-access-token",
+			expires_in: 3600,
+			id_token: "provider-id-token",
+			token_type: "Bearer",
+		});
+	try {
+		return await run();
+	} finally {
+		globalThis.fetch = originalFetch;
+	}
+}
+
+describe("configureAuthEntryMethods", () => {
+	it("rejects incomplete provider credential pairs without disclosing a secret", () => {
+		for (const provider of ["google", "github"] as const) {
+			for (const partial of [
+				{ clientId: "client", clientSecret: "" },
+				{ clientId: "", clientSecret: "must-not-appear" },
+				{ clientId: "client" },
+				{ clientSecret: "must-not-appear" },
+			]) {
+				expect(() =>
+					configureAuthEntryMethods({
+						credentials: { enabled: true },
+						socialProviders: { [provider]: partial },
+						requireVerifiedProviderEmail: true,
+					} as AuthEntryMethodsInput),
+				).toThrow(`Auth entry provider "${provider}"`);
+			}
+		}
+	});
+
+	it("derives a deterministic secret-free catalog from the effective config", () => {
+		const result = configureAuthEntryMethods({
+			credentials: { enabled: true },
+			socialProviders: {
+				github: {
+					clientId: "github-client",
+					clientSecret: "github-secret",
+				},
+				google: {
+					clientId: "google-client",
+					clientSecret: "google-secret",
+				},
+			},
+			requireVerifiedProviderEmail: true,
+		});
+
+		expect(result.publicMethods).toEqual([
+			{ id: "email", kind: "credentials" },
+			{ id: "google", kind: "social" },
+			{ id: "github", kind: "social" },
+		]);
+		expect(JSON.stringify(result.publicMethods)).not.toContain("secret");
+		expect(result.authOptions.account?.accountLinking).toMatchObject({
+			disableImplicitLinking: true,
+		});
+	});
+
+	it("omits an absent provider from both the server config and public catalog", () => {
+		const result = configureAuthEntryMethods({
+			credentials: { enabled: false },
+			socialProviders: {
+				google: {
+					clientId: "google-client",
+					clientSecret: "google-secret",
+				},
+			},
+			requireVerifiedProviderEmail: true,
+		});
+
+		expect(Object.keys(result.authOptions.socialProviders ?? {})).toEqual([
+			"google",
+		]);
+		expect(result.publicMethods).toEqual([{ id: "google", kind: "social" }]);
+	});
+
+	it("merges an existing auth config while applying the protected provider last", async () => {
+		const basePlugin = { id: "base-auth-plugin" };
+		const configured = configureAuthEntryMethods({
+			authOptions: {
+				emailAndPassword: { minPasswordLength: 14 },
+				account: { updateAccountOnSignIn: false },
+				plugins: [basePlugin],
+			},
+			...socialInput({
+				id: "protected-user",
+				name: "Protected",
+				email: "protected@example.test",
+				emailVerified: false,
+			}),
+		});
+		const database = emptyDatabase();
+
+		expect(configured.authOptions.emailAndPassword?.minPasswordLength).toBe(14);
+		expect(configured.authOptions.account?.updateAccountOnSignIn).toBe(false);
+		expect(configured.authOptions.plugins?.map(({ id }) => id)).toContain(
+			basePlugin.id,
+		);
+		expect(
+			(await signInWithGoogleIdToken(createTestAuth(configured, database))).ok,
+		).toBe(false);
+		expect(database.user).toHaveLength(0);
+	});
+
+	it("rejects social entry methods outside the protected catalog", () => {
+		for (const authOptions of [
+			{
+				socialProviders: {
+					google: { clientId: "bypass-client", clientSecret: "bypass-secret" },
+				},
+			},
+			{ plugins: [{ id: "generic-oauth" }] },
+			{ plugins: [{ id: "one-tap" }] },
+			{ plugins: [{ id: "oauth-proxy" }] },
+		]) {
+			expect(() =>
+				configureAuthEntryMethods({
+					authOptions,
+					credentials: { enabled: true },
+					requireVerifiedProviderEmail: true,
+				} as AuthEntryMethodsInput),
+			).toThrow();
+		}
+	});
+
+	it.each([
+		["missing", undefined],
+		["null", null],
+		["blank", "   "],
+		["unverified", "person@example.test"],
+	] as const)(
+		"rejects a %s provider email before new user account or session persistence",
+		async (_, email) => {
+			const database = emptyDatabase();
+			const auth = createTestAuth(
+				configureAuthEntryMethods(
+					socialInput({
+						id: "provider-user-new",
+						name: "Provider Person",
+						email,
+						emailVerified: email === undefined,
+					}),
+				),
+				database,
+			);
+
+			const response = await signInWithGoogleIdToken(auth);
+
+			expect(response.ok).toBe(false);
+			expect(await response.json()).toEqual({
+				code: "social_provider_error",
+				message: "Social provider authentication failed",
+			});
+			expect(database.user).toHaveLength(0);
+			expect(database.account).toHaveLength(0);
+			expect(database.session).toHaveLength(0);
+		},
+	);
+
+	it("rejects a verified profile without a stable provider identity", async () => {
+		const database = emptyDatabase();
+		const response = await signInWithGoogleIdToken(
+			createTestAuth(
+				configureAuthEntryMethods(
+					socialInput({
+						id: "   ",
+						name: "Missing Identity",
+						email: "missing-id@example.test",
+						emailVerified: true,
+					}),
+				),
+				database,
+			),
+		);
+
+		expect(response.ok).toBe(false);
+		expect(database.user).toHaveLength(0);
+		expect(database.account).toHaveLength(0);
+		expect(database.session).toHaveLength(0);
+	});
+
+	it("leaves an existing normalized-email identity unchanged for an unverified response", async () => {
+		const now = new Date();
+		const existingUser = {
+			id: "existing-collision",
+			name: "Existing Person",
+			email: "person@example.test",
+			emailVerified: true,
+			createdAt: now,
+			updatedAt: now,
+		};
+		const database: MemoryDB = {
+			...emptyDatabase(),
+			user: [existingUser],
+		};
+		const auth = createTestAuth(
+			configureAuthEntryMethods(
+				socialInput({
+					id: "provider-collision",
+					name: "Provider Person",
+					email: "PERSON@example.test",
+					emailVerified: false,
+				}),
+			),
+			database,
+		);
+
+		expect((await signInWithGoogleIdToken(auth)).ok).toBe(false);
+		expect(database.user).toEqual([existingUser]);
+		expect(database.account).toHaveLength(0);
+		expect(database.session).toHaveLength(0);
+	});
+
+	it("does not refresh an already-linked account or create a session for an unverified response", async () => {
+		const now = new Date();
+		const existingUser = {
+			id: "existing-linked-user",
+			name: "Existing Linked",
+			email: "linked@example.test",
+			emailVerified: true,
+			createdAt: now,
+			updatedAt: now,
+		};
+		const existingAccount = {
+			id: "existing-linked-account",
+			userId: existingUser.id,
+			providerId: "google",
+			accountId: "linked-provider-user",
+			accessToken: "old-access-token",
+			createdAt: now,
+			updatedAt: now,
+		};
+		const database: MemoryDB = {
+			...emptyDatabase(),
+			user: [existingUser],
+			account: [existingAccount],
+		};
+		const auth = createTestAuth(
+			configureAuthEntryMethods(
+				socialInput({
+					id: existingAccount.accountId,
+					name: "Provider Linked",
+					email: existingUser.email,
+					emailVerified: false,
+				}),
+			),
+			database,
+		);
+
+		expect((await signInWithGoogleIdToken(auth)).ok).toBe(false);
+		expect(database.user).toEqual([existingUser]);
+		expect(database.account).toEqual([existingAccount]);
+		expect(database.session).toHaveLength(0);
+	});
+
+	it("persists one user account and session for a verified new identity", async () => {
+		const database = emptyDatabase();
+		const auth = createTestAuth(
+			configureAuthEntryMethods(
+				socialInput({
+					id: "verified-provider-user",
+					name: "Verified Person",
+					email: "verified@example.test",
+					emailVerified: true,
+				}),
+			),
+			database,
+		);
+
+		expect((await signInWithGoogleIdToken(auth)).ok).toBe(true);
+		expect(database.user).toHaveLength(1);
+		expect(database.account).toHaveLength(1);
+		expect(database.session).toHaveLength(1);
+	});
+
+	it("does not link a verified identity to an existing normalized email", async () => {
+		const now = new Date();
+		const existingUser = {
+			id: "verified-collision",
+			name: "Existing Person",
+			email: "collision@example.test",
+			emailVerified: true,
+			createdAt: now,
+			updatedAt: now,
+		};
+		const database: MemoryDB = {
+			...emptyDatabase(),
+			user: [existingUser],
+		};
+		const auth = createTestAuth(
+			configureAuthEntryMethods(
+				socialInput({
+					id: "verified-provider-collision",
+					name: "Provider Person",
+					email: "  COLLISION@example.test  ",
+					emailVerified: true,
+				}),
+			),
+			database,
+		);
+
+		expect((await signInWithGoogleIdToken(auth)).ok).toBe(false);
+		expect(database.user).toEqual([existingUser]);
+		expect(database.account).toHaveLength(0);
+		expect(database.session).toHaveLength(0);
+	});
+
+	it.each(["google", "github"] as const)(
+		"applies the verified-email gate to the %s authorization-code callback",
+		async (provider) => {
+			const database = emptyDatabase();
+			const configured = configureAuthEntryMethods({
+				credentials: { enabled: false },
+				socialProviders: {
+					[provider]: {
+						clientId: `${provider}-client`,
+						clientSecret: `${provider}-secret`,
+						getUserInfo: async () => ({
+							user: {
+								id: `${provider}-callback-user`,
+								name: "Callback Person",
+								email: "callback@example.test",
+								emailVerified: false,
+							},
+							data: { privateProfile: true },
+						}),
+					},
+				},
+				requireVerifiedProviderEmail: true,
+			});
+			const auth = createTestAuth(configured, database);
+			const { state, cookie } = await beginSocialCallback(auth, provider);
+
+			const response = await withFakeTokenExchange(() =>
+				auth.handler(
+					new Request(
+						`https://auth.example.test/api/auth/callback/${provider}?code=provider-code&state=${state}`,
+						{ headers: { cookie } },
+					),
+				),
+			);
+
+			expect(response.status).toBe(302);
+			const location = response.headers.get("location") ?? "";
+			expect(location).toContain("error=social_provider_error");
+			expect(location).not.toContain("unable_to_get_user_info");
+			expect(location).not.toContain("privateProfile");
+			expect(database.user).toHaveLength(0);
+			expect(database.account).toHaveLength(0);
+			expect(database.session).toHaveLength(0);
+		},
+	);
+
+	it.each(["normalized-email collision", "already-linked account"] as const)(
+		"keeps the %s unchanged on an unverified authorization-code callback",
+		async (scenario) => {
+			const now = new Date();
+			const existingUser = {
+				id: "callback-existing-user",
+				name: "Existing Callback User",
+				email: "callback-existing@example.test",
+				emailVerified: true,
+				createdAt: now,
+				updatedAt: now,
+			};
+			const existingAccount = {
+				id: "callback-existing-account",
+				userId: existingUser.id,
+				providerId: "google",
+				accountId: "callback-provider-user",
+				accessToken: "old-callback-token",
+				createdAt: now,
+				updatedAt: now,
+			};
+			const database: MemoryDB = {
+				...emptyDatabase(),
+				user: [existingUser],
+				account: scenario === "already-linked account" ? [existingAccount] : [],
+			};
+			const auth = createTestAuth(
+				configureAuthEntryMethods({
+					credentials: { enabled: false },
+					socialProviders: {
+						google: {
+							clientId: "google-client",
+							clientSecret: "google-secret",
+							getUserInfo: async () => ({
+								user: {
+									id: existingAccount.accountId,
+									name: "Unverified Callback",
+									email: existingUser.email.toUpperCase(),
+									emailVerified: false,
+								},
+								data: {},
+							}),
+						},
+					},
+					requireVerifiedProviderEmail: true,
+				}),
+				database,
+			);
+			const { state, cookie } = await beginSocialCallback(auth, "google");
+
+			const response = await withFakeTokenExchange(() =>
+				auth.handler(
+					new Request(
+						`https://auth.example.test/api/auth/callback/google?code=provider-code&state=${state}`,
+						{ headers: { cookie } },
+					),
+				),
+			);
+
+			expect(response.headers.get("location")).toContain(
+				"error=social_provider_error",
+			);
+			expect(database.user).toEqual([existingUser]);
+			expect(database.account).toEqual(
+				scenario === "already-linked account" ? [existingAccount] : [],
+			);
+			expect(database.session).toHaveLength(0);
+		},
+	);
+
+	it("scrubs an unknown callback failure code and description", async () => {
+		const configured = configureAuthEntryMethods({
+			authOptions: {
+				databaseHooks: {
+					user: {
+						create: {
+							before: async () => {
+								throw new APIError("BAD_REQUEST", {
+									code: "internal_detail_leaked-secret-token-abc",
+									message: "private database detail",
+								});
+							},
+						},
+					},
+				},
+			},
+			...socialInput({
+				id: "hook-error-user",
+				name: "Hook Error",
+				email: "hook-error@example.test",
+				emailVerified: true,
+			}),
+		});
+		const auth = createTestAuth(configured);
+		const { state, cookie } = await beginSocialCallback(auth, "google");
+		const response = await withFakeTokenExchange(() =>
+			auth.handler(
+				new Request(
+					`https://auth.example.test/api/auth/callback/google?code=provider-code&state=${state}`,
+					{ headers: { cookie } },
+				),
+			),
+		);
+		const location = response.headers.get("location") ?? "";
+
+		expect(location).toContain("error=social_provider_error");
+		expect(location).not.toContain("internal_detail");
+		expect(location).not.toContain("private+database+detail");
+	});
+
+	it("preserves a relative successful callback redirect", async () => {
+		const database = emptyDatabase();
+		const configured = configureAuthEntryMethods(
+			socialInput({
+				id: "relative-callback-user",
+				name: "Relative Callback",
+				email: "relative@example.test",
+				emailVerified: true,
+			}),
+		);
+		const auth = createTestAuth(configured, database);
+		const { state, cookie } = await beginSocialCallback(
+			auth,
+			"google",
+			"/complete?error=none&next=/inbox",
+		);
+
+		const response = await withFakeTokenExchange(() =>
+			auth.handler(
+				new Request(
+					`https://auth.example.test/api/auth/callback/google?code=provider-code&state=${state}`,
+					{ headers: { cookie } },
+				),
+			),
+		);
+
+		expect(response.status).toBe(302);
+		expect(response.headers.get("location")).toBe(
+			"/complete?error=none&next=/inbox",
+		);
+		expect(database.user).toHaveLength(1);
+		expect(database.account).toHaveLength(1);
+		expect(database.session).toHaveLength(1);
+	});
+
+	it("keeps non-social credential error codes unchanged", async () => {
+		const auth = createTestAuth(
+			configureAuthEntryMethods({
+				credentials: { enabled: true },
+				requireVerifiedProviderEmail: true,
+			}),
+		);
+		const response = await auth.handler(
+			new Request("https://auth.example.test/api/auth/reset-password", {
+				method: "POST",
+				headers: jsonHeaders,
+				body: JSON.stringify({
+					newPassword: "a-secure-test-password",
+					token: "bad-token",
+				}),
+			}),
+		);
+
+		expect(response.status).toBe(400);
+		expect(await response.json()).toMatchObject({ code: "INVALID_TOKEN" });
+	});
+
+	it("does not let mapProfileToUser upgrade an unverified provider email", async () => {
+		const database = emptyDatabase();
+		const input = socialInput({
+			id: "mapper-user",
+			name: "Mapper User",
+			email: "mapper@example.test",
+			emailVerified: false,
+		});
+		if (!input.socialProviders?.google)
+			throw new Error("missing fixture provider");
+		input.socialProviders.google.mapProfileToUser = async () => ({
+			emailVerified: true,
+		});
+
+		const response = await signInWithGoogleIdToken(
+			createTestAuth(configureAuthEntryMethods(input), database),
+		);
+
+		expect(response.ok).toBe(false);
+		expect(database.user).toHaveLength(0);
+		expect(database.account).toHaveLength(0);
+		expect(database.session).toHaveLength(0);
+	});
+
+	it("normalizes provider cancellation without reflecting its raw description", async () => {
+		const diagnostics: string[] = [];
+		const configured = configureAuthEntryMethods({
+			authOptions: {
+				logger: {
+					log: (_level, message, ...details) =>
+						diagnostics.push(`${message} ${JSON.stringify(details)}`),
+				},
+			},
+			credentials: { enabled: false },
+			socialProviders: {
+				google: {
+					clientId: "google-client",
+					clientSecret: "google-secret",
+				},
+			},
+			requireVerifiedProviderEmail: true,
+		});
+		const auth = createTestAuth(configured);
+		const { state, cookie } = await beginSocialCallback(auth, "google");
+		const response = await auth.handler(
+			new Request(
+				`https://auth.example.test/api/auth/callback/%67oogle?error=access_denied&error_description=private-provider-detail&state=${state}`,
+				{ headers: { cookie } },
+			),
+		);
+		const location = response.headers.get("location") ?? "";
+
+		expect(response.status).toBe(302);
+		expect(location).toContain("error=social_provider_error");
+		expect(location).not.toContain("access_denied");
+		expect(location).not.toContain("private-provider-detail");
+		expect(location).not.toContain("error_description");
+		expect(diagnostics.join("\n")).toContain("private-provider-detail");
+	});
+
+	it("enables the browser-only last-method cookie only with multiple methods", async () => {
+		const multiple = configureAuthEntryMethods({
+			credentials: { enabled: true },
+			socialProviders: {
+				google: {
+					clientId: "google-client",
+					clientSecret: "google-secret",
+				},
+			},
+			requireVerifiedProviderEmail: true,
+			lastLoginMethod: {
+				enabledWhenMultiple: true,
+				storeInDatabase: false,
+			},
+		});
+		const database = emptyDatabase();
+		const response = await createTestAuth(multiple, database).handler(
+			new Request("https://auth.example.test/api/auth/sign-up/email", {
+				method: "POST",
+				headers: jsonHeaders,
+				body: JSON.stringify({
+					email: "last-method@example.test",
+					name: "Last Method",
+					password: "a-secure-test-password",
+				}),
+			}),
+		);
+		const cookies = response.headers.getSetCookie().join("\n");
+
+		expect(response.ok).toBe(true);
+		expect(cookies).toContain("better-auth.last_used_login_method=email");
+		expect(cookies.toLowerCase()).toContain("max-age=2592000");
+		expect(JSON.stringify(database.user)).not.toContain("lastLoginMethod");
+
+		const single = configureAuthEntryMethods({
+			credentials: { enabled: true },
+			requireVerifiedProviderEmail: true,
+			lastLoginMethod: {
+				enabledWhenMultiple: true,
+				storeInDatabase: false,
+			},
+		});
+		expect(single.authOptions.plugins).toEqual([]);
+	});
+
+	it.each(["github", "disabled-provider", "stale-provider"])(
+		"ignores a forged or stale last-method cookie value %s",
+		async (cookieValue) => {
+			const configured = configureAuthEntryMethods({
+				credentials: { enabled: true },
+				socialProviders: {
+					google: {
+						clientId: "google-client",
+						clientSecret: "google-secret",
+					},
+				},
+				requireVerifiedProviderEmail: true,
+				lastLoginMethod: {
+					enabledWhenMultiple: true,
+					storeInDatabase: false,
+				},
+			});
+			const database = emptyDatabase();
+			const response = await createTestAuth(configured, database).handler(
+				new Request("https://auth.example.test/api/auth/sign-up/email", {
+					method: "POST",
+					headers: {
+						...jsonHeaders,
+						cookie: `better-auth.last_used_login_method=${cookieValue}`,
+					},
+					body: JSON.stringify({
+						email: `${cookieValue}@example.test`,
+						name: "Cookie Oracle",
+						password: "a-secure-test-password",
+					}),
+				}),
+			);
+
+			expect(response.ok).toBe(true);
+			expect(response.headers.getSetCookie().join("\n")).toContain(
+				"better-auth.last_used_login_method=email",
+			);
+			expect(database.account).toHaveLength(1);
+			expect(database.account[0]?.providerId).toBe("credential");
+		},
+	);
+});

--- a/packages/questpie/test/integration/auth-entry-methods.test.ts
+++ b/packages/questpie/test/integration/auth-entry-methods.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "bun:test";
 
+import { oauthProvider } from "@better-auth/oauth-provider";
 import { APIError, betterAuth } from "better-auth";
 import { memoryAdapter, type MemoryDB } from "better-auth/adapters/memory";
+import { jwt } from "better-auth/plugins";
 
 import {
 	configureAuthEntryMethods,
@@ -33,38 +35,28 @@ const jsonHeaders = {
 	origin: "https://auth.example.test",
 };
 
-const socialInput = (user: {
-	id: string;
+type TestProviderUser = {
+	id: string | number;
 	name: string;
 	email?: string | null;
 	emailVerified: boolean;
-}): AuthEntryMethodsInput => ({
-	credentials: { enabled: false },
-	socialProviders: {
-		google: {
-			clientId: "google-client",
-			clientSecret: "google-secret",
-			verifyIdToken: async () => true,
-			getUserInfo: async () => ({ user, data: { privateProfile: true } }),
-		},
-	},
-	requireVerifiedProviderEmail: true,
-});
+};
 
-const signInWithGoogleIdToken = (auth: ReturnType<typeof betterAuth>) =>
-	auth.handler(
-		new Request("https://auth.example.test/api/auth/sign-in/social", {
-			method: "POST",
-			headers: jsonHeaders,
-			body: JSON.stringify({
-				provider: "google",
-				idToken: {
-					token: "provider-id-token",
-					accessToken: "new-provider-access-token",
-				},
-			}),
-		}),
-	);
+let activeGoogleFixture: TestProviderUser | undefined;
+
+const socialInput = (user: TestProviderUser): AuthEntryMethodsInput => {
+	activeGoogleFixture = user;
+	return {
+		credentials: { enabled: false },
+		socialProviders: {
+			google: {
+				clientId: "google-client",
+				clientSecret: "google-secret",
+			},
+		},
+		requireVerifiedProviderEmail: true,
+	};
+};
 
 async function beginSocialCallback(
 	auth: ReturnType<typeof betterAuth>,
@@ -93,20 +85,203 @@ async function beginSocialCallback(
 	};
 }
 
-async function withFakeTokenExchange<T>(run: () => Promise<T>): Promise<T> {
+async function beginLinkCallback(
+	auth: ReturnType<typeof betterAuth>,
+	sessionCookie: string,
+	callbackURL: string,
+) {
+	const response = await auth.handler(
+		new Request("https://auth.example.test/api/auth/link-social", {
+			method: "POST",
+			headers: { ...jsonHeaders, cookie: sessionCookie },
+			body: JSON.stringify({
+				provider: "google",
+				callbackURL,
+				errorCallbackURL: "https://auth.example.test/link-error",
+				disableRedirect: true,
+			}),
+		}),
+	);
+	const body = (await response.json()) as { url: string };
+	return {
+		state: new URL(body.url).searchParams.get("state") ?? "",
+		cookie: [
+			sessionCookie,
+			...response.headers.getSetCookie().map((value) => value.split(";", 1)[0]),
+		].join("; "),
+	};
+}
+
+function fakeGoogleIdToken(user: TestProviderUser): string {
+	const encode = (value: object) =>
+		btoa(JSON.stringify(value))
+			.replaceAll("+", "-")
+			.replaceAll("/", "_")
+			.replaceAll("=", "");
+	return `${encode({ alg: "none", typ: "JWT" })}.${encode({
+		sub: user.id,
+		name: user.name,
+		email: user.email,
+		email_verified: user.emailVerified,
+		picture: "https://example.test/avatar.png",
+	})}.signature`;
+}
+
+function bytesToBase64Url(bytes: Uint8Array): string {
+	let binary = "";
+	for (const byte of bytes) binary += String.fromCharCode(byte);
+	return btoa(binary)
+		.replaceAll("+", "-")
+		.replaceAll("/", "_")
+		.replaceAll("=", "");
+}
+
+async function createSignedGoogleIdToken(user: TestProviderUser) {
+	const keys = await crypto.subtle.generateKey(
+		{
+			name: "RSASSA-PKCS1-v1_5",
+			modulusLength: 2048,
+			publicExponent: new Uint8Array([1, 0, 1]),
+			hash: "SHA-256",
+		},
+		true,
+		["sign", "verify"],
+	);
+	const now = Math.floor(Date.now() / 1000);
+	const header = bytesToBase64Url(
+		new TextEncoder().encode(
+			JSON.stringify({ alg: "RS256", kid: "questpie-test-key", typ: "JWT" }),
+		),
+	);
+	const payload = bytesToBase64Url(
+		new TextEncoder().encode(
+			JSON.stringify({
+				sub: String(user.id),
+				name: user.name,
+				email: user.email,
+				email_verified: user.emailVerified,
+				picture: "https://example.test/avatar.png",
+				iss: "https://accounts.google.com",
+				aud: "google-client",
+				iat: now,
+				exp: now + 300,
+			}),
+		),
+	);
+	const signingInput = `${header}.${payload}`;
+	const signature = await crypto.subtle.sign(
+		"RSASSA-PKCS1-v1_5",
+		keys.privateKey,
+		new TextEncoder().encode(signingInput),
+	);
+	const publicJwk = await crypto.subtle.exportKey("jwk", keys.publicKey);
+	return {
+		token: `${signingInput}.${bytesToBase64Url(new Uint8Array(signature))}`,
+		publicJwk: {
+			...publicJwk,
+			alg: "RS256",
+			kid: "questpie-test-key",
+			use: "sig",
+		},
+	};
+}
+
+async function signInWithSignedGoogleIdToken(
+	auth: ReturnType<typeof betterAuth>,
+	user: TestProviderUser,
+) {
+	const { token, publicJwk } = await createSignedGoogleIdToken(user);
 	const originalFetch = globalThis.fetch;
-	globalThis.fetch = async () =>
-		Response.json({
-			access_token: "provider-access-token",
-			expires_in: 3600,
-			id_token: "provider-id-token",
-			token_type: "Bearer",
-		});
+	globalThis.fetch = async (input) => {
+		const url = String(input);
+		if (url === "https://www.googleapis.com/oauth2/v3/certs") {
+			return Response.json({ keys: [publicJwk] });
+		}
+		throw new Error(`Unexpected Google verification request: ${url}`);
+	};
+	try {
+		return await auth.handler(
+			new Request("https://auth.example.test/api/auth/sign-in/social", {
+				method: "POST",
+				headers: jsonHeaders,
+				body: JSON.stringify({
+					provider: "google",
+					idToken: {
+						token,
+						accessToken: "provider-access-token",
+					},
+				}),
+			}),
+		);
+	} finally {
+		globalThis.fetch = originalFetch;
+	}
+}
+
+async function withFakeProviderNetwork<T>(
+	provider: "google" | "github",
+	user: TestProviderUser,
+	run: () => Promise<T>,
+): Promise<T> {
+	const originalFetch = globalThis.fetch;
+	globalThis.fetch = async (input) => {
+		const url = String(input);
+		if (url.includes("access_token") || url.includes("/token")) {
+			return Response.json({
+				access_token: "provider-access-token",
+				expires_in: 3600,
+				id_token: fakeGoogleIdToken(user),
+				token_type: "Bearer",
+			});
+		}
+		if (provider === "github" && url.endsWith("/user/emails")) {
+			return Response.json(
+				user.email
+					? [
+							{
+								email: user.email,
+								primary: true,
+								verified: user.emailVerified,
+								visibility: "private",
+							},
+						]
+					: [],
+			);
+		}
+		if (provider === "github" && url.endsWith("/user")) {
+			return Response.json({
+				id: user.id,
+				login: "github-user",
+				name: user.name,
+				email: user.email,
+				avatar_url: "https://example.test/avatar.png",
+			});
+		}
+		throw new Error(`Unexpected provider request: ${url}`);
+	};
 	try {
 		return await run();
 	} finally {
 		globalThis.fetch = originalFetch;
 	}
+}
+
+async function withFakeTokenExchange<T>(run: () => Promise<T>): Promise<T> {
+	if (!activeGoogleFixture) throw new Error("missing Google fixture");
+	return withFakeProviderNetwork("google", activeGoogleFixture, run);
+}
+
+async function signInWithGoogleCallback(auth: ReturnType<typeof betterAuth>) {
+	if (!activeGoogleFixture) throw new Error("missing Google fixture");
+	const { state, cookie } = await beginSocialCallback(auth, "google");
+	return withFakeProviderNetwork("google", activeGoogleFixture, () =>
+		auth.handler(
+			new Request(
+				`https://auth.example.test/api/auth/callback/google?code=provider-code&state=${state}`,
+				{ headers: { cookie } },
+			),
+		),
+	);
 }
 
 describe("configureAuthEntryMethods", () => {
@@ -127,6 +302,239 @@ describe("configureAuthEntryMethods", () => {
 				).toThrow(`Auth entry provider "${provider}"`);
 			}
 		}
+	});
+
+	it("rejects provider identity and token verification overrides", () => {
+		for (const socialProviders of [
+			{
+				google: {
+					clientId: "google-client",
+					clientSecret: "google-secret",
+					getUserInfo: async () => null,
+				},
+			},
+			{
+				google: {
+					clientId: "google-client",
+					clientSecret: "google-secret",
+					verifyIdToken: async () => true,
+				},
+			},
+			{
+				github: {
+					clientId: "github-client",
+					clientSecret: "github-secret",
+					getUserInfo: async () => null,
+				},
+			},
+		]) {
+			expect(() =>
+				configureAuthEntryMethods({
+					credentials: { enabled: false },
+					socialProviders,
+					requireVerifiedProviderEmail: true,
+				} as AuthEntryMethodsInput),
+			).toThrow("does not allow");
+		}
+	});
+
+	it("rejects plugins outside the reviewed non-entry allowlist", () => {
+		for (const id of ["anonymous", "magic-link", "username", "custom-entry"]) {
+			expect(() =>
+				configureAuthEntryMethods({
+					authOptions: { plugins: [{ id }] },
+					credentials: { enabled: true },
+					requireVerifiedProviderEmail: true,
+				} as AuthEntryMethodsInput),
+			).toThrow(`plugin "${id}"`);
+		}
+	});
+
+	it("composes the OAuth authorization server without adding a human entry method", async () => {
+		const database = emptyDatabase();
+		(database as MemoryDB & { oauthClient: unknown[] }).oauthClient = [];
+		const configured = configureAuthEntryMethods({
+			authOptions: {
+				plugins: [
+					jwt(),
+					oauthProvider({
+						loginPage: "/sign-in",
+						consentPage: "/oauth/consent",
+						scopes: ["openid", "profile", "email", "mcp:tools"],
+						allowDynamicClientRegistration: true,
+						allowUnauthenticatedClientRegistration: true,
+					}),
+				],
+			},
+			credentials: { enabled: true },
+			requireVerifiedProviderEmail: true,
+		});
+
+		expect(configured.publicMethods).toEqual([
+			{ id: "email", kind: "credentials" },
+		]);
+		expect(configured.authOptions.plugins?.map(({ id }) => id)).toEqual([
+			"jwt",
+			"oauth-provider",
+		]);
+
+		const auth = createTestAuth(configured, database);
+		const registrationResponse = await auth.handler(
+			new Request("https://auth.example.test/api/auth/oauth2/register", {
+				method: "POST",
+				headers: jsonHeaders,
+				body: JSON.stringify({
+					client_name: "Test MCP client",
+					redirect_uris: ["https://client.example.test/callback"],
+					token_endpoint_auth_method: "none",
+					grant_types: ["authorization_code"],
+					response_types: ["code"],
+				}),
+			}),
+		);
+		expect(registrationResponse.ok).toBe(true);
+		const registration = (await registrationResponse.json()) as {
+			client_id: string;
+		};
+		const authorizeURL = new URL(
+			"https://auth.example.test/api/auth/oauth2/authorize",
+		);
+		authorizeURL.searchParams.set("response_type", "code");
+		authorizeURL.searchParams.set("client_id", registration.client_id);
+		authorizeURL.searchParams.set(
+			"redirect_uri",
+			"https://client.example.test/callback",
+		);
+		authorizeURL.searchParams.set("scope", "openid");
+		authorizeURL.searchParams.set(
+			"code_challenge",
+			"a-valid-pkce-code-challenge-with-at-least-43-characters",
+		);
+		authorizeURL.searchParams.set("code_challenge_method", "S256");
+		const authorizeResponse = await auth.handler(new Request(authorizeURL));
+		expect(authorizeResponse.status).toBe(302);
+		expect(authorizeResponse.headers.get("location")).toStartWith("/sign-in?");
+		expect(database.user).toHaveLength(0);
+		expect(database.account).toHaveLength(0);
+		expect(database.session).toHaveLength(0);
+
+		const response = await auth.handler(
+			new Request("https://auth.example.test/api/auth/sign-up/email", {
+				method: "POST",
+				headers: jsonHeaders,
+				body: JSON.stringify({
+					email: "oauth-composition@example.test",
+					name: "OAuth Composition",
+					password: "a-secure-test-password",
+				}),
+			}),
+		);
+		expect(response.ok).toBe(true);
+		expect(database.user).toHaveLength(1);
+		expect(database.account).toHaveLength(1);
+	});
+
+	it("normalizes the built-in GitHub numeric profile id", async () => {
+		const configured = configureAuthEntryMethods({
+			credentials: { enabled: false },
+			socialProviders: {
+				github: {
+					clientId: "github-client",
+					clientSecret: "github-secret",
+				},
+			},
+			requireVerifiedProviderEmail: true,
+		});
+		const provider = configured.authOptions.socialProviders?.github;
+		if (!provider?.getUserInfo) throw new Error("missing GitHub provider");
+		const originalFetch = globalThis.fetch;
+		globalThis.fetch = async (input) => {
+			const url = String(input);
+			if (url.endsWith("/user/emails")) {
+				return Response.json([
+					{
+						email: "github@example.test",
+						primary: true,
+						verified: true,
+						visibility: "private",
+					},
+				]);
+			}
+			return Response.json({
+				id: 123456789,
+				login: "github-user",
+				name: "GitHub User",
+				email: "github@example.test",
+				avatar_url: "https://example.test/avatar.png",
+			});
+		};
+		try {
+			const result = await provider.getUserInfo({ accessToken: "token" });
+			expect(result?.user.id).toBe("123456789");
+			expect(result?.user.emailVerified).toBe(true);
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
+	});
+
+	it("rejects an unverified signed Google ID token before persistence", async () => {
+		const database = emptyDatabase();
+		const configured = configureAuthEntryMethods({
+			credentials: { enabled: false },
+			socialProviders: {
+				google: {
+					clientId: "google-client",
+					clientSecret: "google-secret",
+				},
+			},
+			requireVerifiedProviderEmail: true,
+		});
+		const response = await signInWithSignedGoogleIdToken(
+			createTestAuth(configured, database),
+			{
+				id: "google-id-token-unverified",
+				name: "Unverified ID Token",
+				email: "unverified-id-token@example.test",
+				emailVerified: false,
+			},
+		);
+
+		expect(response.status).toBe(401);
+		expect(await response.json()).toEqual({
+			code: "social_provider_error",
+			message: "Social provider authentication failed",
+		});
+		expect(database.user).toHaveLength(0);
+		expect(database.account).toHaveLength(0);
+		expect(database.session).toHaveLength(0);
+	});
+
+	it("persists a verified signed Google ID token identity", async () => {
+		const database = emptyDatabase();
+		const configured = configureAuthEntryMethods({
+			credentials: { enabled: false },
+			socialProviders: {
+				google: {
+					clientId: "google-client",
+					clientSecret: "google-secret",
+				},
+			},
+			requireVerifiedProviderEmail: true,
+		});
+		const response = await signInWithSignedGoogleIdToken(
+			createTestAuth(configured, database),
+			{
+				id: "google-id-token-verified",
+				name: "Verified ID Token",
+				email: "verified-id-token@example.test",
+				emailVerified: true,
+			},
+		);
+
+		expect(response.ok).toBe(true);
+		expect(database.user).toHaveLength(1);
+		expect(database.account).toHaveLength(1);
+		expect(database.session).toHaveLength(1);
 	});
 
 	it("derives a deterministic secret-free catalog from the effective config", () => {
@@ -175,7 +583,7 @@ describe("configureAuthEntryMethods", () => {
 	});
 
 	it("merges an existing auth config while applying the protected provider last", async () => {
-		const basePlugin = { id: "base-auth-plugin" };
+		const basePlugin = { id: "bearer" as const };
 		const configured = configureAuthEntryMethods({
 			authOptions: {
 				emailAndPassword: { minPasswordLength: 14 },
@@ -197,7 +605,7 @@ describe("configureAuthEntryMethods", () => {
 			basePlugin.id,
 		);
 		expect(
-			(await signInWithGoogleIdToken(createTestAuth(configured, database))).ok,
+			(await signInWithGoogleCallback(createTestAuth(configured, database))).ok,
 		).toBe(false);
 		expect(database.user).toHaveLength(0);
 	});
@@ -244,13 +652,12 @@ describe("configureAuthEntryMethods", () => {
 				database,
 			);
 
-			const response = await signInWithGoogleIdToken(auth);
+			const response = await signInWithGoogleCallback(auth);
 
 			expect(response.ok).toBe(false);
-			expect(await response.json()).toEqual({
-				code: "social_provider_error",
-				message: "Social provider authentication failed",
-			});
+			expect(response.headers.get("location")).toContain(
+				"error=social_provider_error",
+			);
 			expect(database.user).toHaveLength(0);
 			expect(database.account).toHaveLength(0);
 			expect(database.session).toHaveLength(0);
@@ -259,7 +666,7 @@ describe("configureAuthEntryMethods", () => {
 
 	it("rejects a verified profile without a stable provider identity", async () => {
 		const database = emptyDatabase();
-		const response = await signInWithGoogleIdToken(
+		const response = await signInWithGoogleCallback(
 			createTestAuth(
 				configureAuthEntryMethods(
 					socialInput({
@@ -305,7 +712,7 @@ describe("configureAuthEntryMethods", () => {
 			database,
 		);
 
-		expect((await signInWithGoogleIdToken(auth)).ok).toBe(false);
+		expect((await signInWithGoogleCallback(auth)).ok).toBe(false);
 		expect(database.user).toEqual([existingUser]);
 		expect(database.account).toHaveLength(0);
 		expect(database.session).toHaveLength(0);
@@ -347,7 +754,7 @@ describe("configureAuthEntryMethods", () => {
 			database,
 		);
 
-		expect((await signInWithGoogleIdToken(auth)).ok).toBe(false);
+		expect((await signInWithGoogleCallback(auth)).ok).toBe(false);
 		expect(database.user).toEqual([existingUser]);
 		expect(database.account).toEqual([existingAccount]);
 		expect(database.session).toHaveLength(0);
@@ -367,7 +774,9 @@ describe("configureAuthEntryMethods", () => {
 			database,
 		);
 
-		expect((await signInWithGoogleIdToken(auth)).ok).toBe(true);
+		expect((await signInWithGoogleCallback(auth)).headers.get("location")).toBe(
+			"https://auth.example.test/complete",
+		);
 		expect(database.user).toHaveLength(1);
 		expect(database.account).toHaveLength(1);
 		expect(database.session).toHaveLength(1);
@@ -399,7 +808,7 @@ describe("configureAuthEntryMethods", () => {
 			database,
 		);
 
-		expect((await signInWithGoogleIdToken(auth)).ok).toBe(false);
+		expect((await signInWithGoogleCallback(auth)).ok).toBe(false);
 		expect(database.user).toEqual([existingUser]);
 		expect(database.account).toHaveLength(0);
 		expect(database.session).toHaveLength(0);
@@ -409,21 +818,18 @@ describe("configureAuthEntryMethods", () => {
 		"applies the verified-email gate to the %s authorization-code callback",
 		async (provider) => {
 			const database = emptyDatabase();
+			const providerUser = {
+				id: provider === "github" ? 987654321 : "google-callback-user",
+				name: "Callback Person",
+				email: "callback@example.test",
+				emailVerified: false,
+			};
 			const configured = configureAuthEntryMethods({
 				credentials: { enabled: false },
 				socialProviders: {
 					[provider]: {
 						clientId: `${provider}-client`,
 						clientSecret: `${provider}-secret`,
-						getUserInfo: async () => ({
-							user: {
-								id: `${provider}-callback-user`,
-								name: "Callback Person",
-								email: "callback@example.test",
-								emailVerified: false,
-							},
-							data: { privateProfile: true },
-						}),
 					},
 				},
 				requireVerifiedProviderEmail: true,
@@ -431,20 +837,22 @@ describe("configureAuthEntryMethods", () => {
 			const auth = createTestAuth(configured, database);
 			const { state, cookie } = await beginSocialCallback(auth, provider);
 
-			const response = await withFakeTokenExchange(() =>
-				auth.handler(
-					new Request(
-						`https://auth.example.test/api/auth/callback/${provider}?code=provider-code&state=${state}`,
-						{ headers: { cookie } },
+			const response = await withFakeProviderNetwork(
+				provider,
+				providerUser,
+				() =>
+					auth.handler(
+						new Request(
+							`https://auth.example.test/api/auth/callback/${provider}?code=provider-code&state=${state}`,
+							{ headers: { cookie } },
+						),
 					),
-				),
 			);
 
 			expect(response.status).toBe(302);
 			const location = response.headers.get("location") ?? "";
 			expect(location).toContain("error=social_provider_error");
 			expect(location).not.toContain("unable_to_get_user_info");
-			expect(location).not.toContain("privateProfile");
 			expect(database.user).toHaveLength(0);
 			expect(database.account).toHaveLength(0);
 			expect(database.session).toHaveLength(0);
@@ -477,6 +885,12 @@ describe("configureAuthEntryMethods", () => {
 				user: [existingUser],
 				account: scenario === "already-linked account" ? [existingAccount] : [],
 			};
+			const providerUser = {
+				id: existingAccount.accountId,
+				name: "Unverified Callback",
+				email: existingUser.email.toUpperCase(),
+				emailVerified: false,
+			};
 			const auth = createTestAuth(
 				configureAuthEntryMethods({
 					credentials: { enabled: false },
@@ -484,15 +898,6 @@ describe("configureAuthEntryMethods", () => {
 						google: {
 							clientId: "google-client",
 							clientSecret: "google-secret",
-							getUserInfo: async () => ({
-								user: {
-									id: existingAccount.accountId,
-									name: "Unverified Callback",
-									email: existingUser.email.toUpperCase(),
-									emailVerified: false,
-								},
-								data: {},
-							}),
 						},
 					},
 					requireVerifiedProviderEmail: true,
@@ -501,13 +906,16 @@ describe("configureAuthEntryMethods", () => {
 			);
 			const { state, cookie } = await beginSocialCallback(auth, "google");
 
-			const response = await withFakeTokenExchange(() =>
-				auth.handler(
-					new Request(
-						`https://auth.example.test/api/auth/callback/google?code=provider-code&state=${state}`,
-						{ headers: { cookie } },
+			const response = await withFakeProviderNetwork(
+				"google",
+				providerUser,
+				() =>
+					auth.handler(
+						new Request(
+							`https://auth.example.test/api/auth/callback/google?code=provider-code&state=${state}`,
+							{ headers: { cookie } },
+						),
 					),
-				),
 			);
 
 			expect(response.headers.get("location")).toContain(
@@ -596,6 +1004,63 @@ describe("configureAuthEntryMethods", () => {
 		expect(database.session).toHaveLength(1);
 	});
 
+	it("preserves a successful explicit-link callback containing an error key", async () => {
+		const database = emptyDatabase();
+		const configured = configureAuthEntryMethods({
+			credentials: { enabled: true },
+			socialProviders: {
+				google: {
+					clientId: "google-client",
+					clientSecret: "google-secret",
+				},
+			},
+			requireVerifiedProviderEmail: true,
+		});
+		const auth = createTestAuth(configured, database);
+		const signUp = await auth.handler(
+			new Request("https://auth.example.test/api/auth/sign-up/email", {
+				method: "POST",
+				headers: jsonHeaders,
+				body: JSON.stringify({
+					email: "link@example.test",
+					name: "Link Person",
+					password: "a-secure-test-password",
+				}),
+			}),
+		);
+		const sessionCookie = signUp.headers
+			.getSetCookie()
+			.map((value) => value.split(";", 1)[0])
+			.join("; ");
+		const { state, cookie } = await beginLinkCallback(
+			auth,
+			sessionCookie,
+			"/settings?error=none&tab=accounts",
+		);
+		const response = await withFakeProviderNetwork(
+			"google",
+			{
+				id: "linked-google-user",
+				name: "Link Person",
+				email: "link@example.test",
+				emailVerified: true,
+			},
+			() =>
+				auth.handler(
+					new Request(
+						`https://auth.example.test/api/auth/callback/google?code=provider-code&state=${state}`,
+						{ headers: { cookie } },
+					),
+				),
+		);
+
+		expect(response.headers.get("location")).toBe(
+			"/settings?error=none&tab=accounts",
+		);
+		expect(database.user).toHaveLength(1);
+		expect(database.account).toHaveLength(2);
+	});
+
 	it("keeps non-social credential error codes unchanged", async () => {
 		const auth = createTestAuth(
 			configureAuthEntryMethods({
@@ -632,7 +1097,7 @@ describe("configureAuthEntryMethods", () => {
 			emailVerified: true,
 		});
 
-		const response = await signInWithGoogleIdToken(
+		const response = await signInWithGoogleCallback(
 			createTestAuth(configureAuthEntryMethods(input), database),
 		);
 

--- a/skills/questpie/AGENTS.md
+++ b/skills/questpie/AGENTS.md
@@ -7556,7 +7556,7 @@ Detailed authentication configuration for QUESTPIE using Better Auth.
 
 - [File Convention](#file-convention), `config/auth.ts`, `authConfig()` factory
 - [Configuration Options](#configuration-options), options table + effective defaults
-- [Social Providers (OAuth)](#social-providers-oauth), `socialProviders`, client `signIn.social`
+- [Social Providers (OAuth)](#social-providers-oauth), `socialProviders`, verified Google/GitHub entry catalog, client `signIn.social`
 - [Session Access](#session-access), routes, hooks, access rules
 - [User Collection](#user-collection), starter user model, merge + extend recipe
 - [Reaching the App from Better Auth Callbacks](#reaching-the-app-from-better-auth-callbacks), `getContext<App>()`, partial overrides
@@ -7619,6 +7619,61 @@ Trigger the OAuth flow from the client with `signIn.social`:
 ```tsx
 await authClient.signIn.social({ provider: "google", callbackURL: "/" });
 ```
+
+### Verified Google/GitHub Entry Catalog
+
+Use `configureAuthEntryMethods()` when the product must expose a public sign-in
+method catalog and must reject an unverified Google or GitHub identity before
+QUESTPIE persists a user, account, token, or session. Declare and validate these
+environment variables in `env.ts`; do not send provider secrets to the client.
+
+```ts
+// config/auth.ts
+import { authConfig } from "questpie/app";
+import { configureAuthEntryMethods } from "questpie/auth";
+
+import env from "../env";
+
+const entryMethods = configureAuthEntryMethods({
+	authOptions: {
+		baseURL: env.APP_URL,
+		secret: env.BETTER_AUTH_SECRET,
+	},
+	credentials: { enabled: true },
+	socialProviders: {
+		google: {
+			clientId: env.GOOGLE_CLIENT_ID,
+			clientSecret: env.GOOGLE_CLIENT_SECRET,
+		},
+		github: {
+			clientId: env.GITHUB_CLIENT_ID,
+			clientSecret: env.GITHUB_CLIENT_SECRET,
+		},
+	},
+	requireVerifiedProviderEmail: true,
+	lastLoginMethod: {
+		enabledWhenMultiple: true,
+		storeInDatabase: false,
+	},
+});
+
+export const publicAuthEntryMethods = entryMethods.publicMethods;
+export default authConfig(entryMethods.authOptions);
+```
+
+Omit a provider property to disable that provider. If a provider is present,
+both `clientId` and `clientSecret` must be non-empty. The helper accepts only
+Google and GitHub, requires `emailVerified === true` plus non-empty provider ID
+and email, disables implicit account linking, and returns `publicMethods` in the
+stable `email`, `google`, `github` order without secrets. It also rejects social
+providers passed through `authOptions` and the `generic-oauth`, `one-tap`, and
+`oauth-proxy` plugins so they cannot bypass the verified-provider catalog.
+
+The optional last-login method hint is enabled only when at least two methods
+are configured and remains browser-only (`storeInDatabase: false`). Provider
+callback failures are sanitized for the client; their raw diagnostics stay in
+server logs. Explicit account linking remains a separate authenticated
+operation.
 
 ## Session Access
 

--- a/skills/questpie/AGENTS.md
+++ b/skills/questpie/AGENTS.md
@@ -7666,8 +7666,13 @@ both `clientId` and `clientSecret` must be non-empty. The helper accepts only
 Google and GitHub, requires `emailVerified === true` plus non-empty provider ID
 and email, disables implicit account linking, and returns `publicMethods` in the
 stable `email`, `google`, `github` order without secrets. It also rejects social
-providers passed through `authOptions` and the `generic-oauth`, `one-tap`, and
-`oauth-proxy` plugins so they cannot bypass the verified-provider catalog.
+providers passed through `authOptions`, provider `getUserInfo` overrides, and a
+Google `verifyIdToken` override. Only the reviewed non-entry `admin`, `bearer`,
+`open-api`, `jwt`, and OAuth authorization-server `oauth-provider` plugins may
+pass through `authOptions`; every other plugin is rejected so it cannot add an
+undeclared human entry method outside the catalog. The OAuth provider authorizes
+an existing session and redirects an unauthenticated person to its configured
+login page; it does not authenticate a new human identity itself.
 
 The optional last-login method hint is enabled only when at least two methods
 are configured and remains browser-only (`storeInDatabase: false`). Provider

--- a/skills/questpie/references/auth.md
+++ b/skills/questpie/references/auth.md
@@ -123,8 +123,13 @@ both `clientId` and `clientSecret` must be non-empty. The helper accepts only
 Google and GitHub, requires `emailVerified === true` plus non-empty provider ID
 and email, disables implicit account linking, and returns `publicMethods` in the
 stable `email`, `google`, `github` order without secrets. It also rejects social
-providers passed through `authOptions` and the `generic-oauth`, `one-tap`, and
-`oauth-proxy` plugins so they cannot bypass the verified-provider catalog.
+providers passed through `authOptions`, provider `getUserInfo` overrides, and a
+Google `verifyIdToken` override. Only the reviewed non-entry `admin`, `bearer`,
+`open-api`, `jwt`, and OAuth authorization-server `oauth-provider` plugins may
+pass through `authOptions`; every other plugin is rejected so it cannot add an
+undeclared human entry method outside the catalog. The OAuth provider authorizes
+an existing session and redirects an unauthenticated person to its configured
+login page; it does not authenticate a new human identity itself.
 
 The optional last-login method hint is enabled only when at least two methods
 are configured and remains browser-only (`storeInDatabase: false`). Provider

--- a/skills/questpie/references/auth.md
+++ b/skills/questpie/references/auth.md
@@ -13,7 +13,7 @@ Detailed authentication configuration for QUESTPIE using Better Auth.
 
 - [File Convention](#file-convention), `config/auth.ts`, `authConfig()` factory
 - [Configuration Options](#configuration-options), options table + effective defaults
-- [Social Providers (OAuth)](#social-providers-oauth), `socialProviders`, client `signIn.social`
+- [Social Providers (OAuth)](#social-providers-oauth), `socialProviders`, verified Google/GitHub entry catalog, client `signIn.social`
 - [Session Access](#session-access), routes, hooks, access rules
 - [User Collection](#user-collection), starter user model, merge + extend recipe
 - [Reaching the App from Better Auth Callbacks](#reaching-the-app-from-better-auth-callbacks), `getContext<App>()`, partial overrides
@@ -76,6 +76,61 @@ Trigger the OAuth flow from the client with `signIn.social`:
 ```tsx
 await authClient.signIn.social({ provider: "google", callbackURL: "/" });
 ```
+
+### Verified Google/GitHub Entry Catalog
+
+Use `configureAuthEntryMethods()` when the product must expose a public sign-in
+method catalog and must reject an unverified Google or GitHub identity before
+QUESTPIE persists a user, account, token, or session. Declare and validate these
+environment variables in `env.ts`; do not send provider secrets to the client.
+
+```ts
+// config/auth.ts
+import { authConfig } from "questpie/app";
+import { configureAuthEntryMethods } from "questpie/auth";
+
+import env from "../env";
+
+const entryMethods = configureAuthEntryMethods({
+	authOptions: {
+		baseURL: env.APP_URL,
+		secret: env.BETTER_AUTH_SECRET,
+	},
+	credentials: { enabled: true },
+	socialProviders: {
+		google: {
+			clientId: env.GOOGLE_CLIENT_ID,
+			clientSecret: env.GOOGLE_CLIENT_SECRET,
+		},
+		github: {
+			clientId: env.GITHUB_CLIENT_ID,
+			clientSecret: env.GITHUB_CLIENT_SECRET,
+		},
+	},
+	requireVerifiedProviderEmail: true,
+	lastLoginMethod: {
+		enabledWhenMultiple: true,
+		storeInDatabase: false,
+	},
+});
+
+export const publicAuthEntryMethods = entryMethods.publicMethods;
+export default authConfig(entryMethods.authOptions);
+```
+
+Omit a provider property to disable that provider. If a provider is present,
+both `clientId` and `clientSecret` must be non-empty. The helper accepts only
+Google and GitHub, requires `emailVerified === true` plus non-empty provider ID
+and email, disables implicit account linking, and returns `publicMethods` in the
+stable `email`, `google`, `github` order without secrets. It also rejects social
+providers passed through `authOptions` and the `generic-oauth`, `one-tap`, and
+`oauth-proxy` plugins so they cannot bypass the verified-provider catalog.
+
+The optional last-login method hint is enabled only when at least two methods
+are configured and remains browser-only (`storeInDatabase: false`). Provider
+callback failures are sanitized for the client; their raw diagnostics stay in
+server logs. Explicit account linking remains a separate authenticated
+operation.
 
 ## Session Access
 


### PR DESCRIPTION
## Summary

- add a generic public QUESTPIE auth entry-method configuration seam for credentials, Google, and GitHub
- require complete provider credential pairs and verified provider email before any user, account, token, or session persistence
- disable implicit account linking and expose a deterministic secret-free configured-method catalog
- sanitize provider failures while retaining raw server-side diagnostics
- add behavioral fake-provider zero-write coverage and a patch changeset

## Better Auth evidence

- requested: ^1.6.23
- installed: 1.6.25
- latest registry release inspected: 1.6.26
- inspected installed and latest official provider/link-account source before implementation

## Verification

- auth integration: 27 pass, 0 fail
- QUESTPIE package suite: 3136 pass, 65 skip, 0 fail
- QUESTPIE package typecheck and build: pass
- root format, lint, and typecheck: pass
- Claude Opus 5 medium independent audit: PASS
- root suite: 4437 pass, 75 skip, 1 unrelated nondeterministic observability failure; immediate standalone observability rerun: 6 pass, 0 fail

## Follow-up

Merge, release, and the exact Autopilot consumer pin remain separate post-review work. This PR does not merge itself.