### PR TITLE
fix(mcp): preserve request context for generated tools

### DIFF
--- a/.changeset/calm-contexts-list.md
+++ b/.changeset/calm-contexts-list.md
@@ -1,0 +1,12 @@
+---
+"@questpie/mcp": patch
+"questpie": patch
+---
+
+Preserve the full request authority context when MCP discovers generated collection/global tools
+and schema resources, so OAuth callers see the same access-filtered catalog as ordinary QUESTPIE
+requests. Generated writes for optimistic-concurrency collections now require and forward
+`expectedRevision` for update and delete operations.
+Consumers can now disable generated relation expansion while keeping relation identifier fields
+available for filtering and projection.
+Generated collection list tools now apply their documented `sort` input to QUESTPIE `orderBy`.

--- a/packages/mcp/src/server/crud-tools.ts
+++ b/packages/mcp/src/server/crud-tools.ts
@@ -28,7 +28,7 @@ import {
 	workloadRequirementForOperation,
 } from "./policy.js";
 import type { RuntimeScope } from "./runtime.js";
-import { toToolError, toToolResult } from "./runtime.js";
+import { toRequestContext, toToolError, toToolResult } from "./runtime.js";
 import type { McpConfig } from "./types.js";
 import {
 	authorizeWorkload,
@@ -39,11 +39,21 @@ import { toToolInputJsonSchema } from "./zod-json-schema.js";
 
 const idSchema = z.union([z.string(), z.number()]);
 
-const deleteSchema = z
-	.object({
-		id: idSchema,
-	})
-	.strict();
+function optimisticConcurrencyEnabled(collection: unknown): boolean {
+	return (
+		(
+			collection as {
+				state?: { options?: { optimisticConcurrency?: boolean } };
+			}
+		).state?.options?.optimisticConcurrency === true
+	);
+}
+
+function expectedRevisionShape(collection: unknown) {
+	return optimisticConcurrencyEnabled(collection)
+		? { expectedRevision: z.number().int().min(1) }
+		: {};
+}
 
 const MAX_QUERY_FIELDS = 64;
 const MAX_WHERE_DEPTH = 3;
@@ -149,7 +159,10 @@ function relationLoadSchema(relations: string[]) {
 
 function collectionReadSchemas(collection: unknown, policy: ResolvedMcpPolicy) {
 	const fields = allowedEntityFieldNames(collection, policy);
-	const relations = allowedEntityRelationNames(collection, policy);
+	const relations =
+		policy.relationLoading === false
+			? []
+			: allowedEntityRelationNames(collection, policy);
 	const common = {
 		with: relationLoadSchema(relations).optional(),
 		columns: columnsSchema(fields).optional(),
@@ -185,7 +198,10 @@ function collectionReadSchemas(collection: unknown, policy: ResolvedMcpPolicy) {
 
 function globalOperationBaseSchema(global: unknown, policy: ResolvedMcpPolicy) {
 	const fields = allowedEntityFieldNames(global, policy);
-	const relations = allowedEntityRelationNames(global, policy);
+	const relations =
+		policy.relationLoading === false
+			? []
+			: allowedEntityRelationNames(global, policy);
 	return {
 		with: relationLoadSchema(relations).optional(),
 		columns: columnsSchema(fields).optional(),
@@ -211,11 +227,17 @@ const COLLECTION_OPERATIONS: Array<{
 		name: "list",
 		kind: "read",
 		description: (name) => `List ${name} records.`,
-		execute: (crud, input, ctx, maxLimit) =>
-			crud.find(
-				{ ...input, limit: Math.min(input.limit ?? maxLimit, maxLimit) },
+		execute: (crud, input, ctx, maxLimit) => {
+			const { sort, ...options } = input;
+			return crud.find(
+				{
+					...options,
+					...(sort === undefined ? {} : { orderBy: sort }),
+					limit: Math.min(input.limit ?? maxLimit, maxLimit),
+				},
 				ctx,
-			),
+			);
+		},
 	},
 	{
 		name: "count",
@@ -243,13 +265,31 @@ const COLLECTION_OPERATIONS: Array<{
 		kind: "write",
 		description: (name) => `Update a ${name} record by id.`,
 		execute: (crud, input, ctx) =>
-			crud.updateById({ id: input.id, data: input.data }, ctx),
+			crud.updateById(
+				{
+					id: input.id,
+					data: input.data,
+					...(input.expectedRevision === undefined
+						? {}
+						: { expectedRevision: input.expectedRevision }),
+				},
+				ctx,
+			),
 	},
 	{
 		name: "delete",
 		kind: "delete",
 		description: (name) => `Delete a ${name} record by id.`,
-		execute: (crud, input, ctx) => crud.deleteById({ id: input.id }, ctx),
+		execute: (crud, input, ctx) =>
+			crud.deleteById(
+				{
+					id: input.id,
+					...(input.expectedRevision === undefined
+						? {}
+						: { expectedRevision: input.expectedRevision }),
+				},
+				ctx,
+			),
 	},
 ];
 
@@ -293,11 +333,17 @@ function collectionOperationSchema(
 			.object({
 				id: idSchema,
 				data: createCollectionDataSchema(collection, "update", policy),
+				...expectedRevisionShape(collection),
 			})
 			.strict();
 	}
+	if (operationName === "delete") {
+		return z
+			.object({ id: idSchema, ...expectedRevisionShape(collection) })
+			.strict();
+	}
 	const readSchemas = collectionReadSchemas(collection, policy);
-	return readSchemas[operationName as keyof typeof readSchemas] ?? deleteSchema;
+	return readSchemas[operationName as keyof typeof readSchemas];
 }
 
 function globalOperationSchema(
@@ -325,13 +371,10 @@ async function questpieAllows(
 ): Promise<boolean> {
 	if (scope.accessMode === "system") return true;
 
-	const crudContext = {
-		db: ctx.db ?? scope.app.db,
-		session: ctx.session,
-		locale: ctx.locale,
-		accessMode: scope.accessMode,
-		stage: ctx.stage,
-	};
+	const crudContext = toRequestContext(
+		{ ...ctx, db: ctx.db ?? scope.app.db },
+		scope.accessMode,
+	);
 
 	if (kind === "collection") {
 		const collection = (scope.app.getCollections() as Record<string, any>)[

--- a/packages/mcp/src/server/policy.ts
+++ b/packages/mcp/src/server/policy.ts
@@ -58,6 +58,7 @@ export interface ResolvedMcpPolicy {
 	workload?: McpWorkloadRequirement;
 	operationWorkloads: Record<string, McpWorkloadRequirement>;
 	fields?: { include?: string[]; exclude?: string[] };
+	relationLoading?: boolean;
 	description?: string;
 }
 
@@ -295,6 +296,7 @@ function normalizePolicy(
 		workload: defaults.workload,
 		operationWorkloads: { ...(defaults.operationWorkloads ?? {}) },
 		fields: defaults.fields,
+		relationLoading: defaults.relationLoading,
 		description: defaults.description,
 	};
 

--- a/packages/mcp/src/server/resources.ts
+++ b/packages/mcp/src/server/resources.ts
@@ -25,7 +25,7 @@ import {
 	scopesFromContext,
 } from "./policy.js";
 import type { RuntimeScope } from "./runtime.js";
-import { jsonResource } from "./runtime.js";
+import { jsonResource, toRequestContext } from "./runtime.js";
 import { toJsonSchema } from "./zod-json-schema.js";
 
 function fallbackExtra(requestId: string): McpHandlerExtra {
@@ -63,13 +63,7 @@ async function collectionSchema(
 	const collection = (scope.app.getCollections() as Record<string, any>)[name];
 	return introspectCollection(
 		collection,
-		{
-			db: ctx.db ?? scope.app.db,
-			session: ctx.session,
-			locale: ctx.locale,
-			accessMode: scope.accessMode,
-			stage: ctx.stage,
-		},
+		toRequestContext({ ...ctx, db: ctx.db ?? scope.app.db }, scope.accessMode),
 		scope.app,
 	);
 }
@@ -82,13 +76,7 @@ async function globalSchema(
 	const global = (scope.app.getGlobals() as Record<string, any>)[name];
 	return introspectGlobal(
 		global,
-		{
-			db: ctx.db ?? scope.app.db,
-			session: ctx.session,
-			locale: ctx.locale,
-			accessMode: scope.accessMode,
-			stage: ctx.stage,
-		},
+		toRequestContext({ ...ctx, db: ctx.db ?? scope.app.db }, scope.accessMode),
 		scope.app,
 	);
 }

--- a/packages/mcp/src/server/runtime.ts
+++ b/packages/mcp/src/server/runtime.ts
@@ -79,6 +79,7 @@ export function toRequestContext(
 	return {
 		session: ctx.session,
 		principal: ctx.principal,
+		actor: ctx.actor,
 		locale: ctx.locale,
 		defaultLocale: ctx.defaultLocale,
 		localeFallback: ctx.localeFallback,
@@ -86,7 +87,10 @@ export function toRequestContext(
 		stage: ctx.stage,
 		requestId: ctx.requestId,
 		traceId: ctx.traceId,
+		workload: ctx.workload,
+		logger: ctx.logger,
 		db: ctx.db,
+		request: ctx.request,
 		"~contextExtensions": ctx["~contextExtensions"],
 	};
 }

--- a/packages/mcp/src/server/types.ts
+++ b/packages/mcp/src/server/types.ts
@@ -67,6 +67,8 @@ export type McpEntityPolicy =
 			workload?: McpWorkloadRequirement;
 			operationWorkloads?: Record<string, McpWorkloadRequirement>;
 			fields?: { include?: string[]; exclude?: string[] };
+			/** Allow callers to expand relation fields with `with`. Defaults to true. */
+			relationLoading?: boolean;
 			description?: string;
 	  };
 

--- a/packages/mcp/test/mcp-server.test.ts
+++ b/packages/mcp/test/mcp-server.test.ts
@@ -18,8 +18,14 @@ const posts = collection("posts")
 		published: f.boolean().default(false),
 		scheduledAt: f.datetime(),
 		secret: f.text(255),
+		relatedPost: f.relation("posts"),
 	}))
 	.access({ read: true, create: true, update: true, delete: true });
+
+const versionedPosts = collection("versionedPosts")
+	.fields(({ f }) => ({ title: f.text(255).required() }))
+	.access({ read: true, create: true, update: true, delete: true })
+	.options({ optimisticConcurrency: true });
 
 const privateNotes = collection("privateNotes")
 	.fields(({ f }) => ({
@@ -179,7 +185,7 @@ describe("@questpie/mcp server", () => {
 		guardedToolAllowed = true;
 		reportRouteAllowed = true;
 		setup = await buildMockApp({
-			collections: { posts, privateNotes },
+			collections: { posts, privateNotes, versionedPosts },
 			globals: { siteSettings },
 			routes: {
 				"reports/generate:POST": reportRoute,
@@ -217,6 +223,9 @@ describe("@questpie/mcp server", () => {
 									create: true,
 									update: true,
 								},
+							},
+							versionedPosts: {
+								operations: { update: true, delete: true },
 							},
 						},
 						globals: {
@@ -515,6 +524,16 @@ describe("@questpie/mcp server", () => {
 			const createdId = (createResult.structuredContent as any).id;
 			expect(typeof createdId).toBe("string");
 
+			const sortedResult = await client.callTool({
+				name: "collections.posts.list",
+				arguments: { sort: { title: "asc" }, limit: 10 },
+			});
+			expect(
+				(sortedResult.structuredContent as any).docs.map(
+					(post: { title: string }) => post.title,
+				),
+			).toEqual(["Created", "Hello"]);
+
 			const ambiguousInstant = await client.callTool({
 				name: "collections.posts.create",
 				arguments: {
@@ -546,6 +565,50 @@ describe("@questpie/mcp server", () => {
 				arguments: { id: createdId },
 			});
 			expect((deleteResult.structuredContent as any).success).toBe(true);
+		} finally {
+			await close();
+		}
+	});
+
+	it("requires and forwards expectedRevision for optimistic collection writes", async () => {
+		const seeded = await setup.app.collections.versionedPosts.create(
+			{ title: "Version one" },
+			createTestContext({ accessMode: "system" }),
+		);
+		const server = await createMcpServer(setup.app, { transport: "http" });
+		const { client, close } = await connect(server);
+
+		try {
+			const tools = await client.listTools();
+			const updateTool = tools.tools.find(
+				(tool) => tool.name === "collections.versionedPosts.update",
+			);
+			expect(updateTool?.inputSchema.required).toContain("expectedRevision");
+
+			const missingRevision = await client.callTool({
+				name: "collections.versionedPosts.update",
+				arguments: { id: seeded.id, data: { title: "Unsafe" } },
+			});
+			expect(missingRevision.isError).toBe(true);
+
+			const updated = await client.callTool({
+				name: "collections.versionedPosts.update",
+				arguments: {
+					id: seeded.id,
+					data: { title: "Version two" },
+					expectedRevision: seeded.revision,
+				},
+			});
+			expect(updated.structuredContent).toMatchObject({
+				title: "Version two",
+				revision: 2,
+			});
+
+			const deleted = await client.callTool({
+				name: "collections.versionedPosts.delete",
+				arguments: { id: seeded.id, expectedRevision: 2 },
+			});
+			expect(deleted.isError).toBeUndefined();
 		} finally {
 			await close();
 		}
@@ -933,6 +996,44 @@ describe("@questpie/mcp server", () => {
 			expect(updateSchema).not.toContain("secret");
 			expect(globalSchema).toContain("siteName");
 			expect(globalSchema).not.toContain("privateToken");
+		} finally {
+			await close();
+		}
+	});
+
+	it("can disable generated relation expansion without hiding relation ids", async () => {
+		const server = await createMcpServer(setup.app, {
+			transport: "http",
+			config: {
+				crud: {
+					collections: {
+						posts: {
+							operations: { list: true, get: true },
+							fields: { include: ["id", "title", "relatedPost"] },
+							relationLoading: false,
+						},
+					},
+				},
+			},
+		});
+		const { client, close } = await connect(server);
+
+		try {
+			const tools = await client.listTools();
+			const listTool = tools.tools.find(
+				(tool) => tool.name === "collections.posts.list",
+			);
+			const schema = listTool?.inputSchema as {
+				properties?: Record<string, { properties?: Record<string, unknown> }>;
+			};
+			expect(schema.properties?.with?.properties).toEqual({});
+			expect(JSON.stringify(schema)).toContain("relatedPost");
+
+			const expanded = await client.callTool({
+				name: "collections.posts.list",
+				arguments: { with: { relatedPost: true } },
+			});
+			expect(expanded.isError).toBe(true);
 		} finally {
 			await close();
 		}

--- a/packages/mcp/test/scope-gate.test.ts
+++ b/packages/mcp/test/scope-gate.test.ts
@@ -47,6 +47,17 @@ const lockedNotes = collection("lockedNotes")
 		delete: false,
 	});
 
+const tenantPosts = collection("tenantPosts")
+	.fields(({ f }) => ({ title: f.text(255).required() }))
+	.access({
+		read: (ctx) =>
+			(ctx as typeof ctx & { tenantId?: string }).tenantId === "tenant-a" &&
+			ctx.actor?.kind === "human",
+		create: false,
+		update: false,
+		delete: false,
+	});
+
 const siteSettings = global("siteSettings")
 	.fields(({ f }) => ({
 		siteName: f.text(255).required(),
@@ -54,6 +65,15 @@ const siteSettings = global("siteSettings")
 	.access({
 		read: ({ session }) => !!session,
 		update: ({ session }) => !!session,
+	});
+
+const tenantSettings = global("tenantSettings")
+	.fields(({ f }) => ({ label: f.text(255) }))
+	.access({
+		read: (ctx) =>
+			(ctx as typeof ctx & { tenantId?: string }).tenantId === "tenant-a" &&
+			ctx.actor?.kind === "human",
+		update: false,
 	});
 
 const reportRoute = route()
@@ -117,6 +137,16 @@ function oauthCtx(scopes: string[]): AppContext & Partial<RequestContext> {
 			tokenId: "token-1",
 		},
 	} as any) as unknown as AppContext & Partial<RequestContext>;
+}
+
+function tenantOauthCtx(
+	scopes: string[],
+): AppContext & Partial<RequestContext> {
+	return {
+		...oauthCtx(scopes),
+		actor: { kind: "human", id: "actor-a" },
+		"~contextExtensions": { tenantId: "tenant-a" },
+	};
 }
 
 // A ctx whose oauth `scopes` array is MUTABLE by reference. Because the runtime
@@ -221,8 +251,8 @@ describe("MO8 OAuth scope gate", () => {
 
 	beforeEach(async () => {
 		setup = await buildMockApp({
-			collections: { posts, lockedNotes },
-			globals: { siteSettings },
+			collections: { posts, lockedNotes, tenantPosts },
+			globals: { siteSettings, tenantSettings },
 			routes: { "reports/generate:POST": reportRoute },
 			mcpTools: { scoped: scopedCustomTool, open: openCustomTool },
 			// Enable write/delete tools over HTTP at the MCP-policy layer. The HTTP
@@ -233,6 +263,10 @@ describe("MO8 OAuth scope gate", () => {
 			// its `.access()` (proving the gate can only remove, never grant).
 			config: {
 				mcp: {
+					resources: {
+						collections: { tenantPosts: true },
+						globals: { tenantSettings: true },
+					},
 					crud: {
 						collections: {
 							posts: {
@@ -255,11 +289,15 @@ describe("MO8 OAuth scope gate", () => {
 									delete: true,
 								},
 							},
+							tenantPosts: {
+								operations: { list: true },
+							},
 						},
 						globals: {
 							siteSettings: {
 								operations: { get: true, update: true },
 							},
+							tenantSettings: { operations: { get: true } },
 						},
 					},
 					routes: {
@@ -302,6 +340,71 @@ describe("MO8 OAuth scope gate", () => {
 		expect(names).not.toContain("collections.posts.create");
 		expect(names).not.toContain("collections.posts.update");
 		expect(names).not.toContain("collections.posts.delete");
+	});
+
+	it("preserves request context extensions for collection access discovery", async () => {
+		const allowed = await listToolNames(
+			tenantOauthCtx([
+				"collections:tenantPosts:read",
+				"globals:tenantSettings:read",
+			]),
+			setup.app,
+		);
+		expect(allowed).toContain("collections.tenantPosts.list");
+		expect(allowed).toContain("globals.tenantSettings.get");
+
+		const denied = await listToolNames(
+			oauthCtx(["collections:tenantPosts:read", "globals:tenantSettings:read"]),
+			setup.app,
+		);
+		expect(denied).not.toContain("collections.tenantPosts.list");
+		expect(denied).not.toContain("globals.tenantSettings.get");
+	});
+
+	it("preserves request context extensions for schema resource discovery", async () => {
+		const allowedServer = await createMcpServer(setup.app, {
+			transport: "http",
+			ctx: tenantOauthCtx([
+				"collections:tenantPosts:read",
+				"globals:tenantSettings:read",
+			]),
+		});
+		const { client: allowedClient, close: closeAllowed } =
+			await connect(allowedServer);
+		try {
+			const collections = await allowedClient.readResource({
+				uri: "questpie://schema/collections",
+			});
+			const globals = await allowedClient.readResource({
+				uri: "questpie://schema/globals",
+			});
+			expect(JSON.stringify(collections.contents)).toContain("tenantPosts");
+			expect(JSON.stringify(globals.contents)).toContain("tenantSettings");
+		} finally {
+			await closeAllowed();
+		}
+
+		const deniedServer = await createMcpServer(setup.app, {
+			transport: "http",
+			ctx: oauthCtx([
+				"collections:tenantPosts:read",
+				"globals:tenantSettings:read",
+			]),
+		});
+		const { client: deniedClient, close: closeDenied } =
+			await connect(deniedServer);
+		try {
+			const collections = await deniedClient.readResource({
+				uri: "questpie://schema/collections",
+			});
+			const globals = await deniedClient.readResource({
+				uri: "questpie://schema/globals",
+			});
+			expect(JSON.stringify(collections.contents)).not.toContain("tenantPosts");
+			expect(JSON.stringify(globals.contents)).not.toContain("tenantSettings");
+		} finally {
+			await closeDenied();
+		}
 	});
 
 	it("oauth with read+write+delete scopes sees the full posts tool set", async () => {

--- a/packages/questpie/src/server/collection/introspection.ts
+++ b/packages/questpie/src/server/collection/introspection.ts
@@ -1233,6 +1233,7 @@ async function evaluateCollectionAccess(
 		actor: context.actor,
 	});
 	const accessContext: AccessContext = {
+		...(context["~contextExtensions"] ?? {}),
 		...services,
 		locale: context.locale,
 	} as AccessContext;

--- a/packages/questpie/src/server/global/introspection.ts
+++ b/packages/questpie/src/server/global/introspection.ts
@@ -477,6 +477,7 @@ async function evaluateGlobalAccess(
 		actor: context.actor,
 	});
 	const accessContext: GlobalAccessContext = {
+		...(context["~contextExtensions"] ?? {}),
 		...services,
 		locale: context.locale,
 	} as GlobalAccessContext;


### PR DESCRIPTION
## Summary

- preserve the full QUESTPIE request context during generated MCP tool and schema discovery
- require and forward optimistic `expectedRevision` values for generated update/delete tools
- map MCP list `sort` to QUESTPIE `orderBy`
- let consumers disable relation expansion without hiding relation identifier fields

## Verification

- `bun test packages/mcp/test/scope-gate.test.ts packages/mcp/test/mcp-server.test.ts` — 49 pass
- `bun run --cwd packages/mcp check-types`
- `bun run --cwd packages/questpie check-types`
- `git diff --check`

The changeset releases patch versions of `@questpie/mcp` and `questpie`.