### PR TITLE
fix(crdt): separate collaborative edit access

### DIFF
--- a/packages/questpie/src/server/collection/builder/collection-builder.ts
+++ b/packages/questpie/src/server/collection/builder/collection-builder.ts
@@ -42,6 +42,7 @@ import {
 import type {
 	CrdtOwnerCapability,
 	CrdtOwnerConfig,
+	CrdtOwnerEditRule,
 } from "#questpie/server/modules/core/integrated/crdt/capability.js";
 import type { SearchableConfig } from "#questpie/server/modules/core/integrated/search/types.js";
 import {
@@ -603,7 +604,7 @@ export class CollectionBuilder<TState extends CollectionBuilderState> {
 
 	/** Enable one collaborative aggregate per collection record. */
 	collaborative<TAwarenessSchema extends ZodType | undefined = undefined>(
-		config?: CrdtOwnerConfig<TAwarenessSchema>,
+		config?: CrdtOwnerConfig<TAwarenessSchema, CollectionSelect<TState>>,
 	): CollectionBuilder<
 		Override<
 			TState,
@@ -621,6 +622,19 @@ export class CollectionBuilder<TState extends CollectionBuilderState> {
 			}),
 			collaborative: {
 				awarenessSchema: config?.awareness,
+				...(config?.access
+					? {
+							editAccess: config.access.edit,
+							fieldEditAccess: Object.fromEntries(
+								Object.entries(
+									(config.access.fields ?? {}) as Record<
+										string,
+										{ edit: CrdtOwnerEditRule }
+									>,
+								).map(([path, access]) => [path, access.edit]),
+							),
+						}
+					: {}),
 			},
 		} as any;
 		return this._derive(newState);

--- a/packages/questpie/src/server/global/builder/global-builder.ts
+++ b/packages/questpie/src/server/global/builder/global-builder.ts
@@ -22,6 +22,7 @@ import {
 import type {
 	CrdtOwnerCapability,
 	CrdtOwnerConfig,
+	CrdtOwnerEditRule,
 } from "#questpie/server/modules/core/integrated/crdt/capability.js";
 import type { Override, Prettify } from "#questpie/shared/type-utils.js";
 
@@ -326,7 +327,10 @@ export class GlobalBuilder<TState extends GlobalBuilderState> {
 
 	/** Enable one collaborative aggregate for this global singleton/scope. */
 	collaborative<TAwarenessSchema extends ZodType | undefined = undefined>(
-		config?: CrdtOwnerConfig<TAwarenessSchema>,
+		config?: CrdtOwnerConfig<
+			TAwarenessSchema,
+			Global<TState>["$infer"]["select"]
+		>,
 	): GlobalBuilder<
 		Override<
 			TState,
@@ -344,6 +348,19 @@ export class GlobalBuilder<TState extends GlobalBuilderState> {
 			}),
 			collaborative: {
 				awarenessSchema: config?.awareness,
+				...(config?.access
+					? {
+							editAccess: config.access.edit,
+							fieldEditAccess: Object.fromEntries(
+								Object.entries(
+									(config.access.fields ?? {}) as Record<
+										string,
+										{ edit: CrdtOwnerEditRule }
+									>,
+								).map(([path, access]) => [path, access.edit]),
+							),
+						}
+					: {}),
 			},
 		} as any;
 		return this._derive(newState);

--- a/packages/questpie/src/server/modules/core/integrated/crdt/capability.ts
+++ b/packages/questpie/src/server/modules/core/integrated/crdt/capability.ts
@@ -1,15 +1,52 @@
 import type { output as ZodOutput, ZodType } from "zod";
 
+import type { AppContext } from "#questpie/server/config/app-context.js";
+
+export type CrdtOwnerEditContext<TRow = any> = AppContext & {
+	/** The loaded owner record whose collaborative aggregate will be edited. */
+	data: TRow;
+	/** Incoming HTTP request when authorization runs through an HTTP adapter. */
+	request?: Request;
+};
+
+export type CrdtOwnerEditRule<TRow = any> =
+	| boolean
+	| ((context: CrdtOwnerEditContext<TRow>) => boolean | Promise<boolean>);
+
+export type CrdtOwnerAccess<TRow = any> = Readonly<{
+	edit: CrdtOwnerEditRule<TRow>;
+	fields?: Partial<
+		Record<
+			Extract<keyof TRow, string>,
+			Readonly<{ edit: CrdtOwnerEditRule<TRow> }>
+		>
+	>;
+}>;
+
 export type CrdtOwnerConfig<
 	TAwarenessSchema extends ZodType | undefined = undefined,
-> = TAwarenessSchema extends ZodType
+	TRow = any,
+> = (TAwarenessSchema extends ZodType
 	? { awareness: TAwarenessSchema }
-	: { awareness?: undefined };
+	: { awareness?: undefined }) & {
+	/**
+	 * Explicit aggregate edit policy for CRDT operations. This policy receives
+	 * the current owner record but no proposed value: CRDT changes are appended
+	 * after the session grant is issued and cannot safely reuse a CRUD patch
+	 * policy. When `access` is omitted, the legacy CRUD update and field-update
+	 * policies remain in effect.
+	 */
+	access?: CrdtOwnerAccess<TRow>;
+};
 
 export type CrdtOwnerCapability<
 	TAwarenessSchema extends ZodType | undefined = undefined,
 > = Readonly<{
 	awarenessSchema: TAwarenessSchema;
+	/** Explicit CRDT aggregate edit policy, independent of ordinary CRUD update. */
+	editAccess?: CrdtOwnerEditRule;
+	/** Optional CRDT field edit policies, independent of ordinary field update. */
+	fieldEditAccess?: Readonly<Record<string, CrdtOwnerEditRule>>;
 	/** Type-only carrier used by generated aggregate APIs. */
 	awareness: TAwarenessSchema extends ZodType
 		? ZodOutput<TAwarenessSchema>

--- a/packages/questpie/src/server/modules/core/integrated/crdt/questpie-authorization.ts
+++ b/packages/questpie/src/server/modules/core/integrated/crdt/questpie-authorization.ts
@@ -171,20 +171,31 @@ export async function evaluateQuestpieCrdtOwnerPolicy(
 		return { ownerRead: false, ownerEdit: false, fields: {} };
 	}
 	let edit = false;
+	const collaborativeEdit = state.collaborative?.editAccess;
+	const collaborativeFieldEdit = state.collaborative?.fieldEditAccess;
 	try {
-		edit = await ownerAccess(
-			app,
-			state,
-			"update",
-			context,
-			record,
-			Object.freeze({}),
-			owner.kind === "collection",
-			database,
-			table,
-			i18nTable,
-			crdtFields,
-		);
+		edit =
+			collaborativeEdit !== undefined
+				? await explicitCollaborativeEdit(
+						app,
+						collaborativeEdit,
+						context,
+						record,
+						database,
+					)
+				: await ownerAccess(
+						app,
+						state,
+						"update",
+						context,
+						record,
+						Object.freeze({}),
+						owner.kind === "collection",
+						database,
+						table,
+						i18nTable,
+						crdtFields,
+					);
 	} catch {
 		edit = false;
 	}
@@ -206,21 +217,57 @@ export async function evaluateQuestpieCrdtOwnerPolicy(
 			: (app.crdtRegistry.globals[owner.key]?.fields ?? {}),
 	)) {
 		const readField = !restricted.has(path);
-		const editField =
-			readField &&
-			edit &&
-			(await checkFieldWriteAccess(
-				path,
-				fieldAccess,
-				context,
-				{ app, db: database },
-				"update",
-				record,
-			));
+		let editField = false;
+		if (readField && edit) {
+			const explicitFieldRule = collaborativeFieldEdit?.[path];
+			editField =
+				collaborativeEdit !== undefined
+					? explicitFieldRule === undefined ||
+						(await explicitCollaborativeEdit(
+							app,
+							explicitFieldRule,
+							context,
+							record,
+							database,
+						))
+					: await checkFieldWriteAccess(
+							path,
+							fieldAccess,
+							context,
+							{ app, db: database },
+							"update",
+							record,
+						);
+		}
 		fields[path] = { read: readField, edit: editField };
 	}
 	return { ownerRead: true, ownerEdit: edit, fields };
 }
+
+async function explicitCollaborativeEdit(
+	app: Questpie<any>,
+	rule: NonNullable<CrdtOwnerCapabilityLike["editAccess"]>,
+	context: CRUDContext,
+	record: Record<string, unknown>,
+	database: Questpie<any>["db"],
+): Promise<boolean> {
+	const result = await executeAccessRule(rule, {
+		app,
+		db: database,
+		session: context.session,
+		principal: context.principal,
+		actor: context.actor,
+		locale: context.locale,
+		row: record,
+		request: (context as CRUDContext & { request?: Request }).request,
+		contextExtensions: context["~contextExtensions"],
+	});
+	return result === true;
+}
+
+type CrdtOwnerCapabilityLike = NonNullable<
+	CollectionBuilderState["collaborative"]
+>;
 
 async function ownerAccess(
 	app: Questpie<any>,

--- a/packages/questpie/test/crdt/security/questpie-authorization.test.ts
+++ b/packages/questpie/test/crdt/security/questpie-authorization.test.ts
@@ -143,6 +143,31 @@ const setDocuments = collection("crdt_set_policy_documents")
 		read: () => ({ tags: { containsAll: ["allowed"] } }),
 		update: true,
 	});
+const shapedUpdateDocuments = collection("crdt_shaped_update_documents")
+	.fields(({ f }) => ({
+		content: f
+			.textarea()
+			.required()
+			.default("")
+			.crdt({ format: "text" })
+			.access({ update: false }),
+	}))
+	.collaborative({
+		access: {
+			edit: ({ data }) => data.content !== "owner-locked",
+			fields: { content: { edit: ({ data }) => data.content === "" } },
+		},
+	})
+	.access({
+		read: true,
+		update: ({ input }) =>
+			Boolean(
+				input &&
+				typeof input === "object" &&
+				Object.keys(input).length === 1 &&
+				(input as Record<string, unknown>).content === "",
+			),
+	});
 const textEngine = createDeterministicTextEngine();
 const crdtConfig = {
 	namespace: "crdt-policy-test",
@@ -159,6 +184,7 @@ const registry = createCrdtRegistry({
 		crdt_raw_policy_documents: rawDocuments.build(),
 		crdt_empty_relation_nodes: emptyRelationNodes.build(),
 		crdt_set_policy_documents: setDocuments.build(),
+		crdt_shaped_update_documents: shapedUpdateDocuments.build(),
 	},
 	globals: {},
 });
@@ -187,6 +213,7 @@ describe("QUESTPIE CRDT owner policy", () => {
 					crdt_raw_policy_documents: rawDocuments,
 					crdt_empty_relation_nodes: emptyRelationNodes,
 					crdt_set_policy_documents: setDocuments,
+					crdt_shaped_update_documents: shapedUpdateDocuments,
 				},
 				crdtManifest: manifest,
 			},
@@ -259,6 +286,70 @@ describe("QUESTPIE CRDT owner policy", () => {
 			ownerEdit: false,
 			fields: {},
 		});
+	});
+
+	it("keeps explicit CRDT edit policy independent from ordinary update policy", async () => {
+		const created =
+			await setup.app.collections.crdt_shaped_update_documents.create(
+				{},
+				createTestContext(),
+			);
+		const owner = {
+			kind: "collection" as const,
+			key: "crdt_shaped_update_documents",
+			ownerKey: "crdt_shaped_update_documents",
+			id: created.id,
+			locator: canonicalCrdtCollectionLocator(created.id),
+		};
+		const record = await loadQuestpieCrdtOwnerRecord(setup.app, owner);
+
+		await expect(
+			evaluateQuestpieCrdtOwnerPolicy(
+				setup.app,
+				owner,
+				record!,
+				createTestContext({ accessMode: "user" }),
+			),
+		).resolves.toMatchObject({
+			ownerRead: true,
+			ownerEdit: true,
+			fields: { content: { read: true, edit: true } },
+		});
+		await expect(
+			evaluateQuestpieCrdtOwnerPolicy(
+				setup.app,
+				owner,
+				{ ...record!, content: "locked" },
+				createTestContext({ accessMode: "user" }),
+			),
+		).resolves.toMatchObject({
+			ownerRead: true,
+			ownerEdit: true,
+			fields: { content: { read: true, edit: false } },
+		});
+		await expect(
+			evaluateQuestpieCrdtOwnerPolicy(
+				setup.app,
+				owner,
+				{ ...record!, content: "owner-locked" },
+				createTestContext({ accessMode: "user" }),
+			),
+		).resolves.toMatchObject({
+			ownerRead: true,
+			ownerEdit: false,
+			fields: { content: { read: true, edit: false } },
+		});
+
+		await expect(
+			setup.app.collections.crdt_shaped_update_documents.updateById(
+				{
+					id: created.id,
+					expectedRevision: created.revision,
+					data: { content: "" } as never,
+				},
+				createTestContext({ accessMode: "user" }),
+			),
+		).rejects.toThrow("cannot be changed through ordinary CRUD");
 	});
 
 	it("keeps a nested logically empty OR access predicate denied", async () => {


### PR DESCRIPTION
## Summary

- add explicit owner and field edit policies to `.collaborative({ access })`
- keep CRDT authorization independent from ordinary CRUD patch semantics
- preserve legacy CRUD access behavior when the explicit policy is absent
- prove ordinary CRUD still rejects CRDT-managed fields

## Verification

- `bun run --cwd packages/questpie check-types`
- `QUESTPIE_MIGRATIONS_SILENT=1 bun test --max-concurrency=1 --timeout=60000 ./packages/questpie/test/crdt/codegen.test.ts ./packages/questpie/test/crdt/security` (35 pass)
- focused Oxlint and Oxfmt checks
- cross-model adversarial review: no remaining findings