### PR TITLE
chore: release CRDT edit access

### DIFF
--- a/.changeset/fancy-eagles-invent.md
+++ b/.changeset/fancy-eagles-invent.md
@@ -1,0 +1,5 @@
+---
+"questpie": patch
+---
+
+Add explicit owner and field authorization policies for CRDT edits.


### PR DESCRIPTION
Add the patch changeset for the explicit CRDT owner and field authorization seam merged in #328.

The implementation PR passed all 7 CI checks.