### PR TITLE
fix(crdt): compile collection access policies in SQL

### DIFF
--- a/.changeset/fix-crdt-access-where.md
+++ b/.changeset/fix-crdt-access-where.md
@@ -1,0 +1,5 @@
+---
+"questpie": patch
+---
+
+Evaluate collection CRDT owner access predicates through the SQL query compiler so operator, relation, and queryable virtual-field rules authorize the same rows as CRUD reads.

--- a/packages/questpie/src/server/collection/crud/query-builders/where-builder.ts
+++ b/packages/questpie/src/server/collection/crud/query-builders/where-builder.ts
@@ -9,6 +9,7 @@ import {
 	and,
 	type Column,
 	eq,
+	getTableName,
 	gt,
 	gte,
 	inArray,
@@ -20,7 +21,8 @@ import {
 	type SQL,
 	sql,
 } from "drizzle-orm";
-import type { AnyPgColumn, PgTable } from "drizzle-orm/pg-core";
+import { mapColumnsInSQLToAlias } from "drizzle-orm/alias";
+import { alias, type AnyPgColumn, type PgTable } from "drizzle-orm/pg-core";
 
 import type {
 	CollectionBuilderState,
@@ -67,6 +69,10 @@ export interface BuildWhereClauseOptions {
 	db?: any;
 	/** Internal: this subtree came from an access rule and must never weaken. */
 	failClosedAccess?: boolean;
+	/** Internal: exact parent values for correlation without an outer table alias. */
+	parentRecord?: Readonly<Record<string, unknown>>;
+	/** Internal: unique relation aliases for a single-record access evaluation. */
+	relationAliasDepth?: number;
 }
 
 /**
@@ -228,6 +234,8 @@ export function buildWhereClause(
 						useI18n,
 						db: options.db,
 						failClosedAccess,
+						parentRecord: options.parentRecord,
+						relationAliasDepth: options.relationAliasDepth,
 					}),
 				)
 				.filter(Boolean) as SQL[];
@@ -247,11 +255,15 @@ export function buildWhereClause(
 						useI18n,
 						db: options.db,
 						failClosedAccess,
+						parentRecord: options.parentRecord,
+						relationAliasDepth: options.relationAliasDepth,
 					}),
 				)
 				.filter(Boolean) as SQL[];
 			if (subClauses.length > 0) {
 				conditions.push(or(...subClauses)!);
+			} else if (failClosedAccess) {
+				conditions.push(sql`false`);
 			}
 		} else if (key === "NOT" && typeof value === "object") {
 			const subClause = buildWhereClause(value as Where, {
@@ -264,9 +276,13 @@ export function buildWhereClause(
 				useI18n,
 				db: options.db,
 				failClosedAccess,
+				parentRecord: options.parentRecord,
+				relationAliasDepth: options.relationAliasDepth,
 			});
 			if (subClause) {
 				conditions.push(not(subClause));
+			} else if (failClosedAccess) {
+				conditions.push(sql`false`);
 			}
 		} else if (key === "RAW" && typeof value === "function") {
 			conditions.push(
@@ -330,6 +346,14 @@ export function buildWhereClause(
 			];
 			const relationQuantifiers = ["some", "none", "every", "is", "isNot"];
 			const valueKeys = Object.keys(value as Record<string, any>);
+			if (
+				valueKeys.length === 0 &&
+				failClosedAccess &&
+				!state.relations?.[key]
+			) {
+				conditions.push(sql`false`);
+				continue;
+			}
 
 			// A key is a field operator if it's in the standard list OR in the field's operator map
 			const hasFieldOperators = valueKeys.some(
@@ -384,6 +408,8 @@ export function buildWhereClause(
 					app,
 					db: options.db,
 					failClosedAccess,
+					parentRecord: options.parentRecord,
+					relationAliasDepth: options.relationAliasDepth,
 				});
 				if (relationClause) {
 					conditions.push(relationClause);
@@ -609,6 +635,75 @@ interface BuildRelationWhereOptions {
 	db?: any;
 	/** Whether this relation predicate originated from access control. */
 	failClosedAccess?: boolean;
+	/** Exact parent values used instead of a shadowable outer correlation. */
+	parentRecord?: Readonly<Record<string, unknown>>;
+	/** Unique relation aliases for a single-record access evaluation. */
+	relationAliasDepth?: number;
+}
+
+function relationQueryTarget(
+	baseTable: PgTable,
+	state: CollectionBuilderState,
+	options: BuildRelationWhereOptions,
+): { table: PgTable; state: CollectionBuilderState } {
+	const depth = options.relationAliasDepth;
+	if (
+		depth === undefined ||
+		getTableName(options.parentTable) !== getTableName(baseTable)
+	) {
+		return { table: baseTable, state };
+	}
+
+	const aliasName = `qp_access_relation_${depth}`;
+	const table = alias(baseTable, aliasName);
+	const virtuals = Object.fromEntries(
+		Object.entries(state.virtuals ?? {}).flatMap(([field, expression]) => {
+			if (hasUnsafeRelationVirtualReference(expression, baseTable)) return [];
+			return [[field, mapColumnsInSQLToAlias(expression, aliasName)]];
+		}),
+	);
+	return { table, state: { ...state, virtuals } };
+}
+
+function hasUnsafeRelationVirtualReference(
+	expression: SQL,
+	baseTable: PgTable,
+): boolean {
+	const tableName = getTableName(baseTable);
+	const qualifiedName = new RegExp(
+		`(?:^|[^A-Za-z0-9_])(?:"[^"]+"\\s*\\.\\s*)?"?${escapeRegExp(tableName)}"?\\s*\\.`,
+	);
+	const visit = (chunk: unknown): boolean => {
+		if (!chunk || typeof chunk !== "object") return false;
+		if ("table" in chunk && "name" in chunk) {
+			const table = (chunk as { table?: unknown }).table;
+			if (table && typeof table === "object") {
+				try {
+					return getTableName(table as PgTable) !== tableName;
+				} catch {
+					return true;
+				}
+			}
+		}
+		if ("value" in chunk) {
+			const value = (chunk as { value?: unknown }).value;
+			if (
+				Array.isArray(value) &&
+				value.some(
+					(part) => typeof part === "string" && qualifiedName.test(part),
+				)
+			) {
+				return true;
+			}
+		}
+		if ("queryChunks" in chunk) {
+			const children = (chunk as { queryChunks?: unknown }).queryChunks;
+			if (Array.isArray(children) && children.some(visit)) return true;
+		}
+		if ("sql" in chunk) return visit((chunk as { sql?: unknown }).sql);
+		return false;
+	};
+	return visit(expression);
 }
 
 /**
@@ -750,8 +845,13 @@ export function buildBelongsToExistsClause(
 	}
 
 	const relatedCrud = app.collections[relation.collection];
-	const relatedTable = relatedCrud["~internalRelatedTable"];
-	const relatedState = relatedCrud["~internalState"];
+	const relatedTarget = relationQueryTarget(
+		relatedCrud["~internalRelatedTable"],
+		relatedCrud["~internalState"],
+		options,
+	);
+	const relatedTable = relatedTarget.table;
+	const relatedState = relatedTarget.state;
 
 	// Build join conditions supporting both formats
 	let joinConditions: SQL[] = [];
@@ -767,7 +867,15 @@ export function buildBelongsToExistsClause(
 			: undefined;
 
 		if (sourceColumn && targetColumn) {
-			joinConditions.push(eq(targetColumn, sourceColumn));
+			joinConditions.push(
+				eq(
+					targetColumn,
+					options.parentRecord &&
+						Object.hasOwn(options.parentRecord, relation.field)
+						? options.parentRecord[relation.field]
+						: sourceColumn,
+				),
+			);
 		}
 	} else if (relation.fields && relation.fields.length > 0) {
 		// Array field format: fields: [table.userId], references: ["id"]
@@ -787,7 +895,13 @@ export function buildBelongsToExistsClause(
 					? getColumn(parentTable, sourceFieldName)
 					: undefined;
 				return targetColumn && sourceColumn
-					? eq(targetColumn, sourceColumn)
+					? eq(
+							targetColumn,
+							options.parentRecord &&
+								Object.hasOwn(options.parentRecord, sourceFieldName!)
+								? options.parentRecord[sourceFieldName!]
+								: sourceColumn,
+						)
 					: undefined;
 			})
 			.filter(Boolean) as SQL[];
@@ -810,6 +924,10 @@ export function buildBelongsToExistsClause(
 			useI18n: false,
 			db: options.db,
 			failClosedAccess: options.failClosedAccess,
+			relationAliasDepth:
+				options.relationAliasDepth === undefined
+					? undefined
+					: options.relationAliasDepth + 1,
 		});
 		if (nestedClause) whereConditions.push(nestedClause);
 	}
@@ -843,8 +961,13 @@ export function buildHasManyExistsClause(
 	if (!app || relation.fields) return undefined;
 
 	const relatedCrud = app.collections[relation.collection];
-	const relatedTable = relatedCrud["~internalRelatedTable"];
-	const relatedState = relatedCrud["~internalState"];
+	const relatedTarget = relationQueryTarget(
+		relatedCrud["~internalRelatedTable"],
+		relatedCrud["~internalState"],
+		options,
+	);
+	const relatedTable = relatedTarget.table;
+	const relatedState = relatedTarget.state;
 	const reverseRelationName = relation.relationName;
 	const reverseRelation = reverseRelationName
 		? relatedState.relations?.[reverseRelationName]
@@ -870,7 +993,13 @@ export function buildHasManyExistsClause(
 				? getColumn(relatedTable, foreignFieldName)
 				: undefined;
 			return parentColumn && foreignColumn
-				? eq(foreignColumn, parentColumn)
+				? eq(
+						foreignColumn,
+						options.parentRecord &&
+							Object.hasOwn(options.parentRecord, parentFieldName!)
+							? options.parentRecord[parentFieldName!]
+							: parentColumn,
+					)
 				: undefined;
 		})
 		.filter(Boolean) as SQL[];
@@ -891,6 +1020,10 @@ export function buildHasManyExistsClause(
 			useI18n: false,
 			db: options.db,
 			failClosedAccess: options.failClosedAccess,
+			relationAliasDepth:
+				options.relationAliasDepth === undefined
+					? undefined
+					: options.relationAliasDepth + 1,
 		});
 		if (nestedClause) whereConditions.push(nestedClause);
 	}
@@ -925,9 +1058,14 @@ export function buildManyToManyExistsClause(
 
 	const relatedCrud = app.collections[relation.collection];
 	const junctionCrud = app.collections[relation.through];
-	const relatedTable = relatedCrud["~internalRelatedTable"];
+	const relatedTarget = relationQueryTarget(
+		relatedCrud["~internalRelatedTable"],
+		relatedCrud["~internalState"],
+		options,
+	);
+	const relatedTable = relatedTarget.table;
 	const junctionTable = junctionCrud["~internalRelatedTable"];
-	const relatedState = relatedCrud["~internalState"];
+	const relatedState = relatedTarget.state;
 	const junctionState = junctionCrud["~internalState"];
 
 	const sourceKey = relation.sourceKey || "id";
@@ -953,7 +1091,14 @@ export function buildManyToManyExistsClause(
 		return undefined;
 	}
 
-	const whereConditions: SQL[] = [eq(junctionSourceColumn, parentColumn)];
+	const whereConditions: SQL[] = [
+		eq(
+			junctionSourceColumn,
+			options.parentRecord && Object.hasOwn(options.parentRecord, sourceKey)
+				? options.parentRecord[sourceKey]
+				: parentColumn,
+		),
+	];
 
 	if (relationWhere) {
 		// Note: For relation subqueries, we don't use i18n fallback (useI18n: false)
@@ -967,6 +1112,10 @@ export function buildManyToManyExistsClause(
 			useI18n: false,
 			db: options.db,
 			failClosedAccess: options.failClosedAccess,
+			relationAliasDepth:
+				options.relationAliasDepth === undefined
+					? undefined
+					: options.relationAliasDepth + 1,
 		});
 		if (nestedClause) whereConditions.push(nestedClause);
 	}
@@ -1004,4 +1153,8 @@ function accessCompilationError(
 	return new Error(
 		`Cannot compile access predicate '${collection}.${field}'${suffix}`,
 	);
+}
+
+function escapeRegExp(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }

--- a/packages/questpie/src/server/modules/core/integrated/crdt/questpie-authorization.ts
+++ b/packages/questpie/src/server/modules/core/integrated/crdt/questpie-authorization.ts
@@ -26,6 +26,7 @@ import {
 } from "#questpie/server/collection/crud/shared/access-control.js";
 import type { CRUDContext } from "#questpie/server/collection/crud/types.js";
 import type { Questpie } from "#questpie/server/config/questpie.js";
+import { rowsOf } from "#questpie/server/db/driver-result.js";
 
 import type { CrdtAuthentication } from "./authority.js";
 import {
@@ -315,34 +316,34 @@ async function ownerAccess(
 			sourceColumns,
 			record,
 		);
-		const baseQuery = database.select({ matched: sql<number>`1` }).from(table);
-		const currentLocaleQuery = i18nCurrentTable
-			? baseQuery.leftJoin(
-					i18nCurrentTable,
-					and(
-						eq(getTableColumns(i18nCurrentTable).parentId, sourceId),
-						eq(
-							getTableColumns(i18nCurrentTable).locale,
-							context.locale ?? context.defaultLocale ?? "en",
-						),
+		const currentLocaleJoin = i18nCurrentTable
+			? sql`LEFT JOIN ${i18nTable} AS ${sql.identifier("crdt_i18n_current")} ON ${and(
+					eq(getTableColumns(i18nCurrentTable).parentId, sourceId),
+					eq(
+						getTableColumns(i18nCurrentTable).locale,
+						context.locale ?? context.defaultLocale ?? "en",
 					),
-				)
-			: baseQuery;
-		const query = i18nFallbackTable
-			? currentLocaleQuery.leftJoin(
-					i18nFallbackTable,
-					and(
-						eq(getTableColumns(i18nFallbackTable).parentId, sourceId),
-						eq(
-							getTableColumns(i18nFallbackTable).locale,
-							context.defaultLocale ?? "en",
-						),
+				)}`
+			: sql.empty();
+		const fallbackLocaleJoin = i18nFallbackTable
+			? sql`LEFT JOIN ${i18nTable} AS ${sql.identifier("crdt_i18n_fallback")} ON ${and(
+					eq(getTableColumns(i18nFallbackTable).parentId, sourceId),
+					eq(
+						getTableColumns(i18nFallbackTable).locale,
+						context.defaultLocale ?? "en",
 					),
-				)
-			: currentLocaleQuery;
-		const [match] = await query
-			.where(and(eq(sourceId, recordId), ...projectionGuards, access))
-			.limit(1);
+				)}`
+			: sql.empty();
+		const [match] = rowsOf<{ matched: number }>(
+			await database.execute(sql`
+				SELECT 1 AS matched
+				FROM ${table}
+				${currentLocaleJoin}
+				${fallbackLocaleJoin}
+				WHERE ${and(eq(sourceId, recordId), ...projectionGuards, access)}
+				LIMIT 1
+			`),
+		);
 		return match !== undefined;
 	}
 	return false;

--- a/packages/questpie/src/server/modules/core/integrated/crdt/questpie-authorization.ts
+++ b/packages/questpie/src/server/modules/core/integrated/crdt/questpie-authorization.ts
@@ -1,11 +1,27 @@
-import { eq, getTableColumns } from "drizzle-orm";
+import {
+	and,
+	Column,
+	eq,
+	getTableColumns,
+	is,
+	Name,
+	not,
+	or,
+	SQL,
+	type SQLChunk,
+	sql,
+} from "drizzle-orm";
+import { alias, type PgTable } from "drizzle-orm/pg-core";
 
-import type { AccessWhere } from "#questpie/server/collection/builder/types.js";
+import type {
+	AccessWhere,
+	CollectionBuilderState,
+} from "#questpie/server/collection/builder/types.js";
+import { buildWhereClause } from "#questpie/server/collection/crud/query-builders/where-builder.js";
 import {
 	checkFieldWriteAccess,
 	executeAccessRule,
 	getRestrictedReadFields,
-	matchesAccessConditions,
 	mergeFieldAccessRules,
 } from "#questpie/server/collection/crud/shared/access-control.js";
 import type { CRUDContext } from "#questpie/server/collection/crud/types.js";
@@ -127,11 +143,15 @@ export async function evaluateQuestpieCrdtOwnerPolicy(
 			? (app.collections as Record<string, any>)[owner.key]
 			: (app.globals as Record<string, any>)[owner.key];
 	const state = crud?.["~internalState"] as
-		| {
+		| (CollectionBuilderState & {
 				access?: Record<string, any>;
-				fieldDefinitions?: Record<string, unknown>;
-		  }
+		  })
 		| undefined;
+	const table = crud?.["~internalRelatedTable"] as PgTable | undefined;
+	const i18nTable = crud?.["~internalI18nTable"] as PgTable | null | undefined;
+	const crdtFields = new Set(
+		Object.keys(app.crdtRegistry.collections[owner.key]?.fields ?? {}),
+	);
 	if (!state) throw new Error("CRDT owner policy state is unavailable");
 	const read = await ownerAccess(
 		app,
@@ -142,6 +162,9 @@ export async function evaluateQuestpieCrdtOwnerPolicy(
 		undefined,
 		owner.kind === "collection",
 		database,
+		table,
+		i18nTable,
+		crdtFields,
 	);
 	if (!read) {
 		return { ownerRead: false, ownerEdit: false, fields: {} };
@@ -157,6 +180,9 @@ export async function evaluateQuestpieCrdtOwnerPolicy(
 			Object.freeze({}),
 			owner.kind === "collection",
 			database,
+			table,
+			i18nTable,
+			crdtFields,
 		);
 	} catch {
 		edit = false;
@@ -197,13 +223,16 @@ export async function evaluateQuestpieCrdtOwnerPolicy(
 
 async function ownerAccess(
 	app: Questpie<any>,
-	state: { access?: Record<string, any> },
+	state: CollectionBuilderState & { access?: Record<string, any> },
 	operation: "read" | "update",
 	context: CRUDContext,
 	record: Record<string, unknown>,
 	input: unknown,
 	allowWhere: boolean,
 	database: Questpie<any>["db"],
+	table?: PgTable,
+	i18nTable?: PgTable | null,
+	crdtFields: ReadonlySet<string> = new Set(),
 ): Promise<boolean> {
 	const rule = state.access?.[operation] ?? app.defaultAccess?.[operation];
 	const result = await executeAccessRule(rule, {
@@ -219,13 +248,266 @@ async function ownerAccess(
 		contextExtensions: context["~contextExtensions"],
 	});
 	if (result === true) return true;
-	if (
-		allowWhere &&
-		result &&
-		typeof result === "object" &&
-		(await matchesAccessConditions(result as AccessWhere, record))
-	) {
-		return true;
+	if (allowWhere && result && typeof result === "object" && table) {
+		const sourceId = getTableColumns(table).id;
+		const recordId = record.id;
+		if (
+			!sourceId ||
+			(typeof recordId !== "string" && typeof recordId !== "number")
+		) {
+			return false;
+		}
+		const useI18n = Boolean(i18nTable);
+		const needsFallback =
+			useI18n &&
+			context.localeFallback !== false &&
+			context.locale !== context.defaultLocale;
+		const i18nCurrentTable = useI18n
+			? alias(i18nTable!, "crdt_i18n_current")
+			: null;
+		const i18nFallbackTable = needsFallback
+			? alias(i18nTable!, "crdt_i18n_fallback")
+			: null;
+		const sourceColumns = getTableColumns(table);
+		const currentCrdtExpressions = Object.fromEntries(
+			[...crdtFields]
+				.filter((field) => field in record && sourceColumns[field])
+				.map((field) => [
+					field,
+					sql`CAST(${sql.param(record[field], sourceColumns[field])} AS ${sql.raw(sourceColumns[field]!.getSQLType())})`,
+				]),
+		);
+		const currentAwareVirtuals = Object.fromEntries(
+			Object.entries(state.virtuals ?? {}).map(([field, expression]) => [
+				field,
+				rewriteCrdtVirtualExpression(
+					expression,
+					sourceColumns,
+					currentCrdtExpressions,
+				),
+			]),
+		);
+		const policyState = {
+			...state,
+			virtuals: { ...currentAwareVirtuals, ...currentCrdtExpressions },
+		};
+		const compiledAccess = buildCrdtAccessWhereClause(result as AccessWhere, {
+			table,
+			state: policyState,
+			i18nCurrentTable,
+			i18nFallbackTable,
+			useI18n,
+			context,
+			app,
+			db: database,
+			failClosedAccess: true,
+			parentRecord: record,
+			relationAliasDepth: 0,
+		});
+		const access = rewriteCrdtVirtualExpression(
+			compiledAccess,
+			sourceColumns,
+			currentCrdtExpressions,
+		);
+		const projectionGuards = buildCrdtProjectionGuards(
+			access,
+			crdtFields,
+			sourceColumns,
+			record,
+		);
+		let query: any = database.select({ matched: sql<number>`1` }).from(table);
+		if (i18nCurrentTable) {
+			query = query.leftJoin(
+				i18nCurrentTable,
+				and(
+					eq(getTableColumns(i18nCurrentTable).parentId, sourceId),
+					eq(
+						getTableColumns(i18nCurrentTable).locale,
+						context.locale ?? context.defaultLocale ?? "en",
+					),
+				),
+			);
+			if (i18nFallbackTable) {
+				query = query.leftJoin(
+					i18nFallbackTable,
+					and(
+						eq(getTableColumns(i18nFallbackTable).parentId, sourceId),
+						eq(
+							getTableColumns(i18nFallbackTable).locale,
+							context.defaultLocale ?? "en",
+						),
+					),
+				);
+			}
+		}
+		const [match] = await query
+			.where(and(eq(sourceId, recordId), ...projectionGuards, access))
+			.limit(1);
+		return match !== undefined;
 	}
 	return false;
+}
+
+function rewriteCrdtVirtualExpression(
+	expression: SQL,
+	columns: ReturnType<typeof getTableColumns>,
+	currentValues: Readonly<Record<string, SQL>>,
+): SQL {
+	const replacements = new Map(
+		Object.entries(currentValues).flatMap(([field, current]) => {
+			const column = columns[field];
+			return column ? [[column, current] as const] : [];
+		}),
+	);
+	const byName = new Map(
+		Object.entries(currentValues).map(([field, current]) => [
+			columns[field]?.name ?? field,
+			current,
+		]),
+	);
+	const rewriteUnqualifiedNames = hasOnlyTopLevelUnqualifiedNames(expression);
+	const rewrite = (chunk: SQLChunk): SQLChunk => {
+		if (is(chunk, Column)) return replacements.get(chunk) ?? chunk;
+		if (is(chunk, Name) && rewriteUnqualifiedNames) {
+			return byName.get(chunk.value) ?? chunk;
+		}
+		if (is(chunk, SQL)) {
+			return new SQL(chunk.queryChunks.map(rewrite));
+		}
+		if (is(chunk, SQL.Aliased)) {
+			return new SQL.Aliased(rewrite(chunk.sql) as SQL, chunk.fieldAlias);
+		}
+		return chunk;
+	};
+	return rewrite(expression) as SQL;
+}
+
+function hasOnlyTopLevelUnqualifiedNames(expression: SQL): boolean {
+	let unsafeRawSql = false;
+	const nestedScope = /\b(?:select|with|from|join|table|lateral|values)\b/i;
+	const visit = (chunk: unknown): void => {
+		if (!chunk || typeof chunk !== "object") return;
+		if ("value" in chunk) {
+			const value = (chunk as { value?: unknown }).value;
+			if (
+				Array.isArray(value) &&
+				value.some(
+					(part) =>
+						typeof part === "string" &&
+						(nestedScope.test(part) || part.includes(".")),
+				)
+			) {
+				unsafeRawSql = true;
+			}
+		}
+		if ("queryChunks" in chunk) {
+			const children = (chunk as { queryChunks?: unknown }).queryChunks;
+			if (Array.isArray(children)) children.forEach(visit);
+		}
+		if ("sql" in chunk) visit((chunk as { sql?: unknown }).sql);
+	};
+	visit(expression);
+	return !unsafeRawSql;
+}
+
+function buildCrdtProjectionGuards(
+	access: SQL,
+	crdtFields: ReadonlySet<string>,
+	columns: ReturnType<typeof getTableColumns>,
+	record: Record<string, unknown>,
+): SQL[] {
+	return [...crdtFields].flatMap((field) => {
+		const column = columns[field];
+		if (!column || !(field in record)) return [];
+		return sqlExpressionReferencesColumn(access, column.name)
+			? [eq(column, sql.param(record[field], column))]
+			: [];
+	});
+}
+
+function sqlExpressionReferencesColumn(
+	expression: unknown,
+	columnName: string,
+): boolean {
+	const identifier = new RegExp(
+		`(?:^|[^A-Za-z0-9_])${escapeRegExp(columnName)}(?:$|[^A-Za-z0-9_])`,
+		"i",
+	);
+	const visit = (chunk: unknown): boolean => {
+		if (!chunk || typeof chunk !== "object") return false;
+		if (
+			"name" in chunk &&
+			"table" in chunk &&
+			(chunk as { name?: unknown }).name === columnName
+		) {
+			return true;
+		}
+		if ("value" in chunk) {
+			const value = (chunk as { value?: unknown }).value;
+			if (
+				typeof value === "string" &&
+				value.toLocaleLowerCase("en-US") ===
+					columnName.toLocaleLowerCase("en-US")
+			) {
+				return true;
+			}
+			if (
+				Array.isArray(value) &&
+				value.some((part) => typeof part === "string" && identifier.test(part))
+			) {
+				return true;
+			}
+		}
+		if ("queryChunks" in chunk) {
+			const children = (chunk as { queryChunks?: unknown }).queryChunks;
+			if (Array.isArray(children) && children.some(visit)) return true;
+		}
+		if ("sql" in chunk) return visit((chunk as { sql?: unknown }).sql);
+		return false;
+	};
+	return visit(expression);
+}
+
+function escapeRegExp(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function buildCrdtAccessWhereClause(
+	where: AccessWhere,
+	options: Parameters<typeof buildWhereClause>[1],
+): SQL {
+	const clauses: SQL[] = [];
+	const fields: Record<string, unknown> = {};
+
+	for (const [key, value] of Object.entries(where)) {
+		if (key === "AND" && Array.isArray(value)) {
+			clauses.push(
+				and(
+					...(value as AccessWhere[]).map((entry) =>
+						buildCrdtAccessWhereClause(entry, options),
+					),
+				) ?? sql`true`,
+			);
+		} else if (key === "OR" && Array.isArray(value)) {
+			clauses.push(
+				or(
+					...(value as AccessWhere[]).map((entry) =>
+						buildCrdtAccessWhereClause(entry, options),
+					),
+				) ?? sql`false`,
+			);
+		} else if (key === "NOT" && value && typeof value === "object") {
+			clauses.push(
+				not(buildCrdtAccessWhereClause(value as AccessWhere, options)),
+			);
+		} else {
+			fields[key] = value;
+		}
+	}
+
+	if (Object.keys(fields).length > 0) {
+		const fieldsClause = buildWhereClause(fields, options);
+		clauses.push(fieldsClause ?? sql`false`);
+	}
+	return and(...clauses) ?? sql`true`;
 }

--- a/packages/questpie/src/server/modules/core/integrated/crdt/questpie-authorization.ts
+++ b/packages/questpie/src/server/modules/core/integrated/crdt/questpie-authorization.ts
@@ -315,20 +315,21 @@ async function ownerAccess(
 			sourceColumns,
 			record,
 		);
-		let query: any = database.select({ matched: sql<number>`1` }).from(table);
-		if (i18nCurrentTable) {
-			query = query.leftJoin(
-				i18nCurrentTable,
-				and(
-					eq(getTableColumns(i18nCurrentTable).parentId, sourceId),
-					eq(
-						getTableColumns(i18nCurrentTable).locale,
-						context.locale ?? context.defaultLocale ?? "en",
+		const baseQuery = database.select({ matched: sql<number>`1` }).from(table);
+		const currentLocaleQuery = i18nCurrentTable
+			? baseQuery.leftJoin(
+					i18nCurrentTable,
+					and(
+						eq(getTableColumns(i18nCurrentTable).parentId, sourceId),
+						eq(
+							getTableColumns(i18nCurrentTable).locale,
+							context.locale ?? context.defaultLocale ?? "en",
+						),
 					),
-				),
-			);
-			if (i18nFallbackTable) {
-				query = query.leftJoin(
+				)
+			: baseQuery;
+		const query = i18nFallbackTable
+			? currentLocaleQuery.leftJoin(
 					i18nFallbackTable,
 					and(
 						eq(getTableColumns(i18nFallbackTable).parentId, sourceId),
@@ -337,9 +338,8 @@ async function ownerAccess(
 							context.defaultLocale ?? "en",
 						),
 					),
-				);
-			}
-		}
+				)
+			: currentLocaleQuery;
 		const [match] = await query
 			.where(and(eq(sourceId, recordId), ...projectionGuards, access))
 			.limit(1);

--- a/packages/questpie/test/crdt/security/questpie-authorization.test.ts
+++ b/packages/questpie/test/crdt/security/questpie-authorization.test.ts
@@ -1,0 +1,526 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+
+import { sql } from "drizzle-orm";
+
+import { collection } from "../../../src/exports/index.js";
+import { createDeterministicTextEngine } from "../../../src/server/modules/core/integrated/crdt/deterministic-engine.js";
+import { createCrdtManifestDeclarations } from "../../../src/server/modules/core/integrated/crdt/manifest-runtime.js";
+import { updateCrdtManifestArtifact } from "../../../src/server/modules/core/integrated/crdt/manifest.js";
+import { canonicalCrdtCollectionLocator } from "../../../src/server/modules/core/integrated/crdt/owner-lifecycle.js";
+import {
+	evaluateQuestpieCrdtOwnerPolicy,
+	loadQuestpieCrdtOwnerRecord,
+} from "../../../src/server/modules/core/integrated/crdt/questpie-authorization.js";
+import { createCrdtRegistry } from "../../../src/server/modules/core/integrated/crdt/registry.js";
+import { buildMockApp } from "../../utils/mocks/mock-app-builder.js";
+import { createTestContext } from "../../utils/test-context.js";
+import { runTestDbMigrations } from "../../utils/test-db.js";
+
+const documents = collection("crdt_policy_documents")
+	.options({ schema: "crdt_auth" })
+	.fields(({ f }) => ({
+		label: f.text().required().localized(),
+		status: f
+			.select([
+				{ value: "draft", label: "Draft" },
+				{ value: "published", label: "Published" },
+			])
+			.required(),
+		content: f.textarea().required().default("").crdt({ format: "text" }),
+		visible: f
+			.boolean()
+			.virtual(sql<boolean>`(crdt_policy_documents.status = 'published')`),
+		unqualifiedVisible: f
+			.boolean()
+			.virtual(sql<boolean>`(status = 'published')`),
+		schemaVisible: f
+			.boolean()
+			.virtual(
+				sql<boolean>`(crdt_auth.crdt_policy_documents.status = 'published')`,
+			),
+	}))
+	.collaborative()
+	.access({
+		read: () => ({
+			AND: [
+				{ label: "Visible" },
+				{ status: { in: ["published"] } },
+				{ visible: true },
+				{ unqualifiedVisible: true },
+				{ schemaVisible: true },
+				{ content: { ne: "blocked" } },
+			],
+		}),
+		update: true,
+	});
+const emptyPredicateDocuments = collection("crdt_empty_policy_documents")
+	.fields(({ f }) => ({
+		content: f.textarea().required().default("").crdt({ format: "text" }),
+	}))
+	.collaborative()
+	.access({
+		read: ({ locale }) =>
+			locale === "sk"
+				? { AND: [{ OR: [] }, { content: { ne: "blocked" } }] }
+				: { OR: [{ content: { eq: "blocked" } }, { content: {} }] },
+		update: true,
+	});
+const selfNodes = collection("crdt_self_nodes")
+	.fields(({ f }) => ({
+		status: f.text().required(),
+		parent: f.relation("crdt_self_nodes").relationName("parent"),
+		content: f.textarea().required().default("").crdt({ format: "text" }),
+	}))
+	.collaborative()
+	.access({
+		read: ({ locale }) =>
+			locale === "sk"
+				? { parent: { is: { status: { eq: "published" } } } }
+				: {
+						parent: {
+							is: { parent: { is: { status: { eq: "published" } } } },
+						},
+					},
+		update: true,
+	});
+const identifierDocuments = collection("crdt_identifier_policy_documents")
+	.fields(({ f }) => ({
+		status: f.text().required().default("published"),
+		content: f.textarea().required().default("").crdt({ format: "text" }),
+		visible: f
+			.boolean()
+			.virtual(
+				sql<boolean>`(${sql.identifier("content")} <> 'blocked' AND ${sql.identifier("status")} = 'published')`,
+			),
+	}))
+	.collaborative()
+	.access({ read: () => ({ visible: true }), update: true });
+const scopedIdentifierDocuments = collection("crdt_scoped_identifier_documents")
+	.fields(({ f }) => ({
+		content: f.textarea().required().default("").crdt({ format: "text" }),
+		visible: f.boolean().virtual(sql<boolean>`EXISTS (
+			SELECT 1 FROM (VALUES ('private')) AS inner_rows(content)
+			WHERE ${sql.identifier("content")} = 'public'
+		)`),
+	}))
+	.collaborative()
+	.access({ read: () => ({ visible: true }), update: true });
+const foldedIdentifierDocuments = collection("crdt_folded_identifier_documents")
+	.fields(({ f }) => ({
+		content: f.textarea().required().default("").crdt({ format: "text" }),
+		visible: f.boolean().virtual(sql<boolean>`(CONTENT <> 'blocked')`),
+	}))
+	.collaborative()
+	.access({ read: () => ({ visible: true }), update: true });
+const rawDocuments = collection("crdt_raw_policy_documents")
+	.fields(({ f }) => ({
+		visible: f.boolean().required().default(true),
+		content: f.textarea().required().default("").crdt({ format: "text" }),
+	}))
+	.collaborative()
+	.access({
+		read: () => ({ RAW: ({ table }) => sql`${table.visible} = true` }),
+		update: true,
+	});
+const emptyRelationNodes = collection("crdt_empty_relation_nodes")
+	.fields(({ f }) => ({
+		parent: f.relation("crdt_empty_relation_nodes").relationName("parent"),
+		content: f.textarea().required().default("").crdt({ format: "text" }),
+	}))
+	.collaborative()
+	.access({ read: () => ({ parent: { is: { OR: [] } } }), update: true });
+const setDocuments = collection("crdt_set_policy_documents")
+	.fields(({ f }) => ({
+		tags: f
+			.text({ mode: "text" })
+			.array()
+			.default([])
+			.required()
+			.crdt({ format: "set", conflict: "add-wins" }),
+	}))
+	.collaborative()
+	.access({
+		read: () => ({ tags: { containsAll: ["allowed"] } }),
+		update: true,
+	});
+const textEngine = createDeterministicTextEngine();
+const crdtConfig = {
+	namespace: "crdt-policy-test",
+	engines: { text: textEngine },
+};
+const registry = createCrdtRegistry({
+	collections: {
+		crdt_policy_documents: documents.build(),
+		crdt_empty_policy_documents: emptyPredicateDocuments.build(),
+		crdt_self_nodes: selfNodes.build(),
+		crdt_identifier_policy_documents: identifierDocuments.build(),
+		crdt_scoped_identifier_documents: scopedIdentifierDocuments.build(),
+		crdt_folded_identifier_documents: foldedIdentifierDocuments.build(),
+		crdt_raw_policy_documents: rawDocuments.build(),
+		crdt_empty_relation_nodes: emptyRelationNodes.build(),
+		crdt_set_policy_documents: setDocuments.build(),
+	},
+	globals: {},
+});
+const manifest = updateCrdtManifestArtifact({
+	namespace: crdtConfig.namespace,
+	declarations: createCrdtManifestDeclarations({
+		registry,
+		config: crdtConfig,
+	}),
+	createStableFieldId: uuidSequence().next,
+});
+
+describe("QUESTPIE CRDT owner policy", () => {
+	let setup: Awaited<ReturnType<typeof buildMockApp>>;
+
+	beforeEach(async () => {
+		setup = await buildMockApp(
+			{
+				collections: {
+					crdt_policy_documents: documents,
+					crdt_empty_policy_documents: emptyPredicateDocuments,
+					crdt_self_nodes: selfNodes,
+					crdt_identifier_policy_documents: identifierDocuments,
+					crdt_scoped_identifier_documents: scopedIdentifierDocuments,
+					crdt_folded_identifier_documents: foldedIdentifierDocuments,
+					crdt_raw_policy_documents: rawDocuments,
+					crdt_empty_relation_nodes: emptyRelationNodes,
+					crdt_set_policy_documents: setDocuments,
+				},
+				crdtManifest: manifest,
+			},
+			{ crdt: crdtConfig, secret: "s".repeat(32) },
+		);
+		await setup.app.db.execute(sql`CREATE SCHEMA IF NOT EXISTS crdt_auth`);
+		await runTestDbMigrations(setup.app);
+	});
+
+	afterEach(async () => {
+		await setup.cleanup();
+	});
+
+	it("evaluates collection AccessWhere through SQL operators and virtual fields", async () => {
+		const system = createTestContext();
+		const published = await setup.app.collections.crdt_policy_documents.create(
+			{ label: "Visible", status: "published" },
+			system,
+		);
+		const draft = await setup.app.collections.crdt_policy_documents.create(
+			{ label: "Visible", status: "draft" },
+			system,
+		);
+		const context = createTestContext({ accessMode: "user" });
+
+		const evaluate = async (id: string) => {
+			const owner = {
+				kind: "collection" as const,
+				key: "crdt_policy_documents",
+				ownerKey: "crdt_policy_documents",
+				id,
+				locator: canonicalCrdtCollectionLocator(id),
+			};
+			const record = await loadQuestpieCrdtOwnerRecord(setup.app, owner);
+			expect(record).not.toBeNull();
+			return evaluateQuestpieCrdtOwnerPolicy(
+				setup.app,
+				owner,
+				record!,
+				context,
+			);
+		};
+
+		expect(await evaluate(published.id)).toMatchObject({
+			ownerRead: true,
+			fields: { content: { read: true } },
+		});
+		const publishedOwner = {
+			kind: "collection" as const,
+			key: "crdt_policy_documents",
+			ownerKey: "crdt_policy_documents",
+			id: published.id,
+			locator: canonicalCrdtCollectionLocator(published.id),
+		};
+		const projectedRecord = await loadQuestpieCrdtOwnerRecord(
+			setup.app,
+			publishedOwner,
+		);
+		expect(projectedRecord?.content).toBe("");
+		await expect(
+			evaluateQuestpieCrdtOwnerPolicy(
+				setup.app,
+				publishedOwner,
+				{ ...projectedRecord!, content: "blocked" },
+				context,
+			),
+		).resolves.toEqual({ ownerRead: false, ownerEdit: false, fields: {} });
+		await expect(evaluate(draft.id)).resolves.toEqual({
+			ownerRead: false,
+			ownerEdit: false,
+			fields: {},
+		});
+	});
+
+	it("keeps a nested logically empty OR access predicate denied", async () => {
+		const created =
+			await setup.app.collections.crdt_empty_policy_documents.create(
+				{},
+				createTestContext(),
+			);
+		const owner = {
+			kind: "collection" as const,
+			key: "crdt_empty_policy_documents",
+			ownerKey: "crdt_empty_policy_documents",
+			id: created.id,
+			locator: canonicalCrdtCollectionLocator(created.id),
+		};
+		const record = await loadQuestpieCrdtOwnerRecord(setup.app, owner);
+
+		for (const locale of ["en", "sk"]) {
+			await expect(
+				evaluateQuestpieCrdtOwnerPolicy(
+					setup.app,
+					owner,
+					record!,
+					createTestContext({ accessMode: "user", locale }),
+				),
+			).resolves.toEqual({ ownerRead: false, ownerEdit: false, fields: {} });
+		}
+	});
+
+	it("correlates direct and nested self-relation access to the exact owner", async () => {
+		const system = createTestContext();
+		const grandparent = await setup.app.collections.crdt_self_nodes.create(
+			{ status: "published" },
+			system,
+		);
+		const parent = await setup.app.collections.crdt_self_nodes.create(
+			{ status: "published", parent: grandparent.id },
+			system,
+		);
+		const child = await setup.app.collections.crdt_self_nodes.create(
+			{ status: "draft", parent: parent.id },
+			system,
+		);
+		const selfLoop = await setup.app.collections.crdt_self_nodes.create(
+			{ status: "published" },
+			system,
+		);
+		await setup.app.collections.crdt_self_nodes.updateById(
+			{
+				id: selfLoop.id,
+				expectedRevision: selfLoop.revision,
+				data: { parent: selfLoop.id },
+			},
+			system,
+		);
+		const unrelated = await setup.app.collections.crdt_self_nodes.create(
+			{ status: "draft" },
+			system,
+		);
+		const evaluate = async (id: string, locale: string) => {
+			const owner = {
+				kind: "collection" as const,
+				key: "crdt_self_nodes",
+				ownerKey: "crdt_self_nodes",
+				id,
+				locator: canonicalCrdtCollectionLocator(id),
+			};
+			const record = await loadQuestpieCrdtOwnerRecord(setup.app, owner);
+			return evaluateQuestpieCrdtOwnerPolicy(
+				setup.app,
+				owner,
+				record!,
+				createTestContext({ accessMode: "user", locale }),
+			);
+		};
+
+		expect((await evaluate(child.id, "sk")).ownerRead).toBe(true);
+		expect((await evaluate(child.id, "en")).ownerRead).toBe(true);
+		expect((await evaluate(unrelated.id, "sk")).ownerRead).toBe(false);
+		expect((await evaluate(unrelated.id, "en")).ownerRead).toBe(false);
+	});
+
+	it("detects sql.identifier dependencies on current CRDT fields", async () => {
+		const created =
+			await setup.app.collections.crdt_identifier_policy_documents.create(
+				{},
+				createTestContext(),
+			);
+		const owner = {
+			kind: "collection" as const,
+			key: "crdt_identifier_policy_documents",
+			ownerKey: "crdt_identifier_policy_documents",
+			id: created.id,
+			locator: canonicalCrdtCollectionLocator(created.id),
+		};
+		const record = await loadQuestpieCrdtOwnerRecord(setup.app, owner);
+
+		const result = await evaluateQuestpieCrdtOwnerPolicy(
+			setup.app,
+			owner,
+			{ ...record!, content: "blocked" },
+			createTestContext({ accessMode: "user" }),
+		);
+		expect(result).toEqual({ ownerRead: false, ownerEdit: false, fields: {} });
+
+		const previouslyBlocked =
+			await setup.app.collections.crdt_identifier_policy_documents.create(
+				{ content: "blocked" },
+				createTestContext(),
+			);
+		const allowedOwner = {
+			...owner,
+			id: previouslyBlocked.id,
+			locator: canonicalCrdtCollectionLocator(previouslyBlocked.id),
+		};
+		const blockedRecord = await loadQuestpieCrdtOwnerRecord(
+			setup.app,
+			allowedOwner,
+		);
+		await expect(
+			evaluateQuestpieCrdtOwnerPolicy(
+				setup.app,
+				allowedOwner,
+				{ ...blockedRecord!, content: "allowed" },
+				createTestContext({ accessMode: "user" }),
+			),
+		).resolves.toMatchObject({ ownerRead: true });
+	});
+
+	it("does not rewrite sql.identifier inside a nested SQL scope", async () => {
+		const created =
+			await setup.app.collections.crdt_scoped_identifier_documents.create(
+				{ content: "public" },
+				createTestContext(),
+			);
+		const owner = {
+			kind: "collection" as const,
+			key: "crdt_scoped_identifier_documents",
+			ownerKey: "crdt_scoped_identifier_documents",
+			id: created.id,
+			locator: canonicalCrdtCollectionLocator(created.id),
+		};
+		const record = await loadQuestpieCrdtOwnerRecord(setup.app, owner);
+
+		await expect(
+			evaluateQuestpieCrdtOwnerPolicy(
+				setup.app,
+				owner,
+				record!,
+				createTestContext({ accessMode: "user" }),
+			),
+		).resolves.toEqual({ ownerRead: false, ownerEdit: false, fields: {} });
+	});
+
+	it("fails closed for folded raw identifiers while projection is stale", async () => {
+		const created =
+			await setup.app.collections.crdt_folded_identifier_documents.create(
+				{},
+				createTestContext(),
+			);
+		const owner = {
+			kind: "collection" as const,
+			key: "crdt_folded_identifier_documents",
+			ownerKey: "crdt_folded_identifier_documents",
+			id: created.id,
+			locator: canonicalCrdtCollectionLocator(created.id),
+		};
+		const record = await loadQuestpieCrdtOwnerRecord(setup.app, owner);
+
+		await expect(
+			evaluateQuestpieCrdtOwnerPolicy(
+				setup.app,
+				owner,
+				{ ...record!, content: "blocked" },
+				createTestContext({ accessMode: "user" }),
+			),
+		).resolves.toEqual({ ownerRead: false, ownerEdit: false, fields: {} });
+	});
+
+	it("does not guard CRDT fields absent from a RAW access expression", async () => {
+		const created =
+			await setup.app.collections.crdt_raw_policy_documents.create(
+				{},
+				createTestContext(),
+			);
+		const owner = {
+			kind: "collection" as const,
+			key: "crdt_raw_policy_documents",
+			ownerKey: "crdt_raw_policy_documents",
+			id: created.id,
+			locator: canonicalCrdtCollectionLocator(created.id),
+		};
+		const record = await loadQuestpieCrdtOwnerRecord(setup.app, owner);
+
+		await expect(
+			evaluateQuestpieCrdtOwnerPolicy(
+				setup.app,
+				owner,
+				{ ...record!, content: "canonical ahead" },
+				createTestContext({ accessMode: "user" }),
+			),
+		).resolves.toMatchObject({ ownerRead: true });
+	});
+
+	it("keeps an empty OR inside a relation access predicate denied", async () => {
+		const system = createTestContext();
+		const parent = await setup.app.collections.crdt_empty_relation_nodes.create(
+			{},
+			system,
+		);
+		const child = await setup.app.collections.crdt_empty_relation_nodes.create(
+			{ parent: parent.id },
+			system,
+		);
+		const owner = {
+			kind: "collection" as const,
+			key: "crdt_empty_relation_nodes",
+			ownerKey: "crdt_empty_relation_nodes",
+			id: child.id,
+			locator: canonicalCrdtCollectionLocator(child.id),
+		};
+		const record = await loadQuestpieCrdtOwnerRecord(setup.app, owner);
+
+		await expect(
+			evaluateQuestpieCrdtOwnerPolicy(
+				setup.app,
+				owner,
+				record!,
+				createTestContext({ accessMode: "user" }),
+			),
+		).resolves.toEqual({ ownerRead: false, ownerEdit: false, fields: {} });
+	});
+
+	it("binds the current CRDT set value with its PostgreSQL storage type", async () => {
+		const created =
+			await setup.app.collections.crdt_set_policy_documents.create(
+				{},
+				createTestContext(),
+			);
+		const owner = {
+			kind: "collection" as const,
+			key: "crdt_set_policy_documents",
+			ownerKey: "crdt_set_policy_documents",
+			id: created.id,
+			locator: canonicalCrdtCollectionLocator(created.id),
+		};
+		const record = await loadQuestpieCrdtOwnerRecord(setup.app, owner);
+
+		const result = await evaluateQuestpieCrdtOwnerPolicy(
+			setup.app,
+			owner,
+			{ ...record!, tags: ["allowed"] },
+			createTestContext({ accessMode: "user" }),
+		);
+		expect(result).toMatchObject({ ownerRead: true });
+	});
+});
+
+function uuidSequence() {
+	let counter = 0x900;
+	return {
+		next: () =>
+			`00000000-0000-4000-8000-${(++counter).toString(16).padStart(12, "0")}`,
+	};
+}


### PR DESCRIPTION
## Summary

- compile collection CRDT owner `AccessWhere` rules through the same SQL builder as CRUD reads
- evaluate canonical CRDT values safely during projection lag, including queryable virtual fields and RAW predicates
- fail closed for malformed logical/operator/relation predicates and correlate self-relations to the exact owner row

## Root cause

The CRDT open route deliberately returns one disclosure-safe 404 shape. Behind that response, collection access objects were passed to an in-memory equality matcher that cannot evaluate operators, relations, localized fields, or SQL virtual fields. An authenticated open therefore threw and appeared identical to an unauthenticated request.

## Proof

- `bun test packages/questpie/test/crdt/security packages/questpie/test/collection/access-where-compilation.test.ts` — 36 pass
- `bun run --cwd packages/questpie check-types`
- `bun run format:check`
- `bun run lint` — existing warnings only, no errors
- `bun run --cwd packages/questpie build`

The regression suite covers operator predicates, localization, qualified and unqualified virtual SQL, canonical projection lag in both directions, RAW access, PostgreSQL identifier folding, nested SQL scopes, sets, empty logical predicates, and direct/nested self-relations.
