### PR TITLE
feat(auth): add transaction-safe password recovery

### DIFF
--- a/.changeset/bright-pandas-recover.md
+++ b/.changeset/bright-pandas-recover.md
@@ -1,0 +1,5 @@
+---
+"questpie": patch
+---
+
+Add transaction-safe password recovery with hashed reset credentials, a token-free browser challenge, session and trusted-device revocation, durable notification dispatch, and neutral request state.

--- a/packages/questpie/src/exports/auth.ts
+++ b/packages/questpie/src/exports/auth.ts
@@ -17,6 +17,11 @@ export {
 	type AuthTransactionalQueueTransaction,
 	withAuthTransactionalQueue,
 } from "#questpie/server/modules/core/integrated/auth/transactional-queue.js";
+export {
+	passwordRecovery,
+	type PasswordRecoveryDispatchContext,
+	type PasswordRecoveryOptions,
+} from "#questpie/server/modules/core/integrated/auth/password-recovery.js";
 export type { AuthConfig } from "#questpie/server/config/module-types.js";
 export {
 	type AccessRuleEvaluationContext,

--- a/packages/questpie/src/server/modules/core/integrated/auth/password-recovery.ts
+++ b/packages/questpie/src/server/modules/core/integrated/auth/password-recovery.ts
@@ -1,0 +1,577 @@
+import { createHash, randomBytes } from "node:crypto";
+
+import type { BetterAuthPlugin, DBTransactionAdapter } from "better-auth";
+import { APIError } from "better-auth/api";
+import { createAuthEndpoint, createAuthMiddleware } from "better-auth/api";
+import { z } from "zod";
+
+import type { AuthTransactionalQueuePublish } from "./transactional-queue.js";
+import { withAuthTransactionalQueue } from "./transactional-queue.js";
+
+const REQUEST_STATE_COOKIE = "password_recovery_request";
+const CHALLENGE_COOKIE = "password_recovery_challenge";
+const RESET_PREFIX = "questpie-password-recovery:reset:";
+const CHALLENGE_PREFIX = "questpie-password-recovery:challenge:";
+const REQUEST_PREFIX = "questpie-password-recovery:request:";
+
+type AuthUser = {
+	id: string;
+	email: string;
+	name: string;
+	emailVerified: boolean;
+} & Record<string, unknown>;
+
+export interface PasswordRecoveryDispatchContext {
+	publish: AuthTransactionalQueuePublish;
+}
+
+export interface PasswordRecoveryOptions<TUser extends AuthUser = AuthUser> {
+	resetPath?: string;
+	resetTokenTtlSeconds?: number;
+	challengeTtlSeconds?: number;
+	resendCooldownSeconds?: number;
+	deliverResetLink: (
+		input: {
+			user: TUser | null;
+			exchangeUrl: string | null;
+			idempotencyKey: string;
+		},
+		context: PasswordRecoveryDispatchContext,
+	) => Promise<void>;
+	/**
+	 * Validate and optionally normalize the candidate before hashing. When set,
+	 * this callback owns the complete password policy; when omitted, Better
+	 * Auth's configured minimum and maximum are enforced.
+	 */
+	preparePassword?: (input: {
+		password: string;
+		user: TUser;
+	}) => Promise<string>;
+	notifyResetCommitted: (
+		input: {
+			user: TUser;
+			occurredAt: Date;
+			idempotencyKey: string;
+		},
+		context: PasswordRecoveryDispatchContext,
+	) => Promise<void>;
+}
+
+type VerificationRow = {
+	identifier: string;
+	value: string;
+	expiresAt: Date;
+};
+
+type AccountRow = { id: string; userId: string; providerId: string };
+
+type RequestState = {
+	email: string;
+	maskedEmail: string;
+	retryAt: string;
+};
+
+const token = () => randomBytes(32).toString("base64url");
+const digest = (value: string) =>
+	createHash("sha256").update(value).digest("base64url");
+const identifier = (prefix: string, value: string) =>
+	`${prefix}${digest(value)}`;
+
+function maskEmail(email: string): string {
+	const separator = email.lastIndexOf("@");
+	if (separator < 1) return "•••";
+	const local = email.slice(0, separator);
+	const domain = email.slice(separator + 1);
+	return `${local.slice(0, Math.min(2, local.length))}•••@${domain}`;
+}
+
+function expiry(seconds: number): Date {
+	return new Date(Date.now() + seconds * 1_000);
+}
+
+async function createVerification(
+	auth: DBTransactionAdapter,
+	data: VerificationRow,
+): Promise<void> {
+	await auth.create({ model: "verification", data });
+}
+
+async function findCredentialIdentity(
+	auth: DBTransactionAdapter,
+	email: string,
+): Promise<AuthUser | null> {
+	const user = await auth.findOne<AuthUser>({
+		model: "user",
+		where: [{ field: "email", value: email }],
+	});
+	const account = await auth.findOne<AccountRow>({
+		model: "account",
+		where: [
+			{ field: "userId", value: user?.id ?? digest(email) },
+			{ field: "providerId", value: "credential" },
+		],
+	});
+	return user?.emailVerified && account ? user : null;
+}
+
+/**
+ * Add token-free, transaction-safe password recovery to a Better Auth instance.
+ *
+ * Reset tokens and browser challenge handles are hashed before persistence. The
+ * credential write, session/trusted-device revocation and durable notification
+ * publication share one adapter transaction.
+ */
+export function passwordRecovery<TUser extends AuthUser = AuthUser>(
+	options: PasswordRecoveryOptions<TUser>,
+): BetterAuthPlugin {
+	const resetPath = options.resetPath ?? "/reset-password";
+	const resetTtl = options.resetTokenTtlSeconds ?? 3_600;
+	const challengeTtl = options.challengeTtlSeconds ?? 900;
+	const cooldown = options.resendCooldownSeconds ?? 60;
+	const issueResetLink = async (input: {
+		auth: DBTransactionAdapter;
+		publish: AuthTransactionalQueuePublish;
+		email: string;
+		baseURL: string;
+		hashForTiming: (value: string) => Promise<string>;
+	}) => {
+		const resetToken = token();
+		await input.hashForTiming(resetToken);
+		const user = await findCredentialIdentity(input.auth, input.email);
+		await createVerification(input.auth, {
+			identifier: identifier(RESET_PREFIX, resetToken),
+			value: user?.id ?? `unavailable:${digest(resetToken)}`,
+			expiresAt: expiry(resetTtl),
+		});
+		const idempotencyKey = `password-recovery-link:${digest(resetToken)}`;
+		await options.deliverResetLink(
+			{
+				user: user ? (user as TUser) : null,
+				exchangeUrl: user
+					? `${input.baseURL}/password-recovery/exchange?token=${encodeURIComponent(resetToken)}`
+					: null,
+				idempotencyKey,
+			},
+			{ publish: input.publish },
+		);
+	};
+
+	const request = createAuthEndpoint(
+		"/password-recovery/request",
+		{
+			method: "POST",
+			body: z.object({ email: z.email() }),
+		},
+		async (ctx) => {
+			const email = ctx.body.email.toLowerCase();
+			const stateHandle = token();
+			const retryAt = new Date(Date.now() + cooldown * 1_000);
+			await withAuthTransactionalQueue(ctx, async ({ auth, publish }) => {
+				await issueResetLink({
+					auth,
+					publish,
+					email,
+					baseURL: ctx.context.baseURL,
+					hashForTiming: (value) => ctx.context.password.hash(value),
+				});
+				await createVerification(auth, {
+					identifier: identifier(REQUEST_PREFIX, stateHandle),
+					value: JSON.stringify({
+						email,
+						maskedEmail: maskEmail(email),
+						retryAt: retryAt.toISOString(),
+					}),
+					expiresAt: expiry(Math.max(resetTtl, cooldown)),
+				});
+			});
+			const stateCookie = ctx.context.createAuthCookie(REQUEST_STATE_COOKIE, {
+				httpOnly: true,
+				sameSite: "lax",
+				path: "/",
+				maxAge: Math.max(resetTtl, cooldown),
+			});
+			await ctx.setSignedCookie(
+				stateCookie.name,
+				stateHandle,
+				ctx.context.secret,
+				stateCookie.attributes,
+			);
+			return ctx.json({ status: true });
+		},
+	);
+
+	const requestState = createAuthEndpoint(
+		"/password-recovery/request-state",
+		{ method: "GET" },
+		async (ctx) => {
+			const stateCookie = ctx.context.createAuthCookie(REQUEST_STATE_COOKIE);
+			const handle = await ctx.getSignedCookie(
+				stateCookie.name,
+				ctx.context.secret,
+			);
+			if (!handle) return ctx.json({ status: "missing" as const });
+			const row = await ctx.context.adapter.findOne<VerificationRow>({
+				model: "verification",
+				where: [
+					{ field: "identifier", value: identifier(REQUEST_PREFIX, handle) },
+				],
+			});
+			if (!row || new Date(row.expiresAt) <= new Date()) {
+				ctx.setCookie(stateCookie.name, "", {
+					...stateCookie.attributes,
+					maxAge: 0,
+				});
+				return ctx.json({ status: "missing" as const });
+			}
+			const state = JSON.parse(row.value) as RequestState;
+			return ctx.json({
+				status: "ready" as const,
+				maskedEmail: state.maskedEmail,
+				retryAt: state.retryAt,
+			});
+		},
+	);
+
+	const resend = createAuthEndpoint(
+		"/password-recovery/resend",
+		{ method: "POST" },
+		async (ctx) => {
+			const stateCookie = ctx.context.createAuthCookie(REQUEST_STATE_COOKIE);
+			const handle = await ctx.getSignedCookie(
+				stateCookie.name,
+				ctx.context.secret,
+			);
+			if (!handle)
+				throw APIError.from("BAD_REQUEST", {
+					code: "PASSWORD_RECOVERY_REQUEST_MISSING",
+					message: "Password recovery request is missing",
+				});
+			const nextRetryAt = new Date(Date.now() + cooldown * 1_000);
+			const outcome = await withAuthTransactionalQueue(
+				ctx,
+				async ({ auth, publish }) => {
+					const stateRow = await auth.consumeOne<VerificationRow>({
+						model: "verification",
+						where: [
+							{
+								field: "identifier",
+								value: identifier(REQUEST_PREFIX, handle),
+							},
+							{ field: "expiresAt", operator: "gt", value: new Date() },
+						],
+					});
+					if (!stateRow) return { status: "missing" as const };
+					const state = JSON.parse(stateRow.value) as RequestState;
+					if (new Date(state.retryAt) > new Date()) {
+						await createVerification(auth, {
+							identifier: stateRow.identifier,
+							value: stateRow.value,
+							expiresAt: stateRow.expiresAt,
+						});
+						return { status: "cooldown" as const, retryAt: state.retryAt };
+					}
+					await issueResetLink({
+						auth,
+						publish,
+						email: state.email,
+						baseURL: ctx.context.baseURL,
+						hashForTiming: (value) => ctx.context.password.hash(value),
+					});
+					await createVerification(auth, {
+						identifier: stateRow.identifier,
+						value: JSON.stringify({
+							...state,
+							retryAt: nextRetryAt.toISOString(),
+						}),
+						expiresAt: stateRow.expiresAt,
+					});
+					return {
+						status: "ready" as const,
+						retryAt: nextRetryAt.toISOString(),
+					};
+				},
+			);
+			if (outcome.status === "missing")
+				throw APIError.from("BAD_REQUEST", {
+					code: "PASSWORD_RECOVERY_REQUEST_MISSING",
+					message: "Password recovery request is missing",
+				});
+			if (outcome.status === "cooldown") {
+				return new Response(
+					JSON.stringify({
+						status: "cooldown" as const,
+						retryAt: outcome.retryAt,
+					}),
+					{
+						status: 429,
+						headers: {
+							"cache-control": "no-store",
+							"content-type": "application/json; charset=utf-8",
+						},
+					},
+				);
+			}
+			return ctx.json({ status: true, retryAt: outcome.retryAt });
+		},
+	);
+
+	const exchange = createAuthEndpoint(
+		"/password-recovery/exchange",
+		{ method: "GET", query: z.object({ token: z.string().optional() }) },
+		async (ctx) => {
+			if (
+				!ctx.query.token ||
+				ctx.query.token.length < 32 ||
+				ctx.query.token.length > 128
+			) {
+				ctx.setHeader("cache-control", "no-store");
+				ctx.setHeader("referrer-policy", "no-referrer");
+				throw ctx.redirect("/forgot-password?reason=invalid");
+			}
+			const resetToken = ctx.query.token;
+			const challenge = token();
+			const exchanged = await ctx.context.adapter.transaction(async (auth) => {
+				const reset = await auth.consumeOne<VerificationRow>({
+					model: "verification",
+					where: [
+						{
+							field: "identifier",
+							value: identifier(RESET_PREFIX, resetToken),
+						},
+						{ field: "expiresAt", operator: "gt", value: new Date() },
+					],
+				});
+				if (!reset) return false;
+				await createVerification(auth, {
+					identifier: identifier(CHALLENGE_PREFIX, challenge),
+					value: reset.value,
+					expiresAt: expiry(challengeTtl),
+				});
+				return true;
+			});
+			const location = exchanged
+				? resetPath
+				: "/forgot-password?reason=invalid";
+			if (exchanged) {
+				const challengeCookie = ctx.context.createAuthCookie(CHALLENGE_COOKIE, {
+					httpOnly: true,
+					sameSite: "lax",
+					path: "/",
+					maxAge: challengeTtl,
+				});
+				await ctx.setSignedCookie(
+					challengeCookie.name,
+					challenge,
+					ctx.context.secret,
+					challengeCookie.attributes,
+				);
+			}
+			ctx.setHeader("cache-control", "no-store");
+			ctx.setHeader("referrer-policy", "no-referrer");
+			throw ctx.redirect(location);
+		},
+	);
+
+	const challengeState = createAuthEndpoint(
+		"/password-recovery/challenge-state",
+		{ method: "GET" },
+		async (ctx) => {
+			const challengeCookie = ctx.context.createAuthCookie(CHALLENGE_COOKIE);
+			const handle = await ctx.getSignedCookie(
+				challengeCookie.name,
+				ctx.context.secret,
+			);
+			if (!handle) return ctx.json({ status: "invalid" as const });
+			const row = await ctx.context.adapter.findOne<VerificationRow>({
+				model: "verification",
+				where: [
+					{ field: "identifier", value: identifier(CHALLENGE_PREFIX, handle) },
+					{ field: "expiresAt", operator: "gt", value: new Date() },
+				],
+			});
+			return ctx.json({
+				status: row ? ("ready" as const) : ("invalid" as const),
+			});
+		},
+	);
+
+	const commit = createAuthEndpoint(
+		"/password-recovery/commit",
+		{
+			method: "POST",
+			body: z.object({ newPassword: z.string() }),
+		},
+		async (ctx) => {
+			const challengeCookie = ctx.context.createAuthCookie(CHALLENGE_COOKIE);
+			const handle = await ctx.getSignedCookie(
+				challengeCookie.name,
+				ctx.context.secret,
+			);
+			if (!handle)
+				throw APIError.from("BAD_REQUEST", {
+					code: "INVALID_PASSWORD_RECOVERY_CHALLENGE",
+					message: "Invalid password recovery challenge",
+				});
+			const challenge = await ctx.context.adapter.findOne<VerificationRow>({
+				model: "verification",
+				where: [
+					{ field: "identifier", value: identifier(CHALLENGE_PREFIX, handle) },
+					{ field: "expiresAt", operator: "gt", value: new Date() },
+				],
+			});
+			const recoveryUser = challenge
+				? await ctx.context.adapter.findOne<AuthUser>({
+						model: "user",
+						where: [{ field: "id", value: challenge.value }],
+					})
+				: null;
+			if (!recoveryUser)
+				throw APIError.from("BAD_REQUEST", {
+					code: "INVALID_PASSWORD_RECOVERY_CHALLENGE",
+					message: "Invalid password recovery challenge",
+				});
+			const preparedPassword = options.preparePassword
+				? await options.preparePassword({
+						password: ctx.body.newPassword,
+						user: recoveryUser as TUser,
+					})
+				: ctx.body.newPassword;
+			if (!options.preparePassword) {
+				const minimum = ctx.context.password.config.minPasswordLength;
+				const maximum = ctx.context.password.config.maxPasswordLength;
+				if (preparedPassword.length < minimum)
+					throw APIError.from("BAD_REQUEST", {
+						code: "PASSWORD_TOO_SHORT",
+						message: "Password is too short",
+					});
+				if (preparedPassword.length > maximum)
+					throw APIError.from("BAD_REQUEST", {
+						code: "PASSWORD_TOO_LONG",
+						message: "Password is too long",
+					});
+			}
+			const hashedPassword = await ctx.context.password.hash(preparedPassword);
+			await withAuthTransactionalQueue(ctx, async ({ auth, publish }) => {
+				const challenge = await auth.consumeOne<VerificationRow>({
+					model: "verification",
+					where: [
+						{
+							field: "identifier",
+							value: identifier(CHALLENGE_PREFIX, handle),
+						},
+						{ field: "expiresAt", operator: "gt", value: new Date() },
+					],
+				});
+				if (!challenge)
+					throw APIError.from("BAD_REQUEST", {
+						code: "INVALID_PASSWORD_RECOVERY_CHALLENGE",
+						message: "Invalid password recovery challenge",
+					});
+				const account = await auth.findOne<AccountRow>({
+					model: "account",
+					where: [
+						{ field: "userId", value: challenge.value },
+						{ field: "providerId", value: "credential" },
+					],
+				});
+				const user = await auth.findOne<AuthUser>({
+					model: "user",
+					where: [{ field: "id", value: challenge.value }],
+				});
+				if (!account || !user)
+					throw APIError.from("BAD_REQUEST", {
+						code: "INVALID_PASSWORD_RECOVERY_CHALLENGE",
+						message: "Invalid password recovery challenge",
+					});
+				await auth.update({
+					model: "account",
+					where: [{ field: "id", value: account.id }],
+					update: { password: hashedPassword },
+				});
+				await auth.deleteMany({
+					model: "session",
+					where: [{ field: "userId", value: user.id }],
+				});
+				await auth.deleteMany({
+					model: "verification",
+					where: [
+						{ field: "value", value: user.id },
+						{
+							field: "identifier",
+							operator: "starts_with",
+							value: "trust-device-",
+						},
+					],
+				});
+				for (const recoveryPrefix of [RESET_PREFIX, CHALLENGE_PREFIX]) {
+					await auth.deleteMany({
+						model: "verification",
+						where: [
+							{ field: "value", value: user.id },
+							{
+								field: "identifier",
+								operator: "starts_with",
+								value: recoveryPrefix,
+							},
+						],
+					});
+				}
+				const occurredAt = new Date();
+				const idempotencyKey = `password-recovery-committed:${digest(handle)}`;
+				await options.notifyResetCommitted(
+					{ user: user as TUser, occurredAt, idempotencyKey },
+					{ publish },
+				);
+			});
+			ctx.setCookie(challengeCookie.name, "", {
+				...challengeCookie.attributes,
+				maxAge: 0,
+			});
+			return ctx.json({ status: true });
+		},
+	);
+
+	return {
+		id: "questpie-password-recovery",
+		endpoints: {
+			request,
+			requestState,
+			resend,
+			exchange,
+			challengeState,
+			commit,
+		},
+		rateLimit: [
+			{
+				pathMatcher: (path) => path === "/password-recovery/request",
+				window: 60,
+				max: 3,
+			},
+			{
+				pathMatcher: (path) => path === "/password-recovery/resend",
+				window: 60,
+				max: 3,
+			},
+			{
+				pathMatcher: (path) => path === "/password-recovery/commit",
+				window: 60,
+				max: 5,
+			},
+		],
+		hooks: {
+			before: [
+				{
+					matcher: (ctx) =>
+						ctx.path === "/reset-password" ||
+						ctx.path === "/request-password-reset",
+					handler: createAuthMiddleware(async () => {
+						throw APIError.from("NOT_FOUND", {
+							code: "PASSWORD_RECOVERY_ROUTE_DISABLED",
+							message: "Password recovery route disabled",
+						});
+					}),
+				},
+			],
+		},
+	};
+}

--- a/packages/questpie/test/integration/password-recovery.test.ts
+++ b/packages/questpie/test/integration/password-recovery.test.ts
@@ -1,0 +1,463 @@
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	setDefaultTimeout,
+	test,
+} from "bun:test";
+
+import { z } from "zod";
+
+import { passwordRecovery } from "../../src/exports/auth.js";
+import { job } from "../../src/exports/index.js";
+import account from "../../src/server/modules/starter/collections/account.js";
+import assets from "../../src/server/modules/starter/collections/assets.js";
+import session from "../../src/server/modules/starter/collections/session.js";
+import user from "../../src/server/modules/starter/collections/user.js";
+import verification from "../../src/server/modules/starter/collections/verification.js";
+import { buildMockApp } from "../utils/mocks/mock-app-builder.js";
+import { runTestDbMigrations } from "../utils/test-db.js";
+
+const resetEmail = job({
+	name: "password-recovery-link",
+	schema: z.object({
+		userId: z.string().nullable(),
+		exchangeUrl: z.string().nullable(),
+	}),
+	handler: async () => {},
+});
+
+const securityEmail = job({
+	name: "password-recovery-committed",
+	schema: z.object({ userId: z.string(), occurredAt: z.string() }),
+	handler: async () => {},
+});
+
+type VerificationRowForTest = {
+	identifier: string;
+	value: string;
+	expiresAt: Date;
+};
+
+setDefaultTimeout(30_000);
+
+describe("passwordRecovery", () => {
+	let setup: Awaited<ReturnType<typeof buildMockApp>>;
+	let dispatchedExchangeUrl: string | undefined;
+	let failSecurityDispatch = false;
+
+	beforeEach(async () => {
+		dispatchedExchangeUrl = undefined;
+		failSecurityDispatch = false;
+		setup = await buildMockApp(
+			{
+				collections: { user, account, session, verification, assets },
+				jobs: { resetEmail, securityEmail },
+				auth: {
+					emailAndPassword: {
+						enabled: true,
+						minPasswordLength: 8,
+						maxPasswordLength: 128,
+					},
+					plugins: [
+						passwordRecovery({
+							deliverResetLink: async (
+								{ user, exchangeUrl, idempotencyKey },
+								{ publish },
+							) => {
+								dispatchedExchangeUrl = exchangeUrl ?? undefined;
+								await publish(
+									resetEmail,
+									{ userId: user?.id ?? null, exchangeUrl },
+									{ idempotencyKey },
+								);
+							},
+							notifyResetCommitted: async (
+								{ user, occurredAt, idempotencyKey },
+								{ publish },
+							) => {
+								if (failSecurityDispatch)
+									throw new Error("security dispatch unavailable");
+								await publish(
+									securityEmail,
+									{ userId: user.id, occurredAt: occurredAt.toISOString() },
+									{ idempotencyKey },
+								);
+							},
+						}),
+					],
+				},
+			},
+			{ secret: "test-password-recovery-secret-at-least-32-bytes" },
+		);
+		await runTestDbMigrations(setup.app);
+	});
+
+	afterEach(async () => {
+		await setup?.cleanup();
+	});
+
+	const request = (path: string, init?: RequestInit) =>
+		setup.app.auth.handler(
+			new Request(`http://localhost:3000/api/auth${path}`, {
+				...init,
+				headers: {
+					origin: "http://localhost:3000",
+					...(init?.body ? { "content-type": "application/json" } : {}),
+					...init?.headers,
+				},
+			}),
+		);
+
+	async function seedCredentialIdentity(
+		userId: string,
+		email: string,
+		password: string,
+	) {
+		const context = await setup.app.auth.$context;
+		await context.adapter.create({
+			model: "user",
+			forceAllowId: true,
+			data: {
+				id: userId,
+				email,
+				name: "Owner",
+				emailVerified: true,
+				createdAt: new Date(),
+				updatedAt: new Date(),
+			},
+		});
+		await context.adapter.create({
+			model: "account",
+			data: {
+				userId,
+				accountId: userId,
+				providerId: "credential",
+				password: await context.password.hash(password),
+				createdAt: new Date(),
+				updatedAt: new Date(),
+			},
+		});
+		return context;
+	}
+
+	test("exchanges a hashed one-use token and commits password, revocation and notification once", async () => {
+		const userId = "password-recovery-user";
+		const context = await seedCredentialIdentity(
+			userId,
+			"owner@example.test",
+			"old-password",
+		);
+		await context.adapter.create({
+			model: "session",
+			data: {
+				userId,
+				token: "old-session",
+				expiresAt: new Date(Date.now() + 60_000),
+				createdAt: new Date(),
+				updatedAt: new Date(),
+			},
+		});
+		await context.adapter.create({
+			model: "verification",
+			data: {
+				identifier: "trust-device-existing",
+				value: userId,
+				expiresAt: new Date(Date.now() + 60_000),
+				createdAt: new Date(),
+				updatedAt: new Date(),
+			},
+		});
+		await context.adapter.create({
+			model: "verification",
+			data: {
+				identifier: "2fa-otp-existing",
+				value: userId,
+				expiresAt: new Date(Date.now() + 60_000),
+				createdAt: new Date(),
+				updatedAt: new Date(),
+			},
+		});
+		await context.adapter.create({
+			model: "account",
+			data: {
+				userId,
+				accountId: "oauth-subject",
+				providerId: "github",
+				createdAt: new Date(),
+				updatedAt: new Date(),
+			},
+		});
+
+		const requested = await request("/password-recovery/request", {
+			method: "POST",
+			body: JSON.stringify({ email: "owner@example.test" }),
+		});
+		expect(requested.status).toBe(200);
+		expect(await requested.json()).toEqual({ status: true });
+		const requestStateCookie = requested.headers
+			.get("set-cookie")
+			?.split(";")[0];
+		expect(requestStateCookie).toContain("password_recovery_request=");
+		const state = await request("/password-recovery/request-state", {
+			headers: { cookie: requestStateCookie! },
+		});
+		expect(await state.json()).toMatchObject({
+			status: "ready",
+			maskedEmail: "ow•••@example.test",
+		});
+		const earlyResend = await request("/password-recovery/resend", {
+			method: "POST",
+			headers: { cookie: requestStateCookie! },
+		});
+		const earlyResendBody = await earlyResend.json();
+		expect(earlyResendBody).toMatchObject({ status: "cooldown" });
+		expect(earlyResend.status).toBe(429);
+		const requestStateRow = (
+			await context.adapter.findMany<VerificationRowForTest>({
+				model: "verification",
+			})
+		).find((row) => row.value.includes('"email":"owner@example.test"'));
+		expect(requestStateRow).toBeDefined();
+		const requestStateValue = JSON.parse(requestStateRow!.value) as Record<
+			string,
+			unknown
+		>;
+		await context.adapter.update({
+			model: "verification",
+			where: [{ field: "identifier", value: requestStateRow!.identifier }],
+			update: {
+				value: JSON.stringify({
+					...requestStateValue,
+					retryAt: new Date(0).toISOString(),
+				}),
+			},
+		});
+		const racingResends = await Promise.all(
+			["first", "second"].map(() =>
+				request("/password-recovery/resend", {
+					method: "POST",
+					headers: { cookie: requestStateCookie! },
+				}),
+			),
+		);
+		expect(
+			racingResends.filter((response) => response.status === 200),
+		).toHaveLength(1);
+		const resetDispatch = setup.app.mocks.queue
+			.getJobs()
+			.find((entry) => entry.name === resetEmail.name);
+		expect(resetDispatch).toBeDefined();
+		expect(
+			setup.app.mocks.queue
+				.getJobs()
+				.filter((entry) => entry.name === resetEmail.name),
+		).toHaveLength(2);
+		const exchangeUrl = dispatchedExchangeUrl;
+		expect(exchangeUrl).toStartWith(
+			"http://localhost:3000/api/auth/password-recovery/exchange?token=",
+		);
+		const rawToken = new URL(exchangeUrl!).searchParams.get("token");
+		expect(rawToken).toBeString();
+		const persisted = await context.adapter.findMany<{ identifier: string }>({
+			model: "verification",
+		});
+		expect(JSON.stringify(persisted)).not.toContain(rawToken!);
+
+		const exchanged = await request(
+			`/password-recovery/exchange?token=${encodeURIComponent(rawToken!)}`,
+			{ redirect: "manual" },
+		);
+		expect(exchanged.status).toBeGreaterThanOrEqual(300);
+		expect(exchanged.status).toBeLessThan(400);
+		expect(exchanged.headers.get("location")).toBe("/reset-password");
+		expect(exchanged.headers.get("cache-control")).toBe("no-store");
+		expect(exchanged.headers.get("referrer-policy")).toBe("no-referrer");
+		const challengeCookie = exchanged.headers.get("set-cookie")?.split(";")[0];
+		expect(challengeCookie).toContain("password_recovery_challenge=");
+		for (const invalidUrl of [
+			"/password-recovery/exchange?token=short",
+			`/password-recovery/exchange?token=${encodeURIComponent(rawToken!)}`,
+		]) {
+			const invalid = await request(invalidUrl, { redirect: "manual" });
+			expect(invalid.status).toBeGreaterThanOrEqual(300);
+			expect(invalid.status).toBeLessThan(400);
+			expect(invalid.headers.get("location")).toBe(
+				"/forgot-password?reason=invalid",
+			);
+		}
+
+		const commits = await Promise.all(
+			["first", "second"].map(() =>
+				request("/password-recovery/commit", {
+					method: "POST",
+					headers: { cookie: challengeCookie! },
+					body: JSON.stringify({ newPassword: "new-password" }),
+				}),
+			),
+		);
+		expect(commits.filter((response) => response.status === 200)).toHaveLength(
+			1,
+		);
+		expect(commits.filter((response) => response.status === 400)).toHaveLength(
+			1,
+		);
+		expect(
+			await context.adapter.findMany({
+				model: "session",
+				where: [{ field: "userId", value: userId }],
+			}),
+		).toEqual([]);
+		expect(
+			await context.adapter.findOne({
+				model: "verification",
+				where: [{ field: "identifier", value: "2fa-otp-existing" }],
+			}),
+		).not.toBeNull();
+		expect(
+			await context.adapter.findOne({
+				model: "account",
+				where: [
+					{ field: "userId", value: userId },
+					{ field: "providerId", value: "github" },
+				],
+			}),
+		).not.toBeNull();
+		expect(
+			await context.adapter.findMany({
+				model: "verification",
+				where: [
+					{
+						field: "identifier",
+						operator: "starts_with",
+						value: "trust-device-",
+					},
+				],
+			}),
+		).toEqual([]);
+		expect(
+			setup.app.mocks.queue
+				.getJobs()
+				.filter((entry) => entry.name === securityEmail.name),
+		).toHaveLength(1);
+		const credential = await context.adapter.findOne<{ password: string }>({
+			model: "account",
+			where: [
+				{ field: "userId", value: userId },
+				{ field: "providerId", value: "credential" },
+			],
+		});
+		expect(
+			await context.password.verify({
+				hash: credential!.password,
+				password: "new-password",
+			}),
+		).toBe(true);
+		expect(
+			await context.password.verify({
+				hash: credential!.password,
+				password: "old-password",
+			}),
+		).toBe(false);
+	});
+
+	test("returns the same public request result for unknown and social-only identities", async () => {
+		const context = await setup.app.auth.$context;
+		await context.adapter.create({
+			model: "user",
+			forceAllowId: true,
+			data: {
+				id: "social-only-user",
+				email: "social@example.test",
+				name: "Social User",
+				emailVerified: true,
+				createdAt: new Date(),
+				updatedAt: new Date(),
+			},
+		});
+		await context.adapter.create({
+			model: "account",
+			data: {
+				userId: "social-only-user",
+				accountId: "provider-subject",
+				providerId: "github",
+				createdAt: new Date(),
+				updatedAt: new Date(),
+			},
+		});
+		const unknown = await request("/password-recovery/request", {
+			method: "POST",
+			body: JSON.stringify({ email: "unknown@example.test" }),
+		});
+		const socialOnly = await request("/password-recovery/request", {
+			method: "POST",
+			body: JSON.stringify({ email: "social@example.test" }),
+		});
+		expect(unknown.status).toBe(200);
+		expect(socialOnly.status).toBe(200);
+		expect(await unknown.json()).toEqual(await socialOnly.json());
+	});
+
+	test("rolls the reset back when the durable security notification cannot be published", async () => {
+		const userId = "password-recovery-rollback";
+		const context = await seedCredentialIdentity(
+			userId,
+			"rollback@example.test",
+			"old-password",
+		);
+		await context.adapter.create({
+			model: "session",
+			data: {
+				userId,
+				token: "rollback-session",
+				expiresAt: new Date(Date.now() + 60_000),
+				createdAt: new Date(),
+				updatedAt: new Date(),
+			},
+		});
+		await request("/password-recovery/request", {
+			method: "POST",
+			body: JSON.stringify({ email: "rollback@example.test" }),
+		});
+		const rawToken = new URL(dispatchedExchangeUrl!).searchParams.get("token")!;
+		const exchanged = await request(
+			`/password-recovery/exchange?token=${encodeURIComponent(rawToken)}`,
+			{ redirect: "manual" },
+		);
+		const challengeCookie = exchanged.headers.get("set-cookie")?.split(";")[0];
+		failSecurityDispatch = true;
+		const failed = await request("/password-recovery/commit", {
+			method: "POST",
+			headers: { cookie: challengeCookie! },
+			body: JSON.stringify({ newPassword: "new-password" }),
+		});
+		expect(failed.status).toBe(500);
+		const credential = await context.adapter.findOne<{ password: string }>({
+			model: "account",
+			where: [
+				{ field: "userId", value: userId },
+				{ field: "providerId", value: "credential" },
+			],
+		});
+		expect(
+			await context.password.verify({
+				hash: credential!.password,
+				password: "old-password",
+			}),
+		).toBe(true);
+		expect(
+			await context.adapter.findMany({
+				model: "session",
+				where: [{ field: "userId", value: userId }],
+			}),
+		).toHaveLength(1);
+		failSecurityDispatch = false;
+		const retried = await request("/password-recovery/commit", {
+			method: "POST",
+			headers: { cookie: challengeCookie! },
+			body: JSON.stringify({ newPassword: "new-password" }),
+		});
+		expect(retried.status).toBe(200);
+	});
+});

--- a/skills/questpie/AGENTS.md
+++ b/skills/questpie/AGENTS.md
@@ -7559,6 +7559,7 @@ Detailed authentication configuration for QUESTPIE using Better Auth.
 - [Social Providers (OAuth)](#social-providers-oauth), `socialProviders`, verified Google/GitHub entry catalog, client `signIn.social`
 - [Session Access](#session-access), routes, hooks, access rules
 - [User Collection](#user-collection), starter user model, merge + extend recipe
+- [Password Recovery](#password-recovery), neutral request, clean challenge exchange, atomic reset
 - [Reaching the App from Better Auth Callbacks](#reaching-the-app-from-better-auth-callbacks), `getContext<App>()`, partial overrides
 - [Client-Side Auth (authClient)](#client-side-auth-authclient), sign-in/up/out, `useSession`
 - [Environment Variables](#environment-variables)
@@ -7679,6 +7680,67 @@ are configured and remains browser-only (`storeInDatabase: false`). Provider
 callback failures are sanitized for the client; their raw diagnostics stay in
 server logs. Explicit account linking remains a separate authenticated
 operation.
+
+## Password Recovery
+
+Use `passwordRecovery()` when an application needs email password recovery. The
+integration replaces Better Auth's direct reset endpoints with a neutral request,
+a server-held challenge, and an atomic password, session, and trusted-device
+rotation. Register the returned plugin in `authConfig()` and publish both emails
+through the provided transactional Queue capability:
+
+```ts
+import { authConfig } from "questpie/app";
+import { passwordRecovery } from "questpie/auth";
+
+export default authConfig({
+	emailAndPassword: { enabled: true, requireEmailVerification: true },
+	plugins: [
+		passwordRecovery({
+			resetPath: "/reset-password",
+			deliverResetLink: async (
+				{ user, exchangeUrl, idempotencyKey },
+				{ publish },
+			) => {
+				await publish(
+					passwordRecoveryEmailJob,
+					{ to: user?.email ?? null, resetUrl: exchangeUrl },
+					{ idempotencyKey },
+				);
+			},
+			notifyResetCommitted: async (
+				{ user, occurredAt, idempotencyKey },
+				{ publish },
+			) => {
+				await publish(
+					passwordChangedEmailJob,
+					{ to: user.email, occurredAt },
+					{ idempotencyKey },
+				);
+			},
+		}),
+	],
+});
+```
+
+The public request is deliberately identical for an existing credential user,
+an unknown email, and a social-only identity. `deliverResetLink` therefore
+receives `user: null` for a neutral dummy dispatch; its job must accept that
+payload and finish without sending mail. Select the message locale from the
+stored user profile, not request headers or cookies.
+
+The emailed `exchangeUrl` contains the one-time reset credential. Do not log it.
+The exchange endpoint validates it, stores only a hashed server challenge, sets
+an HttpOnly challenge cookie, and redirects to the clean `resetPath`. The commit
+endpoint consumes that challenge once in the same transaction that updates the
+existing credential, deletes every session and `trust-device-*` verification,
+and publishes the security notification. Notification publication failure rolls
+the whole reset back. TOTP and OAuth accounts are not changed.
+
+If the product has a stronger password contract than Better Auth's configured
+minimum and maximum lengths, implement it in `preparePassword`. That callback
+owns the full normalization and validation policy and runs before the challenge
+transaction.
 
 ## Session Access
 

--- a/skills/questpie/references/auth.md
+++ b/skills/questpie/references/auth.md
@@ -16,6 +16,7 @@ Detailed authentication configuration for QUESTPIE using Better Auth.
 - [Social Providers (OAuth)](#social-providers-oauth), `socialProviders`, verified Google/GitHub entry catalog, client `signIn.social`
 - [Session Access](#session-access), routes, hooks, access rules
 - [User Collection](#user-collection), starter user model, merge + extend recipe
+- [Password Recovery](#password-recovery), neutral request, clean challenge exchange, atomic reset
 - [Reaching the App from Better Auth Callbacks](#reaching-the-app-from-better-auth-callbacks), `getContext<App>()`, partial overrides
 - [Client-Side Auth (authClient)](#client-side-auth-authclient), sign-in/up/out, `useSession`
 - [Environment Variables](#environment-variables)
@@ -136,6 +137,67 @@ are configured and remains browser-only (`storeInDatabase: false`). Provider
 callback failures are sanitized for the client; their raw diagnostics stay in
 server logs. Explicit account linking remains a separate authenticated
 operation.
+
+## Password Recovery
+
+Use `passwordRecovery()` when an application needs email password recovery. The
+integration replaces Better Auth's direct reset endpoints with a neutral request,
+a server-held challenge, and an atomic password, session, and trusted-device
+rotation. Register the returned plugin in `authConfig()` and publish both emails
+through the provided transactional Queue capability:
+
+```ts
+import { authConfig } from "questpie/app";
+import { passwordRecovery } from "questpie/auth";
+
+export default authConfig({
+	emailAndPassword: { enabled: true, requireEmailVerification: true },
+	plugins: [
+		passwordRecovery({
+			resetPath: "/reset-password",
+			deliverResetLink: async (
+				{ user, exchangeUrl, idempotencyKey },
+				{ publish },
+			) => {
+				await publish(
+					passwordRecoveryEmailJob,
+					{ to: user?.email ?? null, resetUrl: exchangeUrl },
+					{ idempotencyKey },
+				);
+			},
+			notifyResetCommitted: async (
+				{ user, occurredAt, idempotencyKey },
+				{ publish },
+			) => {
+				await publish(
+					passwordChangedEmailJob,
+					{ to: user.email, occurredAt },
+					{ idempotencyKey },
+				);
+			},
+		}),
+	],
+});
+```
+
+The public request is deliberately identical for an existing credential user,
+an unknown email, and a social-only identity. `deliverResetLink` therefore
+receives `user: null` for a neutral dummy dispatch; its job must accept that
+payload and finish without sending mail. Select the message locale from the
+stored user profile, not request headers or cookies.
+
+The emailed `exchangeUrl` contains the one-time reset credential. Do not log it.
+The exchange endpoint validates it, stores only a hashed server challenge, sets
+an HttpOnly challenge cookie, and redirects to the clean `resetPath`. The commit
+endpoint consumes that challenge once in the same transaction that updates the
+existing credential, deletes every session and `trust-device-*` verification,
+and publishes the security notification. Notification publication failure rolls
+the whole reset back. TOTP and OAuth accounts are not changed.
+
+If the product has a stronger password contract than Better Auth's configured
+minimum and maximum lengths, implement it in `preparePassword`. That callback
+owns the full normalization and validation policy and runs before the challenge
+transaction.
 
 ## Session Access
 


### PR DESCRIPTION
Summary:
- add a generic Better Auth password-recovery plugin with neutral request state and race-safe resend
- exchange hashed one-time reset tokens for HttpOnly browser challenges
- atomically update an existing credential, revoke sessions and trusted devices, and publish a durable security notification

Proof:
- package typecheck
- focused password recovery integration: 3 pass, 41 assertions
- repository format check
- targeted Oxlint

Full-suite note: packaged-bin checks need a built dist in a fresh worktree; the focused integration and type gates are green.