### PR TITLE
fix(crdt): keep PostgreSQL admission reads live

### DIFF
--- a/.changeset/calm-crdts-connect.md
+++ b/.changeset/calm-crdts-connect.md
@@ -1,0 +1,7 @@
+---
+"questpie": patch
+---
+
+Prevent CRDT open and pull admission reads from exhausting bounded PostgreSQL
+pools, and preserve opaque 16-byte pull identifiers without requiring RFC UUID
+version or variant bits.

--- a/packages/questpie/src/server/modules/core/integrated/crdt/open-store.ts
+++ b/packages/questpie/src/server/modules/core/integrated/crdt/open-store.ts
@@ -348,28 +348,29 @@ async function enforceCaps(
 ): Promise<void> {
 	const authorization = input.authorization;
 	const edgeSessionKey = Buffer.from(input.edge.sessionKey);
-	const [global, subject, credential, resource, edge] = await Promise.all([
-		activeSessionCount(db),
-		activeSessionCount(
-			db,
-			eq(questpieCrdtSessionTable.subjectId, authorization.subjectId),
+	// Keep all reads on the transaction connection. Running these together can
+	// escape through a bounded node-postgres pool while the transaction itself
+	// holds one connection, which leaves the final read waiting for itself.
+	const global = await activeSessionCount(db);
+	const subject = await activeSessionCount(
+		db,
+		eq(questpieCrdtSessionTable.subjectId, authorization.subjectId),
+	);
+	const credential = await activeSessionCount(
+		db,
+		eq(
+			questpieCrdtSessionTable.credentialFingerprint,
+			Buffer.from(authorization.credentialFingerprint),
 		),
-		activeSessionCount(
-			db,
-			eq(
-				questpieCrdtSessionTable.credentialFingerprint,
-				Buffer.from(authorization.credentialFingerprint),
-			),
-		),
-		activeSessionCount(
-			db,
-			eq(questpieCrdtSessionTable.resourceId, authorization.resourceId),
-		),
-		activeSessionCount(
-			db,
-			eq(questpieCrdtSessionTable.edgeSessionKey, edgeSessionKey),
-		),
-	]);
+	);
+	const resource = await activeSessionCount(
+		db,
+		eq(questpieCrdtSessionTable.resourceId, authorization.resourceId),
+	);
+	const edge = await activeSessionCount(
+		db,
+		eq(questpieCrdtSessionTable.edgeSessionKey, edgeSessionKey),
+	);
 	if (
 		global >= limits.maximumSessions ||
 		subject >= limits.maximumSessionsPerSubject ||

--- a/packages/questpie/src/server/modules/core/integrated/crdt/pull-store.ts
+++ b/packages/questpie/src/server/modules/core/integrated/crdt/pull-store.ts
@@ -370,40 +370,31 @@ async function reservePull(
 				PULL_MINIMUM_AUTHORITY_WINDOW_MS,
 			);
 			await expireStalePullLeases(tx, session.bindingId);
-			const [
-				active,
-				subjectActive,
-				retained,
-				subjectRetained,
-				bindingRetained,
-				retainedBytes,
-				subjectRetainedBytes,
-				bindingRetainedBytes,
-			] = await Promise.all([
-				activePullCount(tx),
-				activePullCount(
-					tx,
-					eq(questpieCrdtPullTable.subjectId, input.authorization.subjectId),
-				),
-				retainedPullCount(tx),
-				retainedPullCount(
-					tx,
-					eq(questpieCrdtPullTable.subjectId, input.authorization.subjectId),
-				),
-				retainedPullCount(
-					tx,
-					eq(questpieCrdtPullTable.bindingId, session.bindingId),
-				),
-				retainedPullBytes(tx),
-				retainedPullBytes(
-					tx,
-					eq(questpieCrdtPullTable.subjectId, input.authorization.subjectId),
-				),
-				retainedPullBytes(
-					tx,
-					eq(questpieCrdtPullTable.bindingId, session.bindingId),
-				),
-			]);
+			// Keep all reads on the transaction connection. A bounded
+			// node-postgres pool can deadlock when these are started together.
+			const active = await activePullCount(tx);
+			const subjectActive = await activePullCount(
+				tx,
+				eq(questpieCrdtPullTable.subjectId, input.authorization.subjectId),
+			);
+			const retained = await retainedPullCount(tx);
+			const subjectRetained = await retainedPullCount(
+				tx,
+				eq(questpieCrdtPullTable.subjectId, input.authorization.subjectId),
+			);
+			const bindingRetained = await retainedPullCount(
+				tx,
+				eq(questpieCrdtPullTable.bindingId, session.bindingId),
+			);
+			const retainedBytes = await retainedPullBytes(tx);
+			const subjectRetainedBytes = await retainedPullBytes(
+				tx,
+				eq(questpieCrdtPullTable.subjectId, input.authorization.subjectId),
+			);
+			const bindingRetainedBytes = await retainedPullBytes(
+				tx,
+				eq(questpieCrdtPullTable.bindingId, session.bindingId),
+			);
 			if (
 				active >= MAX_ACTIVE_PULLS ||
 				subjectActive >= MAX_ACTIVE_PULLS_PER_SUBJECT ||
@@ -1658,11 +1649,9 @@ async function expireBuildingPullRow(
 }
 
 function uuidToBytes(value: string): Buffer {
-	if (
-		!/^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
-			value,
-		)
-	) {
+	// Pull ids are opaque protocol bytes stored in a PostgreSQL uuid column.
+	// They do not carry RFC version or variant semantics.
+	if (!/^[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}$/i.test(value)) {
 		throw recovery();
 	}
 	return Buffer.from(value.replaceAll("-", ""), "hex");

--- a/packages/questpie/test/crdt/server/open-store.test.ts
+++ b/packages/questpie/test/crdt/server/open-store.test.ts
@@ -1,4 +1,5 @@
 import {
+	afterAll,
 	afterEach,
 	beforeAll,
 	beforeEach,
@@ -7,10 +8,13 @@ import {
 	it,
 } from "bun:test";
 import { Buffer } from "node:buffer";
+import { randomUUID } from "node:crypto";
 
 import { PGlite } from "@electric-sql/pglite";
 import { count, eq, sql } from "drizzle-orm";
+import { drizzle as drizzlePg } from "drizzle-orm/node-postgres";
 import { drizzle } from "drizzle-orm/pglite";
+import pg from "pg";
 
 import { CoreNoticeRouter } from "../../../src/server/modules/core/integrated/collaboration/notice-router.js";
 import type { CrdtAuthorizationSnapshot } from "../../../src/server/modules/core/integrated/crdt/authorization.js";
@@ -713,6 +717,62 @@ describe("CRDT idempotent open store", () => {
 		unblock();
 		await release();
 	});
+});
+
+const postgresUrl =
+	process.env.QUESTPIE_CRDT_DATABASE_URL ??
+	process.env.QUESTPIE_TRANSACTION_LOCK_DATABASE_URL;
+
+describe.skipIf(!postgresUrl)("CRDT open store on bounded PostgreSQL", () => {
+	const schemaName = `questpie_crdt_open_${randomUUID().replaceAll("-", "")}`;
+	let admin: pg.Pool;
+	let pool: pg.Pool;
+	let postgresDb: ReturnType<typeof drizzlePg<typeof questpieCrdtTables>>;
+
+	beforeAll(async () => {
+		admin = new pg.Pool({ connectionString: postgresUrl, max: 1 });
+		await admin.query(`CREATE SCHEMA "${schemaName}"`);
+		pool = new pg.Pool({
+			connectionString: postgresUrl,
+			max: 5,
+			options: `-c search_path=${schemaName}`,
+		});
+		postgresDb = drizzlePg({ client: pool, schema: questpieCrdtTables });
+		const { generateDrizzleJson, generateMigration } =
+			await import("drizzle-kit/api-postgres");
+		const empty = {
+			id: "00000000-0000-0000-0000-000000000000",
+			dialect: "postgres" as const,
+			prevIds: [],
+			version: "8" as const,
+			ddl: [],
+			renames: [],
+		};
+		for (const statement of await generateMigration(
+			empty,
+			await generateDrizzleJson(questpieCrdtTables, empty.id),
+		)) {
+			if (statement.trim()) await postgresDb.execute(sql.raw(statement));
+		}
+		await seedResource(postgresDb);
+	});
+
+	afterEach(async () => {
+		await postgresDb?.delete(questpieCrdtSessionGrantTable);
+		await postgresDb?.delete(questpieCrdtSessionTable);
+	});
+
+	afterAll(async () => {
+		await pool?.end();
+		await admin?.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+		await admin?.end();
+	});
+
+	it("does not exhaust the pool while enforcing session caps", async () => {
+		const opened =
+			await createCrdtOpenSessionStore(postgresDb).open(openInput());
+		expect(opened.sessionId).toBeString();
+	}, 3_000);
 });
 
 function openInput(

--- a/packages/questpie/test/crdt/sync/store.test.ts
+++ b/packages/questpie/test/crdt/sync/store.test.ts
@@ -1,9 +1,12 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { Buffer } from "node:buffer";
+import { randomUUID } from "node:crypto";
 
 import { PGlite } from "@electric-sql/pglite";
 import { eq, inArray, sql } from "drizzle-orm";
+import { drizzle as drizzlePg } from "drizzle-orm/node-postgres";
 import { drizzle } from "drizzle-orm/pglite";
+import pg from "pg";
 
 import { collectCrdtGarbage } from "../../../src/server/modules/core/integrated/crdt/compaction-store.js";
 import {
@@ -170,6 +173,48 @@ describe("CRDT repeatable aggregate sync store", () => {
 				fieldCursor: fixture.title.headFieldCursor,
 			},
 		]);
+	});
+
+	it("round-trips opaque pull ids without RFC version or variant bits", async () => {
+		const authorization = await currentAuthorization(db, fixture);
+		const pullId = "00000000-0000-0000-0000-000000000560";
+		const store = createCrdtPullStore(db, {
+			namespace: "sync-test",
+			deploymentFingerprint: "deployment-a",
+			secret: "test-secret-that-is-long-enough",
+			resolveEngine: () => textEngine,
+		});
+
+		const page = await store.pull({
+			claim: {
+				sessionId: SESSION_ID,
+				bindingId: authorization.bindingId,
+				resourceId: RESOURCE_ID,
+				requestedMode: "edit",
+				effectiveMode: "edit",
+				sessionGeneration: 0n,
+				deliveryGeneration: 0n,
+			},
+			authorization: authorization.snapshot,
+			pullId,
+			schemaVersion: manifest.version,
+			continuation: null,
+			proofs: [
+				{
+					fieldSlot: fixture.title.fieldSlot,
+					fieldEpoch: fixture.title.fieldEpoch,
+					proof: Uint8Array.of(1),
+				},
+			],
+		});
+
+		const frame = decodeStoredPull(page.payload);
+		expect(frame.opcode).toBe(0x81);
+		if (frame.opcode !== 0x81) throw new Error("expected pull page");
+		expect(Buffer.from(frame.payload.pullId)).toEqual(
+			Buffer.from(pullId.replaceAll("-", ""), "hex"),
+		);
+		await expireAndCollectPulls(db, store, [pullId]);
 	});
 
 	it("stops awaiting pull materialization when the request is aborted", async () => {
@@ -1209,6 +1254,97 @@ describe("CRDT repeatable aggregate sync store", () => {
 			chunks: after.payload.chunks,
 		});
 	});
+});
+
+const postgresUrl =
+	process.env.QUESTPIE_CRDT_DATABASE_URL ??
+	process.env.QUESTPIE_TRANSACTION_LOCK_DATABASE_URL;
+
+describe.skipIf(!postgresUrl)("CRDT pull store on bounded PostgreSQL", () => {
+	const schemaName = `questpie_crdt_pull_${randomUUID().replaceAll("-", "")}`;
+	let admin: pg.Pool;
+	let pool: pg.Pool;
+	let postgresDb: ReturnType<typeof drizzlePg<typeof questpieCrdtTables>>;
+	let compatibleDb: ReturnType<typeof drizzle<typeof questpieCrdtTables>>;
+	let postgresFixture: Awaited<ReturnType<typeof seed>>;
+
+	beforeAll(async () => {
+		admin = new pg.Pool({ connectionString: postgresUrl, max: 1 });
+		await admin.query(`CREATE SCHEMA "${schemaName}"`);
+		pool = new pg.Pool({
+			connectionString: postgresUrl,
+			max: 5,
+			options: `-c search_path=${schemaName}`,
+		});
+		postgresDb = drizzlePg({ client: pool, schema: questpieCrdtTables });
+		compatibleDb = postgresDb as unknown as typeof compatibleDb;
+		const { generateDrizzleJson, generateMigration } =
+			await import("drizzle-kit/api-postgres");
+		const empty = {
+			id: "00000000-0000-0000-0000-000000000000",
+			dialect: "postgres" as const,
+			prevIds: [],
+			version: "8" as const,
+			ddl: [],
+			renames: [],
+		};
+		for (const statement of await generateMigration(
+			empty,
+			await generateDrizzleJson(questpieCrdtTables, empty.id),
+		)) {
+			if (statement.trim()) await postgresDb.execute(sql.raw(statement));
+		}
+		await postgresDb.execute(sql`
+			CREATE TABLE articles (
+				id text PRIMARY KEY,
+				title text NOT NULL,
+				content text NOT NULL
+			)
+		`);
+		postgresFixture = await seed(compatibleDb);
+	});
+
+	afterAll(async () => {
+		await pool?.end();
+		await admin?.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+		await admin?.end();
+	});
+
+	it("does not exhaust the pool while reserving a pull", async () => {
+		const authorization = await currentAuthorization(
+			compatibleDb,
+			postgresFixture,
+		);
+		const store = createCrdtPullStore(postgresDb, {
+			namespace: "sync-test",
+			deploymentFingerprint: "deployment-a",
+			secret: "test-secret-that-is-long-enough",
+			resolveEngine: () => textEngine,
+		});
+		const page = await store.pull({
+			claim: {
+				sessionId: SESSION_ID,
+				bindingId: authorization.bindingId,
+				resourceId: RESOURCE_ID,
+				requestedMode: "edit",
+				effectiveMode: "edit",
+				sessionGeneration: 0n,
+				deliveryGeneration: 0n,
+			},
+			authorization: authorization.snapshot,
+			pullId: "00000000-0000-0000-0000-000000000561",
+			schemaVersion: manifest.version,
+			continuation: null,
+			proofs: [
+				{
+					fieldSlot: postgresFixture.title.fieldSlot,
+					fieldEpoch: postgresFixture.title.fieldEpoch,
+					proof: Uint8Array.of(1),
+				},
+			],
+		});
+		expect(page.opcode).toBe(0x81);
+	}, 3_000);
 });
 
 async function currentFieldProof(


### PR DESCRIPTION
## Summary
- serialize CRDT open and pull cap reads on their PostgreSQL transaction connection
- preserve opaque 16-byte pull ids without RFC UUID version or variant requirements
- cover both stores with bounded real-PostgreSQL regressions

## Verification
- real PostgreSQL open store: 18 pass
- real PostgreSQL pull store: 16 pass
- format check, lint, questpie typecheck, and questpie build
- cross-model adversarial review: no findings

The downstream authenticated HTTP E2E now gets a 201 open response and reaches a ready CRDT document with the locally built patch.