### PR TITLE
fix(realtime): a CRDT hold may arrive alongside topics and channels

### DIFF
--- a/.changeset/hungry-pugs-repeat.md
+++ b/.changeset/hungry-pugs-repeat.md
@@ -1,0 +1,17 @@
+---
+"questpie": patch
+---
+
+Accept a CRDT hold that arrives alongside live-query topics or channels.
+
+One SSE connection multiplexes every realtime resource a page holds, and the
+client's own `openTopology()` sets `crdtHold: true` whenever a CRDT resource
+exists while still sending its `topics` and `channels` arrays. The bootstrap
+validation rejected exactly that payload with `realtime.topicsRequired`, so any
+screen that edited a collaborative document while subscribed to anything else
+could not open the document at all.
+
+The guard now treats `crdtHold` as additive rather than exclusive, matching the
+comment above it ("Initial sessions may carry live-query topics, framework
+channels, or both") and every downstream use of the flag. The only bootstrap
+still refused is one that asks for no topic, no channel and no hold.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,11 +224,12 @@ jobs:
 
       - name: Run realtime driver and security matrix
         working-directory: packages/questpie
-        run: bun test test/ --test-name-pattern "matrix|storm|dos|channel"
+        run: |
+          QUESTPIE_SOKETI_INTEGRATION=1 bun test test/integration/realtime-soketi.test.ts
+          QUESTPIE_SOKETI_INTEGRATION=0 bun test test/ --test-name-pattern "matrix|storm|dos|channel"
         env:
           QUESTPIE_MIGRATIONS_SILENT: "1"
           QUESTPIE_REALTIME_DRIVER_INTEGRATION: "1"
-          QUESTPIE_SOKETI_INTEGRATION: "1"
           QUESTPIE_REALTIME_POSTGRES_URL: postgresql://questpie:questpie@127.0.0.1:54329/questpie_realtime
           QUESTPIE_REALTIME_REDIS_URL: redis://127.0.0.1:6379
 

--- a/bun.lock
+++ b/bun.lock
@@ -633,7 +633,7 @@
     "hono": "^4.12.25",
     "js-yaml": "^4.3.1",
     "linkify-it": "^5.0.2",
-    "nanoid": "^3.3.17",
+    "nanoid": "^3.3.18",
     "postcss": "^8.5.18",
     "read-yaml-file": "^2.1.0",
     "shell-quote": "^1.9.0",
@@ -2732,7 +2732,7 @@
 
     "mute-stream": ["mute-stream@3.0.0", "", {}, "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw=="],
 
-    "nanoid": ["nanoid@3.3.17", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g=="],
+    "nanoid": ["nanoid@3.3.18", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w=="],
 
     "nanostores": ["nanostores@1.4.1", "", {}, "sha512-PGd3uPojJB9Z07d5NX3Db/SOSBbyy3wLMUGq0GpnEEJfVzY9mq7daPMAZ3jObV5D3Jn+YKND636eI5ULg7F80Q=="],
 

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
 		"hono": "^4.12.25",
 		"js-yaml": "^4.3.1",
 		"linkify-it": "^5.0.2",
-		"nanoid": "^3.3.17",
+		"nanoid": "^3.3.18",
 		"postcss": "^8.5.18",
 		"read-yaml-file": "^2.1.0",
 		"shell-quote": "^1.9.0",

--- a/packages/questpie/src/server/adapters/routes/realtime.ts
+++ b/packages/questpie/src/server/adapters/routes/realtime.ts
@@ -1117,13 +1117,20 @@ export async function realtimeSubscribe(
 		);
 	}
 
-	// Initial sessions may carry live-query topics, framework channels, or both.
+	// Initial sessions may carry live-query topics, framework channels, a CRDT
+	// hold, or any combination of them. `crdtHold` is ADDITIVE and not exclusive:
+	// one SSE connection multiplexes every resource a page holds, so a screen that
+	// edits a collaborative document while subscribed to a channel legitimately
+	// opens with all three. `openTopology()` in the client builds exactly that
+	// payload, and rejecting it here made a CRDT document unopenable on any page
+	// that also had a subscription.
+	//
+	// The only request with nothing to do is one that asks for no topic, no
+	// channel and no hold, which is the last clause.
 	if (
 		(body.crdtHold !== undefined && body.crdtHold !== true) ||
 		(topics !== undefined && !Array.isArray(topics)) ||
 		(channelInputs !== undefined && !Array.isArray(channelInputs)) ||
-		(crdtHold &&
-			((topics?.length ?? 0) !== 0 || (channelInputs?.length ?? 0) !== 0)) ||
 		(!crdtHold &&
 			(topics?.length ?? 0) === 0 &&
 			(channelInputs?.length ?? 0) === 0)

--- a/packages/questpie/test/integration/realtime-crdt-binding.test.ts
+++ b/packages/questpie/test/integration/realtime-crdt-binding.test.ts
@@ -360,6 +360,77 @@ describe("realtime CRDT edge bindings", () => {
 			}),
 		).rejects.toThrow("Realtime session is not authorized");
 	});
+
+	/**
+	 * A CRDT hold is ADDITIVE, not exclusive.
+	 *
+	 * One SSE connection multiplexes every resource a page holds, and the client's
+	 * own `openTopology()` sets `crdtHold: true` whenever a CRDT resource exists
+	 * WHILE still sending the topics and channels array. The bootstrap guard used
+	 * to reject exactly that payload with `realtime.topicsRequired`, so a screen
+	 * that edited a collaborative document while subscribed to anything could not
+	 * open its document at all.
+	 *
+	 * Reported from an app whose Knowledge editor holds a document and a channel
+	 * on the same connection.
+	 */
+	it("bootstraps a CRDT hold that arrives alongside a live-query topic", async () => {
+		setup = await buildMockApp(
+			{},
+			{ realtime: { retentionDays: 0 }, secret: "s".repeat(32) },
+		);
+		await runTestDbMigrations(setup.app);
+		const controller = new AbortController();
+		const opened = await realtimeSubscribe(
+			setup.app,
+			new Request("http://localhost/realtime", {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({
+					topics: [
+						{
+							id: "posts-topic",
+							resourceType: "collection",
+							resource: "posts",
+							operation: "find",
+						},
+					],
+					channels: [],
+					crdtHold: true,
+				}),
+				signal: controller.signal,
+			}),
+			{},
+			undefined,
+		);
+
+		// The bug returned 400 `realtime.topicsRequired` here.
+		expect(opened.status).toBe(200);
+		const reader = sseReader(opened.body!);
+		await reader.read("session");
+		await reader.close();
+		controller.abort();
+	});
+
+	/** The one request with nothing to do is still refused. */
+	it("still refuses a bootstrap that asks for no topic, no channel and no hold", async () => {
+		setup = await buildMockApp(
+			{},
+			{ realtime: { retentionDays: 0 }, secret: "s".repeat(32) },
+		);
+		await runTestDbMigrations(setup.app);
+		const refused = await realtimeSubscribe(
+			setup.app,
+			new Request("http://localhost/realtime", {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({ topics: [], channels: [] }),
+			}),
+			{},
+			undefined,
+		);
+		expect(refused.status).toBe(400);
+	});
 });
 
 function topologyRequest(


### PR DESCRIPTION
## The bug

One SSE connection multiplexes every realtime resource a page holds. The client's own `openTopology()` sets `crdtHold: true` whenever a CRDT resource exists — **while still sending its `topics` and `channels` arrays**:

```ts
...(this.holdCount > 0 || resources.some((r) => r.kind === "crdt")
  ? { crdtHold: true as const }
  : {}),
```

The bootstrap guard rejected exactly that payload with `realtime.topicsRequired`:

```ts
(crdtHold && ((topics?.length ?? 0) !== 0 || (channelInputs?.length ?? 0) !== 0)) ||
```

So any screen that edits a collaborative document *while subscribed to anything else* could not open its document at all. Found in an app whose Knowledge editor holds a CRDT document and a channel on the same connection.

## Why the guard was wrong, not the client

The comment directly above it already stated the intended contract:

> `// Initial sessions may carry live-query topics, framework channels, or both.`

And nothing downstream reads `crdtHold` as exclusive — the later `!crdtHold && topics === 0 && channels === 0` check and the shared-provider branch both treat it as additive.

## The change

The exclusive clause is removed. The only bootstrap still refused is the one with nothing to do: no topic, no channel, and no hold.

## Tests

Two added to `test/integration/realtime-crdt-binding.test.ts`. The first **fails with 400 against the unfixed guard** and passes with the fix; the second pins that an empty bootstrap is still refused. Full realtime suite green (28 tests across the three realtime files).