### PR TITLE
docs(v4): close executable contract gaps

### DIFF
--- a/apps/docs/content/docs/v4/context-and-policy.mdx
+++ b/apps/docs/content/docs/v4/context-and-policy.mdx
@@ -9,12 +9,10 @@ enforces one compiled Policy model for application authorization. Context
 resolves trusted identity and application scope once. Policy checks current
 relational evidence where the data operation runs.
 
-## Define the collaboration fixture
+## Define collaboration data
 
-The schema and structural Query guides use a Barbershop to introduce data
-primitives. From this page onward, the examples use one collaboration fixture
-because its Company, Space, Channel, Membership, and Message graph makes
-relational authorization visible:
+This guide uses a Company, Space, Channel, Membership, and Message graph to
+make relational authorization visible:
 
 ```ts title="src/data/collaboration.ts"
 import { constraint, defineCollection, field } from "questpie";

--- a/apps/docs/content/docs/v4/definition-composition.mdx
+++ b/apps/docs/content/docs/v4/definition-composition.mdx
@@ -113,10 +113,10 @@ Each segment has 1–63 characters. The complete name has at most 255 characters
 invalid. QUESTPIE reports `QP-COMPOSE-003 invalidResourceName` for an invalid
 kind or name.
 
-Resource Kind is a closed compiler protocol. The composition foundation
-allocates `collection` and `seed`; accepted executable Definitions also
-allocate `query`, `mutation`, `action`, `route`, `reaction`, and `job`. A
-Package cannot add another Resource Kind.
+Resource Kind is a closed compiler protocol. Structural schema composition
+allocates `collection` and `seed`. Executable Definitions allocate exactly
+seven Resource Kinds: `query`, `mutation`, `action`, `route`, `reaction`,
+`job`, and `workflow`. A Package cannot add another Resource Kind.
 
 Each Definition supplies its name explicitly:
 

--- a/apps/docs/content/docs/v4/durable-jobs-and-workflows.mdx
+++ b/apps/docs/content/docs/v4/durable-jobs-and-workflows.mdx
@@ -99,11 +99,10 @@ Step names are unique and ordered. Each command has canonical bytes that must
 match history. A live run pins its Workflow semantic version and executable
 digest; a deployment cannot replay it against arbitrary latest code.
 
-The complete Workflow product is deliberately deferred. Signal authorization,
-child work, compensation, continuation and history limits, and multi-version
-evolution must pass their focused vertical before Workflow becomes a supported
-public release surface. The shared kernel and compatibility seam are fixed now
-so that later breadth does not require a second runtime.
+The Workflow contract contains named Mutation and Action steps, timers, typed
+signals, and version-pinned history. It excludes arbitrary callbacks, child
+work, compensation, continuation, and application-controlled history
+evolution.
 
 ## Map lifecycle work to its owner
 

--- a/apps/docs/content/docs/v4/executable-definitions.mdx
+++ b/apps/docs/content/docs/v4/executable-definitions.mdx
@@ -44,6 +44,7 @@ import {
 	defineQuery,
 	defineReaction,
 	defineRoute,
+	defineWorkflow,
 } from "#questpie/app";
 ```
 
@@ -78,8 +79,8 @@ the Current App Contract and reject stale generated output.
 
 An inline handler is the normal form. The `messageSummary` Definition above
 owns one Executable Slot: the one handler position the compiler records for
-that Definition. Query, Mutation, Action, Route, Reaction, and Job Definitions
-each carry exactly one handler.
+that Definition. Query, Mutation, Action, Route, Reaction, Job, and Workflow
+Definitions each carry exactly one handler.
 
 The compiler keeps the handler and its runtime-only imports outside controlled
 structural evaluation. It records a stable slot in the structural contract and

--- a/apps/docs/content/docs/v4/files-search-and-contract-projections.mdx
+++ b/apps/docs/content/docs/v4/files-search-and-contract-projections.mdx
@@ -75,12 +75,11 @@ All three are compiler outputs with exact source digests. They cannot define
 business handlers, authorize calls, expose secrets, or create another
 observability path. Their invocation telemetry stays in the Execution Envelope.
 
-## What remains later
+## Know the current limits
 
-Multipart and presigned uploads, ranges, scanning, transforms, CDN, retention
-erasure, public buckets, full-text Index syntax, external and vector Search,
-highlighting, and analyzer breadth remain focused later verticals. Their named
-seams are preserved without optional methods or provider-specific behavior in
-the beta contract.
+This contract does not include multipart or presigned uploads, ranges,
+scanning, transforms, CDN, retention erasure, public buckets, full-text Index
+syntax, external or vector Search, highlighting, or analyzer configuration.
+The named seams contain no optional methods or provider-specific behavior.
 
-The accepted proof uses only B-tree Indexes and emits no RLS claim.
+The Index contract is B-tree-only, and QUESTPIE emits no RLS claim.

--- a/apps/docs/content/docs/v4/index.mdx
+++ b/apps/docs/content/docs/v4/index.mdx
@@ -68,8 +68,8 @@ the same authorization decision to every execution surface.
 QUESTPIE has seven executable Definition kinds: Query, Mutation, Action, Route,
 Reaction, Job, and Workflow. They import application-specialized factories from
 `#questpie/app`; the compiler binds every handler statically in a matched
-Runtime Build. Complete Workflow product breadth remains a later release
-vertical, but its factory and shared checkpoint kernel are fixed.
+Runtime Build. The Workflow contract uses the shared durable kernel and
+contains only named steps, timers, and typed signals.
 
 A Mutation owns its PostgreSQL transaction and can add durable work to the same
 commit. Query reads and Mutation writes use exact generated contracts and the

--- a/apps/docs/content/docs/v4/multi-instance-and-acceleration.mdx
+++ b/apps/docs/content/docs/v4/multi-instance-and-acceleration.mdx
@@ -102,4 +102,4 @@ reset, scheduler contention, claims, executable compatibility, and Channel
 replay without exposing credentials, raw Context, Policy evidence, payloads,
 or database URLs.
 
-The accepted proof uses only B-tree Indexes and emits no RLS claim.
+The Index contract is B-tree-only, and QUESTPIE emits no RLS claim.


### PR DESCRIPTION
## Outcome

Closes bounded, mechanical gaps in the public v4 documentation without changing product authority or redesigning the information architecture.

- lists all seven executable Definition factories, including `defineWorkflow`;
- keeps the closed executable Resource inventory aligned with the accepted contract;
- removes a confusing procedural Barbershop-to-collaboration transition;
- replaces proof/beta/future implementation language with present contract limits;
- preserves the distinction between nested server capabilities and exact-key client/App surfaces.

## Verification

- `bun run --cwd apps/docs types:check`
- `bun run --cwd apps/docs build`
- `bunx oxfmt --check apps/docs/content/docs/v4`
- `git diff --check origin/feat/v4...HEAD`

All PASS. The docs build retains only its pre-existing large-chunk warning.

## Explicitly deferred

This PR does not choose whether `/docs/v4` should primarily describe the accepted ideal contract, the currently shipped beta, or a dual/versioned model. It also does not force every teaching example into one domain. Those are product/IA decisions and should be handled as a separate docs pass.
