### PR TITLE
feat(docs): refresh marketing pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,11 +224,12 @@ jobs:
 
       - name: Run realtime driver and security matrix
         working-directory: packages/questpie
-        run: bun test test/ --test-name-pattern "matrix|storm|dos|channel"
+        run: |
+          QUESTPIE_SOKETI_INTEGRATION=1 bun test test/integration/realtime-soketi.test.ts
+          QUESTPIE_SOKETI_INTEGRATION=0 bun test test/ --test-name-pattern "matrix|storm|dos|channel"
         env:
           QUESTPIE_MIGRATIONS_SILENT: "1"
           QUESTPIE_REALTIME_DRIVER_INTEGRATION: "1"
-          QUESTPIE_SOKETI_INTEGRATION: "1"
           QUESTPIE_REALTIME_POSTGRES_URL: postgresql://questpie:questpie@127.0.0.1:54329/questpie_realtime
           QUESTPIE_REALTIME_REDIS_URL: redis://127.0.0.1:6379
 

--- a/apps/docs/AUTOPILOT_MEDIA.md
+++ b/apps/docs/AUTOPILOT_MEDIA.md
@@ -1,0 +1,52 @@
+# Autopilot marketing media handoff
+
+The `/autopilot` page deliberately ships with neutral, correctly sized media slots. Replace them only with captures from the release candidate. Do not recreate the interface for marketing.
+
+## Files to prepare
+
+Put the final files in `apps/docs/public/media/autopilot/`.
+
+| Slot             | Filename                                   | Capture                                                                                                                                              |
+| ---------------- | ------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Hero workflow    | `workflow.webm` and `workflow-poster.webp` | 12–18 second silent loop: create or assign one task, show agent progress, stop at one approval, then show completion. Record at 1440×1080 or larger. |
+| Shared queue     | `work-queue.webp`                          | A real queue containing both people and agents, clear owners and statuses, and one genuine blocker. Export at 1600×1100 or larger.                   |
+| Approval         | `approval.webp`                            | A consequential proposal showing source context, the exact intended change and approve/reject controls. Export at 1920×1200 or larger.               |
+| Activity history | `activity-history.webp`                    | The completed run with agent actions and human decisions in one readable history. Export at 1600×1100 or larger.                                     |
+
+## One coherent demo story
+
+Use the same staging workspace and the same task in every capture. A good sequence is:
+
+1. A person assigns a recurring operational task.
+2. The agent reads the records or files needed for that task.
+3. Progress appears in the shared queue.
+4. A consequential change pauses for approval.
+5. The person approves or rejects it.
+6. The final result and full history remain attached to the task.
+
+Use real staging data that is safe to publish. Redact personal information; do not replace it with invented customer names, revenue, testimonials or performance metrics.
+
+## Recording rules
+
+- Use the final production theme, browser scale and navigation.
+- Hide bookmarks, extensions, tokens, localhost URLs and personal notifications.
+- Keep the cursor still unless it explains an action. Do not add decorative zooms.
+- Do not splice out meaningful waits if the page makes a speed claim.
+- Prefer WebM to GIF. Keep the hero video under 8 MB if practical and include a static poster.
+- No autoplay audio. Caption the staging build and capture month when the real files are wired in.
+- Check the page at 1280 px and 390 px after every replacement; media must use the existing frame without changing its aspect ratio.
+
+## Wiring the files
+
+In `src/components/marketing/autopilot.tsx`, add these props to the matching `ProductMedia` calls:
+
+```text
+Hero:             src="/media/autopilot/workflow.webm"
+                  poster="/media/autopilot/workflow-poster.webp"
+                  kind="video"
+Shared queue:     src="/media/autopilot/work-queue.webp"
+Approval:         src="/media/autopilot/approval.webp"
+Activity history: src="/media/autopilot/activity-history.webp"
+```
+
+The hero video intentionally waits for user playback. Do not add autoplay without also respecting `prefers-reduced-motion`.

--- a/apps/docs/marketing-research.md
+++ b/apps/docs/marketing-research.md
@@ -1,0 +1,115 @@
+# QUESTPIE marketing page research
+
+Research date: 2026-08-12. Sources are official product pages, documentation, or first-party launch material.
+
+## Executive recommendation
+
+- Keep both pages text-led. Use one real product artifact at a time: code and generated output for Framework; a recorded task, its activity log, approval, and final result for Autopilot.
+- The opening screen must identify the category, say what the product changes, and offer one primary action. Do not make the reader decode an architecture diagram.
+- Framework should prove the contract: one collection definition becomes a PostgreSQL schema, typed REST API, and typed client. Optional modules should remain explicitly optional.
+- Autopilot should prove controlled execution, not generic intelligence: the source context, steps taken, approval boundary, and resulting change should all be inspectable.
+- Until production captures are ready, reserve honestly labelled media slots. Do not draw speculative product UI or populate it with invented customer data.
+
+## 1. Framework and headless backend references
+
+| Product                            | Page hierarchy and CTA                                                                                                                                                           | Artifact used as proof                                                                                                                                                   | Trust signal                                                                                            | Lesson for QUESTPIE                                                                                                                                               |
+| ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Payload](https://payloadcms.com/) | Category claim, install command/demo CTA, product split for developers and editors, use cases, customer proof, ownership story.                                                  | Real config/code alongside admin and live-preview captures.                                                                                                              | Open-source ownership, production users, named customer stories.                                        | Pair the collection file with the interface it produces. Keep "own your backend" as supporting proof, not the entire hero.                                        |
+| [Convex](https://www.convex.dev/)  | Memorable outcome, exact platform inventory, agent-setup prompt or create command, hard guarantees, components, founder credibility, enterprise controls, repeated build CTA.    | Copyable setup prompt, install command, named components and operational guarantees; its [AI proof page](https://www.convex.dev/ai) adds evaluations and measured tests. | ACID transactions, end-to-end types, scaling claims, SOC 2 Type II, HIPAA, RBAC/SSO.                    | Name concrete invariants. A copyable agent prompt can sit beside the normal install path without replacing docs.                                                  |
+| [Supabase](https://supabase.com/)  | Outcome headline, exact Postgres platform definition, start/demo split, logos, individual products, integrations, customer stories, templates, open-source statement, final CTA. | Actual dashboard states, starter templates, code/examples, product surfaces.                                                                                             | PostgreSQL foundation, public GitHub/open-source posture, named customers and case studies.             | Explain the core in one sentence, then let visitors inspect individual capabilities. Use templates/examples as proof when adoption metrics are not yet available. |
+| [Directus](https://directus.com/)  | Whole-team promise, exact outputs, free/demo CTA and command, developer/team/AI uses, concrete scenarios, governed AI, admin capabilities, quantified stories.                   | API response, real interface captures, specific team tasks with inputs and results.                                                                                      | Self-host/cloud choice, access policies shared by people and AI, downloads and named case studies.      | Show the same data through developer and operator views. The access model is a strong bridge between Framework and Autopilot.                                     |
+| [Encore](https://encore.dev/)      | Exact infrastructure claim, signup plus copyable agent prompt, code declaration and terminal output, customer outcomes, mechanism, comparison, migration path, final proof.      | Source code followed immediately by real CLI runtime output and deployed infrastructure.                                                                                 | Open-source SDK, GitHub count, own AWS/GCP account, status/security/SLA links, quantified case studies. | The best Framework demo is an input/output pair. Show what QUESTPIE reads, generates, and starts; avoid abstract capability cards.                                |
+| [Elysia](https://elysiajs.com/)    | Category and differentiators, create command, design principle, compact runnable code, attributed benchmark, single-source-of-truth explanation, deeper examples.                | Small runnable code samples and a benchmark with methodology/source.                                                                                                     | Reproducible API, linked TechEmpower benchmark, transparent docs/LLM documentation.                     | Use the smallest example that demonstrates the mental model. Attribute any benchmark or omit it.                                                                  |
+
+### Recommended Framework page hierarchy
+
+1. **Hero:** “One backend model. Every typed surface stays aligned.” One factual paragraph, `bunx create-questpie`, and “Read the first app”.
+2. **Input → output proof:** a real collection file next to generated API/client use. On mobile, show them in sequence rather than connected by arrows.
+3. **The contract:** fields, access, hooks, and request context explained in short prose with one code excerpt each.
+4. **Core and modules:** plain two-column text. Core: collections, globals, REST, client, access, hooks, jobs, services. Optional: admin, OpenAPI, MCP, realtime, search, storage, email, queues.
+5. **Runs where the app runs:** Hono/Elysia for headless use; TanStack Start/Next when using the admin runtime. State only adapters currently supported by the repository.
+6. **Operational path:** local generation, migration creation/review, deploy. Never present development `push` as the production path.
+7. **Proof:** example applications, public source, version/release link, and real testimonials only when available.
+8. **Final CTA:** create an app; secondary CTA to architecture/docs.
+
+### Framework capture list
+
+- `framework-model.webp`: editor capture of a genuine `posts` collection, 1440×900 or larger.
+- `framework-admin.webp`: the generated collection list/form from that exact model, same sample data.
+- `framework-api.webp`: real OpenAPI/Scalar route output for the same collection.
+- `framework-types.gif`: 6–10 second loop: rename a field, run generation, show the client type error/autocomplete update. No cursor circling or decorative zooms.
+- `framework-terminal.webp`: successful generate/migrate/start output with secrets and local usernames removed.
+
+## 2. Autopilot and agentic work references
+
+| Product                                                              | Page hierarchy and CTA                                                                                                                                                                                                                                                                                                    | Artifact used as proof                                                                                            | Trust/safety treatment                                                                                                                                                                      | Lesson for QUESTPIE                                                                                                                                                                                                                                       |
+| -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Linear for Agents](https://linear.app/agents)                       | Teammate framing, real prompt examples, delegate/automate/orchestrate explanation, agent directory, build-your-own CTA.                                                                                                                                                                                                   | Recognizable issue delegation, comments, progress, and agent contributions inside the actual work surface.        | Human stays primary assignee; agent is a contributor; changes and reasoning are inspectable. [Docs](https://linear.app/docs/agents-in-linear) add admin installation and team-level access. | Make accountability visible in the artifact. Autopilot can do work, but a person owns the outcome.                                                                                                                                                        |
+| [Linear Agent](https://linear.app/docs/linear-agent)                 | Capability overview, entry points, context, chat behavior, examples, configuration and permissions.                                                                                                                                                                                                                       | Real chats tied to projects/issues and multiple concurrent work tabs.                                             | Existing user permissions bound both reading and changes; admins can disable the agent.                                                                                                     | Show the context boundary and actor identity, not just the chat response.                                                                                                                                                                                 |
+| [OpenAI ChatGPT Work](https://help.openai.com/en/articles/20001275/) | Clear split between Chat, Work, and Codex; supported deliverables; availability; start flow; review and follow-up. The earlier [ChatGPT agent launch](https://openai.com/index/introducing-chatgpt-agent/) used concrete jobs, completed task replays, benchmarks, a safety section, limitations, and one direct try CTA. | Finished documents, spreadsheets, presentations, reports, Sites, plus visible progress through a multi-step task. | User can follow progress, interrupt or redirect, and approve important actions; local access requires permission.                                                                           | Lead with finished work and reviewability. Avoid “autonomous” as an unqualified promise. The older agent/Operator flow has been superseded by Work according to [OpenAI's current help page](https://help.openai.com/en/articles/11752874-chatgpt-agent). |
+| [Notion Agents](https://www.notion.com/product/agents)               | 24/7 team claim, free/demo CTA, recurring-agent categories, builder, on-demand agent, integrations, enterprise controls, FAQ.                                                                                                                                                                                             | Real Agent Builder and workspace/database captures, plus concrete Q&A, routing, and report examples.              | Per-agent permissions, inherited user permissions, run logs, audit trail, reversible changes, no training on customer content, prompt-injection protection.                                 | Trust deserves a complete section before signup. Use triggers, permissions, run history, and undo as visible product features.                                                                                                                            |
+| [Lindy](https://www.lindy.ai/)                                       | Broad teammate claim, free trial, customer logos, numbered toolkit, concrete jobs, work surfaces, social proof, role-based use cases.                                                                                                                                                                                     | Product UI for scheduled routines, editable memory files, skills, meetings, and channel-specific work.            | Says it asks before altering anything; memory is readable/editable; separate security page is prominent in navigation.                                                                      | A simple numbered narrative works if every claim is backed by a capture. Show editable memory/context if Autopilot genuinely exposes it.                                                                                                                  |
+| [Relevance AI](https://relevanceai.com/)                             | Outcome/timeline, deployment service, catalogue of named agents, case-study ROI, platform mechanism, enterprise controls, integrations.                                                                                                                                                                                   | Named agent jobs with live-looking run data, model/eval/cost tables, traces, and quantified case studies.         | RBAC, SSO/SAML, human approvals, version control, monitoring, traces, cost visibility, residency, PII masking, no training.                                                                 | For technical buyers, evals, traceability, cost per run, and retry behavior are stronger proof than a chat mockup.                                                                                                                                        |
+| [Relay.app](https://relay.app/)                                      | Not a current positioning reference: the official homepage now announces shutdown in August/September 2026.                                                                                                                                                                                                               | The wind-down page provides explicit JSON/prompt/run-history/CSV export paths.                                    | Clear deletion dates, credential removal, refunds, export and support commitments.                                                                                                          | Do not cite Relay as market momentum. Do learn from its exit UX: portable workflows, history export, credential deletion, and clear lifecycle commitments reduce platform risk.                                                                           |
+
+### Recommended Autopilot page hierarchy
+
+1. **Hero:** state the job and current availability precisely. Suggested structure: “Give Autopilot an outcome. Review the work, not every step.” If it is not generally available, use “Launching soon” plus an honest date/window and waitlist/demo CTA.
+2. **One end-to-end run:** show a real task request, selected context, live progress, an approval boundary, and the finished artifact or recorded system change.
+3. **Where it works:** name the actual QUESTPIE entities and enabled tools it can read or change. Avoid generic integration logos until each integration is functional.
+4. **Control:** permissions, actor identity, approvals, audit trail, cancellation, retry behavior, and rollback/reversibility. Separate shipped behavior from roadmap.
+5. **Repeatable work:** triggers/schedules only if implemented. Show a genuine recurring run and its history rather than an animated diagram.
+6. **Use cases:** three narrow jobs backed by the product: for example content operations, support triage, and internal operations. Each needs trigger → work → output.
+7. **Relationship to Framework:** Framework is the typed system; Autopilot operates through its contracts and access rules. Autopilot must be optional.
+8. **Availability CTA:** before launch, “Join early access” or “Book a walkthrough”; after launch, “Start a run”. Do not leave an early-access CTA after GA.
+
+### Honest media placeholders now
+
+Use reserved `<figure>` regions with a visible label such as **Product capture coming before launch** and a caption that describes the exact planned evidence. Keep a neutral background and correct final aspect ratio so replacing the file does not alter layout. A placeholder must not look interactive and must not contain invented messages, people, company names, metrics, or completed actions.
+
+Recommended slots:
+
+- `autopilot-run.gif` — 12–18 seconds, 1440×900: enter one real task, show plan/progress, pause at one approval, then show completion. Capture at 1× or 2×; under 8 MB if practical.
+- `autopilot-context.webp` — 1440×900: the exact records/files/tools selected for a run; redact real personal data rather than replacing it with a fake enterprise.
+- `autopilot-approval.webp` — 1200×750: a consequential proposed change with approve/reject controls and a clear explanation of impact.
+- `autopilot-history.webp` — 1440×900: run list with status, actor, duration, timestamp, and inspectable steps. Use real staging runs.
+- `autopilot-result.webp` — 1440×900: the actual output where it lives (admin record, issue, report, email draft, etc.), not a celebratory success card.
+- `autopilot-mobile.webp` — 780×1688 only if the mobile product is genuinely supported; otherwise omit it.
+
+Recording rules:
+
+- Seed one coherent, non-sensitive demo workspace and reuse it across every capture.
+- Record at the final production theme and browser scale; hide bookmarks, extensions, tokens, localhost paths, and personal notifications.
+- Prefer WebM/MP4 with controls for demonstrations longer than roughly 15 seconds; use GIF only for a short silent loop.
+- Provide a static poster image and descriptive alt text. Respect reduced-motion preferences and never autoplay audio.
+- Do not splice out waiting states if speed is part of the claim. It is acceptable to trim dead time when the caption says the recording is shortened.
+- Caption what is real and what environment was used, for example: “Recorded in the QUESTPIE Autopilot staging build, August 2026.”
+
+## Copy and design guardrails
+
+- Prefer: “uses your existing access rules”, “shows every attempted change”, “asks before publishing”, “can be stopped”, “result remains editable”. Use these only when verified in the shipping build.
+- Avoid: “works autonomously”, “never makes mistakes”, “secure by default”, “understands your whole company”, or quantified time savings without measured evidence.
+- Avoid card walls and arrow diagrams. Use section headings, two-column prose, numbered rows, code, product captures, and thin separators.
+- One section should make one argument. Do not repeat “one model powers everything” in the hero, diagram, feature cards, and CTA.
+- The Framework and Autopilot pages should share typography, spacing, buttons, media frames, and footer, but use different proof: code/output versus task/activity/result.
+
+## Source index
+
+- [Payload homepage](https://payloadcms.com/)
+- [Convex homepage](https://www.convex.dev/)
+- [Supabase homepage](https://supabase.com/)
+- [Directus homepage](https://directus.com/)
+- [Encore homepage](https://encore.dev/)
+- [Elysia homepage](https://elysiajs.com/)
+- [Linear for Agents](https://linear.app/agents)
+- [Linear Agent docs](https://linear.app/docs/linear-agent)
+- [AI Agents in Linear docs](https://linear.app/docs/agents-in-linear)
+- [ChatGPT Work and Codex](https://help.openai.com/en/articles/20001275/)
+- [Introducing ChatGPT agent](https://openai.com/index/introducing-chatgpt-agent/)
+- [ChatGPT agent system card](https://openai.com/index/chatgpt-agent-system-card/)
+- [ChatGPT Work release notes](https://help.openai.com/en/articles/6825453-custom-instructions-for-chatgpt)
+- [Notion Agents](https://www.notion.com/product/agents)
+- [Notion Agent help](https://www.notion.com/help/notion-agent)
+- [Lindy homepage](https://www.lindy.ai/)
+- [Relevance AI homepage](https://relevanceai.com/)
+- [Relay.app shutdown notice](https://relay.app/)

--- a/apps/docs/src/components/marketing/autopilot.tsx
+++ b/apps/docs/src/components/marketing/autopilot.tsx
@@ -1,154 +1,23 @@
-/* The Autopilot page, band for band from ui_kits/marketing/autopilot.html.
- *
- * Four bands: the approval that is the product, one list holding both kinds of
- * teammate, the three limits, and the ask.
- *
- * Everything that looks like a product screenshot here is live DOM. Nothing on
- * this page is interactive, though: the buttons inside the two devices render as
- * spans rather than <button>, so a keyboard user does not tab into an
- * illustration and press something that cannot respond.
- */
 import { type FormEvent, useState } from "react";
 
-import { CodeSample } from "./code";
+import { ProductMedia } from "./product-media";
 
-/* Confirmed by the owner. The form opens a mail composer rather than posting,
- * because the repo has no capture endpoint; when one exists, `submit` below is
- * the only thing that changes. The page this replaces held the address in React
- * state and dropped it on submit while showing a thank-you, so every lead was
- * lost silently. */
 const EARLY_ACCESS_EMAIL = "info@questpie.com";
 
-/* The kit wrote `orders.update(4412, { … })`. The documented accessor is
- * `collections.<name>.updateById({ id, data })` (docs/concepts/collections.mdx,
- * optimistic-concurrency.mdx) — and a proposal reads better against the row it
- * loaded than against the order number a human sees. */
-const PROPOSAL = `await collections.orders.updateById({
-  id: order.id,
-  data: {
-    status: "paid",
-    paidAt: new Date(),
-  },
-});`;
-
-const LIMITS = [
+const BOUNDARIES = [
 	{
-		body: "An agent reads the same permission table a person does. No side channel, no service account.",
-		title: "A role, not a key",
+		body: "An agent joins with a name and a role. It works through the same permissions as the people beside it.",
+		title: "A seat, not a master key",
 	},
 	{
-		body: "Anything that changes data comes to you first. You see what it read and what it would do.",
-		title: "Proposals, not writes",
+		body: "Choose which actions can run and which must stop for review. The proposal shows the intended change before it happens.",
+		title: "Approval where it matters",
 	},
 	{
-		body: "Every step is written in plain sentences, next to the work it belongs to.",
-		title: "A log you can read",
+		body: "Requests, decisions and results stay attached to the work, so the next person does not have to reconstruct the story.",
+		title: "A record people can follow",
 	},
 ];
-
-function ApprovalCard() {
-	return (
-		<div className="hero-card">
-			<div className="hero-card-head">
-				<span className="qp-eyebrow">Waiting on you</span>
-				<span className="count">order #4412</span>
-			</div>
-
-			<div className="row" style={{ alignItems: "flex-start" }}>
-				<span className="av agent">AI</span>
-				<div className="rb">
-					<span className="rt">Amount matches Stripe: 1 248,00 €</span>
-					<span className="rm">
-						agent Ada read the order and the charge. Difference 0,00 €.
-					</span>
-				</div>
-			</div>
-
-			<CodeSample code={PROPOSAL} mark="+4 +5" />
-
-			<div
-				style={{
-					alignItems: "center",
-					display: "flex",
-					/* .btn is nowrap, so on a phone the two of them plus the question
-					   ran off the card; they drop to a second line instead. */
-					flexWrap: "wrap",
-					gap: "var(--space-3)",
-					padding: "var(--space-2)",
-				}}
-			>
-				<div className="rb">
-					<span className="rt">Close the order?</span>
-					<span className="rm">
-						Marks it paid and sends one e-mail. Undo for 10 minutes.
-					</span>
-				</div>
-				<span className="btn g sm">Not yet</span>
-				<span className="btn p sm">Close order</span>
-			</div>
-		</div>
-	);
-}
-
-function SharedList() {
-	return (
-		<div
-			className="card"
-			style={{
-				borderRadius: "var(--radius-sheet)",
-				display: "flex",
-				flexDirection: "column",
-				gap: "var(--spacing-gap-rows)",
-			}}
-		>
-			<div className="row pin">
-				<div className="rb">
-					<span className="qp-eyebrow">From you</span>
-					<span className="rt" style={{ fontWeight: "var(--weight-semibold)" }}>
-						Send the November invoices by Friday, check the amounts in Stripe.
-					</span>
-				</div>
-			</div>
-			<div className="row" style={{ alignItems: "flex-start" }}>
-				<span className="av agent">AI</span>
-				<div className="rb">
-					<span className="rt">Preparing 14 invoices</span>
-					<span className="rm">agent Ada · role Accounting</span>
-					<span
-						style={{
-							alignItems: "center",
-							display: "flex",
-							gap: "var(--space-3)",
-							marginTop: "var(--space-3)",
-						}}
-					>
-						<span className="meter">
-							{/* 8 of 14 is 57%, so the bar stops 43% short */}
-							<span style={{ right: "43%" }} />
-						</span>
-						<span className="count">8/14</span>
-					</span>
-				</div>
-			</div>
-			<div className="row">
-				<span className="av i2">AB</span>
-				<div className="rb">
-					<span className="rt">Reply to the supplier e-mail</span>
-					<span className="rm">Anna B. · 2 h</span>
-				</div>
-				<span className="chip">Waiting on Anna</span>
-			</div>
-			<div className="row">
-				<span className="av agent">AI</span>
-				<div className="rb">
-					<span className="rt">Close order #4412</span>
-					<span className="rm">agent proposed · waits for your yes</span>
-				</div>
-				<span className="chip ok">Needs you</span>
-			</div>
-		</div>
-	);
-}
 
 function EarlyAccessForm() {
 	const [email, setEmail] = useState("");
@@ -161,36 +30,21 @@ function EarlyAccessForm() {
 	};
 
 	return (
-		<form
-			onSubmit={submit}
-			style={{
-				display: "flex",
-				flexWrap: "wrap",
-				gap: "var(--space-3)",
-				justifyContent: "center",
-				marginTop: "var(--space-8)",
-			}}
-		>
+		<form className="early-access-form" onSubmit={submit}>
+			<label className="sr-only" htmlFor="autopilot-email">
+				Work e-mail address
+			</label>
 			<input
-				aria-label="Your e-mail address"
+				autoComplete="email"
+				id="autopilot-email"
 				onChange={(event) => setEmail(event.target.value)}
 				placeholder="you@company.com"
-				style={{
-					background: "var(--surface-mid)",
-					border: "1px solid var(--input)",
-					borderRadius: "var(--radius-control)",
-					color: "var(--foreground)",
-					fontFamily: "var(--font-sans)",
-					fontSize: "var(--type-md)",
-					height: "var(--control-large)",
-					padding: "0 var(--spacing-input)",
-					width: 300,
-				}}
+				required
 				type="email"
 				value={email}
 			/>
 			<button className="btn p lg" type="submit">
-				Get early access
+				Request early access
 			</button>
 		</form>
 	);
@@ -199,93 +53,149 @@ function EarlyAccessForm() {
 export function AutopilotPageContent() {
 	return (
 		<>
-			<section className="band hero">
+			<section className="band hero autopilot-hero">
 				<div className="wrap split">
 					<div className="head">
-						<p className="qp-aside">the work, and who has it</p>
+						<p className="qp-aside">shared work for people and agents</p>
 						<h1 className="qp-display-xl">
-							Agents on the team. <em className="qp-hl">Same rules.</em>
+							Give agents real work.{" "}
+							<em className="qp-hl">Keep the last word.</em>
 						</h1>
 						<p className="qp-lead">
-							Autopilot holds the work: goals, tasks, messages. An agent picks
-							something up, asks when it is unsure, and hands back a proposal
-							you accept in one click.
+							Autopilot keeps goals, tasks, messages and agent work in one
+							place. Agents work through named roles, ask when context is
+							missing and bring sensitive changes back for approval.
 						</p>
-						<div
-							style={{
-								display: "flex",
-								flexWrap: "wrap",
-								gap: "var(--space-3)",
-								marginTop: "var(--space-4)",
-							}}
-						>
-							<a className="btn p lg" href="#cta">
-								Get early access
+						<div className="actions">
+							<a className="btn p lg" href="#access">
+								Request early access
 							</a>
-							<a className="btn s lg" href="/docs">
-								Read the docs
+							<a className="btn s lg" href="#workflow">
+								See the workflow
 							</a>
 						</div>
 						<p className="qp-eyebrow">
-							Free during the pilot · we set it up with you
+							Private beta · guided setup · built on QUESTPIE
 						</p>
 					</div>
 
-					<ApprovalCard />
+					<ProductMedia
+						alt="Autopilot moving a task from assignment to an approval-ready result"
+						description="A short product loop: assign work, watch the agent progress and review the result."
+						eyebrow="Product GIF · 12–18 seconds"
+						kind="video"
+						title="One task, from request to review"
+						variant="hero"
+					/>
+				</div>
+			</section>
+
+			<section className="band editorial-band" id="workflow">
+				<div className="wrap editorial-split">
+					<div className="head">
+						<p className="qp-aside">the work stays visible</p>
+						<h2 className="qp-display-m">
+							You see who has it and what happens next
+						</h2>
+						<p>
+							People and agents share the same work queue. Ownership, progress
+							and blockers are visible without opening a separate agent console.
+						</p>
+						<p>
+							When an agent needs context, the question stays with the task.
+							When it finishes, the result returns to the same place.
+						</p>
+					</div>
+					<ProductMedia
+						alt="Autopilot work queue showing tasks owned by people and agents"
+						description="Show a real mixed work queue with clear owners, status and one visible blocker."
+						eyebrow="Product screenshot · 1600 × 1100"
+						title="A shared queue, not a second inbox"
+					/>
 				</div>
 			</section>
 
 			<section className="band raised">
-				<div className="wrap split lean">
-					<div className="head">
-						<p className="qp-aside">one list, two kinds of teammate</p>
-						<h2 className="qp-display-m">People and agents, same table</h2>
-						<p>
-							They share the list, the roles and the log. The avatar says who
-							has a task; the chip says what it waits for.
-						</p>
-					</div>
-					<SharedList />
-				</div>
-			</section>
-
-			<section className="band">
 				<div className="wrap">
 					<div className="head">
-						<p className="qp-aside">where the limits are</p>
-						<h2 className="qp-display-m">The limits are the product</h2>
+						<p className="qp-aside">autonomy with explicit boundaries</p>
+						<h2 className="qp-display-m">Control is part of the workflow</h2>
+						<p>
+							The useful question is not whether an agent can act. It is who the
+							agent is, what it may do and where a person must decide.
+						</p>
 					</div>
-					<div
-						className="grid3"
-						style={{ gridAutoRows: "1fr", marginTop: "var(--space-10)" }}
-					>
-						{LIMITS.map((limit) => (
-							<div
-								className="card"
-								key={limit.title}
-								style={{ display: "flex", flexDirection: "column" }}
-							>
-								<h3>{limit.title}</h3>
-								<p>{limit.body}</p>
-							</div>
+					<div className="depth-list">
+						{BOUNDARIES.map((boundary, index) => (
+							<section key={boundary.title}>
+								<span className="qp-eyebrow">0{index + 1}</span>
+								<div>
+									<h3>{boundary.title}</h3>
+									<p>{boundary.body}</p>
+								</div>
+							</section>
 						))}
 					</div>
 				</div>
 			</section>
 
-			<section
-				className="band"
-				id="cta"
-				style={{ paddingBottom: "var(--space-16)" }}
-			>
+			<section className="band">
+				<div className="wrap product-story">
+					<div className="head">
+						<p className="qp-aside">a decision with the context beside it</p>
+						<h2 className="qp-display-m">
+							Review the change, not a vague summary
+						</h2>
+						<p>
+							A proposal should show what the agent used, what it plans to
+							change and what follows after approval. The reviewer gets a
+							decision, not another investigation.
+						</p>
+					</div>
+					<ProductMedia
+						alt="Autopilot approval view with source context and proposed changes"
+						description="Capture a real approval with its source context, proposed change and primary decision."
+						eyebrow="Product screenshot · 1920 × 1200"
+						title="The approval is the proof"
+						variant="wide"
+					/>
+				</div>
+			</section>
+
+			<section className="band raised">
+				<div className="wrap editorial-split">
+					<div className="head">
+						<p className="qp-aside">the handoff remains readable</p>
+						<h2 className="qp-display-m">
+							The next person can continue the work
+						</h2>
+						<p>
+							Autopilot keeps the request, agent activity, human decisions and
+							final result together. A teammate can understand what happened
+							without reading a raw model transcript.
+						</p>
+					</div>
+					<ProductMedia
+						alt="Autopilot activity history combining agent actions and human decisions"
+						description="Show the activity history after completion, with both agent and human actions visible."
+						eyebrow="Product screenshot · 1600 × 1100"
+						title="A history written for the team"
+					/>
+				</div>
+			</section>
+
+			<section className="band launch-band" id="access">
 				<div className="wrap">
 					<div className="cta-block">
 						<div className="head head-center">
-							<p className="qp-aside">we set it up with you</p>
-							<h2 className="qp-display-m">Give an agent a seat this month</h2>
+							<p className="qp-aside">start with one real workflow</p>
+							<h2 className="qp-display-m">
+								Bring the work you want off your plate
+							</h2>
 							<p>
-								Free during the pilot. Bring one job you would rather not do
-								again.
+								The private beta includes guided setup. Start with one recurring
+								job, the people responsible for it and the decisions that must
+								stay human.
 							</p>
 						</div>
 						<EarlyAccessForm />

--- a/apps/docs/src/components/marketing/chrome.tsx
+++ b/apps/docs/src/components/marketing/chrome.tsx
@@ -21,7 +21,12 @@ import questpiePackage from "../../../../../packages/questpie/package.json";
 const GITHUB_URL = "https://github.com/questpie/questpie";
 const CREATE_APP = "/docs/learn/first-app";
 
-export type MarketingPage = "home" | "autopilot" | "framework" | "docs";
+export type MarketingPage =
+	| "home"
+	| "autopilot"
+	| "framework"
+	| "docs"
+	| "works";
 
 const LINKS: { id: MarketingPage; label: string; href: string }[] = [
 	{ id: "framework", label: "Framework", href: "/framework" },
@@ -29,8 +34,16 @@ const LINKS: { id: MarketingPage; label: string; href: string }[] = [
 	{ id: "docs", label: "Docs", href: "/docs" },
 ];
 
+/* Works is footer-only by decision: the root is a thesis plus two doors at
+ * ~60/40 (specs/questpie-com-v2/00-DECISIONS.md §1, §3), and a services page in
+ * the nav would make it a third. */
+const FOOTER_LINKS: typeof LINKS = [
+	...LINKS,
+	{ id: "works", label: "Works", href: "/works" },
+];
+
 /** The routes that carry the mesh, the grain and the forced dark theme. */
-const MARKETING_PATHS = new Set(["/", "/framework", "/autopilot"]);
+const MARKETING_PATHS = new Set(["/", "/framework", "/autopilot", "/works"]);
 
 export function isMarketingPath(pathname: string): boolean {
 	return MARKETING_PATHS.has(pathname.replace(/(.)\/$/, "$1"));
@@ -189,7 +202,7 @@ function MarketingFooter() {
 				<Lockup fontSize={17} size={22} />
 				<span>Open source. Self-hosted. MIT.</span>
 				<nav>
-					{LINKS.map((link) => (
+					{FOOTER_LINKS.map((link) => (
 						<a href={link.href} key={link.id}>
 							{link.label}
 						</a>

--- a/apps/docs/src/components/marketing/chrome.tsx
+++ b/apps/docs/src/components/marketing/chrome.tsx
@@ -19,13 +19,13 @@ import { useEffect, useState } from "react";
 import questpiePackage from "../../../../../packages/questpie/package.json";
 
 const GITHUB_URL = "https://github.com/questpie/questpie";
-const EARLY_ACCESS = "/autopilot#cta";
+const CREATE_APP = "/docs/learn/first-app";
 
 export type MarketingPage = "home" | "autopilot" | "framework" | "docs";
 
 const LINKS: { id: MarketingPage; label: string; href: string }[] = [
-	{ id: "autopilot", label: "Autopilot", href: "/autopilot" },
 	{ id: "framework", label: "Framework", href: "/framework" },
+	{ id: "autopilot", label: "Autopilot", href: "/autopilot" },
 	{ id: "docs", label: "Docs", href: "/docs" },
 ];
 
@@ -38,7 +38,7 @@ export function isMarketingPath(pathname: string): boolean {
 
 function Lockup({ fontSize, size }: { fontSize: number; size: number }) {
 	return (
-		<Link className="lockup" to="/">
+		<Link aria-label="QUESTPIE home" className="lockup" to="/">
 			{/* The bare mark carries no <text>, so an <img> is safe: nothing in it
 			    depends on a font the page stylesheet cannot reach. alt is empty
 			    because the wordmark beside it already names the link. */}
@@ -138,8 +138,8 @@ function MarketingNav({ page }: { page: MarketingPage }) {
 					>
 						GitHub
 					</a>
-					<a className="btn p" href={EARLY_ACCESS}>
-						Get early access
+					<a className="btn p" href={CREATE_APP}>
+						Create an app
 					</a>
 					<button
 						aria-controls="marketing-nav-menu"

--- a/apps/docs/src/components/marketing/code.tsx
+++ b/apps/docs/src/components/marketing/code.tsx
@@ -1,3 +1,4 @@
+/* oxlint-disable jsx-a11y/no-noninteractive-tabindex -- Code blocks scroll horizontally and need keyboard access. */
 /* The grammars from the kit's questpie-highlight.js, ported to return React nodes
  * instead of an HTML string.
  *
@@ -130,9 +131,12 @@ export function CodeSample({
 
 	return (
 		<pre
+			aria-label="Code sample"
 			className={bare ? "qp-code bare" : "qp-code"}
 			data-lang={lang}
 			data-numbers={numbers ? "" : undefined}
+			role="region"
+			tabIndex={0}
 		>
 			<code>
 				{code.split("\n").map((line, index) => (

--- a/apps/docs/src/components/marketing/code.tsx
+++ b/apps/docs/src/components/marketing/code.tsx
@@ -13,7 +13,7 @@
  */
 import type { ReactNode } from "react";
 
-type Lang = "bash" | "ts";
+type Lang = "bash" | "http" | "ts";
 
 const KEYWORDS_TS =
 	"import|from|export|default|const|let|var|function|return|await|async|new|class|extends|implements|interface|type|enum|namespace|declare|if|else|for|while|do|switch|case|break|continue|try|catch|finally|throw|typeof|instanceof|keyof|in|of|as|satisfies|public|private|protected|readonly|static|abstract|get|set|yield|delete|void|null|undefined|true|false|this|super";
@@ -31,6 +31,10 @@ const GRAMMARS: Record<Lang, [role: string, pattern: string][]> = {
 		["number", "\\b\\d+\\b"],
 		["prop", "--?[A-Za-z][\\w-]*"],
 		["punct", "[|&;<>(){}$=]+"],
+	],
+	http: [
+		["keyword", "\\b(?:GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS)\\b"],
+		["string", "\\/[A-Za-z0-9_/:.\\-]+"],
 	],
 	ts: [
 		["comment", "\\/\\/[^\\n]*|\\/\\*[\\s\\S]*?\\*\\/"],

--- a/apps/docs/src/components/marketing/code.tsx
+++ b/apps/docs/src/components/marketing/code.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 /* oxlint-disable jsx-a11y/no-noninteractive-tabindex -- Code blocks scroll horizontally and need keyboard access. */
 /* The grammars from the kit's questpie-highlight.js, ported to return React nodes
  * instead of an HTML string.
@@ -11,9 +13,16 @@
  * Rule order is load-bearing: the alternation is tried left to right, so a
  * keyword inside a string stays part of the string.
  */
-import type { ReactNode } from "react";
+import { useEffect, useId, useState } from "react";
+import type { CSSProperties, ReactNode } from "react";
+import { createPortal } from "react-dom";
 
 type Lang = "bash" | "http" | "ts";
+
+export type CodeAnnotation = {
+	description: string;
+	match: string;
+};
 
 const KEYWORDS_TS =
 	"import|from|export|default|const|let|var|function|return|await|async|new|class|extends|implements|interface|type|enum|namespace|declare|if|else|for|while|do|switch|case|break|continue|try|catch|finally|throw|typeof|instanceof|keyof|in|of|as|satisfies|public|private|protected|readonly|static|abstract|get|set|yield|delete|void|null|undefined|true|false|this|super";
@@ -98,6 +107,74 @@ function tokenize(line: string, lang: Lang): ReactNode[] {
 	return out;
 }
 
+function annotatedLine(
+	line: string,
+	lineIndex: number,
+	lang: Lang,
+	annotations: readonly CodeAnnotation[],
+	activeKey: string | undefined,
+	tooltipId: string,
+	show: (
+		element: HTMLButtonElement,
+		annotation: CodeAnnotation,
+		key: string,
+	) => void,
+	hide: (key: string) => void,
+) {
+	const parts: ReactNode[] = [];
+	let cursor = 0;
+	let part = 0;
+
+	while (cursor < line.length) {
+		let next: { annotation: CodeAnnotation; at: number } | undefined;
+		for (const annotation of annotations) {
+			const at = line.indexOf(annotation.match, cursor);
+			if (at >= 0 && (!next || at < next.at)) next = { annotation, at };
+		}
+
+		if (!next) {
+			parts.push(
+				<span key={`text-${part++}`}>
+					{tokenize(line.slice(cursor), lang)}
+				</span>,
+			);
+			break;
+		}
+		if (next.at > cursor) {
+			parts.push(
+				<span key={`text-${part++}`}>
+					{tokenize(line.slice(cursor, next.at), lang)}
+				</span>,
+			);
+		}
+
+		const key = `${lineIndex}-${next.at}-${next.annotation.match}`;
+		parts.push(
+			<button
+				aria-describedby={activeKey === key ? tooltipId : undefined}
+				aria-label={`${next.annotation.match.replace(/:$/, "")}: ${next.annotation.description}`}
+				className="qp-code-annotation"
+				key={key}
+				onBlur={() => hide(key)}
+				onClick={(event) => show(event.currentTarget, next.annotation, key)}
+				onFocus={(event) => show(event.currentTarget, next.annotation, key)}
+				onMouseEnter={(event) =>
+					show(event.currentTarget, next.annotation, key)
+				}
+				onMouseLeave={(event) => {
+					if (document.activeElement !== event.currentTarget) hide(key);
+				}}
+				type="button"
+			>
+				{tokenize(next.annotation.match, lang)}
+			</button>,
+		);
+		cursor = next.at + next.annotation.match.length;
+	}
+
+	return parts;
+}
+
 /** "2,3" → highlight · "+4" → added · "-5" → removed */
 function parseMarks(spec: string): Record<string, string> {
 	const table: Record<string, string> = {};
@@ -119,12 +196,14 @@ function parseMarks(spec: string): Record<string, string> {
  * would render a second, empty line every time.
  */
 export function CodeSample({
+	annotations = [],
 	bare = false,
 	code,
 	lang = "ts",
 	mark = "",
 	numbers = false,
 }: {
+	annotations?: readonly CodeAnnotation[];
 	bare?: boolean;
 	code: string;
 	lang?: Lang;
@@ -132,27 +211,97 @@ export function CodeSample({
 	numbers?: boolean;
 }) {
 	const marks = parseMarks(mark);
+	const tooltipId = useId();
+	const [annotation, setAnnotation] = useState<{
+		description: string;
+		key: string;
+		style: CSSProperties;
+	}>();
+
+	useEffect(() => {
+		if (!annotation) return;
+		const hide = () => setAnnotation(undefined);
+		window.addEventListener("resize", hide);
+		window.addEventListener("scroll", hide, true);
+		return () => {
+			window.removeEventListener("resize", hide);
+			window.removeEventListener("scroll", hide, true);
+		};
+	}, [annotation]);
+
+	const showAnnotation = (
+		element: HTMLButtonElement,
+		item: CodeAnnotation,
+		key: string,
+	) => {
+		const rect = element.getBoundingClientRect();
+		const width = Math.min(288, window.innerWidth - 32);
+		const left = Math.min(
+			window.innerWidth - width / 2 - 16,
+			Math.max(width / 2 + 16, rect.left + rect.width / 2),
+		);
+		const above = rect.bottom + 112 > window.innerHeight;
+		setAnnotation({
+			description: item.description,
+			key,
+			style: {
+				left,
+				top: above ? rect.top - 10 : rect.bottom + 10,
+				transform: above ? "translate(-50%, -100%)" : "translateX(-50%)",
+				width,
+			},
+		});
+	};
+	const hideAnnotation = (key: string) => {
+		setAnnotation((current) => (current?.key === key ? undefined : current));
+	};
 
 	return (
-		<pre
-			aria-label="Code sample"
-			className={bare ? "qp-code bare" : "qp-code"}
-			data-lang={lang}
-			data-numbers={numbers ? "" : undefined}
-			role="region"
-			tabIndex={0}
-		>
-			<code>
-				{code.split("\n").map((line, index) => (
+		<>
+			<pre
+				aria-label="Code sample"
+				className={bare ? "qp-code bare" : "qp-code"}
+				data-lang={lang}
+				data-numbers={numbers ? "" : undefined}
+				role="region"
+				tabIndex={0}
+			>
+				<code>
+					{code.split("\n").map((line, index) => (
+						<span
+							className="qp-line"
+							data-mark={marks[String(index + 1)]}
+							key={index}
+						>
+							{line
+								? annotatedLine(
+										line,
+										index,
+										lang,
+										annotations,
+										annotation?.key,
+										tooltipId,
+										showAnnotation,
+										hideAnnotation,
+									)
+								: "​"}
+						</span>
+					))}
+				</code>
+			</pre>
+			{annotation &&
+				typeof document !== "undefined" &&
+				createPortal(
 					<span
-						className="qp-line"
-						data-mark={marks[String(index + 1)]}
-						key={index}
+						className="qp-code-tooltip"
+						id={tooltipId}
+						role="tooltip"
+						style={annotation.style}
 					>
-						{line ? tokenize(line, lang) : "​"}
-					</span>
-				))}
-			</code>
-		</pre>
+						{annotation.description}
+					</span>,
+					document.body,
+				)}
+		</>
 	);
 }

--- a/apps/docs/src/components/marketing/framework.tsx
+++ b/apps/docs/src/components/marketing/framework.tsx
@@ -1,86 +1,50 @@
-/* The framework page, band for band from ui_kits/marketing/framework.html.
- *
- * Every code sample here was checked against the repo rather than copied, and
- * most of them moved. The kit invented a fluent job builder, called the client's
- * method `list` on a collection accessor that does not exist, and offered an
- * install pair where one command has no such flag. A framework page that does
- * not compile is worse than no framework page: the first thing a reader does is
- * paste it.
- */
 import questpiePackage from "../../../../../packages/questpie/package.json";
 import { CodeSample } from "./code";
 
 const GITHUB_URL = "https://github.com/questpie/questpie";
 
-/* Verified against docs/getting-started/index.mdx (import path, .title) and
- * docs/concepts/collections.mdx, which chains .label() before .required(). */
-const SCHEMA = `import { collection } from "#questpie/factories";
+const MODEL = `import { collection } from "#questpie/factories";
 
-export const news = collection("news")
+export const posts = collection("posts")
   .fields(({ f }) => ({
-    title: f.text(255).label("Title").required(),
-    content: f.richText(),
-    isPublished: f.boolean().default(false),
+    title: f.text(255).required(),
+    published: f.boolean().default(false),
+    author: f.relation("user").required(),
   }))
-  .title(({ f }) => f.title);`;
+  .access({ read: true });`;
 
-/* The kit listed four routes under a note claiming five. GET /:id was the one
- * missing; docs/client/sdk.mdx maps every method to its verb and path. */
-const REST = `GET    /api/news
-GET    /api/news/:id
-POST   /api/news
-PATCH  /api/news/:id
-DELETE /api/news/:id`;
+const REST = `GET    /api/posts
+GET    /api/posts/:id
+POST   /api/posts
+PATCH  /api/posts/:id
+DELETE /api/posts/:id`;
 
-/* Was `client.news.list(...)` returning `{ data }`. The accessor is namespaced
- * under .collections, the method is find(), and sdk.mdx has a callout about the
- * envelope: "Read your rows off result.docs, never result itself." */
-const CLIENT = `const { docs } = await client.collections.news.find({
-  where: { isPublished: true },
-  limit: 10,
+const CLIENT = `const { docs } = await client.collections.posts.find({
+  where: { published: true },
+  with: { author: true },
 });`;
 
-/* The kit wrote `job("digest").every("1d").run(...)`. There is no such builder:
- * job() takes a definition object, and recurring work is options.cron. */
-const JOB = `export default job({
-  name: "digest",
-  options: { cron: "0 8 * * *" },
-  handler: async ({ collections, email }) => {
-    await email.send(await buildDigest(collections.news));
-  },
-});`;
+const APPLICATION_PARTS = [
+	{
+		body: "Write type-safe endpoints beside the model. Handlers receive the application context and validated input.",
+		title: "Routes for product logic",
+	},
+	{
+		body: "React to collection changes without importing the generated app back into the files it discovers.",
+		title: "Hooks for side effects",
+	},
+	{
+		body: "Run work now, later or on a schedule with typed payloads and the same collections and services.",
+		title: "Jobs for background work",
+	},
+	{
+		body: "Give routes, hooks and jobs one typed dependency instead of rebuilding integrations in every handler.",
+		title: "Services for shared capabilities",
+	},
+];
 
-/* `bun add questpie drizzle-orm@beta zod` + `questpie generate --watch` was the
- * kit's pair. generate takes -c, --dry-run and --verbose — there is no --watch,
- * that command is `questpie dev`. The documented start is the scaffolder, which
- * installs dependencies and runs codegen for you. */
 const START = `bunx create-questpie my-app
 bun run dev`;
-
-const ADMIN_TICKS = [
-	"List with your labels and search",
-	"Editor with the right control per field",
-	"Versions, drafts and publish state",
-];
-
-const APP_PARTS = [
-	{
-		body: "Typed handlers receive the same collections, database and services.",
-		title: "Routes",
-	},
-	{
-		body: "Run work now, later or on a schedule. Keep retries in one place.",
-		title: "Jobs",
-	},
-	{
-		body: "Give hooks, routes and jobs one typed dependency.",
-		title: "Services",
-	},
-	{
-		body: "Add realtime, search, storage, mail and queues when you need them.",
-		title: "Infrastructure",
-	},
-];
 
 export function FrameworkPage() {
 	return (
@@ -88,17 +52,19 @@ export function FrameworkPage() {
 			<section className="band hero">
 				<div className="wrap split">
 					<div className="head">
-						<p className="qp-aside">describe the data once</p>
+						<p className="qp-aside">the backend contract in TypeScript</p>
 						<h1 className="qp-display-xl">
-							One schema. <em className="qp-hl">Everything else follows.</em>
+							Model the application.{" "}
+							<em className="qp-hl">Keep its parts aligned.</em>
 						</h1>
 						<p className="qp-lead">
-							QUESTPIE derives the typed API, the admin, the jobs and the client
-							from one definition. In your codebase, on your servers.
+							QUESTPIE turns collections into a PostgreSQL schema, typed REST
+							API and typed client. Then it gives your routes, hooks and jobs
+							the same application context.
 						</p>
 						<div className="actions">
-							<a className="btn p lg" href="/docs">
-								Read the docs
+							<a className="btn p lg" href="/docs/learn/first-app">
+								Create your first app
 							</a>
 							<a
 								className="btn o lg"
@@ -106,142 +72,122 @@ export function FrameworkPage() {
 								rel="noreferrer"
 								target="_blank"
 							>
-								Star on GitHub
+								View on GitHub
 							</a>
 						</div>
-						{/* Bun 1.3+ and Postgres 15+ are the prerequisites the getting-started
-						    page states; the kit said "Bun or Node 18+", which the template
-						    does not target. */}
 						<p className="qp-eyebrow">
-							MIT · v{questpiePackage.version} · Bun 1.3+ · Postgres 15+
+							MIT · v{questpiePackage.version} · Bun 1.3+ · PostgreSQL 15+
 						</p>
 					</div>
 
-					<div className="hero-card">
+					<div className="hero-card model-preview">
 						<div className="hero-card-head">
-							<span className="qp-eyebrow">collections/news.ts</span>
-							<span className="count">source of truth</span>
+							<span className="qp-eyebrow">collections/posts.ts</span>
+							<span className="count">one source of truth</span>
 						</div>
-						<CodeSample bare code={SCHEMA} mark="4,5" numbers />
+						<CodeSample bare code={MODEL} mark="4,5,6" numbers />
 					</div>
 				</div>
 			</section>
 
-			<section className="band raised">
+			<section className="band editorial-band">
 				<div className="wrap">
 					<div className="head">
-						<p className="qp-aside">derived, not written</p>
-						<h2 className="qp-display-m">Four things you stop maintaining</h2>
+						<p className="qp-aside">a contract you can inspect</p>
+						<h2 className="qp-display-m">The useful output is already typed</h2>
+						<p>
+							The model is not a separate schema language. It stays in the same
+							TypeScript project as the code that uses it.
+						</p>
 					</div>
-					<div
-						className="grid2"
-						style={{ gridAutoRows: "1fr", marginTop: "var(--space-8)" }}
-					>
-						<div className="card stack">
-							<p className="qp-eyebrow">Typed REST</p>
+
+					<div className="code-contract">
+						<section>
+							<p className="qp-eyebrow">Five REST endpoints per collection</p>
 							<CodeSample bare code={REST} lang="bash" />
-							<p className="card-note">
-								Five routes per collection, typed end to end.
-							</p>
-						</div>
-						<div className="card stack">
-							<p className="qp-eyebrow">Client</p>
+						</section>
+						<section>
+							<p className="qp-eyebrow">A client shaped by your model</p>
 							<CodeSample bare code={CLIENT} />
-							<p className="card-note">
-								Method names come from your collection names. No SDK to keep in
-								step.
-							</p>
-						</div>
-						<div className="card stack">
-							<p className="qp-eyebrow">Admin</p>
-							<div className="ticks">
-								{ADMIN_TICKS.map((tick) => (
-									<span key={tick}>
-										<i />
-										{tick}
-									</span>
-								))}
-							</div>
-							<p className="card-note">
-								No layout file: the schema is the layout.{" "}
-								<a href="/docs/admin">See the admin →</a>
-							</p>
-						</div>
-						<div className="card stack">
-							<p className="qp-eyebrow">Jobs</p>
-							<CodeSample bare code={JOB} />
-							{/* The kit promised "a run log". There is no built-in one — the
-							    audit log is opt-in through logAuditEntry(). The cron schedule
-							    is declarative and real, so it takes the third slot. */}
-							<p className="card-note">
-								Queue, retries and a cron schedule, from one file convention.
-							</p>
-						</div>
+						</section>
 					</div>
 				</div>
 			</section>
-
-			<section className="band">
-				<div className="wrap split lean">
-					<div className="head">
-						<p className="qp-aside">one source of truth</p>
-						<h2 className="qp-display-m">Change the model once</h2>
-						<p>
-							The same model types your database, API, admin and client. You do
-							not copy a field or its rules into four files.
-						</p>
-					</div>
-					<div className="derivation-flow">
-						<div className="derivation-source">
-							<span className="qp-eyebrow">Your model</span>
-							<strong>Fields, access, hooks</strong>
-						</div>
-						<span aria-hidden="true" className="flow-arrow">
-							→
-						</span>
-						<div className="derivation-outputs" role="list">
-							{["Database", "Typed API", "Admin", "Client"].map((part) => (
-								<span key={part} role="listitem">
-									{part}
-								</span>
-							))}
-						</div>
-					</div>
-				</div>
-			</section>
-
-			<hr className="rule" />
 
 			<section className="band raised">
 				<div className="wrap">
 					<div className="head">
-						<p className="qp-aside">the model is only the start</p>
-						<h2 className="qp-display-m">
-							Write the parts that make the app yours
-						</h2>
+						<p className="qp-aside">the framework does not stop at CRUD</p>
+						<h2 className="qp-display-m">Your application logic has a home</h2>
 						<p>
-							QUESTPIE handles the repeated work. Your code holds the decisions.
+							File convention removes wiring. Typed context keeps the pieces
+							connected without making them depend on one another.
 						</p>
 					</div>
-					<div className="feature-list" role="list">
-						{APP_PARTS.map((part) => (
-							<div className="feature-item" key={part.title} role="listitem">
-								<h3>{part.title}</h3>
-								<p>{part.body}</p>
-							</div>
+					<div className="depth-list">
+						{APPLICATION_PARTS.map((part, index) => (
+							<section key={part.title}>
+								<span className="qp-eyebrow">0{index + 1}</span>
+								<div>
+									<h3>{part.title}</h3>
+									<p>{part.body}</p>
+								</div>
+							</section>
 						))}
 					</div>
 				</div>
 			</section>
 
 			<section className="band">
-				<div className="wrap split">
+				<div className="wrap editorial-split">
+					<div className="head">
+						<p className="qp-aside">interfaces are modules, not assumptions</p>
+						<h2 className="qp-display-m">Add the surface your users need</h2>
+						<p>
+							The core owns the model and HTTP contract. Admin, OpenAPI and MCP
+							read that contract through explicit modules.
+						</p>
+						<p>
+							Run Hono or Elysia as a headless backend. Use TanStack Start or
+							Next.js when the application needs the generated admin.
+						</p>
+					</div>
+					<div className="generated-list">
+						<div className="generated-row">
+							<span className="qp-eyebrow">01</span>
+							<div>
+								<strong>Admin</strong>
+								<p>Forms and collection views from field metadata.</p>
+							</div>
+						</div>
+						<div className="generated-row">
+							<span className="qp-eyebrow">02</span>
+							<div>
+								<strong>OpenAPI</strong>
+								<p>A machine-readable API description and Scalar UI.</p>
+							</div>
+						</div>
+						<div className="generated-row">
+							<span className="qp-eyebrow">03</span>
+							<div>
+								<strong>MCP</strong>
+								<p>
+									Explicit tools for agents, backed by the same access model.
+								</p>
+							</div>
+						</div>
+					</div>
+				</div>
+			</section>
+
+			<section className="band raised">
+				<div className="wrap editorial-split">
 					<div className="head">
 						<p className="qp-aside">your application stays yours</p>
-						<h2 className="qp-display-m">Run it where you choose</h2>
+						<h2 className="qp-display-m">Choose every runtime boundary</h2>
 						<p>
-							QUESTPIE ships as open-source packages. Your code runs on your
-							server. Your data stays in PostgreSQL.
+							The packages are open source. The application stays in your
+							repository, runs on your server and stores data in PostgreSQL.
 						</p>
 					</div>
 					<div className="ownership-list" role="list">
@@ -255,30 +201,27 @@ export function FrameworkPage() {
 						</div>
 						<div role="listitem">
 							<span className="qp-eyebrow">Runtime</span>
-							<strong>TanStack, Next, Hono or Elysia</strong>
+							<strong>TanStack, Next.js, Hono or Elysia</strong>
 						</div>
 					</div>
 				</div>
 			</section>
 
-			<section className="band" style={{ paddingBottom: "var(--space-16)" }}>
-				<div className="wrap split">
+			<section className="band launch-band">
+				<div className="wrap launch-split">
 					<div className="head">
-						<p className="qp-aside">two commands</p>
-						<h2 className="qp-display-m">Build the first app</h2>
-						{/* "Adapter" is this product's word for a pluggable backend — email,
-						    kv, queue, storage. The thing you pick here is the runtime, and
-						    all four templates ship in create-questpie. */}
+						<p className="qp-aside">from empty directory to typed backend</p>
+						<h2 className="qp-display-l">Build the first application</h2>
 						<p>
-							Pick your runtime: TanStack Start, Next, Hono or Elysia. The
-							generator writes your typed app.
+							Pick a runtime. The generator installs the project, runs codegen
+							and shows the next steps.
 						</p>
 						<div className="actions">
 							<a className="btn p lg" href="/docs/learn/first-app">
 								Create your first app
 							</a>
 							<a className="btn g lg" href="/docs/learn">
-								See how QUESTPIE works
+								Understand the model
 							</a>
 						</div>
 					</div>

--- a/apps/docs/src/components/marketing/framework.tsx
+++ b/apps/docs/src/components/marketing/framework.tsx
@@ -1,5 +1,6 @@
 import questpiePackage from "../../../../../packages/questpie/package.json";
 import { CodeSample } from "./code";
+import { HeroCodeRotator } from "./hero-code-rotator";
 import { SnippetExplorer } from "./snippet-explorer";
 
 const GITHUB_URL = "https://github.com/questpie/questpie";
@@ -13,6 +14,98 @@ export const posts = collection("posts")
     author: f.relation("user").required(),
   }))
   .access({ read: true });`;
+
+const HERO_SNIPPETS = [
+	{
+		annotations: [
+			{
+				description:
+					"Declares the fields that drive storage, validation and generated types.",
+				match: ".fields",
+			},
+			{
+				description:
+					"Makes the field mandatory across writes, generated APIs and clients.",
+				match: ".required",
+			},
+			{
+				description: "Keeps authorization next to the model it protects.",
+				match: ".access",
+			},
+		],
+		code: MODEL,
+		description:
+			"Fields, relations and access rules become the shared contract for the database, API and client.",
+		file: "collections/posts.ts",
+		key: "model",
+		label: "Model",
+		mark: "4,5,6",
+	},
+	{
+		annotations: [
+			{
+				description: "Validates the request before the handler runs.",
+				match: ".schema",
+			},
+			{
+				description:
+					"Uses the same access boundary as the rest of the application.",
+				match: ".access",
+			},
+			{
+				description:
+					"Receives typed input and collections through the application context.",
+				match: ".handler",
+			},
+		],
+		code: `export default route()
+  .post()
+  .schema(z.object({ title: z.string() }))
+  .access(({ session }) => !!session?.user)
+  .handler(async ({ input, collections }) => {
+    const post = await collections.posts.create(input);
+    return { id: post.id };
+  });`,
+		description:
+			"Validated input and typed collections meet inside a route that is discovered from its file.",
+		file: "routes/create-post.ts",
+		key: "route",
+		label: "Route",
+		mark: "3,4,5,6,7",
+	},
+	{
+		annotations: [
+			{
+				description: "Validates the payload before the job is accepted.",
+				match: "schema:",
+			},
+			{
+				description: "Injects typed services when the background job runs.",
+				match: "handler:",
+			},
+			{
+				description:
+					"Uses the configured mail service without rebuilding the integration.",
+				match: "email.send",
+			},
+		],
+		code: `export default job({
+  name: "daily-digest",
+  schema: z.object({ recipient: z.email() }),
+  handler: async ({ payload, email }) =>
+    email.send({
+      to: payload.recipient,
+      subject: "Daily digest",
+    }),
+});`,
+		description:
+			"Background work receives a validated payload and the same typed services as the request path.",
+		file: "jobs/daily-digest.ts",
+		key: "job",
+		label: "Job",
+		mark: "3,4,5,6,7",
+	},
+] as const;
 
 const REST = `GET    /api/posts
 GET    /api/posts/:id
@@ -158,13 +251,7 @@ export function FrameworkPage() {
 						</p>
 					</div>
 
-					<div className="hero-card model-preview">
-						<div className="hero-card-head">
-							<span className="qp-eyebrow">collections/posts.ts</span>
-							<span className="count">one source of truth</span>
-						</div>
-						<CodeSample bare code={MODEL} mark="4,5,6" numbers />
-					</div>
+					<HeroCodeRotator items={HERO_SNIPPETS} />
 				</div>
 			</section>
 

--- a/apps/docs/src/components/marketing/framework.tsx
+++ b/apps/docs/src/components/marketing/framework.tsx
@@ -1,5 +1,6 @@
 import questpiePackage from "../../../../../packages/questpie/package.json";
 import { CodeSample } from "./code";
+import { SnippetExplorer } from "./snippet-explorer";
 
 const GITHUB_URL = "https://github.com/questpie/questpie";
 
@@ -27,21 +28,98 @@ const CLIENT = `const { docs } = await client.collections.posts.find({
 const APPLICATION_PARTS = [
 	{
 		body: "Write type-safe endpoints beside the model. Handlers receive the application context and validated input.",
-		title: "Routes for product logic",
+		code: `export default route()
+  .post()
+  .schema(z.object({ period: z.enum(["day", "week"]) }))
+  .handler(async ({ input, collections }) => {
+    const total = await collections.posts.count({});
+    return { period: input.period, total };
+  });`,
+		file: "routes/post-stats.ts",
+		key: "routes",
+		title: "Routes",
 	},
 	{
 		body: "React to collection changes without importing the generated app back into the files it discovers.",
-		title: "Hooks for side effects",
+		code: `.hooks({
+  afterChange: async ({ data, operation, queue }) => {
+    if (operation !== "create") return;
+    await queue.notifyPost.publish({ postId: data.id });
+  },
+});`,
+		file: "collections/posts.ts",
+		key: "hooks",
+		title: "Hooks",
 	},
 	{
 		body: "Run work now, later or on a schedule with typed payloads and the same collections and services.",
-		title: "Jobs for background work",
+		code: `export default job({
+  name: "daily-digest",
+  schema: z.object({}),
+  handler: async ({ email }) => {
+    await email.send({
+      to: "team@example.com",
+      subject: "Daily digest",
+      html: "<p>The latest posts are ready.</p>",
+    });
+  },
+  options: { cron: "0 8 * * *" },
+});`,
+		file: "jobs/daily-digest.ts",
+		key: "jobs",
+		title: "Jobs",
 	},
 	{
 		body: "Give routes, hooks and jobs one typed dependency instead of rebuilding integrations in every handler.",
-		title: "Services for shared capabilities",
+		code: `export default service({
+  create: () => ({
+    readingTime(content: string) {
+      const words = content.trim().split(/\\s+/).length;
+      return Math.max(1, Math.ceil(words / 200));
+    },
+  }),
+});`,
+		file: "services/editorial.ts",
+		key: "services",
+		title: "Services",
 	},
-];
+] as const;
+
+const PRODUCT_SURFACES = [
+	{
+		body: "Generate collection forms, list views and authentication-aware navigation from field metadata.",
+		code: `import { adminModule } from "@questpie/admin/modules/admin";
+
+export default [adminModule] as const;`,
+		file: "server/modules.ts",
+		key: "admin",
+		title: "Admin",
+	},
+	{
+		body: "Publish the machine-readable schema and a Scalar reference UI from the same application contract.",
+		code: `import { openApiModule } from "@questpie/openapi";
+
+export default [openApiModule] as const;
+
+// /api/openapi.json
+// /api/docs`,
+		file: "server/modules.ts",
+		key: "openapi",
+		title: "OpenAPI",
+	},
+	{
+		body: "Expose approved collection operations and routes as agent tools under the access rules already in the app.",
+		code: `import { adminModule } from "@questpie/admin/modules/admin";
+import { mcpModule } from "@questpie/mcp/modules/mcp";
+
+export default [adminModule, mcpModule] as const;
+
+// OAuth-gated endpoint: /api/mcp`,
+		file: "server/modules.ts",
+		key: "mcp",
+		title: "MCP",
+	},
+] as const;
 
 const START = `bunx create-questpie my-app
 bun run dev`;
@@ -104,7 +182,7 @@ export function FrameworkPage() {
 					<div className="code-contract">
 						<section>
 							<p className="qp-eyebrow">Five REST endpoints per collection</p>
-							<CodeSample bare code={REST} lang="bash" />
+							<CodeSample bare code={REST} lang="http" />
 						</section>
 						<section>
 							<p className="qp-eyebrow">A client shaped by your model</p>
@@ -124,22 +202,12 @@ export function FrameworkPage() {
 							connected without making them depend on one another.
 						</p>
 					</div>
-					<div className="depth-list">
-						{APPLICATION_PARTS.map((part, index) => (
-							<section key={part.title}>
-								<span className="qp-eyebrow">0{index + 1}</span>
-								<div>
-									<h3>{part.title}</h3>
-									<p>{part.body}</p>
-								</div>
-							</section>
-						))}
-					</div>
+					<SnippetExplorer items={APPLICATION_PARTS} />
 				</div>
 			</section>
 
 			<section className="band">
-				<div className="wrap editorial-split">
+				<div className="wrap">
 					<div className="head">
 						<p className="qp-aside">interfaces are modules, not assumptions</p>
 						<h2 className="qp-display-m">Add the surface your users need</h2>
@@ -152,31 +220,7 @@ export function FrameworkPage() {
 							Next.js when the application needs the generated admin.
 						</p>
 					</div>
-					<div className="generated-list">
-						<div className="generated-row">
-							<span className="qp-eyebrow">01</span>
-							<div>
-								<strong>Admin</strong>
-								<p>Forms and collection views from field metadata.</p>
-							</div>
-						</div>
-						<div className="generated-row">
-							<span className="qp-eyebrow">02</span>
-							<div>
-								<strong>OpenAPI</strong>
-								<p>A machine-readable API description and Scalar UI.</p>
-							</div>
-						</div>
-						<div className="generated-row">
-							<span className="qp-eyebrow">03</span>
-							<div>
-								<strong>MCP</strong>
-								<p>
-									Explicit tools for agents, backed by the same access model.
-								</p>
-							</div>
-						</div>
-					</div>
+					<SnippetExplorer compact items={PRODUCT_SURFACES} />
 				</div>
 			</section>
 

--- a/apps/docs/src/components/marketing/hero-code-rotator.tsx
+++ b/apps/docs/src/components/marketing/hero-code-rotator.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import { CodeSample } from "./code";
+import type { CodeAnnotation } from "./code";
+
+export type HeroCodeSnippet = {
+	annotations?: readonly CodeAnnotation[];
+	code: string;
+	description: string;
+	file: string;
+	key: string;
+	label: string;
+	mark?: string;
+};
+
+export function HeroCodeRotator({
+	items,
+}: {
+	items: readonly HeroCodeSnippet[];
+}) {
+	const rootRef = useRef<HTMLDivElement>(null);
+	const [activeIndex, setActiveIndex] = useState(0);
+	const [animate, setAnimate] = useState(false);
+	const [focusWithin, setFocusWithin] = useState(false);
+	const [hovered, setHovered] = useState(false);
+	const [canAutoRotate, setCanAutoRotate] = useState(false);
+
+	useEffect(() => {
+		const root = rootRef.current;
+		if (!root) return;
+
+		const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
+		let inView = false;
+		const sync = () => setCanAutoRotate(inView && !reducedMotion.matches);
+		const observer = new IntersectionObserver(
+			([entry]) => {
+				inView = entry.isIntersecting;
+				sync();
+			},
+			{ threshold: 0.35 },
+		);
+
+		observer.observe(root);
+		reducedMotion.addEventListener("change", sync);
+		return () => {
+			observer.disconnect();
+			reducedMotion.removeEventListener("change", sync);
+		};
+	}, []);
+
+	useEffect(() => {
+		if (!canAutoRotate || focusWithin || hovered) return;
+		const interval = window.setInterval(() => {
+			setAnimate(true);
+			setActiveIndex((current) => (current + 1) % items.length);
+		}, 6000);
+		return () => window.clearInterval(interval);
+	}, [canAutoRotate, focusWithin, hovered, items.length]);
+
+	return (
+		<div
+			className="hero-card model-preview hero-code-rotator"
+			data-animate={animate ? "true" : "false"}
+			onBlurCapture={(event) => {
+				if (!event.currentTarget.contains(event.relatedTarget)) {
+					setFocusWithin(false);
+				}
+			}}
+			onFocusCapture={() => setFocusWithin(true)}
+			onMouseEnter={() => setHovered(true)}
+			onMouseLeave={() => setHovered(false)}
+			ref={rootRef}
+		>
+			<div className="hero-code-stage">
+				{items.map((item, index) => {
+					const active = index === activeIndex;
+					return (
+						<div
+							aria-hidden={!active}
+							className="hero-code-panel"
+							data-active={active ? "true" : "false"}
+							inert={!active}
+							key={item.key}
+						>
+							<div className="hero-card-head">
+								<span className="qp-eyebrow">{item.file}</span>
+								<span className="count">
+									{String(index + 1).padStart(2, "0")} / {items.length}
+								</span>
+							</div>
+							<CodeSample
+								annotations={item.annotations}
+								bare
+								code={item.code}
+								mark={item.mark}
+								numbers
+							/>
+							<p className="hero-code-description">{item.description}</p>
+						</div>
+					);
+				})}
+			</div>
+
+			<div aria-label="Choose code example" className="hero-code-nav">
+				{items.map((item, index) => (
+					<button
+						aria-pressed={index === activeIndex}
+						key={item.key}
+						onClick={() => setActiveIndex(index)}
+						onKeyDown={() => setAnimate(false)}
+						onPointerDown={() => setAnimate(true)}
+						type="button"
+					>
+						<span aria-hidden="true">0{index + 1}</span>
+						{item.label}
+					</button>
+				))}
+			</div>
+		</div>
+	);
+}

--- a/apps/docs/src/components/marketing/landing.tsx
+++ b/apps/docs/src/components/marketing/landing.tsx
@@ -136,7 +136,7 @@ export function Landing() {
 			</section>
 
 			<section className="band">
-				<div className="wrap editorial-split">
+				<div className="wrap editorial-split editorial-split-reversed">
 					<div className="head">
 						<p className="qp-aside">open where ownership matters</p>
 						<h2 className="qp-display-m">Your application remains yours</h2>

--- a/apps/docs/src/components/marketing/landing.tsx
+++ b/apps/docs/src/components/marketing/landing.tsx
@@ -1,128 +1,61 @@
-/* The landing, band for band from the accepted kit (ui_kits/marketing/index.html).
- *
- * Four bands and no more. The page it replaces ran eleven sections deep, which is
- * why nobody reached the end of it: hero, the work itself, the two doors, one ask.
- *
- * Two devices on the page are built from live DOM rather than screenshots — the
- * hero card and the Autopilot door. A capture would go stale the first time the
- * product moved, and at these sizes text in an image is unreadable anyway.
- */
 import questpiePackage from "../../../../../packages/questpie/package.json";
 import { CodeSample } from "./code";
 
-const SCHEMA_SAMPLE = `collection("news")
+const GITHUB_URL = "https://github.com/questpie/questpie";
+
+const MODEL_SAMPLE = `import { collection } from "#questpie/factories";
+
+export const posts = collection("posts")
   .fields(({ f }) => ({
     title: f.text(255).required(),
-    content: f.richText(),
+    published: f.boolean().default(false),
+    author: f.relation("user").required(),
   }))
-  .title(({ f }) => f.title);`;
+  .access({ read: true });`;
 
-const STEPS = [
+const CORE_OUTPUTS = [
 	{
-		body: "Goals, tasks and messages in one place, in your own words.",
-		num: "01",
-		title: "You write down the work",
+		detail: "Tables, relations and constraints are generated from the model.",
+		title: "Database schema",
 	},
 	{
-		body: "It joins with a role, like any hire, and sees only what that role sees.",
-		num: "02",
-		title: "An agent gets a seat",
+		detail:
+			"CRUD endpoints and validation share the same field and access rules.",
+		title: "Typed API",
 	},
 	{
-		body: "We log every step, and anything that matters waits for your yes.",
-		num: "03",
-		title: "You keep the last word",
+		detail: "Queries and mutations know the exact shape of every collection.",
+		title: "Typed client",
 	},
 ];
 
-function HeroCard() {
-	return (
-		<div className="hero-card">
-			<div className="hero-card-head">
-				<span className="qp-eyebrow">Today's work</span>
-				{/* The kit dated this Friday, 30 July. 30 July 2026 is a Thursday, and
-				    the brief below is due Friday — so the day before is both the true
-				    weekday and the one that makes the deadline mean something. */}
-				<span className="count">Thursday, 30 July</span>
-			</div>
-			<div className="rows">
-				<div className="row pin">
-					<div className="rb">
-						<span className="qp-eyebrow">From you</span>
-						<span
-							className="rt"
-							style={{ fontWeight: "var(--weight-semibold)" }}
-						>
-							Send the November invoices by Friday, check the amounts in Stripe.
-						</span>
-					</div>
-				</div>
-				<div className="row" style={{ alignItems: "flex-start" }}>
-					<span className="av agent">AI</span>
-					<div className="rb">
-						<span className="rt">Preparing 14 invoices</span>
-						<span className="rm">agent Ada · role Accounting</span>
-						<span className="progress">
-							<span className="meter">
-								{/* 8 of 14 is 57%, so the bar stops 43% short */}
-								<span style={{ right: "43%" }} />
-							</span>
-							<span className="count">8/14</span>
-						</span>
-					</div>
-				</div>
-				<div className="row">
-					<span className="av i2">AB</span>
-					<div className="rb">
-						<span className="rt">Reply to the supplier e-mail</span>
-						<span className="rm">Anna B. · 2 h</span>
-					</div>
-					<span className="chip">Waiting on Anna</span>
-				</div>
-				<div className="row">
-					<span className="av agent">AI</span>
-					<div className="rb">
-						<span className="rt">Close order #4412</span>
-						<span className="rm">agent proposed · waits for your yes</span>
-					</div>
-					<span className="chip ok">Needs you</span>
-				</div>
-			</div>
-		</div>
-	);
-}
+const DEPTH = [
+	{
+		body: "Collection, field and operation rules live beside the data they protect. The same rules apply whether a request comes from REST, a hook or a job.",
+		title: "One access model",
+	},
+	{
+		body: "Routes, hooks, jobs and services receive typed collections, database and infrastructure services through the same application context.",
+		title: "One application context",
+	},
+	{
+		body: "Start with PostgreSQL. Add queues, storage, search, email or realtime through adapters when the application actually needs them.",
+		title: "Infrastructure on purpose",
+	},
+];
 
-/* The Autopilot door. The kit left a grey "product shot" box here because it had
- * no capture to put in it; neither do we, and a placeholder on a landing page is
- * just an unfinished page. Three rows say what the door claims — an agent, a
- * person, something waiting on you — in the same grammar as the hero. */
-function DoorPreview() {
+function CoreOutputList() {
 	return (
-		<div className="frame preview">
-			<div className="rows" style={{ width: "100%" }}>
-				<div className="row">
-					<span className="av agent">AI</span>
-					<div className="rb">
-						<span className="rt">Drafted the October report</span>
-						<span className="rm">agent Ada · done 09:12</span>
+		<div className="generated-list">
+			{CORE_OUTPUTS.map((output, index) => (
+				<div className="generated-row" key={output.title}>
+					<span className="qp-eyebrow">0{index + 1}</span>
+					<div>
+						<strong>{output.title}</strong>
+						<p>{output.detail}</p>
 					</div>
 				</div>
-				<div className="row">
-					<span className="av i2">MK</span>
-					<div className="rb">
-						<span className="rt">Called the supplier back</span>
-						<span className="rm">Martin K. · done 11:40</span>
-					</div>
-				</div>
-				<div className="row">
-					<span className="av agent">AI</span>
-					<div className="rb">
-						<span className="rt">Raise the price list by 4%</span>
-						<span className="rm">agent proposed · waits for your yes</span>
-					</div>
-					<span className="chip ok">Needs you</span>
-				</div>
-			</div>
+			))}
 		</div>
 	);
 }
@@ -130,165 +63,179 @@ function DoorPreview() {
 export function Landing() {
 	return (
 		<>
-			<section className="band hero">
+			<section className="band hero home-hero">
 				<div className="wrap split">
 					<div className="head">
-						<p className="qp-aside">
-							with everything the company actually does
-						</p>
+						<p className="qp-aside">server-first TypeScript framework</p>
 						<h1 className="qp-display-xl">
-							Software you <em className="qp-hl">can staff</em>
+							Define the model once.{" "}
+							<em className="qp-hl">Keep the app in sync.</em>
 						</h1>
 						<p className="qp-lead">
-							An AI agent joins the way a person does: a role, permissions, and
-							its own name on the work it finishes. Nobody installs anything.
-							Nothing happens behind your back.
+							A collection holds fields, access rules and hooks in one file.
+							QUESTPIE derives the PostgreSQL schema, typed REST API and typed
+							client from it.
 						</p>
 						<div className="actions">
-							<a className="btn p lg" href="/autopilot#cta">
-								Get early access
+							<a className="btn p lg" href="/docs/learn/first-app">
+								Create your first app
 							</a>
-							<a className="btn s lg" href="#how">
-								See how it works
+							<a className="btn s lg" href="#model">
+								Read how it works
 							</a>
 						</div>
 						<p className="qp-eyebrow">
-							MIT · TypeScript · Postgres · self-hosted · v
+							MIT · TypeScript · PostgreSQL · self-hosted · v
 							{questpiePackage.version}
 						</p>
 					</div>
 
-					<HeroCard />
+					<div className="hero-card model-preview">
+						<div className="hero-card-head">
+							<span className="qp-eyebrow">collections/posts.ts</span>
+							<span className="count">one source of truth</span>
+						</div>
+						<CodeSample bare code={MODEL_SAMPLE} mark="4,5,6" />
+					</div>
 				</div>
 			</section>
 
-			<section className="band raised" id="how">
+			<section className="band editorial-band" id="model">
+				<div className="wrap editorial-split">
+					<div className="head">
+						<p className="qp-aside">one definition, fewer contracts</p>
+						<h2 className="qp-display-m">Change the field, not five places</h2>
+						<p>
+							Rename <code>title</code> and the server API and client types move
+							with it. A stale property becomes an editor error instead of a
+							production surprise.
+						</p>
+						<p>
+							There is less to maintain because the contract is not copied into
+							validators, endpoints and SDK types.
+						</p>
+					</div>
+					<CoreOutputList />
+				</div>
+			</section>
+
+			<section className="band raised">
 				<div className="wrap">
 					<div className="head">
-						<p className="qp-aside">three steps, nothing more</p>
-						<h2 className="qp-display-m">How it actually works</h2>
+						<p className="qp-aside">a focused core, modules when needed</p>
+						<h2 className="qp-display-m">
+							Use only the backend your app needs
+						</h2>
+						<p>
+							The framework starts with the application model. Product surfaces
+							and infrastructure stay explicit.
+						</p>
 					</div>
-					<div
-						className="grid3"
-						style={{
-							gridAutoRows: "1fr",
-							marginTop: "var(--space-10)",
-						}}
-					>
-						{STEPS.map((step) => (
-							<div className="card" key={step.num}>
-								<span className="step-num">{step.num}</span>
-								<h3 style={{ marginTop: "var(--space-5)" }}>{step.title}</h3>
-								<p>{step.body}</p>
-							</div>
-						))}
+
+					<div className="contract-columns">
+						<section>
+							<p className="qp-eyebrow">Framework core</p>
+							<h3>The backend contract</h3>
+							<p>
+								Collections, globals, REST, the typed client, access control,
+								hooks, routes, jobs and services.
+							</p>
+						</section>
+						<section>
+							<p className="qp-eyebrow">Optional modules and adapters</p>
+							<h3>Add the surfaces you need</h3>
+							<p>
+								Admin, OpenAPI, MCP, workflows, realtime, search, storage, email
+								and queues.
+							</p>
+						</section>
 					</div>
+					<p className="contract-note">
+						Run headless with Hono or Elysia, or add the admin UI with TanStack
+						Start or Next.js.
+					</p>
 				</div>
 			</section>
 
 			<section className="band">
-				<div className="wrap split lean">
+				<div className="wrap">
 					<div className="head">
-						<p className="qp-aside">one system, two ways to use it</p>
-						<h2 className="qp-display-m">Build the rules. Run the work.</h2>
-						<p>
-							The framework defines the data, permissions and workflows.
-							Autopilot gives people and agents one place to use them.
-						</p>
+						<p className="qp-aside">beyond generated CRUD</p>
+						<h2 className="qp-display-m">
+							The rest of the backend speaks the same language
+						</h2>
 					</div>
-					<div className="system-flow" role="list">
-						<div className="system-step" role="listitem">
-							<span className="qp-eyebrow">Define</span>
-							<strong>Data, permissions, workflows</strong>
-						</div>
-						<div className="system-step" role="listitem">
-							<span className="qp-eyebrow">Build</span>
-							<strong>API, admin, jobs, client</strong>
-						</div>
-						<div className="system-step" role="listitem">
-							<span className="qp-eyebrow">Run</span>
-							<strong>People and agents at work</strong>
-						</div>
+					<div className="depth-list">
+						{DEPTH.map((item, index) => (
+							<section key={item.title}>
+								<span className="qp-eyebrow">0{index + 1}</span>
+								<div>
+									<h3>{item.title}</h3>
+									<p>{item.body}</p>
+								</div>
+							</section>
+						))}
 					</div>
 				</div>
 			</section>
 
 			<hr className="rule" />
 
-			<section className="band" id="doors">
+			<section className="band" id="products">
 				<div className="wrap">
 					<div className="head">
-						<p className="qp-aside">two doors</p>
-						<h2 className="qp-display-m">
-							One for running the company, one for building it
-						</h2>
+						<p className="qp-aside">
+							open source foundation, practical product
+						</p>
+						<h2 className="qp-display-m">Build on QUESTPIE today</h2>
 					</div>
-					<div
-						className="grid2"
-						style={{
-							gridAutoRows: "1fr",
-							marginTop: "var(--space-10)",
-						}}
-					>
-						<a className="door" href="/autopilot">
-							<span className="chip" style={{ alignSelf: "flex-start" }}>
-								Autopilot
-							</span>
-							<DoorPreview />
-							<div>
-								<h3>For the people running the company</h3>
-								<p className="door-line">
-									Work arrives, someone picks it up, someone closes it. You see
-									who did what.
-								</p>
-								<span
-									className="door-cta"
-									style={{ color: "var(--primary-text)" }}
-								>
-									Get early access →
-								</span>
-							</div>
-						</a>
-						<a className="door" href="/framework">
-							<span className="chip" style={{ alignSelf: "flex-start" }}>
-								Framework
-							</span>
-							<div className="frame code">
-								<CodeSample bare code={SCHEMA_SAMPLE} />
-							</div>
-							<div>
-								<h3>For the people building it</h3>
-								<p className="door-line">
-									Describe the data once. The typed API, the admin, the jobs and
-									the client follow from it.
-								</p>
-								<span className="door-cta">Read the docs →</span>
-							</div>
-						</a>
+					<div className="product-paths">
+						<section>
+							<p className="qp-eyebrow">Framework · available now</p>
+							<h3>Own the application</h3>
+							<p>
+								Keep the code, database and deployment. QUESTPIE gives you the
+								typed foundation without taking over your runtime.
+							</p>
+							<a href="/framework">Explore the framework →</a>
+						</section>
+						<section>
+							<p className="qp-eyebrow">Autopilot · early access</p>
+							<h3>See the foundation at work</h3>
+							<p>
+								Autopilot is a product built on QUESTPIE for shared work between
+								people and agents. It is not required to use the framework.
+							</p>
+							<a href="/autopilot">Meet Autopilot →</a>
+						</section>
 					</div>
 				</div>
 			</section>
 
-			<section className="band" style={{ paddingBottom: "var(--space-16)" }}>
-				<div className="wrap">
-					<div className="cta-block">
-						<div className="head head-center">
-							<p className="qp-aside">we are our own first customer</p>
-							<h2 className="qp-display-l">QUESTPIE runs on QUESTPIE</h2>
-							<p>
-								Every goal, task and message behind this page lives in
-								Autopilot.
-							</p>
-						</div>
-						<div className="actions" style={{ justifyContent: "center" }}>
-							<a className="btn p lg" href="/autopilot#cta">
-								Get early access
+			<section className="band launch-band">
+				<div className="wrap launch-split">
+					<div className="head">
+						<p className="qp-aside">your code, your data, your runtime</p>
+						<h2 className="qp-display-l">Start with a working application</h2>
+						<p>
+							Choose TanStack Start, Next.js, Hono or Elysia. The generator
+							installs the project, runs codegen and shows the next steps.
+						</p>
+						<div className="actions">
+							<a className="btn p lg" href="/docs/learn/first-app">
+								Create your first app
 							</a>
-							<a className="btn g lg" href="/docs">
-								Read the docs
+							<a
+								className="btn g lg"
+								href={GITHUB_URL}
+								rel="noreferrer"
+								target="_blank"
+							>
+								View on GitHub
 							</a>
 						</div>
 					</div>
+					<CodeSample code="bunx create-questpie my-app" lang="bash" />
 				</div>
 			</section>
 		</>

--- a/apps/docs/src/components/marketing/landing.tsx
+++ b/apps/docs/src/components/marketing/landing.tsx
@@ -3,211 +3,161 @@ import { CodeSample } from "./code";
 
 const GITHUB_URL = "https://github.com/questpie/questpie";
 
-const MODEL_SAMPLE = `import { collection } from "#questpie/factories";
-
-export const posts = collection("posts")
-  .fields(({ f }) => ({
-    title: f.text(255).required(),
-    published: f.boolean().default(false),
-    author: f.relation("user").required(),
-  }))
-  .access({ read: true });`;
-
-const CORE_OUTPUTS = [
+const SHARED_FOUNDATION = [
 	{
-		detail: "Tables, relations and constraints are generated from the model.",
-		title: "Database schema",
+		body: "Data, relationships and validation start in one TypeScript model instead of being copied between tools.",
+		title: "One application model",
 	},
 	{
-		detail:
-			"CRUD endpoints and validation share the same field and access rules.",
-		title: "Typed API",
-	},
-	{
-		detail: "Queries and mutations know the exact shape of every collection.",
-		title: "Typed client",
-	},
-];
-
-const DEPTH = [
-	{
-		body: "Collection, field and operation rules live beside the data they protect. The same rules apply whether a request comes from REST, a hook or a job.",
+		body: "People, APIs and agents meet the same permissions at the boundary where work is executed.",
 		title: "One access model",
 	},
 	{
-		body: "Routes, hooks, jobs and services receive typed collections, database and infrastructure services through the same application context.",
-		title: "One application context",
-	},
-	{
-		body: "Start with PostgreSQL. Add queues, storage, search, email or realtime through adapters when the application actually needs them.",
-		title: "Infrastructure on purpose",
+		body: "Routes, hooks, jobs and agent actions run with the context of the application they belong to.",
+		title: "One execution context",
 	},
 ];
-
-function CoreOutputList() {
-	return (
-		<div className="generated-list">
-			{CORE_OUTPUTS.map((output, index) => (
-				<div className="generated-row" key={output.title}>
-					<span className="qp-eyebrow">0{index + 1}</span>
-					<div>
-						<strong>{output.title}</strong>
-						<p>{output.detail}</p>
-					</div>
-				</div>
-			))}
-		</div>
-	);
-}
 
 export function Landing() {
 	return (
 		<>
 			<section className="band hero home-hero">
-				<div className="wrap split">
+				<div className="wrap split ecosystem-hero">
 					<div className="head">
-						<p className="qp-aside">server-first TypeScript framework</p>
+						<p className="qp-aside">one ecosystem for applications and work</p>
 						<h1 className="qp-display-xl">
-							Define the model once.{" "}
-							<em className="qp-hl">Keep the app in sync.</em>
+							Build the system. <em className="qp-hl">Put it to work.</em>
 						</h1>
 						<p className="qp-lead">
-							A collection holds fields, access rules and hooks in one file.
-							QUESTPIE derives the PostgreSQL schema, typed REST API and typed
-							client from it.
+							QUESTPIE brings the application and the work happening inside it
+							under one model. Framework gives developers the foundation.
+							Autopilot gives people and agents a place to operate it together.
 						</p>
 						<div className="actions">
-							<a className="btn p lg" href="/docs/learn/first-app">
-								Create your first app
+							<a className="btn p lg" href="/framework">
+								Explore Framework
 							</a>
-							<a className="btn s lg" href="#model">
-								Read how it works
+							<a className="btn s lg" href="/autopilot">
+								Meet Autopilot
 							</a>
 						</div>
 						<p className="qp-eyebrow">
-							MIT · TypeScript · PostgreSQL · self-hosted · v
+							Open source foundation · TypeScript · PostgreSQL · v
 							{questpiePackage.version}
 						</p>
 					</div>
 
-					<div className="hero-card model-preview">
-						<div className="hero-card-head">
-							<span className="qp-eyebrow">collections/posts.ts</span>
-							<span className="count">one source of truth</span>
+					<div className="ecosystem-index" aria-label="QUESTPIE ecosystem">
+						<div>
+							<span className="qp-eyebrow">01 · Framework</span>
+							<strong>Build the application</strong>
+							<p>Model the data and rules. Derive the API, client and admin.</p>
 						</div>
-						<CodeSample bare code={MODEL_SAMPLE} mark="4,5,6" />
+						<div>
+							<span className="qp-eyebrow">02 · Autopilot</span>
+							<strong>Run the work</strong>
+							<p>
+								Give people and agents shared tasks, boundaries and history.
+							</p>
+						</div>
+						<p className="ecosystem-common">
+							The same model · the same permissions · the same application
+						</p>
 					</div>
 				</div>
 			</section>
 
-			<section className="band editorial-band" id="model">
-				<div className="wrap editorial-split">
+			<section className="band editorial-band" id="ecosystem">
+				<div className="wrap">
 					<div className="head">
-						<p className="qp-aside">one definition, fewer contracts</p>
-						<h2 className="qp-display-m">Change the field, not five places</h2>
+						<p className="qp-aside">two products, one foundation</p>
+						<h2 className="qp-display-m">
+							Start with the system. Add the way of working.
+						</h2>
 						<p>
-							Rename <code>title</code> and the server API and client types move
-							with it. A stale property becomes an editor error instead of a
-							production surprise.
-						</p>
-						<p>
-							There is less to maintain because the contract is not copied into
-							validators, endpoints and SDK types.
+							Framework and Autopilot solve different parts of the same problem.
+							Use the open-source framework on its own, or let Autopilot work
+							with the application it defines.
 						</p>
 					</div>
-					<CoreOutputList />
+
+					<div className="product-paths ecosystem-paths">
+						<section>
+							<p className="qp-eyebrow">Framework · available now</p>
+							<h3>A foundation developers can own</h3>
+							<p>
+								Define collections, access, routes, hooks and jobs in
+								TypeScript. Keep the code, PostgreSQL database and deployment in
+								your hands.
+							</p>
+							<a href="/framework">See how Framework works →</a>
+						</section>
+						<section>
+							<p className="qp-eyebrow">Autopilot · early access</p>
+							<h3>A workspace for people and agents</h3>
+							<p>
+								Turn requests into visible work. Let agents act within explicit
+								roles, pause for approval and leave a history people can
+								inspect.
+							</p>
+							<a href="/autopilot">See what Autopilot adds →</a>
+						</section>
+					</div>
 				</div>
 			</section>
 
 			<section className="band raised">
-				<div className="wrap">
+				<div className="wrap editorial-split">
 					<div className="head">
-						<p className="qp-aside">a focused core, modules when needed</p>
-						<h2 className="qp-display-m">
-							Use only the backend your app needs
-						</h2>
+						<p className="qp-aside">the connection is the product</p>
+						<h2 className="qp-display-m">The rules survive the interface</h2>
 						<p>
-							The framework starts with the application model. Product surfaces
-							and infrastructure stay explicit.
+							A screen, an API call and an agent action should not invent three
+							different versions of the application. QUESTPIE keeps their shared
+							contract close to the code that enforces it.
+						</p>
+						<p>
+							That is the big picture: Framework defines what the system is.
+							Autopilot helps trusted actors move work through it.
 						</p>
 					</div>
-
-					<div className="contract-columns">
-						<section>
-							<p className="qp-eyebrow">Framework core</p>
-							<h3>The backend contract</h3>
-							<p>
-								Collections, globals, REST, the typed client, access control,
-								hooks, routes, jobs and services.
-							</p>
-						</section>
-						<section>
-							<p className="qp-eyebrow">Optional modules and adapters</p>
-							<h3>Add the surfaces you need</h3>
-							<p>
-								Admin, OpenAPI, MCP, workflows, realtime, search, storage, email
-								and queues.
-							</p>
-						</section>
-					</div>
-					<p className="contract-note">
-						Run headless with Hono or Elysia, or add the admin UI with TanStack
-						Start or Next.js.
-					</p>
-				</div>
-			</section>
-
-			<section className="band">
-				<div className="wrap">
-					<div className="head">
-						<p className="qp-aside">beyond generated CRUD</p>
-						<h2 className="qp-display-m">
-							The rest of the backend speaks the same language
-						</h2>
-					</div>
-					<div className="depth-list">
-						{DEPTH.map((item, index) => (
-							<section key={item.title}>
+					<div className="generated-list">
+						{SHARED_FOUNDATION.map((item, index) => (
+							<div className="generated-row" key={item.title}>
 								<span className="qp-eyebrow">0{index + 1}</span>
 								<div>
-									<h3>{item.title}</h3>
+									<strong>{item.title}</strong>
 									<p>{item.body}</p>
 								</div>
-							</section>
+							</div>
 						))}
 					</div>
 				</div>
 			</section>
 
-			<hr className="rule" />
-
-			<section className="band" id="products">
-				<div className="wrap">
+			<section className="band">
+				<div className="wrap editorial-split">
 					<div className="head">
-						<p className="qp-aside">
-							open source foundation, practical product
+						<p className="qp-aside">open where ownership matters</p>
+						<h2 className="qp-display-m">Your application remains yours</h2>
+						<p>
+							Framework is MIT licensed and self-hosted. Autopilot is a product
+							built on top, not a requirement hidden beneath it.
 						</p>
-						<h2 className="qp-display-m">Build on QUESTPIE today</h2>
 					</div>
-					<div className="product-paths">
-						<section>
-							<p className="qp-eyebrow">Framework · available now</p>
-							<h3>Own the application</h3>
-							<p>
-								Keep the code, database and deployment. QUESTPIE gives you the
-								typed foundation without taking over your runtime.
-							</p>
-							<a href="/framework">Explore the framework →</a>
-						</section>
-						<section>
-							<p className="qp-eyebrow">Autopilot · early access</p>
-							<h3>See the foundation at work</h3>
-							<p>
-								Autopilot is a product built on QUESTPIE for shared work between
-								people and agents. It is not required to use the framework.
-							</p>
-							<a href="/autopilot">Meet Autopilot →</a>
-						</section>
+					<div className="ownership-list" role="list">
+						<div role="listitem">
+							<span className="qp-eyebrow">Code</span>
+							<strong>Your repository</strong>
+						</div>
+						<div role="listitem">
+							<span className="qp-eyebrow">Data</span>
+							<strong>Your PostgreSQL database</strong>
+						</div>
+						<div role="listitem">
+							<span className="qp-eyebrow">Product</span>
+							<strong>Framework alone, or Framework with Autopilot</strong>
+						</div>
 					</div>
 				</div>
 			</section>
@@ -215,11 +165,11 @@ export function Landing() {
 			<section className="band launch-band">
 				<div className="wrap launch-split">
 					<div className="head">
-						<p className="qp-aside">your code, your data, your runtime</p>
-						<h2 className="qp-display-l">Start with a working application</h2>
+						<p className="qp-aside">start from the foundation</p>
+						<h2 className="qp-display-l">Build the first application</h2>
 						<p>
-							Choose TanStack Start, Next.js, Hono or Elysia. The generator
-							installs the project, runs codegen and shows the next steps.
+							Create a working QUESTPIE project now, or explore how Autopilot
+							will put that foundation to work.
 						</p>
 						<div className="actions">
 							<a className="btn p lg" href="/docs/learn/first-app">

--- a/apps/docs/src/components/marketing/product-media.tsx
+++ b/apps/docs/src/components/marketing/product-media.tsx
@@ -1,0 +1,56 @@
+type ProductMediaProps = {
+	alt: string;
+	description: string;
+	eyebrow: string;
+	kind?: "image" | "video";
+	poster?: string;
+	src?: string;
+	title: string;
+	variant?: "hero" | "wide";
+};
+
+// Keep media optional until the final product captures exist. A missing source
+// renders an honest, correctly sized handoff slot instead of speculative UI.
+export function ProductMedia({
+	alt,
+	description,
+	eyebrow,
+	kind = "image",
+	poster,
+	src,
+	title,
+	variant = "wide",
+}: ProductMediaProps) {
+	return (
+		<figure className={`product-media product-media-${variant}`}>
+			{src ? (
+				kind === "video" ? (
+					<video
+						aria-label={alt}
+						controls
+						loop
+						muted
+						playsInline
+						poster={poster}
+						preload="metadata"
+						src={src}
+					/>
+				) : (
+					<img alt={alt} loading="lazy" src={src} />
+				)
+			) : (
+				<div className="product-media-placeholder">
+					<span className="qp-eyebrow">{eyebrow}</span>
+					<strong>{title}</strong>
+					<p>{description}</p>
+				</div>
+			)}
+			{src ? (
+				<figcaption>
+					<strong>{title}</strong>
+					<span>{description}</span>
+				</figcaption>
+			) : null}
+		</figure>
+	);
+}

--- a/apps/docs/src/components/marketing/snippet-explorer.tsx
+++ b/apps/docs/src/components/marketing/snippet-explorer.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { Tabs } from "@base-ui/react/tabs";
+import { useState } from "react";
+
+import { CodeSample } from "./code";
+
+export type SnippetExplorerItem<TValue extends string = string> = {
+	body: string;
+	code: string;
+	file: string;
+	key: TValue;
+	title: string;
+};
+
+export function SnippetExplorer<TValue extends string>({
+	compact = false,
+	items,
+}: {
+	compact?: boolean;
+	items: readonly SnippetExplorerItem<TValue>[];
+}) {
+	const [activeItem, setActiveItem] = useState<TValue>(items[0].key);
+	const [animateItem, setAnimateItem] = useState(false);
+
+	return (
+		<Tabs.Root
+			className={`logic-tabs${compact ? " compact" : ""}`}
+			data-animate={animateItem ? "true" : "false"}
+			onKeyDownCapture={() => setAnimateItem(false)}
+			onPointerDownCapture={() => setAnimateItem(true)}
+			onValueChange={(value) => {
+				if (typeof value !== "string") return;
+				setActiveItem(value as TValue);
+			}}
+			orientation="vertical"
+			value={activeItem}
+		>
+			<Tabs.List className="logic-tabs-list" activateOnFocus>
+				{items.map((item, index) => (
+					<Tabs.Tab className="logic-tab" key={item.key} value={item.key}>
+						<span className="qp-eyebrow">0{index + 1}</span>
+						<span>
+							<strong>{item.title}</strong>
+							<small>{item.body}</small>
+						</span>
+					</Tabs.Tab>
+				))}
+			</Tabs.List>
+			<div className="logic-stage">
+				{items.map((item) => (
+					<Tabs.Panel
+						className="logic-panel"
+						keepMounted
+						key={item.key}
+						value={item.key}
+					>
+						<p className="qp-eyebrow">{item.file}</p>
+						<CodeSample bare code={item.code} />
+					</Tabs.Panel>
+				))}
+			</div>
+		</Tabs.Root>
+	);
+}

--- a/apps/docs/src/components/marketing/works.tsx
+++ b/apps/docs/src/components/marketing/works.tsx
@@ -1,0 +1,626 @@
+/* QUESTPIE Works — the services page.
+ *
+ * Layout is designed separately and mirrored here; keep the two in step rather
+ * than editing this file first. Styles live in styles/works.css, scoped under
+ * .works-page and prefixed .w-*. That is deliberate: the first implementation
+ * reused .editorial-split, .generated-list and .feature-list from the other
+ * marketing routes, which were built for a different content shape, and the
+ * result was misaligned columns, a rule leading nowhere, and a form in three
+ * different widths.
+ *
+ * Structure: what we are, what we do, our stack or yours, how we think, core
+ * team, projects (own products first, then client work), contact.
+ *
+ * Client names in CLIENT below are real and are NOT yet cleared for
+ * publication. Do not deploy this route until they are signed off.
+ */
+
+import { type FormEvent, useState } from "react";
+
+const CONTACT = "#contact";
+const EMAIL = "dominik@questpie.com";
+
+const WHAT_WE_DO = [
+	{
+		body: "Payload and Strapi, past the point the defaults stop helping. Custom fields, access rules, and an admin your staff can work in all day.",
+		title: "CMS work",
+	},
+	{
+		body: "The tool your staff live in. It is usually the thing that used to be a spreadsheet, and it runs the business.",
+		title: "Internal tools",
+	},
+	{
+		body: "Rooms, slots, tables, staff. The hard part is never the calendar, it is making sure two people cannot take the same thing.",
+		title: "Booking systems",
+	},
+	{
+		body: "Postgres, queues, storage, and the deploy. One team from the schema to production, so nobody owns half a system.",
+		title: "Full stack and servers",
+	},
+	{
+		body: "React Native, shipped to both stores, talking to the same backend as the website. One model, not two.",
+		title: "Mobile apps",
+	},
+	{
+		body: "Taking money, refunds, and the boring parts nobody wants to get wrong. Kept in its own service where it belongs.",
+		title: "Payments",
+	},
+	{
+		body: "Agents that do real work inside your app, with their own permissions. We built a product on this and we run our company on it.",
+		title: "AI that does the work",
+	},
+	{
+		body: "Someone else's code, a cloud bill nobody understands, or a build that stopped. We take it over and move it.",
+		title: "Rescue work",
+	},
+];
+
+/* Two capabilities as a choice. An earlier draft was one section with a
+ * disclaimer under it, which promised what we would not do instead of claiming
+ * what we do. The first option also carries the braid: the product does the
+ * selling inside the services pitch, where the buyer already is. */
+const WAYS = [
+	{
+		body: "TypeScript, Postgres, and QUESTPIE, which we wrote. You get help from the people who build it, not from someone who read the docs. A new project starts in week three, not week one. The framework is open source, so you can keep it running without us.",
+		num: "Option A",
+		title: "We bring our stack",
+	},
+	{
+		body: "Your repo, your rules, your review. Payload, Strapi, Next, whatever is already there, including the parts nobody wants to touch. We read the code before we quote, and we leave it the way your team writes it.",
+		num: "Option B",
+		title: "Or we work in yours",
+	},
+];
+
+const STEPS = [
+	{
+		body: "Forty-five minutes on a call, then we write down what is really in there. It is often not what people think.",
+		num: "01 · look",
+		title: "We read the code first",
+	},
+	{
+		body: "What we would build, and in what order. You get it before anyone signs anything.",
+		num: "02 · plan",
+		title: "A written plan",
+	},
+	{
+		body: "Your branch, your review, one short update a week. No status meetings.",
+		num: "03 · build",
+		title: "PRs into your process",
+	},
+	{
+		body: "The servers are part of the app, not a separate bill. You can keep all of it running after we leave.",
+		num: "04 · hand over",
+		title: "You keep it",
+	},
+];
+
+const BELIEFS = [
+	{
+		body: "We use agents on client work every day, and we wrote our own tools to make that safe. Autopilot is our product: agents join a company with their own roles and permissions, instead of borrowing a human's. We are also blunt about where they are still bad.",
+		num: "01",
+		title: "We build with agents, and for them",
+	},
+	{
+		body: "One schema makes the API, the admin, the jobs and the client. We wrote a framework on that idea because we kept inheriting codebases where those four had quietly drifted apart.",
+		num: "02",
+		title: "One model, or it drifts",
+	},
+	{
+		body: "Postgres, not the new thing. We pick tools you can hire for in three years, and we keep the clever parts small enough that the next person can read them.",
+		num: "03",
+		title: "Boring where it counts",
+	},
+	{
+		body: "We write up what did not work, including our own dead framework. If we get something wrong on your project you will hear it from us first.",
+		num: "04",
+		title: "We say what went wrong",
+	},
+];
+
+const CORE = [
+	{
+		body: "Backend and servers. Wrote most of QUESTPIE, and the deploy setup under everything here.",
+		href: "https://drepkovsky.com",
+		name: "Dominik Repkovský",
+		role: "Full stack · infrastructure",
+	},
+	{
+		body: "Full stack and product. The part where a screen has to survive real people using it.",
+		href: "https://martinrapcan.com",
+		name: "Martin Rapčan",
+		role: "Full stack · product",
+	},
+];
+
+/* Imagery is placeholders by owner decision — the real screens get supplied
+ * rather than captured. Every placeholder prints what belongs in it, so the
+ * slot is unambiguous. Never substitute a mockup for a real screen: an honest
+ * empty frame is better than a picture that implies something we did not ship. */
+const OWN = [
+	{
+		addr: "questpie.com",
+		body: "You write one schema. The API, the admin panel, the jobs and the typed client all come out of it. Open source, and we know it better than anyone, because we wrote it.",
+		href: "https://questpie.com/framework",
+		kind: "Framework · MIT · TypeScript",
+		shot: null,
+		need: "questpie.com, framework page or a schema-to-surfaces shot",
+		base: "one schema",
+		top: ["API", "admin", "jobs", "client"],
+		verb: "all generated from",
+		title: "QUESTPIE",
+	},
+	{
+		addr: "questpie.com/autopilot",
+		body: "AI agents with their own roles and permissions, instead of borrowing yours. Goals, tasks and channels shared by people and agents. We run our own company on it.",
+		href: "https://questpie.com/autopilot",
+		kind: "Product · agents as team members",
+		shot: null,
+		need: "Autopilot, the running app: goals, tasks, an agent in a channel",
+		base: "one permission model",
+		top: ["people", "agents"],
+		verb: "both work under",
+		title: "Autopilot",
+	},
+	{
+		addr: "jubli.app",
+		body: "Our own product, built on QUESTPIE and shipped the same way we ship for clients.",
+		href: "https://jubli.app",
+		kind: "Product · in pilot",
+		shot: null,
+		need: "Jubli, the product in use",
+		base: "QUESTPIE",
+		top: ["web", "admin"],
+		verb: "both built on",
+		title: "Jubli",
+	},
+	{
+		addr: "github.com/drepkovsky",
+		body: "drizzle-migrations, agent-board and probe. We needed them, could not find them, so we wrote them. People we have never met use them.",
+		href: "https://github.com/drepkovsky",
+		kind: "Open source · developer tools",
+		shot: null,
+		need: "a repo page, or the CLI in a terminal",
+		top: ["drizzle-migrations", "agent-board", "probe"],
+		title: "Tools we maintain",
+	},
+];
+
+const CLIENT = [
+	{
+		addr: "chatacerenka.eu",
+		kind: "Booking engine · operator console",
+		body: "A booking system, the console the staff run the place from, and the public site. All on one schema, so the two can never disagree about a free room.",
+		href: "https://chatacerenka.eu",
+		shot: null,
+		need: "the operator console, the strongest proof on this page",
+		base: "one schema",
+		top: ["booking form", "operator console"],
+		verb: "both read",
+		title: "One schema behind the desk and the booking form",
+	},
+	{
+		addr: "jinejsvet.questpie.app",
+		kind: "Klára pomáhá · accounts · block builder",
+		body: "A place for young people who have lost someone. Accounts, their own writing, and a block builder underneath, so the charity can add pages without us.",
+		href: "https://jinejsvet.questpie.app",
+		shot: null,
+		need: "the portal: the candles or the timeline, plus the block builder mid-edit",
+		base: "typed blocks",
+		top: ["pages", "posts"],
+		verb: "the charity builds from",
+		title: "A grief support portal the charity runs itself",
+	},
+	{
+		addr: "nutrimeals.eu",
+		kind: "React Native + Payload CMS · IoT",
+		body: "A React Native app and a website on top of Payload CMS, driving smart fridges. App, database and deploy, all in one job.",
+		href: "https://nutrimeals.eu",
+		shot: null,
+		need: "the React Native app, or a fridge in the field",
+		base: "one Payload CMS",
+		top: ["iOS + Android", "web", "fridges"],
+		verb: "all talk to",
+		title: "One codebase driving an app, a site and the fridges",
+	},
+	{
+		addr: "byvak",
+		kind: "Multi-tenant platform · four years",
+		body: "A property platform with paying customers. App, API, a separate payments service and the public site, in one repo, kept running for four years.",
+		href: null,
+		shot: null,
+		need: "byvak, the platform, any surface",
+		base: "one monorepo",
+		top: ["app", "API", "payments", "site"],
+		verb: "all live in",
+		title: "Four apps, one monorepo, four years in production",
+	},
+];
+
+const FIELDS = [
+	{ id: "name", label: "Name", type: "text", wide: false },
+	{ id: "email", label: "Email", type: "email", wide: false },
+	{ id: "company", label: "Company", type: "text", wide: true },
+];
+
+function Schematic({
+	base,
+	top,
+	verb,
+}: {
+	base?: string;
+	top: string[];
+	verb?: string;
+}) {
+	return (
+		<div className="w-schema">
+			<div className="w-schema-row">
+				{top.map((n) => (
+					<span key={n}>{n}</span>
+				))}
+			</div>
+			{base ? (
+				<>
+					<div className="w-schema-legs">
+						{top.map((n) => (
+							<i key={n} />
+						))}
+					</div>
+					<p className="w-schema-verb">{verb}</p>
+					<div className="w-schema-base">{base}</div>
+				</>
+			) : null}
+		</div>
+	);
+}
+
+function Window({
+	addr,
+	alt,
+	base,
+	href,
+	need,
+	shot,
+	top,
+	verb,
+}: {
+	addr: string;
+	alt: string;
+	base?: string;
+	href: string | null;
+	need?: string;
+	shot: string | null;
+	top?: string[];
+	verb?: string;
+}) {
+	const inner = (
+		<>
+			<span className="w-chrome">
+				<i />
+				<i />
+				<i />
+				<em>{addr}</em>
+			</span>
+			{shot ? (
+				<img alt={alt} height={900} loading="lazy" src={shot} width={1440} />
+			) : top ? (
+				<Schematic base={base} top={top} verb={verb} />
+			) : (
+				<span className="w-ph">
+					<em>{need ?? alt}</em>
+				</span>
+			)}
+		</>
+	);
+
+	return href ? (
+		<a className="w" href={href} rel="noreferrer" target="_blank">
+			{inner}
+		</a>
+	) : (
+		<div className="w">{inner}</div>
+	);
+}
+
+/* The house pattern, same as the Autopilot early-access form: compose a
+ * mailto rather than post to a form service. Nothing to authenticate, nothing
+ * to keep alive, and the message lands in the same inbox the page advertises. */
+function ProjectForm() {
+	const [values, setValues] = useState<Record<string, string>>({});
+
+	const set = (id: string, v: string) =>
+		setValues((prev) => ({ ...prev, [id]: v }));
+
+	const submit = (event: FormEvent) => {
+		event.preventDefault();
+		const body = [
+			`Name: ${values.name ?? ""}`,
+			`Email: ${values.email ?? ""}`,
+			`Company: ${values.company ?? ""}`,
+			"",
+			"The project:",
+			values.project ?? "",
+		].join("\n");
+		window.location.href = `mailto:${EMAIL}?subject=${encodeURIComponent(
+			"Project enquiry",
+		)}&body=${encodeURIComponent(body)}`;
+	};
+
+	return (
+		<form className="w-fields" onSubmit={submit}>
+			{FIELDS.map((f) => (
+				<div className={f.wide ? "w-field wide" : "w-field"} key={f.id}>
+					<label htmlFor={`w-${f.id}`}>{f.label}</label>
+					<input
+						id={`w-${f.id}`}
+						name={f.id}
+						onChange={(e) => set(f.id, e.target.value)}
+						type={f.type}
+						value={values[f.id] ?? ""}
+					/>
+				</div>
+			))}
+			<div className="w-field wide">
+				<label htmlFor="w-project">The project</label>
+				<textarea
+					id="w-project"
+					name="project"
+					onChange={(e) => set("project", e.target.value)}
+					rows={5}
+					value={values.project ?? ""}
+				/>
+			</div>
+			<div className="wide">
+				<button className="btn p lg" type="submit">
+					Send
+				</button>
+			</div>
+		</form>
+	);
+}
+
+export function WorksPage() {
+	return (
+		<div className="works-page">
+			<header className="w-band">
+				<div className="w-page w-stack">
+					<div className="w-hero-head">
+						<p className="w-label">questpie works</p>
+						<h1 className="w-display">
+							Software for other people.
+							<span>A framework of our own.</span>
+						</h1>
+					</div>
+					<p className="w-lead">
+						We are a small team of engineers in Slovakia. We wrote QUESTPIE, an
+						open source framework in TypeScript. We also build for other people,
+						in their code, under their name.
+					</p>
+					<div className="w-actions">
+						<a className="btn p lg" href={CONTACT}>
+							Start a conversation
+						</a>
+						<a className="btn s lg" href="#projects">
+							See the work
+						</a>
+					</div>
+					<p className="w-strip">
+						TypeScript · Postgres · React · React Native · Payload · GitOps ·
+						MIT
+					</p>
+				</div>
+			</header>
+
+			{/* A portfolio shows before it explains. */}
+			<div className="w-band tight">
+				<div className="w-page">
+					<Window
+						addr="chatacerenka.eu"
+						alt="lead project"
+						href="https://chatacerenka.eu"
+						base="one schema"
+						shot={null}
+						top={["booking form", "operator console", "public site"]}
+						verb="all read"
+					/>
+				</div>
+			</div>
+
+			<section className="w-band" id="what">
+				<div className="w-page w-grid">
+					<div className="w-rail">
+						<p className="w-label">01 · what we do</p>
+						<p className="w-body">Four kinds of work. We say no to the rest.</p>
+					</div>
+					<div className="w-col">
+						<h2 className="w-title">What we are good at.</h2>
+						<div className="w-two dense">
+							{WHAT_WE_DO.map((item, i) => (
+								<article className="w-item" key={item.title}>
+									<span className="w-num">
+										{String(i + 1).padStart(2, "0")}
+									</span>
+									<h3>{item.title}</h3>
+									<p>{item.body}</p>
+								</article>
+							))}
+						</div>
+					</div>
+				</div>
+			</section>
+
+			<section className="w-band raised" id="how">
+				<div className="w-page w-grid">
+					<div className="w-rail">
+						<p className="w-label">02 · how we work</p>
+						<p className="w-body">Two ways in. You pick.</p>
+					</div>
+					<div className="w-col wide">
+						<h2 className="w-title">Our stack, or yours.</h2>
+						<div className="w-two">
+							{WAYS.map((way) => (
+								<article className="w-item" key={way.title}>
+									<span className="w-num">{way.num}</span>
+									<h3>{way.title}</h3>
+									<p>{way.body}</p>
+								</article>
+							))}
+						</div>
+						<hr className="w-rule" />
+						<div className="w-two">
+							{STEPS.map((step) => (
+								<article className="w-item" key={step.title}>
+									<span className="w-num">{step.num}</span>
+									<h3>{step.title}</h3>
+									<p>{step.body}</p>
+								</article>
+							))}
+						</div>
+					</div>
+				</div>
+			</section>
+
+			<section className="w-band" id="think">
+				<div className="w-page w-grid">
+					<div className="w-rail">
+						<p className="w-label">03 · how we think</p>
+						<p className="w-body">
+							Four things we believe. Each one points at something you can go
+							and check.
+						</p>
+					</div>
+					<div className="w-col">
+						<h2 className="w-title">How we think about the work.</h2>
+						<div className="w-two">
+							{BELIEFS.map((item) => (
+								<article className="w-item" key={item.title}>
+									<span className="w-num">{item.num}</span>
+									<h3>{item.title}</h3>
+									<p>{item.body}</p>
+								</article>
+							))}
+						</div>
+					</div>
+				</div>
+			</section>
+
+			<section className="w-band raised" id="team">
+				<div className="w-page w-grid">
+					<div className="w-rail">
+						<p className="w-label">04 · core team</p>
+						<p className="w-body">
+							When a job needs more people, we name them before we start.
+						</p>
+					</div>
+					<div className="w-col">
+						<h2 className="w-title">Who you actually work with.</h2>
+						<p className="w-lead">
+							We do the work ourselves. The person who answers your email is the
+							person writing your code.
+						</p>
+						<div className="w-two">
+							{CORE.map((person) => (
+								<article className="w-person" key={person.name}>
+									<span className="w-num quiet">{person.role}</span>
+									<h3>
+										{person.href ? (
+											<a href={person.href} rel="noreferrer" target="_blank">
+												{person.name} →
+											</a>
+										) : (
+											person.name
+										)}
+									</h3>
+									<p className="w-body">{person.body}</p>
+								</article>
+							))}
+						</div>
+					</div>
+				</div>
+			</section>
+
+			<section className="w-band" id="projects">
+				<div className="w-page w-grid">
+					<div className="w-rail">
+						<p className="w-label">05 · projects</p>
+						<p className="w-body">
+							Some of it. Our own products come first, because they show the
+							most.
+						</p>
+					</div>
+					<h2 className="w-title">Some of what we have built.</h2>
+				</div>
+
+				<div className="w-page w-sub">
+					<p className="w-label">Our own</p>
+				</div>
+				<div className="w-slider">
+					{OWN.map((p) => (
+						<article className="w-card" key={p.title}>
+							<Window
+								addr={p.addr}
+								alt={p.title}
+								base={p.base}
+								href={p.href}
+								need={p.need}
+								shot={p.shot}
+								top={p.top}
+								verb={p.verb}
+							/>
+							<div className="w-card-body">
+								<p className="w-num quiet">{p.kind}</p>
+								<h3>{p.title}</h3>
+								<p className="w-body">{p.body}</p>
+							</div>
+						</article>
+					))}
+				</div>
+
+				<div className="w-page w-sub second">
+					<p className="w-label">For clients</p>
+				</div>
+				<div className="w-slider">
+					{CLIENT.map((p) => (
+						<article className="w-card" key={p.title}>
+							<Window
+								addr={p.addr}
+								alt={p.title}
+								base={p.base}
+								href={p.href}
+								need={p.need}
+								shot={p.shot}
+								top={p.top}
+								verb={p.verb}
+							/>
+							<div className="w-card-body">
+								<p className="w-num quiet">{p.kind}</p>
+								<h3>{p.title}</h3>
+								<p className="w-body">{p.body}</p>
+							</div>
+						</article>
+					))}
+				</div>
+			</section>
+
+			<section className="w-band" id="contact">
+				<div className="w-page w-grid">
+					<div className="w-rail">
+						<p className="w-label">06 · contact</p>
+						<p className="w-body">
+							We answer every message ourselves. Or write straight to{" "}
+							<a href={`mailto:${EMAIL}`}>{EMAIL}</a>.
+						</p>
+					</div>
+					<div className="w-col">
+						<h2 className="w-title">Tell us about the project.</h2>
+						<p className="w-lead">
+							Tell us the stack, the scope, and when you need people. If we are
+							not right for it, we will say so, and say who might be.
+						</p>
+						<ProjectForm />
+					</div>
+				</div>
+			</section>
+		</div>
+	);
+}

--- a/apps/docs/src/lib/seo.ts
+++ b/apps/docs/src/lib/seo.ts
@@ -4,9 +4,9 @@
 
 export const siteConfig = {
 	name: "QUESTPIE",
-	title: "QUESTPIE: define the model once, keep the app in sync",
+	title: "QUESTPIE: build the system, put it to work",
 	description:
-		"Define fields, access rules and hooks once. QUESTPIE derives the PostgreSQL schema, typed REST API and typed client from the same model.",
+		"QUESTPIE is an open-source TypeScript application framework and Autopilot, a product for shared work between people and agents.",
 	url: "https://questpie.com",
 	ogImage: "/og-questpie.png",
 	twitterHandle: "@questpie",

--- a/apps/docs/src/lib/seo.ts
+++ b/apps/docs/src/lib/seo.ts
@@ -4,13 +4,9 @@
 
 export const siteConfig = {
 	name: "QUESTPIE",
-	/* The title the landing itself carries, and the one the accepted kit specifies.
-	   What it replaces — "Open-source TypeScript application framework" — is a
-	   category any competitor could paste unchanged, and it sold only the
-	   framework while the page's first screen is about staffing agents. */
-	title: "QUESTPIE: software you can staff",
+	title: "QUESTPIE: define the model once, keep the app in sync",
 	description:
-		"An AI agent joins the way a person does: a role, permissions, its own name on the work. On an open-source TypeScript framework you run yourself.",
+		"Define fields, access rules and hooks once. QUESTPIE derives the PostgreSQL schema, typed REST API and typed client from the same model.",
 	url: "https://questpie.com",
 	ogImage: "/og-questpie.png",
 	twitterHandle: "@questpie",

--- a/apps/docs/src/routeTree.gen.ts
+++ b/apps/docs/src/routeTree.gen.ts
@@ -17,6 +17,7 @@ import { Route as LlmsFullDottxtRouteImport } from './routes/llms-full[.]txt'
 import { Route as LlmsDottxtRouteImport } from './routes/llms[.]txt'
 import { Route as RssDotxmlRouteImport } from './routes/rss[.]xml'
 import { Route as SitemapDotxmlRouteImport } from './routes/sitemap[.]xml'
+import { Route as WorksRouteImport } from './routes/works'
 import { Route as ApiSearchRouteImport } from './routes/api/search'
 import { Route as DocsSplatRouteImport } from './routes/docs/$'
 import { Route as LlmsDotmdxDocsSplatRouteImport } from './routes/llms[.]mdx.docs.$'
@@ -61,6 +62,11 @@ const SitemapDotxmlRoute = SitemapDotxmlRouteImport.update({
   path: '/sitemap.xml',
   getParentRoute: () => rootRouteImport,
 } as any)
+const WorksRoute = WorksRouteImport.update({
+  id: '/works',
+  path: '/works',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiSearchRoute = ApiSearchRouteImport.update({
   id: '/api/search',
   path: '/api/search',
@@ -86,6 +92,7 @@ export interface FileRoutesByFullPath {
   '/llms.txt': typeof LlmsDottxtRoute
   '/rss.xml': typeof RssDotxmlRoute
   '/sitemap.xml': typeof SitemapDotxmlRoute
+  '/works': typeof WorksRoute
   '/api/search': typeof ApiSearchRoute
   '/docs/$': typeof DocsSplatRoute
   '/llms.mdx/docs/$': typeof LlmsDotmdxDocsSplatRoute
@@ -99,6 +106,7 @@ export interface FileRoutesByTo {
   '/llms.txt': typeof LlmsDottxtRoute
   '/rss.xml': typeof RssDotxmlRoute
   '/sitemap.xml': typeof SitemapDotxmlRoute
+  '/works': typeof WorksRoute
   '/api/search': typeof ApiSearchRoute
   '/docs/$': typeof DocsSplatRoute
   '/llms.mdx/docs/$': typeof LlmsDotmdxDocsSplatRoute
@@ -113,6 +121,7 @@ export interface FileRoutesById {
   '/llms.txt': typeof LlmsDottxtRoute
   '/rss.xml': typeof RssDotxmlRoute
   '/sitemap.xml': typeof SitemapDotxmlRoute
+  '/works': typeof WorksRoute
   '/api/search': typeof ApiSearchRoute
   '/docs/$': typeof DocsSplatRoute
   '/llms.mdx/docs/$': typeof LlmsDotmdxDocsSplatRoute
@@ -128,6 +137,7 @@ export interface FileRouteTypes {
     | '/llms.txt'
     | '/rss.xml'
     | '/sitemap.xml'
+    | '/works'
     | '/api/search'
     | '/docs/$'
     | '/llms.mdx/docs/$'
@@ -141,6 +151,7 @@ export interface FileRouteTypes {
     | '/llms.txt'
     | '/rss.xml'
     | '/sitemap.xml'
+    | '/works'
     | '/api/search'
     | '/docs/$'
     | '/llms.mdx/docs/$'
@@ -154,6 +165,7 @@ export interface FileRouteTypes {
     | '/llms.txt'
     | '/rss.xml'
     | '/sitemap.xml'
+    | '/works'
     | '/api/search'
     | '/docs/$'
     | '/llms.mdx/docs/$'
@@ -168,6 +180,7 @@ export interface RootRouteChildren {
   LlmsDottxtRoute: typeof LlmsDottxtRoute
   RssDotxmlRoute: typeof RssDotxmlRoute
   SitemapDotxmlRoute: typeof SitemapDotxmlRoute
+  WorksRoute: typeof WorksRoute
   ApiSearchRoute: typeof ApiSearchRoute
   DocsSplatRoute: typeof DocsSplatRoute
   LlmsDotmdxDocsSplatRoute: typeof LlmsDotmdxDocsSplatRoute
@@ -231,6 +244,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof SitemapDotxmlRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/works': {
+      id: '/works'
+      path: '/works'
+      fullPath: '/works'
+      preLoaderRoute: typeof WorksRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/search': {
       id: '/api/search'
       path: '/api/search'
@@ -264,6 +284,7 @@ const rootRouteChildren: RootRouteChildren = {
   LlmsDottxtRoute: LlmsDottxtRoute,
   RssDotxmlRoute: RssDotxmlRoute,
   SitemapDotxmlRoute: SitemapDotxmlRoute,
+  WorksRoute: WorksRoute,
   ApiSearchRoute: ApiSearchRoute,
   DocsSplatRoute: DocsSplatRoute,
   LlmsDotmdxDocsSplatRoute: LlmsDotmdxDocsSplatRoute,

--- a/apps/docs/src/routes/autopilot.tsx
+++ b/apps/docs/src/routes/autopilot.tsx
@@ -4,11 +4,9 @@ import { AutopilotPageContent } from "@/components/marketing/autopilot";
 import { MarketingChrome } from "@/components/marketing/chrome";
 import { generateLinks, generateMeta, siteConfig } from "@/lib/seo";
 
-const TITLE = "Autopilot: agents on the team";
-/* The description this replaces promised "Q4 2026 early access". Nothing in the
- * repo dates the pilot, so the page says what it can stand behind instead. */
+const TITLE = "Autopilot: give agents real work, keep the last word";
 const DESCRIPTION =
-	"Autopilot holds the work: goals, tasks, messages. An agent picks something up, asks when it is unsure, and hands back a proposal you accept in one click.";
+	"Autopilot keeps goals, tasks, messages and agent work in one place, with named roles, visible progress and human approval where it matters.";
 
 export const Route = createFileRoute("/autopilot")({
 	component: AutopilotPage,

--- a/apps/docs/src/routes/framework.tsx
+++ b/apps/docs/src/routes/framework.tsx
@@ -4,9 +4,9 @@ import { MarketingChrome } from "@/components/marketing/chrome";
 import { FrameworkPage } from "@/components/marketing/framework";
 import { generateLinks, generateMeta, siteConfig } from "@/lib/seo";
 
-const TITLE = "Framework: one schema, everything else derived";
+const TITLE = "Framework: model the application, keep its parts aligned";
 const DESCRIPTION =
-	"QUESTPIE derives the typed API, the admin, the jobs and the client from one definition. In your codebase, on your servers.";
+	"QUESTPIE turns collections into a PostgreSQL schema, typed REST API and typed client, then gives routes, hooks and jobs the same application context.";
 
 export const Route = createFileRoute("/framework")({
 	component: Framework,

--- a/apps/docs/src/routes/sitemap[.]xml.ts
+++ b/apps/docs/src/routes/sitemap[.]xml.ts
@@ -110,6 +110,7 @@ async function generateSitemap(
 	const staticPages = [
 		{ path: "/autopilot", priority: 0.9, changefreq: "weekly" },
 		{ path: "/framework", priority: 0.9, changefreq: "weekly" },
+		{ path: "/works", priority: 0.8, changefreq: "monthly" },
 	];
 
 	for (const sp of staticPages) {

--- a/apps/docs/src/routes/works.tsx
+++ b/apps/docs/src/routes/works.tsx
@@ -1,0 +1,39 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { MarketingChrome } from "@/components/marketing/chrome";
+import { WorksPage } from "@/components/marketing/works";
+import { generateLinks, generateMeta, siteConfig } from "@/lib/seo";
+
+const TITLE = "White-label engineering, from the team that builds QUESTPIE";
+const DESCRIPTION =
+	"Contract engineering in your repo, your stack and under your name. Headless CMS builds, operator tools, full stack and infrastructure. EU hours, English, invoiced from an EU company.";
+
+export const Route = createFileRoute("/works")({
+	component: Works,
+	head: () => ({
+		links: generateLinks({
+			url: `${siteConfig.url}/works`,
+			includeIcons: false,
+			includePreconnect: false,
+		}),
+		meta: generateMeta({
+			title: TITLE,
+			description: DESCRIPTION,
+			url: `${siteConfig.url}/works`,
+		}),
+	}),
+	headers: () => ({
+		"Cache-Control":
+			"public, max-age=86400, s-maxage=86400, stale-while-revalidate=604800",
+	}),
+	staleTime: 60 * 60_000,
+	gcTime: 2 * 60 * 60_000,
+});
+
+function Works() {
+	return (
+		<MarketingChrome page="works">
+			<WorksPage />
+		</MarketingChrome>
+	);
+}

--- a/apps/docs/src/styles/app.css
+++ b/apps/docs/src/styles/app.css
@@ -8,6 +8,7 @@
 @import "@questpie/tokens/styles.css";
 @import "@questpie/tokens/tokens/mesh.css";
 @import "./marketing.css";
+@import "./works.css";
 
 @import "tw-animate-css";
 @import "shadcn/tailwind.css";

--- a/apps/docs/src/styles/marketing.css
+++ b/apps/docs/src/styles/marketing.css
@@ -367,6 +367,114 @@ body.qp-grain-page {
 	.model-preview .hero-card-head .qp-eyebrow {
 		color: var(--foreground-muted);
 	}
+	.hero-code-stage {
+		display: grid;
+		grid-template-columns: minmax(0, 1fr);
+		min-width: 0;
+	}
+	.hero-code-panel {
+		grid-area: 1 / 1;
+		display: flex;
+		min-width: 0;
+		flex-direction: column;
+		gap: var(--space-5);
+		opacity: 0;
+		visibility: hidden;
+		transform: translateY(6px);
+		pointer-events: none;
+		transition:
+			opacity 140ms cubic-bezier(0.22, 1, 0.36, 1),
+			transform 140ms cubic-bezier(0.22, 1, 0.36, 1),
+			visibility 0s linear 140ms;
+	}
+	.hero-code-panel[data-active="true"] {
+		opacity: 1;
+		visibility: visible;
+		transform: translateY(0);
+		pointer-events: auto;
+		transition:
+			opacity 220ms cubic-bezier(0.22, 1, 0.36, 1),
+			transform 220ms cubic-bezier(0.22, 1, 0.36, 1),
+			visibility 0s;
+	}
+	.hero-code-rotator[data-animate="false"] .hero-code-panel {
+		transition: none;
+	}
+	.hero-code-description {
+		min-height: 2.8rem;
+		padding: 0 var(--space-2);
+		font-size: var(--type-sm);
+		color: var(--foreground-muted);
+		line-height: var(--line-relaxed);
+	}
+	.hero-code-panel .qp-code {
+		width: 100%;
+		min-width: 0;
+		max-width: 100%;
+	}
+	.hero-code-nav {
+		display: flex;
+		flex-wrap: wrap;
+		gap: var(--space-2);
+		padding-top: var(--space-3);
+		border-top: 1px solid var(--border-subtle);
+	}
+	.hero-code-nav button {
+		display: inline-flex;
+		min-height: 2.75rem;
+		align-items: center;
+		gap: var(--space-2);
+		padding: 0 var(--space-3);
+		border: 0;
+		background: transparent;
+		color: var(--foreground-subtle);
+		font: inherit;
+		font-size: var(--type-sm);
+		font-weight: var(--weight-semibold);
+		cursor: pointer;
+		transition: color 160ms ease-out;
+	}
+	.hero-code-nav button span {
+		font-family: var(--font-mono);
+		font-size: var(--type-xs);
+		font-weight: var(--weight-regular);
+		font-variant-numeric: tabular-nums;
+	}
+	.hero-code-nav button:hover,
+	.hero-code-nav button[aria-pressed="true"] {
+		color: var(--foreground);
+	}
+	.hero-code-nav button:focus-visible {
+		outline: 2px solid var(--ring);
+		outline-offset: 2px;
+	}
+	.qp-code-annotation {
+		display: inline;
+		position: relative;
+		padding: 0;
+		border: 0;
+		border-bottom: 1px dashed var(--foreground-subtle);
+		background: transparent;
+		font: inherit;
+		color: inherit;
+		cursor: help;
+	}
+	.qp-code-annotation::after {
+		position: absolute;
+		inset: -0.7rem -0.25rem;
+		content: "";
+	}
+	.qp-code-annotation:hover,
+	.qp-code-annotation:focus-visible {
+		border-bottom-color: var(--coral);
+	}
+	.qp-code-annotation:focus-visible {
+		outline: 1px solid color-mix(in srgb, var(--coral) 55%, transparent);
+		outline-offset: 2px;
+	}
+	.qp-code-annotation > span {
+		pointer-events: none;
+	}
 	.product-media {
 		min-width: 0;
 		margin: 0;
@@ -622,6 +730,17 @@ body.qp-grain-page {
 		grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr);
 		align-items: center;
 		gap: var(--space-16);
+	}
+	.editorial-split-reversed {
+		grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.9fr);
+	}
+	.editorial-split-reversed > .head {
+		grid-column: 2;
+		grid-row: 1;
+	}
+	.editorial-split-reversed > :not(.head) {
+		grid-column: 1;
+		grid-row: 1;
 	}
 	.editorial-split .head > p + p {
 		margin-top: calc(var(--space-2) * -1);
@@ -1059,6 +1178,11 @@ body.qp-grain-page {
 			grid-template-columns: minmax(0, 1fr);
 			gap: var(--space-10);
 		}
+		.editorial-split-reversed > .head,
+		.editorial-split-reversed > :not(.head) {
+			grid-column: 1;
+			grid-row: auto;
+		}
 	}
 	@media (max-width: 45rem) {
 		.system-flow,
@@ -1154,6 +1278,8 @@ body.qp-grain-page {
 		}
 	}
 	@media (prefers-reduced-motion: reduce) {
+		.hero-code-panel,
+		.hero-code-panel[data-active="true"],
 		.logic-tab {
 			transition: none;
 		}
@@ -1430,6 +1556,8 @@ body.qp-grain-page {
 	}
 	/* a code block sitting directly on a card: one surface per cell */
 	.qp-code.bare {
+		min-width: 0;
+		max-width: 100%;
 		border: 0;
 		padding: 0;
 		margin: 0;
@@ -1445,6 +1573,24 @@ body.qp-grain-page {
 
 	/* Marketing is dark-only — the site is one continuous atmosphere. The product
 	   (admin, Autopilot) keeps both themes; that is where people work all day. */
+}
+
+/* Code annotations are portalled to the body so they are not clipped by a
+   horizontally scrollable code surface. Keep the tooltip outside the marketing
+   scope for the same reason. */
+.qp-code-tooltip {
+	position: fixed;
+	z-index: 100;
+	padding: var(--space-3) var(--space-4);
+	border: 1px solid var(--border-subtle);
+	border-radius: var(--radius-object);
+	background: var(--card);
+	box-shadow: var(--elevation-raised);
+	font-family: var(--font-sans);
+	font-size: var(--type-sm);
+	line-height: var(--line-relaxed);
+	color: var(--foreground-muted);
+	pointer-events: none;
 }
 
 /* ============================================================ PROTOTYPE ONLY

--- a/apps/docs/src/styles/marketing.css
+++ b/apps/docs/src/styles/marketing.css
@@ -16,6 +16,17 @@ body.qp-grain-page {
 	background: transparent;
 }
 
+@keyframes qp-logic-panel-in {
+	from {
+		opacity: 0;
+		transform: translateX(8px);
+	}
+	to {
+		opacity: 1;
+		transform: translateX(0);
+	}
+}
+
 .qp-marketing {
 	/* ============================================================================
 	   QUESTPIE — marketing.css
@@ -631,24 +642,132 @@ body.qp-grain-page {
 		color: var(--foreground-muted);
 		line-height: var(--line-relaxed);
 	}
+	.ecosystem-index {
+		align-self: center;
+		border-top: 1px solid var(--border-subtle);
+	}
+	.ecosystem-index > div {
+		padding: var(--space-7) 0;
+		border-bottom: 1px solid var(--border-subtle);
+	}
+	.ecosystem-index strong {
+		display: block;
+		margin-top: var(--space-3);
+		font-size: var(--type-2xl);
+		font-weight: var(--weight-strong);
+		letter-spacing: -0.02em;
+	}
+	.ecosystem-index div p {
+		max-width: 30rem;
+		margin-top: var(--space-2);
+		color: var(--foreground-muted);
+		line-height: var(--line-relaxed);
+	}
+	.ecosystem-common {
+		margin-top: var(--space-5);
+		font-family: var(--font-mono);
+		font-size: var(--type-xs);
+		color: var(--foreground-subtle);
+		letter-spacing: 0.04em;
+		text-transform: uppercase;
+	}
+	.ecosystem-paths {
+		margin-top: var(--space-12);
+	}
 	.code-contract {
 		display: grid;
 		grid-template-columns: repeat(2, minmax(0, 1fr));
+		gap: var(--space-12);
 		margin-top: var(--space-10);
 		border-top: 1px solid var(--border-subtle);
 		border-bottom: 1px solid var(--border-subtle);
 	}
 	.code-contract > section {
 		min-width: 0;
-		padding: var(--space-8) var(--space-10) var(--space-8) 0;
+		padding: var(--space-8) 0;
 	}
 	.code-contract > section + section {
-		padding-right: 0;
-		padding-left: var(--space-10);
-		border-left: 1px solid var(--border-subtle);
+		padding: var(--space-8) 0;
 	}
 	.code-contract .qp-code {
 		margin-top: var(--space-5);
+	}
+	.logic-tabs {
+		display: grid;
+		grid-template-columns: minmax(15rem, 0.72fr) minmax(0, 1.28fr);
+		gap: var(--space-12);
+		align-items: stretch;
+		margin-top: var(--space-10);
+		border-top: 1px solid var(--border-subtle);
+		border-bottom: 1px solid var(--border-subtle);
+	}
+	.logic-tabs-list {
+		display: flex;
+		flex-direction: column;
+	}
+	.logic-tab {
+		display: grid;
+		grid-template-columns: 2.5rem minmax(0, 1fr);
+		gap: var(--space-4);
+		width: 100%;
+		padding: var(--space-5) 0;
+		border: 0;
+		border-bottom: 1px solid var(--border-subtle);
+		background: transparent;
+		color: var(--foreground-muted);
+		font: inherit;
+		text-align: left;
+		cursor: pointer;
+		transition:
+			color 150ms ease-out,
+			padding-left 150ms ease-out;
+	}
+	.logic-tab:last-child {
+		border-bottom: 0;
+	}
+	.logic-tab:hover,
+	.logic-tab[data-active] {
+		color: var(--foreground);
+	}
+	.logic-tab[data-active] {
+		padding-left: var(--space-3);
+	}
+	.logic-tab:focus-visible {
+		outline: 2px solid var(--ring);
+		outline-offset: 3px;
+	}
+	.logic-tab strong,
+	.logic-tab small {
+		display: block;
+	}
+	.logic-tab strong {
+		font-size: var(--type-lg);
+		font-weight: var(--weight-strong);
+	}
+	.logic-tab small {
+		max-width: 29rem;
+		margin-top: var(--space-2);
+		font-size: var(--type-sm);
+		line-height: var(--line-relaxed);
+	}
+	.logic-stage {
+		display: grid;
+		min-width: 0;
+		min-height: 29rem;
+		padding: var(--space-8) 0;
+	}
+	.logic-tabs.compact .logic-stage {
+		min-height: 18rem;
+	}
+	.logic-panel {
+		grid-area: 1 / 1;
+		min-width: 0;
+	}
+	.logic-panel .qp-code {
+		margin-top: var(--space-5);
+	}
+	.logic-tabs[data-animate="true"] .logic-panel:not([hidden]) {
+		animation: qp-logic-panel-in 190ms cubic-bezier(0.22, 1, 0.36, 1);
 	}
 	.contract-columns,
 	.product-paths {
@@ -818,6 +937,7 @@ body.qp-grain-page {
 		.product-paths,
 		.code-contract {
 			grid-template-columns: minmax(0, 1fr);
+			gap: 0;
 		}
 		.contract-columns > section,
 		.product-paths > section {
@@ -837,6 +957,14 @@ body.qp-grain-page {
 			border-top: 1px solid var(--border-subtle);
 			border-left: 0;
 		}
+		.logic-tabs {
+			grid-template-columns: minmax(0, 1fr);
+			gap: 0;
+		}
+		.logic-stage {
+			min-height: 25rem;
+			border-top: 1px solid var(--border-subtle);
+		}
 		.depth-list > section {
 			grid-template-columns: minmax(0, 1fr);
 			gap: var(--space-3);
@@ -852,6 +980,14 @@ body.qp-grain-page {
 		.early-access-form input,
 		.early-access-form .btn {
 			width: 100%;
+		}
+	}
+	@media (prefers-reduced-motion: reduce) {
+		.logic-tab {
+			transition: none;
+		}
+		.logic-tabs[data-animate="true"] .logic-panel:not([hidden]) {
+			animation: none;
 		}
 	}
 	.frame {

--- a/apps/docs/src/styles/marketing.css
+++ b/apps/docs/src/styles/marketing.css
@@ -153,6 +153,21 @@ body.qp-grain-page {
 	.nav-menu {
 		display: none;
 	}
+	.sr-only {
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		padding: 0;
+		margin: -1px;
+		overflow: hidden;
+		clip: rect(0, 0, 0, 0);
+		white-space: nowrap;
+		border: 0;
+	}
+	:where(a, button, input, pre):focus-visible {
+		outline: 2px solid var(--ring);
+		outline-offset: 3px;
+	}
 
 	@media (max-width: 52rem) {
 		.nav-links,
@@ -212,7 +227,7 @@ body.qp-grain-page {
 	}
 	.btn.p {
 		background: var(--primary);
-		color: var(--primary-foreground);
+		color: var(--background);
 		box-shadow: var(--elevation-action);
 	}
 	.btn.p:hover {
@@ -330,6 +345,78 @@ body.qp-grain-page {
 		flex-wrap: wrap;
 		gap: var(--space-2);
 		padding: var(--space-2) var(--space-2) 0;
+	}
+	.model-preview {
+		gap: var(--space-5);
+	}
+	.model-preview .hero-card-head .qp-eyebrow {
+		color: var(--foreground-muted);
+	}
+	.product-media {
+		min-width: 0;
+		margin: 0;
+	}
+	.product-media > img,
+	.product-media > video,
+	.product-media-placeholder {
+		display: flex;
+		width: 100%;
+		aspect-ratio: 16 / 10;
+		border: 1px solid var(--border-subtle);
+		border-radius: var(--radius-sheet);
+		background: var(--card);
+		box-shadow: var(--elevation-raised);
+		overflow: hidden;
+	}
+	.product-media-hero > img,
+	.product-media-hero > video,
+	.product-media-hero .product-media-placeholder {
+		aspect-ratio: 4 / 3;
+	}
+	.product-media > img,
+	.product-media > video {
+		object-fit: cover;
+	}
+	.product-media-placeholder {
+		position: relative;
+		flex-direction: column;
+		justify-content: flex-end;
+		gap: var(--space-3);
+		padding: var(--space-7);
+		background:
+			linear-gradient(to bottom, transparent 0 72%, var(--surface-mid)),
+			var(--card);
+	}
+	.product-media-placeholder::before {
+		content: "Product capture coming before launch";
+		position: absolute;
+		top: var(--space-6);
+		left: var(--space-7);
+		font-family: var(--font-mono);
+		font-size: var(--type-sm);
+		color: var(--foreground-subtle);
+	}
+	.product-media-placeholder strong {
+		max-width: 24rem;
+		font-size: var(--type-xl);
+		line-height: var(--line-snug);
+	}
+	.product-media-placeholder p {
+		max-width: 32rem;
+		color: var(--foreground-muted);
+		line-height: var(--line-relaxed);
+	}
+	.product-media figcaption {
+		display: flex;
+		flex-wrap: wrap;
+		justify-content: space-between;
+		gap: var(--space-2) var(--space-5);
+		padding: var(--space-4) var(--space-1) 0;
+		font-size: var(--type-sm);
+		color: var(--foreground-muted);
+	}
+	.product-media figcaption strong {
+		color: var(--foreground);
 	}
 	/* the one hairline left, and only between the doors and the CTA */
 	.rule {
@@ -505,6 +592,160 @@ body.qp-grain-page {
 		color: var(--foreground-muted);
 		line-height: var(--line-relaxed);
 	}
+	.editorial-band {
+		padding-top: var(--space-16);
+	}
+	.editorial-split,
+	.launch-split {
+		display: grid;
+		grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr);
+		align-items: center;
+		gap: var(--space-16);
+	}
+	.editorial-split .head > p + p {
+		margin-top: calc(var(--space-2) * -1);
+	}
+	.editorial-split code {
+		font-family: var(--font-mono);
+		font-size: 0.92em;
+		color: var(--foreground);
+	}
+	.generated-list {
+		border-top: 1px solid var(--border-subtle);
+	}
+	.generated-row {
+		display: grid;
+		grid-template-columns: 3rem minmax(0, 1fr);
+		gap: var(--space-4);
+		padding: var(--space-5) 0;
+		border-bottom: 1px solid var(--border-subtle);
+	}
+	.generated-row strong {
+		display: block;
+		font-size: var(--type-lg);
+		line-height: var(--line-snug);
+	}
+	.generated-row p {
+		max-width: 34rem;
+		margin-top: var(--space-2);
+		color: var(--foreground-muted);
+		line-height: var(--line-relaxed);
+	}
+	.code-contract {
+		display: grid;
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		margin-top: var(--space-10);
+		border-top: 1px solid var(--border-subtle);
+		border-bottom: 1px solid var(--border-subtle);
+	}
+	.code-contract > section {
+		min-width: 0;
+		padding: var(--space-8) var(--space-10) var(--space-8) 0;
+	}
+	.code-contract > section + section {
+		padding-right: 0;
+		padding-left: var(--space-10);
+		border-left: 1px solid var(--border-subtle);
+	}
+	.code-contract .qp-code {
+		margin-top: var(--space-5);
+	}
+	.contract-columns,
+	.product-paths {
+		display: grid;
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		margin-top: var(--space-10);
+		border-top: 1px solid var(--border-subtle);
+		border-bottom: 1px solid var(--border-subtle);
+	}
+	.contract-columns > section,
+	.product-paths > section {
+		padding: var(--space-8) var(--space-10) var(--space-8) 0;
+	}
+	.contract-columns > section + section,
+	.product-paths > section + section {
+		padding-right: 0;
+		padding-left: var(--space-10);
+		border-left: 1px solid var(--border-subtle);
+	}
+	.contract-columns h3,
+	.product-paths h3,
+	.depth-list h3 {
+		margin-top: var(--space-3);
+		font-size: var(--type-xl);
+		font-weight: var(--weight-strong);
+		letter-spacing: -0.016em;
+	}
+	.contract-columns h3 + p,
+	.product-paths h3 + p,
+	.depth-list h3 + p {
+		max-width: 34rem;
+		margin-top: var(--space-3);
+		color: var(--foreground-muted);
+		line-height: var(--line-relaxed);
+	}
+	.contract-note {
+		max-width: 48rem;
+		margin-top: var(--space-5);
+		font-size: var(--type-sm);
+		color: var(--foreground-muted);
+	}
+	.depth-list {
+		margin-top: var(--space-10);
+		border-top: 1px solid var(--border-subtle);
+	}
+	.depth-list > section {
+		display: grid;
+		grid-template-columns: 4rem minmax(0, 1fr);
+		gap: var(--space-8);
+		padding: var(--space-7) 0;
+		border-bottom: 1px solid var(--border-subtle);
+	}
+	.depth-list h3 {
+		margin-top: 0;
+	}
+	.product-paths a {
+		display: inline-block;
+		margin-top: var(--space-5);
+		color: var(--primary-text);
+		font-weight: var(--weight-semibold);
+	}
+	.product-paths a:hover {
+		text-decoration: underline;
+		text-underline-offset: 0.2em;
+	}
+	.launch-band {
+		padding-bottom: var(--space-16);
+	}
+	.product-story {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-10);
+	}
+	.product-story .product-media {
+		width: 100%;
+	}
+	.early-access-form {
+		display: flex;
+		flex-wrap: wrap;
+		justify-content: center;
+		gap: var(--space-3);
+		margin-top: var(--space-8);
+	}
+	.early-access-form input {
+		width: min(100%, 19rem);
+		height: var(--control-large);
+		padding: 0 var(--spacing-input);
+		border: 1px solid var(--input);
+		border-radius: var(--radius-control);
+		background: var(--surface-mid);
+		color: var(--foreground);
+		font-family: var(--font-sans);
+		font-size: var(--type-md);
+	}
+	.early-access-form input::placeholder {
+		color: var(--foreground-subtle);
+	}
 	.ownership-list {
 		display: flex;
 		flex-direction: column;
@@ -537,6 +778,11 @@ body.qp-grain-page {
 			min-height: 0;
 			padding-top: var(--space-16);
 		}
+		.editorial-split,
+		.launch-split {
+			grid-template-columns: minmax(0, 1fr);
+			gap: var(--space-10);
+		}
 	}
 	@media (max-width: 45rem) {
 		.system-flow,
@@ -567,6 +813,45 @@ body.qp-grain-page {
 		.ownership-list > div {
 			grid-template-columns: minmax(0, 1fr);
 			gap: var(--space-2);
+		}
+		.contract-columns,
+		.product-paths,
+		.code-contract {
+			grid-template-columns: minmax(0, 1fr);
+		}
+		.contract-columns > section,
+		.product-paths > section {
+			padding: var(--space-6) 0;
+		}
+		.contract-columns > section + section,
+		.product-paths > section + section {
+			padding: var(--space-6) 0;
+			border-top: 1px solid var(--border-subtle);
+			border-left: 0;
+		}
+		.code-contract > section {
+			padding: var(--space-6) 0;
+		}
+		.code-contract > section + section {
+			padding: var(--space-6) 0;
+			border-top: 1px solid var(--border-subtle);
+			border-left: 0;
+		}
+		.depth-list > section {
+			grid-template-columns: minmax(0, 1fr);
+			gap: var(--space-3);
+		}
+		.product-media-placeholder {
+			padding: var(--space-5);
+		}
+		.product-media-placeholder::before {
+			top: var(--space-5);
+			left: var(--space-5);
+		}
+		.early-access-form,
+		.early-access-form input,
+		.early-access-form .btn {
+			width: 100%;
 		}
 	}
 	.frame {

--- a/apps/docs/src/styles/marketing.css
+++ b/apps/docs/src/styles/marketing.css
@@ -236,9 +236,13 @@ body.qp-grain-page {
 	.btn:active {
 		transform: translateY(var(--motion-press-y));
 	}
+	/* colors.css, non-negotiable: "A coral fill carries WHITE semibold type at
+	   16px or larger". This painted --background (near-black ink) on coral,
+	   which is the one recipe the canon forbids. */
 	.btn.p {
 		background: var(--primary);
-		color: var(--background);
+		color: var(--primary-foreground);
+		font-weight: 600;
 		box-shadow: var(--elevation-action);
 	}
 	.btn.p:hover {
@@ -475,6 +479,11 @@ body.qp-grain-page {
 
 	/* ── surfaces ─────────────────────────────────────────────────────────────── */
 	.card {
+		display: flex;
+		flex-direction: column;
+		/* Only `.card h3 + p` used to carry a margin, so a card built from an
+		 * eyebrow + strong + p rendered three rows flush against each other. */
+		gap: var(--space-3);
 		background: var(--card);
 		border: 1px solid var(--border-subtle);
 		border-radius: var(--radius-panel);
@@ -540,6 +549,7 @@ body.qp-grain-page {
 		font-family: var(--font-mono);
 		text-align: center;
 	}
+	.card strong,
 	.system-step strong,
 	.derivation-source strong,
 	.ownership-list strong {
@@ -804,6 +814,10 @@ body.qp-grain-page {
 		color: var(--foreground-muted);
 		line-height: var(--line-relaxed);
 	}
+	.contract-columns p + p,
+	.product-paths p + p {
+		margin-top: var(--space-4);
+	}
 	.contract-note {
 		max-width: 48rem;
 		margin-top: var(--space-5);
@@ -865,6 +879,148 @@ body.qp-grain-page {
 	}
 	.early-access-form input::placeholder {
 		color: var(--foreground-subtle);
+	}
+
+	/* /works asks five questions, and .early-access-form is a centred flex row
+	 * built for one email and a button: five controls wrap into a ragged 3-then-2
+	 * with the submit stranded, and 19rem clips the longer placeholders. This is
+	 * the same control skin on a real form grid — labelled, left-aligned inside
+	 * the centred CTA block, with the long answer given a textarea. */
+	/* Work: the page's portfolio. Screenshots carry it, so the image is the
+	   largest element in each row and the copy sits beside it. Rows alternate so
+	   the eye zig-zags down the section instead of scanning one rail. */
+	.work-list {
+		display: grid;
+		gap: clamp(3rem, 6vw, 5.5rem);
+	}
+
+	.work-shot {
+		border: 1px solid var(--qp-line);
+		border-radius: var(--qp-radius-object);
+		display: block;
+		overflow: hidden;
+		transition:
+			border-color 0.2s ease,
+			transform 0.2s ease;
+	}
+
+	.work-shot:hover {
+		border-color: var(--qp-line-strong);
+		transform: translateY(-2px);
+	}
+
+	.work-shot img {
+		display: block;
+		height: auto;
+		width: 100%;
+	}
+
+	.work-body h3 {
+		margin: 0 0 0.5rem;
+	}
+
+	.work-body p {
+		margin: 0;
+	}
+
+	.work-tags {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.4rem;
+		list-style: none;
+		margin: 1.25rem 0 0;
+		padding: 0;
+	}
+
+	.work-tags li {
+		border: 1px solid var(--qp-line);
+		border-radius: 999px;
+		color: var(--qp-ink-dim);
+		font-family: var(--qp-font-mono);
+		font-size: 0.6875rem;
+		letter-spacing: 0.04em;
+		padding: 0.25rem 0.6rem;
+		text-transform: uppercase;
+	}
+
+	.work-link {
+		display: inline-block;
+		font-family: var(--qp-font-mono);
+		font-size: 0.8125rem;
+		margin-top: 1.25rem;
+	}
+
+	.work-note {
+		border-top: 1px solid var(--qp-line);
+		color: var(--qp-ink-dim);
+		margin-top: clamp(3rem, 6vw, 5.5rem);
+		max-width: 58ch;
+		padding-top: 1.5rem;
+	}
+
+	.works-form {
+		display: grid;
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		gap: var(--space-5);
+		max-width: 44rem;
+		margin: var(--space-10) auto 0;
+		text-align: left;
+	}
+	.works-form .field {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-2);
+	}
+	.works-form .field.wide,
+	.works-form .actions {
+		grid-column: 1 / -1;
+	}
+	.works-form label {
+		font-family: var(--font-mono);
+		font-size: 11px;
+		font-weight: 600;
+		letter-spacing: 0.04em;
+		text-transform: uppercase;
+		color: var(--foreground-muted);
+	}
+	.works-form input,
+	.works-form select,
+	.works-form textarea {
+		width: 100%;
+		height: var(--control-large);
+		padding: 0 var(--spacing-input);
+		border: 1px solid var(--input);
+		border-radius: var(--radius-control);
+		background: var(--surface-mid);
+		color: var(--foreground);
+		font-family: var(--font-sans);
+		font-size: var(--type-md);
+	}
+	.works-form textarea {
+		height: auto;
+		min-height: 7.5rem;
+		padding: var(--spacing-input);
+		line-height: var(--line-relaxed);
+		resize: vertical;
+	}
+	.works-form ::placeholder {
+		color: var(--foreground-subtle);
+	}
+	/* The options list is drawn by the OS and does not inherit --surface-mid, so
+	 * it is given the ink it needs rather than left to a light-on-light default. */
+	.works-form select option {
+		background: var(--surface-mid);
+		color: var(--foreground);
+	}
+	.works-form .actions {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: var(--space-5);
+		margin-top: var(--space-2);
+	}
+	.works-form .actions p {
+		margin: 0;
 	}
 	.ownership-list {
 		display: flex;
@@ -983,6 +1139,17 @@ body.qp-grain-page {
 		.early-access-form,
 		.early-access-form input,
 		.early-access-form .btn {
+			width: 100%;
+		}
+		.works-form {
+			grid-template-columns: minmax(0, 1fr);
+		}
+		.works-form .actions {
+			flex-direction: column;
+			align-items: stretch;
+			text-align: center;
+		}
+		.works-form .actions .btn {
 			width: 100%;
 		}
 	}
@@ -1279,3 +1446,7 @@ body.qp-grain-page {
 	/* Marketing is dark-only — the site is one continuous atmosphere. The product
 	   (admin, Autopilot) keeps both themes; that is where people work all day. */
 }
+
+/* ============================================================ PROTOTYPE ONLY
+   Throwaway styles for /works?variant=. Delete together with
+   components/marketing/works-prototype.tsx once a variant wins. */

--- a/apps/docs/src/styles/marketing.css
+++ b/apps/docs/src/styles/marketing.css
@@ -761,6 +761,7 @@ body.qp-grain-page {
 	}
 	.logic-panel {
 		grid-area: 1 / 1;
+		align-self: center;
 		min-width: 0;
 	}
 	.logic-panel .qp-code {
@@ -964,6 +965,9 @@ body.qp-grain-page {
 		.logic-stage {
 			min-height: 25rem;
 			border-top: 1px solid var(--border-subtle);
+		}
+		.logic-panel {
+			align-self: start;
 		}
 		.depth-list > section {
 			grid-template-columns: minmax(0, 1fr);
@@ -1263,6 +1267,13 @@ body.qp-grain-page {
 		padding: 0;
 		margin: 0;
 		background: transparent;
+	}
+	/* A framed code block has enough inset for syntax.css's full-bleed line
+	   margins. A bare block does not: the negative margin lands under its scroll
+	   clip and trims the first glyph (most visibly the G in GET). */
+	.qp-code.bare:not([data-numbers]) .qp-line {
+		padding-inline: 0;
+		margin-inline: 0;
 	}
 
 	/* Marketing is dark-only — the site is one continuous atmosphere. The product

--- a/apps/docs/src/styles/works.css
+++ b/apps/docs/src/styles/works.css
@@ -1,0 +1,595 @@
+/* QUESTPIE Works — page styles.
+ *
+ * Everything is scoped under .works-page and prefixed .w-*. That is deliberate:
+ * the first implementation reused .editorial-split, .generated-list and
+ * .feature-list from the other marketing routes, which were built for a
+ * different content shape, and the result was misaligned columns, a hairline
+ * rule leading nowhere, and a form in three different widths.
+ *
+ * Values come from the shared token layer. The two locals below exist because
+ * this page needs a wider measure than the product shell assumes.
+ *
+ * Trap worth knowing: margin does not apply to elements on this page. The
+ * selector matches and the value is valid, but the computed margin is 0, so
+ * every rhythm here is built from gap and grouping. Something in the docs
+ * cascade wins over margin; worth finding before spacing anything by hand.
+ */
+
+@layer questpie.marketing {
+	.works-page {
+		--w-page-max: 78rem;
+		--w-rail: 14rem;
+	}
+
+	/* ── skeleton ────────────────────────────────────────────────────────── */
+	.works-page .w-page {
+		margin-inline: auto;
+		max-width: var(--w-page-max);
+		padding-inline: var(--section-pad-x);
+	}
+
+	.works-page .w-band {
+		padding-block: clamp(4rem, 8vw, 6rem);
+	}
+
+	.works-page .w-band.tight {
+		padding-block: 0 clamp(3rem, 6vw, 4rem);
+	}
+
+	.works-page .w-band.raised {
+		background: var(--qp-surface, var(--card));
+	}
+
+	/* THE grid: a label rail and content, tops aligned, on every band. This one
+	   decision is what makes the sections read as one document. */
+	.works-page .w-grid {
+		align-items: start;
+		display: grid;
+		gap: clamp(1.5rem, 3vw, 2rem) clamp(2rem, 5vw, 3rem);
+		grid-template-columns: var(--w-rail) minmax(0, 1fr);
+	}
+
+	.works-page .w-rail {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+	}
+
+	.works-page .w-col {
+		display: flex;
+		flex-direction: column;
+		gap: 1.5rem;
+	}
+
+	/* The hero had one flat gap between all five children, so nothing grouped
+	   and it read as a list. The eyebrow belongs to the headline; the buttons
+	   need air; the stack strip is a footnote under them. */
+	.works-page .w-stack {
+		display: flex;
+		flex-direction: column;
+	}
+
+	/* Rhythm by grouping, not by margin: the eyebrow and the headline are one
+	   unit, then lead, then the buttons, then the strip as a footnote. Margin
+	   loses to something in this cascade, gap does not. */
+	.works-page .w-stack {
+		gap: 2.25rem;
+	}
+
+	/* Deleted by accident with the private button block. gap, not margin: margin
+	   does not apply on this page. */
+	.works-page .w-actions {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.75rem;
+	}
+
+	.works-page .w-hero-head {
+		display: flex;
+		flex-direction: column;
+		gap: 0.875rem;
+	}
+
+	.works-page .w-col.wide {
+		gap: 2.5rem;
+	}
+
+	/* ── type ────────────────────────────────────────────────────────────── */
+	/* Two short lines, the second in muted ink. Same shape as the root hero, and
+	   the reason the headline is short: at 89px a sentence wraps to five lines
+	   and reads as a wall. */
+	.works-page .w-display span {
+		color: var(--muted-foreground);
+		display: block;
+	}
+
+	.works-page .w-display {
+		font-size: clamp(3rem, 1.6rem + 4.4vw, 5.75rem);
+		font-weight: 600;
+		letter-spacing: -0.03em;
+		line-height: 0.96;
+		margin: 0;
+		max-width: 22ch;
+		text-wrap: balance;
+	}
+
+	.works-page .w-title {
+		font-size: clamp(1.75rem, 1.15rem + 1.9vw, 2.75rem);
+		font-weight: 600;
+		letter-spacing: -0.02em;
+		line-height: 1.06;
+		margin: 0;
+		max-width: 20ch;
+		text-wrap: balance;
+	}
+
+	.works-page .w-lead {
+		color: var(--muted-foreground);
+		font-size: clamp(1.0625rem, 1rem + 0.3vw, 1.25rem);
+		margin: 0;
+		max-width: 54ch;
+	}
+
+	.works-page .w-body {
+		color: var(--muted-foreground);
+		margin: 0;
+		max-width: 46ch;
+	}
+
+	.works-page .w-label {
+		color: var(--primary-text, var(--primary));
+		font-family: var(--font-mono);
+		font-size: 0.6875rem;
+		letter-spacing: 0.08em;
+		margin: 0;
+		text-transform: uppercase;
+	}
+
+	.works-page .w-num {
+		color: var(--primary-text, var(--primary));
+		display: block;
+		font-family: var(--font-mono);
+		font-size: 0.6875rem;
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+	}
+
+	.works-page .w-num.quiet {
+		color: var(--muted-foreground);
+	}
+
+	/* ── item / person ───────────────────────────────────────────────────── */
+	.works-page .w-two {
+		display: grid;
+		gap: 2rem 3rem;
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+
+	/* Eight capability tiles read as a wall in two columns. */
+	.works-page .w-two.dense {
+		gap: 1.75rem 2.5rem;
+		grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
+	}
+
+	.works-page .w-item,
+	.works-page .w-person {
+		border-top: 1px solid var(--border);
+		padding-top: 1rem;
+	}
+
+	.works-page .w-item h3 {
+		font-size: 1.0625rem;
+		font-weight: 600;
+		margin: 0.5rem 0;
+	}
+
+	.works-page .w-item p {
+		color: var(--muted-foreground);
+		font-size: 0.875rem;
+		margin: 0;
+	}
+
+	.works-page .w-person h3 {
+		font-size: 1.375rem;
+		font-weight: 600;
+		letter-spacing: -0.01em;
+		margin: 0.5rem 0 0.75rem;
+	}
+
+	.works-page .w-person a {
+		color: inherit;
+		text-decoration: none;
+	}
+
+	.works-page .w-person a:hover {
+		color: var(--primary-text, var(--primary));
+	}
+
+	.works-page .w-body a {
+		color: var(--primary-text, var(--primary));
+		text-decoration: none;
+	}
+
+	.works-page .w-body a:hover {
+		text-decoration: underline;
+	}
+
+	.works-page .w-rule {
+		background: var(--border);
+		border: 0;
+		height: 1px;
+		margin: 0;
+	}
+
+	/* ── browser-framed screenshot ───────────────────────────────────────── */
+	.works-page .w {
+		background: var(--card);
+		border: 1px solid var(--border);
+		border-radius: var(--radius-object);
+		display: block;
+		overflow: hidden;
+		text-decoration: none;
+		transition: border-color 0.2s ease;
+	}
+
+	.works-page a.w:hover {
+		border-color: var(--muted-foreground);
+	}
+
+	.works-page .w-chrome {
+		align-items: center;
+		border-bottom: 1px solid var(--border);
+		display: flex;
+		gap: 0.5rem;
+		padding: 0.75rem 1rem;
+	}
+
+	.works-page .w-chrome i {
+		flex: 0 0 auto;
+		background: var(--border);
+		border-radius: 50%;
+		display: block;
+		height: 0.5rem;
+		width: 0.5rem;
+	}
+
+	/* The address can be long ("chatacerenka.eu · booking engine · operator
+	   console") and must never push the card wider than its track. */
+	.works-page .w-chrome em {
+		color: var(--muted-foreground);
+		flex: 1 1 auto;
+		font-family: var(--font-mono);
+		font-size: 0.6875rem;
+		font-style: normal;
+		margin-left: 0.5rem;
+		min-width: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.works-page .w img,
+	.works-page .w-ph {
+		aspect-ratio: 16 / 10;
+		display: block;
+		height: auto;
+		object-fit: cover;
+		width: 100%;
+	}
+
+	/* Honest placeholder — never a mockup standing in for a real screen. It
+	   prints what belongs in the slot so nobody has to guess. */
+	.works-page .w-ph {
+		align-items: center;
+		background: repeating-linear-gradient(
+			135deg,
+			var(--card),
+			var(--card) 0.5rem,
+			var(--secondary) 0.5rem,
+			var(--secondary) 1rem
+		);
+		display: flex;
+		justify-content: center;
+		padding: 1.5rem;
+		text-align: center;
+	}
+
+	.works-page .w-ph em {
+		color: var(--muted-foreground);
+		font-family: var(--font-mono);
+		font-size: 0.75rem;
+		font-style: normal;
+		letter-spacing: 0.04em;
+		max-width: 32ch;
+	}
+
+	/* ── project slider ──────────────────────────────────────────────────── */
+	.works-page .w-sub {
+		margin-bottom: 1rem;
+	}
+
+	.works-page .w-sub.second {
+		margin-top: 3rem;
+	}
+
+	.works-page .w-slider {
+		display: grid;
+		gap: 1.5rem;
+		grid-auto-columns: min(30rem, 78vw);
+		grid-auto-flow: column;
+		overflow-x: auto;
+		padding-block: 0.5rem;
+		padding-inline: max(
+			var(--section-pad-x),
+			calc(50vw - var(--w-page-max) / 2 + var(--section-pad-x))
+		);
+		scroll-padding-inline: max(
+			var(--section-pad-x),
+			calc(50vw - var(--w-page-max) / 2 + var(--section-pad-x))
+		);
+		scroll-snap-type: x mandatory;
+		scrollbar-width: none;
+	}
+
+	.works-page .w-slider::-webkit-scrollbar {
+		display: none;
+	}
+
+	/* Explicit width: the card is a grid item in a 480px track, but something in
+	   the docs-app cascade stops it stretching and it collapsed to 20px. */
+	.works-page .w-card {
+		width: 100%;
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+		scroll-snap-align: start;
+	}
+
+	.works-page .w-card-body {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+	}
+
+	.works-page .w-card-body h3 {
+		font-size: 1.25rem;
+		font-weight: 600;
+		letter-spacing: -0.01em;
+		margin: 0;
+	}
+
+	/* ── form ────────────────────────────────────────────────────────────── */
+	.works-page .w-fields {
+		display: grid;
+		gap: 1.5rem 2rem;
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		max-width: 44rem;
+	}
+
+	.works-page .w-fields .wide {
+		grid-column: 1 / -1;
+	}
+
+	.works-page .w-field {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+	}
+
+	.works-page .w-field label {
+		color: var(--muted-foreground);
+		font-family: var(--font-mono);
+		font-size: 0.6875rem;
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+	}
+
+	/* The house control skin, same as .early-access-form input: a boxed control
+	   on --surface-mid, not the underlined field this page had before. Focus
+	   uses --ring, which is what every other control in the system does. */
+	.works-page .w-field input,
+	.works-page .w-field textarea {
+		background: var(--surface-mid);
+		border: 1px solid var(--input);
+		border-radius: var(--radius-control);
+		color: var(--foreground);
+		font-family: var(--font-sans);
+		font-size: var(--type-md);
+		padding: 0 var(--spacing-input);
+		width: 100%;
+	}
+
+	.works-page .w-field input {
+		height: var(--control-large);
+	}
+
+	.works-page .w-field textarea {
+		padding-block: var(--space-3);
+		resize: vertical;
+	}
+
+	.works-page .w-field input:focus-visible,
+	.works-page .w-field textarea:focus-visible {
+		border-color: var(--ring);
+		outline: 2px solid var(--ring);
+		outline-offset: -1px;
+	}
+
+	.works-page .w-field ::placeholder {
+		color: var(--foreground-subtle);
+	}
+
+	.works-page .w-field input:focus,
+	.works-page .w-field textarea:focus {
+		border-color: var(--primary-text, var(--primary));
+		outline: none;
+	}
+
+	.works-page .w-field textarea {
+		resize: vertical;
+	}
+
+	@media (max-width: 60rem) {
+		.works-page .w-grid,
+		.works-page .w-two,
+		.works-page .w-fields {
+			grid-template-columns: minmax(0, 1fr);
+		}
+	}
+}
+
+@layer questpie.marketing {
+	/* Hairline schematic. The canon permits a schematic and forbids a mockup,
+	   and at card width a marketing screenshot is texture rather than proof.
+	   The diagram is the claim: two surfaces, one thing underneath. */
+	.works-page .w-schema {
+		align-items: center;
+		aspect-ratio: 16 / 10;
+		display: flex;
+		flex-direction: column;
+		gap: 0;
+		justify-content: center;
+		padding: var(--space-6);
+	}
+
+	.works-page .w-schema-row {
+		display: flex;
+		flex-wrap: wrap;
+		gap: var(--space-3);
+		justify-content: center;
+	}
+
+	.works-page .w-schema-row span {
+		border: 1px solid var(--border);
+		border-radius: var(--radius-control);
+		color: var(--foreground);
+		font-family: var(--font-mono);
+		font-size: 0.75rem;
+		padding: var(--space-2) var(--space-3);
+		white-space: nowrap;
+	}
+
+	.works-page .w-schema-legs {
+		display: flex;
+		gap: var(--space-3);
+		justify-content: center;
+	}
+
+	.works-page .w-schema-legs i {
+		background: var(--border);
+		display: block;
+		height: var(--space-6);
+		width: 1px;
+	}
+
+	.works-page .w-schema-base {
+		background: var(--primary-tint);
+		border: 1px solid var(--agent-border, var(--border));
+		border-radius: var(--radius-control);
+		color: var(--primary-text);
+		font-family: var(--font-mono);
+		font-size: 0.75rem;
+		padding: var(--space-2) var(--space-4);
+		white-space: nowrap;
+	}
+}
+
+@layer questpie.marketing {
+	/* The house proof-strip: names in mono, not a wall of logos. A logo grid
+	   reads as commodity because every shop has the same one. */
+	.works-page .w-strip {
+		color: var(--foreground-subtle);
+		font-family: var(--font-mono);
+		font-size: 0.6875rem;
+		letter-spacing: 0.08em;
+		margin: 0;
+		text-transform: uppercase;
+	}
+}
+
+@layer questpie.marketing {
+	/* A diagram with no verb is decoration. This line says what the
+	   relationship is, so the picture makes a claim instead of a shape. */
+	.works-page .w-schema-verb {
+		color: var(--muted-foreground);
+		font-family: var(--font-mono);
+		font-size: 0.6875rem;
+		letter-spacing: 0.08em;
+		margin: 0 0 var(--space-2);
+		text-transform: uppercase;
+	}
+
+	.works-page .w-schema-legs {
+		margin-bottom: var(--space-2);
+	}
+}
+
+@layer questpie.marketing {
+	/* The schematic is the placeholder until real screens exist, so it has to
+	   look deliberate rather than empty. A faint warm wash and a hairline floor
+	   give it the weight of a device without pretending to be a screenshot. */
+	.works-page .w-schema {
+		background:
+			radial-gradient(
+				120% 80% at 50% 0%,
+				color-mix(in srgb, var(--primary) 5%, transparent),
+				transparent 70%
+			),
+			var(--card);
+		position: relative;
+	}
+
+	.works-page .w-schema::after {
+		background: linear-gradient(
+			90deg,
+			transparent,
+			var(--border) 20%,
+			var(--border) 80%,
+			transparent
+		);
+		bottom: 0;
+		content: "";
+		height: 1px;
+		left: 0;
+		position: absolute;
+		right: 0;
+	}
+
+	.works-page .w-schema-row span {
+		background: var(--surface-mid);
+	}
+
+	.works-page .w-schema-base {
+		box-shadow: 0 0 0 4px color-mix(in srgb, var(--primary) 7%, transparent);
+	}
+
+	/* Ready for the real screens. Client sites are light and this page is near
+	   black, so eight bright rectangles would fight the coral. The scrim sits
+	   them back without hiding anything. */
+	.works-page .w img {
+		filter: saturate(0.92);
+	}
+
+	.works-page a.w:hover img {
+		filter: none;
+	}
+
+	.works-page .w:has(img) {
+		position: relative;
+	}
+
+	.works-page .w:has(img)::after {
+		background: linear-gradient(
+			180deg,
+			transparent 55%,
+			color-mix(in srgb, var(--canvas, #12100d) 45%, transparent)
+		);
+		bottom: 0;
+		content: "";
+		left: 0;
+		pointer-events: none;
+		position: absolute;
+		right: 0;
+		top: 0;
+	}
+}

--- a/bun.lock
+++ b/bun.lock
@@ -633,7 +633,7 @@
     "hono": "^4.12.25",
     "js-yaml": "^4.3.1",
     "linkify-it": "^5.0.2",
-    "nanoid": "^3.3.17",
+    "nanoid": "^3.3.18",
     "postcss": "^8.5.18",
     "read-yaml-file": "^2.1.0",
     "shell-quote": "^1.9.0",
@@ -2732,7 +2732,7 @@
 
     "mute-stream": ["mute-stream@3.0.0", "", {}, "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw=="],
 
-    "nanoid": ["nanoid@3.3.17", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g=="],
+    "nanoid": ["nanoid@3.3.18", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w=="],
 
     "nanostores": ["nanostores@1.4.1", "", {}, "sha512-PGd3uPojJB9Z07d5NX3Db/SOSBbyy3wLMUGq0GpnEEJfVzY9mq7daPMAZ3jObV5D3Jn+YKND636eI5ULg7F80Q=="],
 

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
 		"hono": "^4.12.25",
 		"js-yaml": "^4.3.1",
 		"linkify-it": "^5.0.2",
-		"nanoid": "^3.3.17",
+		"nanoid": "^3.3.18",
 		"postcss": "^8.5.18",
 		"read-yaml-file": "^2.1.0",
 		"shell-quote": "^1.9.0",


### PR DESCRIPTION
## What changed

- rebuild the QUESTPIE homepage as a restrained, framework-first presentation
- align the Framework page around the real model, typed REST/client output, application context, optional modules, and ownership
- rebuild the Autopilot page around visible work, explicit boundaries, approvals, and honest product-media slots
- add a capture handoff for the real Autopilot workflow, queue, approval, and activity history
- update navigation, SEO copy, focus behavior, code-region accessibility, and responsive marketing layouts
- include the primary-source marketing research that informed the page hierarchy and media plan

## Why

The previous pages mixed framework and product positioning, repeated the same schema-to-surfaces diagram, and used fabricated UI as product proof. This revision makes each page one coherent argument and reserves real product evidence for real release-candidate captures.

## Validation

- `bun run --cwd apps/docs types:check`
- targeted `oxlint` for all changed TS/TSX files
- `bun run --cwd apps/docs build`
- desktop QA at 1280×800
- mobile QA at 390×844 with no horizontal overflow
- axe WCAG 2 A/AA audit on `/`, `/framework`, and `/autopilot`: 0 violations
- Claude copy/factual/visual critique: pass
