### PR TITLE
fix(crud): hide unauthorized write targets

### DIFF
--- a/.changeset/quiet-pies-guard.md
+++ b/.changeset/quiet-pies-guard.md
@@ -1,0 +1,5 @@
+---
+"questpie": patch
+---
+
+Authorize generated collection writes before exposing target existence, revision conflicts, or domain hook failures, and use neutral access-denial responses.

--- a/bun.lock
+++ b/bun.lock
@@ -1820,7 +1820,7 @@
 
     "bullmq": ["bullmq@5.81.2", "", { "dependencies": { "cron-parser": "4.9.0", "ioredis": "5.11.1", "msgpackr": "2.0.4", "node-abort-controller": "3.1.1", "semver": "7.8.5", "tslib": "2.8.1" }, "peerDependencies": { "redis": ">=5.0.0" }, "optionalPeers": ["redis"] }, "sha512-Hi9GaVCC6HE9bQP65j/FNv1aL1fcEukTF99ezS5pl1Ud+joCFpNWiPCV45mWdkEmpuacS0XJdMMFGKPIHCwoPg=="],
 
-    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+    "bun-types": ["bun-types@1.4.0", "", { "dependencies": { "@types/node": "*" } }, "sha512-iIKw23BspnQQYd3prITOBxeUsxBHnwzX6YJfGMuNOZzeNcMmVqzIIVGRm1l69ogaPQmb4wB6BN8mA5bE9YuC5Q=="],
 
     "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
 
@@ -3496,6 +3496,10 @@
 
     "@quansync/fs/quansync": ["quansync@1.0.0", "", {}, "sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA=="],
 
+    "@questpie/observability/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "@questpie/tanstack-db/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
     "@redis/client/cluster-key-slot": ["cluster-key-slot@1.1.2", "", {}, "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA=="],
 
     "@seriousme/openapi-schema-validator/ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
@@ -3540,11 +3544,15 @@
 
     "city-portal-example/@vitejs/plugin-react": ["@vitejs/plugin-react@5.2.0", "", { "dependencies": { "@babel/core": "^7.29.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-rc.3", "@types/babel__core": "^7.20.5", "react-refresh": "^0.18.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw=="],
 
+    "city-portal-example/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
     "city-portal-example/nitro": ["nitro@3.0.260610-beta", "", { "dependencies": { "consola": "^3.4.2", "crossws": "^0.4.6", "db0": "^0.3.4", "env-runner": "^0.1.12", "h3": "2.0.1-rc.22", "hookable": "^6.1.1", "nf3": "^0.3.17", "ocache": "^0.1.5", "ofetch": "2.0.0-alpha.3", "ohash": "^2.0.11", "rolldown": "^1.1.0", "srvx": "^0.11.16", "unenv": "2.0.0-rc.24", "unstorage": "2.0.0-alpha.7" }, "peerDependencies": { "@vercel/queue": "^0.3.0", "dotenv": "*", "giget": "*", "jiti": "^2.7.0", "rollup": "^4.61.1", "vite": "^7 || ^8", "xml2js": "^0.6.2", "zephyr-agent": "^0.2.0" }, "optionalPeers": ["@vercel/queue", "dotenv", "giget", "jiti", "rollup", "vite", "xml2js", "zephyr-agent"], "bin": { "nitro": "dist/cli/index.mjs" } }, "sha512-KPb4L5yaF/Rx/xoGMpgHRJvZhbhGiqbRKOwwPLCH9jKTKTsEUHLjnJas85AeCzaswqa8Wi52eQBtRsODC4PS0Q=="],
 
     "cliui/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "conf/json-schema-typed": ["json-schema-typed@7.0.3", "", {}, "sha512-7DE8mpG+/fVw+dTpjbxnx47TaMnDfOI1jwft9g1VybltZCduyRQPJPvc+zzKY9WPHxhPWczyFuYa6I8Mw4iU5A=="],
+
+    "create-questpie/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "cross-spawn/which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
@@ -3654,6 +3662,8 @@
 
     "tanstack-barbershop-example/@types/node": ["@types/node@22.20.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q=="],
 
+    "tanstack-barbershop-example/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
     "tanstack-barbershop-example/nitro": ["nitro@3.0.260610-beta", "", { "dependencies": { "consola": "^3.4.2", "crossws": "^0.4.6", "db0": "^0.3.4", "env-runner": "^0.1.12", "h3": "2.0.1-rc.22", "hookable": "^6.1.1", "nf3": "^0.3.17", "ocache": "^0.1.5", "ofetch": "2.0.0-alpha.3", "ohash": "^2.0.11", "rolldown": "^1.1.0", "srvx": "^0.11.16", "unenv": "2.0.0-rc.24", "unstorage": "2.0.0-alpha.7" }, "peerDependencies": { "@vercel/queue": "^0.3.0", "dotenv": "*", "giget": "*", "jiti": "^2.7.0", "rollup": "^4.61.1", "vite": "^7 || ^8", "xml2js": "^0.6.2", "zephyr-agent": "^0.2.0" }, "optionalPeers": ["@vercel/queue", "dotenv", "giget", "jiti", "rollup", "vite", "xml2js", "zephyr-agent"], "bin": { "nitro": "dist/cli/index.mjs" } }, "sha512-KPb4L5yaF/Rx/xoGMpgHRJvZhbhGiqbRKOwwPLCH9jKTKTsEUHLjnJas85AeCzaswqa8Wi52eQBtRsODC4PS0Q=="],
 
     "tedious/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
@@ -3663,6 +3673,8 @@
     "toy-factory-backend-example/@tanstack/devtools-vite": ["@tanstack/devtools-vite@0.8.3", "", { "dependencies": { "@tanstack/devtools-bundler-core": "0.1.1", "@tanstack/devtools-client": "0.0.8", "@tanstack/devtools-event-bus": "0.4.2", "chalk": "^5.6.2" }, "peerDependencies": { "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "bin": { "intent": "./bin/intent.js" } }, "sha512-MqqE4/rdQUG55Y8Zux1Jj1I2wIBHdqYgjAJzP1grMUtFqSZ2XIDB7BHEV9UW/vrbhK7ocl4yFgVaJWROv0zeDA=="],
 
     "toy-factory-backend-example/@tanstack/react-devtools": ["@tanstack/react-devtools@0.10.9", "", { "dependencies": { "@tanstack/devtools": "0.13.0" }, "peerDependencies": { "@types/react": ">=16.8", "@types/react-dom": ">=16.8", "react": ">=16.8", "react-dom": ">=16.8" } }, "sha512-lS6mtccEmUaodsWiRORGM/MGKT0jgzcy5v+eY6pzOPxEgzTHUDhca+WGxShFqKxmF4oneRxXjww1gkvMrWq6uw=="],
+
+    "toy-factory-backend-example/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "toy-factory-backend-example/nitro": ["nitro@3.0.260610-beta", "", { "dependencies": { "consola": "^3.4.2", "crossws": "^0.4.6", "db0": "^0.3.4", "env-runner": "^0.1.12", "h3": "2.0.1-rc.22", "hookable": "^6.1.1", "nf3": "^0.3.17", "ocache": "^0.1.5", "ofetch": "2.0.0-alpha.3", "ohash": "^2.0.11", "rolldown": "^1.1.0", "srvx": "^0.11.16", "unenv": "2.0.0-rc.24", "unstorage": "2.0.0-alpha.7" }, "peerDependencies": { "@vercel/queue": "^0.3.0", "dotenv": "*", "giget": "*", "jiti": "^2.7.0", "rollup": "^4.61.1", "vite": "^7 || ^8", "xml2js": "^0.6.2", "zephyr-agent": "^0.2.0" }, "optionalPeers": ["@vercel/queue", "dotenv", "giget", "jiti", "rollup", "vite", "xml2js", "zephyr-agent"], "bin": { "nitro": "dist/cli/index.mjs" } }, "sha512-KPb4L5yaF/Rx/xoGMpgHRJvZhbhGiqbRKOwwPLCH9jKTKTsEUHLjnJas85AeCzaswqa8Wi52eQBtRsODC4PS0Q=="],
 
@@ -3739,6 +3751,8 @@
     "city-portal-example/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
     "city-portal-example/@vitejs/plugin-react/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.3", "", {}, "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q=="],
+
+    "city-portal-example/bun-types/@types/node": ["@types/node@24.13.3", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q=="],
 
     "city-portal-example/nitro/h3": ["h3@2.0.1-rc.22", "", { "dependencies": { "rou3": "^0.8.1", "srvx": "^0.11.15" }, "peerDependencies": { "crossws": "^0.4.1" }, "optionalPeers": ["crossws"], "bin": { "h3": "bin/h3.mjs" } }, "sha512-Esv0DMIuPkCTSWCA0vO73vcTqwzH1wjSrAO1TXNu/K3up1sZHa9EKMapbmxCDYBeymC3fVTk4qxp7ogQWQ+KgA=="],
 
@@ -3831,6 +3845,8 @@
     "tanstack-barbershop-example/@tanstack/react-router-devtools/@tanstack/router-devtools-core": ["@tanstack/router-devtools-core@1.168.0", "", { "dependencies": { "clsx": "^2.1.1", "goober": "^2.1.16" }, "peerDependencies": { "@tanstack/router-core": "^1.170.0", "csstype": "^3.0.10" }, "optionalPeers": ["csstype"] }, "sha512-wQoQhlBK7nlZgqzaqdYXKWNTpdHdsaREdaPhFZVH0/Ador+F+eM3/NF2i3f2LPeS0GgKraZUQXe1Q/1+KHyEYg=="],
 
     "tanstack-barbershop-example/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "tanstack-barbershop-example/bun-types/@types/node": ["@types/node@24.13.3", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q=="],
 
     "tanstack-barbershop-example/nitro/h3": ["h3@2.0.1-rc.22", "", { "dependencies": { "rou3": "^0.8.1", "srvx": "^0.11.15" }, "peerDependencies": { "crossws": "^0.4.1" }, "optionalPeers": ["crossws"], "bin": { "h3": "bin/h3.mjs" } }, "sha512-Esv0DMIuPkCTSWCA0vO73vcTqwzH1wjSrAO1TXNu/K3up1sZHa9EKMapbmxCDYBeymC3fVTk4qxp7ogQWQ+KgA=="],
 

--- a/packages/questpie/src/server/collection/crud/crud-generator.ts
+++ b/packages/questpie/src/server/collection/crud/crud-generator.ts
@@ -1718,7 +1718,23 @@ export class CRUDGenerator<TState extends CollectionBuilderState> {
 					_hookDepth,
 				},
 				async () => {
-					// Execute beforeOperation hook
+					// Enforce access control
+					const canCreate = await this.enforceAccessControl(
+						"create",
+						normalized,
+						null,
+						input,
+					);
+					if (canCreate === false) {
+						this.throwNeutralWriteDenial("create");
+					}
+					if (
+						typeof canCreate === "object" &&
+						!(await matchesStrictAccessConditions(canCreate, input))
+					) {
+						this.throwNeutralWriteDenial("create");
+					}
+
 					await this.executeHooks(
 						this.state.hooks?.beforeOperation,
 						this.createHookContext({
@@ -1728,21 +1744,6 @@ export class CRUDGenerator<TState extends CollectionBuilderState> {
 							db,
 						}),
 					);
-
-					// Enforce access control
-					const canCreate = await this.enforceAccessControl(
-						"create",
-						normalized,
-						null,
-						input,
-					);
-					if (canCreate === false) {
-						throw ApiError.forbidden({
-							operation: "create",
-							resource: this.state.name,
-							reason: "User does not have permission to create records",
-						});
-					}
 
 					// Execute beforeValidate hook (transform input before validation)
 					await this.executeHooks(
@@ -2153,6 +2154,76 @@ export class CRUDGenerator<TState extends CollectionBuilderState> {
 		return byId;
 	}
 
+	private throwNeutralWriteDenial(
+		operation: "create" | "update" | "delete",
+	): never {
+		throw ApiError.forbidden({
+			operation,
+			resource: this.state.name,
+			reason: "Access denied",
+		});
+	}
+
+	private hasUnconditionalUpdateAuthority(
+		context: CRUDContext,
+		_data: Record<string, any>,
+	): boolean {
+		if (context.accessMode === "system") return true;
+		const rule = this.state.access?.update ?? this.app?.defaultAccess?.update;
+		return rule === true || (rule === undefined && !!context.session);
+	}
+
+	private async enforceUpdateAuthority(
+		records: any[],
+		context: CRUDContext,
+		data: Record<string, any>,
+	): Promise<void> {
+		for (const existing of records) {
+			const canUpdate = await this.enforceAccessControl(
+				"update",
+				context,
+				existing,
+				data,
+			);
+			if (
+				canUpdate === false ||
+				(typeof canUpdate === "object" &&
+					!(await this.checkAccessConditions(canUpdate, existing)))
+			) {
+				this.throwNeutralWriteDenial("update");
+			}
+		}
+	}
+
+	private hasUnconditionalDeleteAuthority(
+		context: CRUDContext,
+		_params: unknown,
+	): boolean {
+		if (context.accessMode === "system") return true;
+		const rule = this.state.access?.delete ?? this.app?.defaultAccess?.delete;
+		return rule === true || (rule === undefined && !!context.session);
+	}
+
+	private async enforceDeleteAuthority(
+		row: OptimisticConcurrencyRecord,
+		context: CRUDContext,
+		params: unknown,
+	): Promise<void> {
+		const canDelete = await this.enforceAccessControl(
+			"delete",
+			context,
+			row,
+			params,
+		);
+		if (
+			canDelete === false ||
+			(typeof canDelete === "object" &&
+				!(await this.checkAccessConditions(canDelete, row)))
+		) {
+			this.throwNeutralWriteDenial("delete");
+		}
+	}
+
 	/**
 	 * Shared core update handler for updateById and updateMany
 	 * Ensures consistency in access control, hooks, validation, and re-fetching.
@@ -2215,6 +2286,9 @@ export class CRUDGenerator<TState extends CollectionBuilderState> {
 				)) as PaginatedResult<any>;
 				if (result.docs.length === 0) {
 					if (isBatch) {
+						if (!this.hasUnconditionalUpdateAuthority(normalized, data)) {
+							this.throwNeutralWriteDenial("update");
+						}
 						this.assertExpectedRevisions(
 							params as {
 								expectedRevisions?: Array<{
@@ -2226,10 +2300,13 @@ export class CRUDGenerator<TState extends CollectionBuilderState> {
 						);
 						return [];
 					}
-					throw ApiError.notFound(
-						"Record",
-						String((params as { id: string | number }).id),
-					);
+					if (await this.hasUnconditionalUpdateAuthority(normalized, data)) {
+						throw ApiError.notFound(
+							"Record",
+							String((params as { id: string | number }).id),
+						);
+					}
+					this.throwNeutralWriteDenial("update");
 				}
 				await lockRelationSourceForWrite({
 					tx,
@@ -2247,6 +2324,9 @@ export class CRUDGenerator<TState extends CollectionBuilderState> {
 				});
 				if (claimedIds.length === 0) {
 					if (isBatch) {
+						if (!this.hasUnconditionalUpdateAuthority(normalized, data)) {
+							this.throwNeutralWriteDenial("update");
+						}
 						this.assertExpectedRevisions(
 							params as {
 								expectedRevisions?: Array<{
@@ -2258,16 +2338,20 @@ export class CRUDGenerator<TState extends CollectionBuilderState> {
 						);
 						return [];
 					}
-					throw ApiError.notFound(
-						"Record",
-						String((params as { id: string | number }).id),
-					);
+					if (await this.hasUnconditionalUpdateAuthority(normalized, data)) {
+						throw ApiError.notFound(
+							"Record",
+							String((params as { id: string | number }).id),
+						);
+					}
+					this.throwNeutralWriteDenial("update");
 				}
 				const lockedRows = await tx
 					.select()
 					.from(this.table)
 					.where(inArray(getColumn(this.table, "id")!, claimedIds))
 					.for("update");
+				await this.enforceUpdateAuthority(lockedRows, normalized, data);
 				if (isBatch) {
 					this.assertExpectedRevisions(
 						params as {
@@ -2291,18 +2375,8 @@ export class CRUDGenerator<TState extends CollectionBuilderState> {
 			});
 		}
 
-		// 1. Execute beforeOperation hook
-		await this.executeHooks(
-			this.state.hooks?.beforeOperation,
-			this.createHookContext({
-				data,
-				operation: "update",
-				context: normalized,
-				db,
-			}),
-		);
-
-		// 2. Load existing records
+		// 1. Load existing records. Hooks must not observe whether a target exists
+		// until the caller has passed row authority below.
 		// Use system mode to ensure hooks have access to full records regardless of read permissions
 		const findOptions: FindManyOptions = isBatch
 			? { where: (params as { where: Where }).where }
@@ -2322,6 +2396,9 @@ export class CRUDGenerator<TState extends CollectionBuilderState> {
 
 		if (records.length === 0) {
 			if (isBatch) {
+				if (!this.hasUnconditionalUpdateAuthority(normalized, data)) {
+					this.throwNeutralWriteDenial("update");
+				}
 				this.assertExpectedRevisions(
 					params as {
 						expectedRevisions?: Array<{
@@ -2333,11 +2410,16 @@ export class CRUDGenerator<TState extends CollectionBuilderState> {
 				);
 				return [];
 			}
-			throw ApiError.notFound(
-				"Record",
-				String((params as { id: string | number }).id),
-			);
+			if (await this.hasUnconditionalUpdateAuthority(normalized, data)) {
+				throw ApiError.notFound(
+					"Record",
+					String((params as { id: string | number }).id),
+				);
+			}
+			this.throwNeutralWriteDenial("update");
 		}
+
+		await this.enforceUpdateAuthority(records, normalized, data);
 		const expectedRevisions = isBatch
 			? this.assertExpectedRevisions(
 					params as {
@@ -2350,36 +2432,18 @@ export class CRUDGenerator<TState extends CollectionBuilderState> {
 				)
 			: undefined;
 
-		// 3. Process each record (Access Control + beforeValidate)
-		for (const existing of records) {
-			// Enforce access control
-			const canUpdate = await this.enforceAccessControl(
-				"update",
-				normalized,
-				existing,
+		await this.executeHooks(
+			this.state.hooks?.beforeOperation,
+			this.createHookContext({
 				data,
-			);
-			if (canUpdate === false) {
-				throw ApiError.forbidden({
-					operation: "update",
-					resource: this.state.name,
-					reason: `User does not have permission to update record ${existing.id}`,
-				});
-			}
-			if (typeof canUpdate === "object") {
-				const matchesConditions = await this.checkAccessConditions(
-					canUpdate,
-					existing,
-				);
-				if (!matchesConditions) {
-					throw ApiError.forbidden({
-						operation: "update",
-						resource: this.state.name,
-						reason: `Record ${existing.id} does not match access control conditions`,
-					});
-				}
-			}
+				operation: "update",
+				context: normalized,
+				db,
+			}),
+		);
 
+		// 3. Process each record (beforeValidate)
+		for (const existing of records) {
 			// Execute beforeValidate hook (transform input before validation)
 			await this.executeHooks(
 				this.state.hooks?.beforeValidate,
@@ -2796,29 +2860,6 @@ export class CRUDGenerator<TState extends CollectionBuilderState> {
 						db: hookDb,
 					}),
 				);
-				const canDelete = await this.enforceAccessControl(
-					"delete",
-					hookContext,
-					row,
-					params,
-				);
-				if (canDelete === false) {
-					throw ApiError.forbidden({
-						operation: "delete",
-						resource: this.state.name,
-						reason: "User does not have permission to delete this record",
-					});
-				}
-				if (
-					typeof canDelete === "object" &&
-					!(await this.checkAccessConditions(canDelete, row))
-				) {
-					throw ApiError.forbidden({
-						operation: "delete",
-						resource: this.state.name,
-						reason: "Record does not match access control conditions",
-					});
-				}
 				await this.executeCollectionHooksWithGlobal(
 					"beforeDelete",
 					this.state.hooks?.beforeDelete,
@@ -2846,9 +2887,13 @@ export class CRUDGenerator<TState extends CollectionBuilderState> {
 					!preimage ||
 					(this.state.options.softDelete && preimage.deletedAt != null)
 				) {
-					throw ApiError.notFound("Record", id);
+					if (await this.hasUnconditionalDeleteAuthority(normalized, params)) {
+						throw ApiError.notFound("Record", id);
+					}
+					this.throwNeutralWriteDenial("delete");
 				}
 				existing = preimage;
+				await this.enforceDeleteAuthority(preimage, normalized, params);
 				await runDeleteGuardsAndHooks(preimage, normalized, db);
 				stagedCrdtOwner = await this.stageCrdtOwner(preimage);
 			}
@@ -2870,8 +2915,18 @@ export class CRUDGenerator<TState extends CollectionBuilderState> {
 						(this.state.options.softDelete &&
 							lockedBeforeDelete.deletedAt != null)
 					) {
-						throw ApiError.notFound("Record", id);
+						if (
+							await this.hasUnconditionalDeleteAuthority(normalized, params)
+						) {
+							throw ApiError.notFound("Record", id);
+						}
+						this.throwNeutralWriteDenial("delete");
 					}
+					await this.enforceDeleteAuthority(
+						lockedBeforeDelete,
+						txContext,
+						params,
+					);
 					this.assertExpectedRevision(params, [lockedBeforeDelete]);
 					await runDeleteGuardsAndHooks(lockedBeforeDelete, txContext, tx);
 					const [revalidated] = await tx
@@ -2887,6 +2942,7 @@ export class CRUDGenerator<TState extends CollectionBuilderState> {
 							"Canonical row changed during delete hooks",
 						);
 					}
+					await this.enforceDeleteAuthority(revalidated, txContext, params);
 					this.assertExpectedRevision(params, [revalidated]);
 					currentExisting = revalidated;
 					crdtFallbackOwner = lockedBeforeDelete;
@@ -3413,8 +3469,22 @@ export class CRUDGenerator<TState extends CollectionBuilderState> {
 							update.expectedRevision,
 						]),
 					);
+					if (locked.length !== ids.length) {
+						const unconditional = await Promise.all(
+							params.updates.map((update) =>
+								this.hasUnconditionalUpdateAuthority(normalized, update.data),
+							),
+						);
+						if (!unconditional.every(Boolean)) {
+							this.throwNeutralWriteDenial("update");
+						}
+						throw ApiError.conflict("Optimistic concurrency conflict");
+					}
+					for (const row of locked) {
+						const update = params.updates.find((entry) => entry.id === row.id)!;
+						await this.enforceUpdateAuthority([row], normalized, update.data);
+					}
 					if (
-						locked.length !== ids.length ||
 						locked.some(
 							(row: OptimisticConcurrencyRecord) =>
 								row.revision !== expectedById.get(row.id),
@@ -3469,10 +3539,13 @@ export class CRUDGenerator<TState extends CollectionBuilderState> {
 			const { docs: records } = await find({ where: params.where }, normalized);
 
 			if (records.length === 0) {
+				if (!(await this.hasUnconditionalDeleteAuthority(normalized, params))) {
+					this.throwNeutralWriteDenial("delete");
+				}
 				this.assertExpectedRevisions(params, records);
 				return { success: true, count: 0 };
 			}
-			const expectedRevisions = this.assertExpectedRevisions(params, records);
+			let expectedRevisions: Map<string | number, number> | undefined;
 			const optimisticConcurrency = this.getOptimisticConcurrency();
 			const stagedCrdtOwners = new Map<
 				string | number,
@@ -3487,23 +3560,7 @@ export class CRUDGenerator<TState extends CollectionBuilderState> {
 					count: records.length,
 				};
 				for (const record of records) {
-					const canDelete = await this.enforceAccessControl(
-						"delete",
-						normalized,
-						record,
-						params,
-					);
-					if (
-						canDelete === false ||
-						(typeof canDelete === "object" &&
-							!(await this.checkAccessConditions(canDelete, record)))
-					) {
-						throw ApiError.forbidden({
-							operation: "delete",
-							resource: this.state.name,
-							reason: `User does not have permission to delete record ${record.id}`,
-						});
-					}
+					await this.enforceDeleteAuthority(record, normalized, params);
 					await this.executeCollectionHooksWithGlobal(
 						"beforeDelete",
 						this.state.hooks?.beforeDelete,
@@ -3523,6 +3580,7 @@ export class CRUDGenerator<TState extends CollectionBuilderState> {
 						if (staged) stagedCrdtOwners.set(record.id, staged);
 					}),
 				);
+				expectedRevisions = this.assertExpectedRevisions(params, records);
 			}
 
 			// 3. Batched DELETE query
@@ -3539,10 +3597,14 @@ export class CRUDGenerator<TState extends CollectionBuilderState> {
 					includeDeleted: false,
 					stage: normalized.stage,
 				});
-				if (expectedRevisions && winnerIdList.length !== records.length) {
-					throw ApiError.conflict("Optimistic concurrency conflict");
+				if (winnerIdList.length === 0) {
+					if (
+						!(await this.hasUnconditionalDeleteAuthority(normalized, params))
+					) {
+						this.throwNeutralWriteDenial("delete");
+					}
+					return [];
 				}
-				if (winnerIdList.length === 0) return [];
 
 				let lockedBeforeDelete = await tx
 					.select()
@@ -3560,18 +3622,33 @@ export class CRUDGenerator<TState extends CollectionBuilderState> {
 						activeIds.has(record.id),
 					);
 					if (winnerIdList.length === 0) {
-						if (expectedRevisions) {
-							throw ApiError.conflict("Optimistic concurrency conflict");
+						if (
+							!(await this.hasUnconditionalDeleteAuthority(normalized, params))
+						) {
+							this.throwNeutralWriteDenial("delete");
 						}
 						return [];
 					}
 				}
+				if (optimisticConcurrency) {
+					for (const record of lockedBeforeDelete) {
+						await this.enforceDeleteAuthority(record, txContext, params);
+					}
+					expectedRevisions = this.assertExpectedRevisions(
+						params,
+						lockedBeforeDelete,
+					);
+				}
+				const expectedRevisionMap = expectedRevisions;
+				if (expectedRevisionMap && winnerIdList.length !== records.length) {
+					throw ApiError.conflict("Optimistic concurrency conflict");
+				}
 				if (
-					expectedRevisions &&
-					(lockedBeforeDelete.length !== expectedRevisions.size ||
+					expectedRevisionMap &&
+					(lockedBeforeDelete.length !== expectedRevisionMap.size ||
 						lockedBeforeDelete.some(
 							(record: OptimisticConcurrencyRecord) =>
-								record.revision !== expectedRevisions.get(record.id),
+								record.revision !== expectedRevisionMap.get(record.id),
 						))
 				) {
 					throw ApiError.conflict("Optimistic concurrency conflict");
@@ -3586,23 +3663,6 @@ export class CRUDGenerator<TState extends CollectionBuilderState> {
 						count: claimedRecords.length,
 					};
 					for (const record of claimedRecords) {
-						const canDelete = await this.enforceAccessControl(
-							"delete",
-							txContext,
-							record,
-							params,
-						);
-						if (
-							canDelete === false ||
-							(typeof canDelete === "object" &&
-								!(await this.checkAccessConditions(canDelete, record)))
-						) {
-							throw ApiError.forbidden({
-								operation: "delete",
-								resource: this.state.name,
-								reason: `User does not have permission to delete record ${record.id}`,
-							});
-						}
 						await this.executeCollectionHooksWithGlobal(
 							"beforeDelete",
 							this.state.hooks?.beforeDelete,
@@ -3633,10 +3693,10 @@ export class CRUDGenerator<TState extends CollectionBuilderState> {
 							lockedBeforeDelete.some(
 								(record: { deletedAt?: unknown }) => record.deletedAt != null,
 							)) ||
-						(expectedRevisions &&
+						(expectedRevisionMap &&
 							lockedBeforeDelete.some(
 								(record: OptimisticConcurrencyRecord) =>
-									record.revision !== expectedRevisions.get(record.id),
+									record.revision !== expectedRevisionMap.get(record.id),
 							))
 					) {
 						throw ApiError.conflict(

--- a/packages/questpie/src/server/collection/crud/crud-generator.ts
+++ b/packages/questpie/src/server/collection/crud/crud-generator.ts
@@ -27,6 +27,19 @@ type TitleExpressionSQL = SQL | Column | null;
 type OptimisticConcurrencyRecord = Record<string, unknown> & {
 	id: string | number;
 };
+type DeferredUpdateOutput = {
+	updatedRecords: OptimisticConcurrencyRecord[];
+	records: OptimisticConcurrencyRecord[];
+};
+type UpdateExecutionInternal = {
+	crdtRestore?: StagedCrdtOwnerActivation;
+	revisionPrelocked?: true;
+	legacyTransactionBound?: true;
+	returnBeforeOutputHooks?: true;
+};
+type UpdateExecutionParams =
+	| UpdateParams<any, any, string | number>
+	| { where: Where; data: Record<string, any> };
 
 // Search/realtime integrations removed (Phase 3 — QUE-251).
 // Side effects now come from core module global hooks.
@@ -2234,10 +2247,10 @@ export class CRUDGenerator<TState extends CollectionBuilderState> {
 	}
 
 	private async runUpdateOutputHooks(
-		updatedRecords: any[],
-		records: any[],
+		updatedRecords: OptimisticConcurrencyRecord[],
+		records: OptimisticConcurrencyRecord[],
 		context: CRUDContext,
-		db: any,
+		db: ReturnType<typeof getDb>,
 	): Promise<void> {
 		for (const updated of updatedRecords) {
 			const original = records.find((record) => record.id === updated.id);
@@ -2274,17 +2287,20 @@ export class CRUDGenerator<TState extends CollectionBuilderState> {
 	 *   in-transaction re-fetch of claimed rows — they are *fact* hooks and
 	 *   fire for winners only.
 	 */
+	private _executeUpdate(
+		params: UpdateExecutionParams,
+		context: CRUDContext,
+		internal: UpdateExecutionInternal & { returnBeforeOutputHooks: true },
+	): Promise<DeferredUpdateOutput>;
+	private _executeUpdate(
+		params: UpdateExecutionParams,
+		context?: CRUDContext,
+		internal?: UpdateExecutionInternal,
+	): Promise<any>;
 	private async _executeUpdate(
-		params:
-			| UpdateParams<any, any, string | number>
-			| { where: Where; data: Record<string, any> },
+		params: UpdateExecutionParams,
 		context: CRUDContext = {},
-		internal?: {
-			crdtRestore?: StagedCrdtOwnerActivation;
-			revisionPrelocked?: true;
-			legacyTransactionBound?: true;
-			returnBeforeOutputHooks?: true;
-		},
+		internal?: UpdateExecutionInternal,
 	): Promise<any> {
 		if (
 			this.getCrdtManifest() &&
@@ -2319,14 +2335,13 @@ export class CRUDGenerator<TState extends CollectionBuilderState> {
 				),
 			);
 			if (Array.isArray(deferred)) return deferred;
-			const output = deferred as { updatedRecords: any[]; records: any[] };
 			await this.runUpdateOutputHooks(
-				output.updatedRecords,
-				output.records,
+				deferred.updatedRecords,
+				deferred.records,
 				normalized,
 				db,
 			);
-			return isBatch ? output.updatedRecords : output.updatedRecords[0];
+			return isBatch ? deferred.updatedRecords : deferred.updatedRecords[0];
 		}
 		if (this.getOptimisticConcurrency() && !internal?.revisionPrelocked) {
 			return withTransaction(db, async (tx) => {

--- a/packages/questpie/src/server/collection/crud/crud-generator.ts
+++ b/packages/questpie/src/server/collection/crud/crud-generator.ts
@@ -2166,7 +2166,7 @@ export class CRUDGenerator<TState extends CollectionBuilderState> {
 
 	private hasUnconditionalUpdateAuthority(
 		context: CRUDContext,
-		_data: Record<string, any>,
+		_data: Record<string, unknown>,
 	): boolean {
 		if (context.accessMode === "system") return true;
 		const rule = this.state.access?.update ?? this.app?.defaultAccess?.update;
@@ -2174,9 +2174,9 @@ export class CRUDGenerator<TState extends CollectionBuilderState> {
 	}
 
 	private async enforceUpdateAuthority(
-		records: any[],
+		records: OptimisticConcurrencyRecord[],
 		context: CRUDContext,
-		data: Record<string, any>,
+		data: Record<string, unknown>,
 	): Promise<void> {
 		for (const existing of records) {
 			const canUpdate = await this.enforceAccessControl(

--- a/packages/questpie/src/server/collection/crud/crud-generator.ts
+++ b/packages/questpie/src/server/collection/crud/crud-generator.ts
@@ -2233,6 +2233,31 @@ export class CRUDGenerator<TState extends CollectionBuilderState> {
 		}
 	}
 
+	private async runUpdateOutputHooks(
+		updatedRecords: any[],
+		records: any[],
+		context: CRUDContext,
+		db: any,
+	): Promise<void> {
+		for (const updated of updatedRecords) {
+			const original = records.find((record) => record.id === updated.id);
+
+			await this.runFieldOutputHooks(updated, "update", context, db, original);
+
+			await this.executeHooks(
+				this.state.hooks?.afterRead,
+				this.createHookContext({
+					data: updated,
+					original,
+					operation: "update",
+					context,
+					db,
+				}),
+			);
+			await this.filterFieldsForRead(updated, context);
+		}
+	}
+
 	/**
 	 * Shared core update handler for updateById and updateMany
 	 * Ensures consistency in access control, hooks, validation, and re-fetching.
@@ -2243,7 +2268,8 @@ export class CRUDGenerator<TState extends CollectionBuilderState> {
 	 *   write transaction so a later conflict rolls their writes back.
 	 * - Legacy last-write-wins mutations retain intent-hook semantics:
 	 *   `beforeValidate`/`beforeChange` may run for rows that later lose the
-	 *   write-time claim check.
+	 *   write-time claim check. They run before the row lock but inside the
+	 *   write transaction so denied mutations roll their writes back.
 	 * - `afterChange`, versioning, and the return value are driven by the
 	 *   in-transaction re-fetch of claimed rows — they are *fact* hooks and
 	 *   fire for winners only.
@@ -2256,6 +2282,8 @@ export class CRUDGenerator<TState extends CollectionBuilderState> {
 		internal?: {
 			crdtRestore?: StagedCrdtOwnerActivation;
 			revisionPrelocked?: true;
+			legacyTransactionBound?: true;
+			returnBeforeOutputHooks?: true;
 		},
 	): Promise<any> {
 		if (
@@ -2278,6 +2306,28 @@ export class CRUDGenerator<TState extends CollectionBuilderState> {
 		const db = this.getDb(normalized);
 		const isBatch = "where" in params;
 		const data = params.data;
+		if (!this.getOptimisticConcurrency() && !internal?.legacyTransactionBound) {
+			const deferred = await withTransaction(db, (tx) =>
+				this._executeUpdate(
+					params,
+					{ ...normalized, db: tx },
+					{
+						...internal,
+						legacyTransactionBound: true,
+						returnBeforeOutputHooks: true,
+					},
+				),
+			);
+			if (Array.isArray(deferred)) return deferred;
+			const output = deferred as { updatedRecords: any[]; records: any[] };
+			await this.runUpdateOutputHooks(
+				output.updatedRecords,
+				output.records,
+				normalized,
+				db,
+			);
+			return isBatch ? output.updatedRecords : output.updatedRecords[0];
+		}
 		if (this.getOptimisticConcurrency() && !internal?.revisionPrelocked) {
 			return withTransaction(db, async (tx) => {
 				const txContext = { ...normalized, db: tx };
@@ -2360,7 +2410,7 @@ export class CRUDGenerator<TState extends CollectionBuilderState> {
 					.from(this.table)
 					.where(inArray(getColumn(this.table, "id")!, claimedIds))
 					.for("update");
-				await this.enforceUpdateAuthority(lockedRows, normalized, data);
+				await this.enforceUpdateAuthority(lockedRows, txContext, data);
 				if (isBatch) {
 					this.assertExpectedRevisions(
 						params as {
@@ -2810,30 +2860,12 @@ export class CRUDGenerator<TState extends CollectionBuilderState> {
 			throw error;
 		}
 
-		// 6. afterRead hooks and notifications
-		for (const updated of updatedRecords) {
-			const original = records.find((r) => r.id === updated.id);
-
-			await this.runFieldOutputHooks(
-				updated,
-				"update",
-				normalized,
-				db,
-				original,
-			);
-
-			await this.executeHooks(
-				this.state.hooks?.afterRead,
-				this.createHookContext({
-					data: updated,
-					original,
-					operation: "update",
-					context: normalized,
-					db,
-				}),
-			);
-			await this.filterFieldsForRead(updated, normalized);
+		if (internal?.returnBeforeOutputHooks) {
+			return { updatedRecords, records };
 		}
+
+		// 6. afterRead hooks and notifications
+		await this.runUpdateOutputHooks(updatedRecords, records, normalized, db);
 
 		return isBatch ? updatedRecords : updatedRecords[0];
 	}
@@ -2887,36 +2919,35 @@ export class CRUDGenerator<TState extends CollectionBuilderState> {
 				);
 			};
 
-			// Legacy collections retain intent-hook semantics: hooks run before
-			// the write-time claim and may observe a concurrent winner. Running
-			// these hooks under a row lock would deadlock hooks that deliberately
-			// exercise the TOCTOU window through the application database.
-			if (!optimisticConcurrency) {
-				const [preimage] = await db
-					.select()
-					.from(this.table)
-					.where(eq(getColumn(this.table, "id")!, id))
-					.limit(1);
-				if (
-					!preimage ||
-					(this.state.options.softDelete && preimage.deletedAt != null)
-				) {
-					if (await this.hasUnconditionalDeleteAuthority(normalized, params)) {
-						throw ApiError.notFound("Record", id);
-					}
-					this.throwNeutralWriteDenial("delete");
-				}
-				existing = preimage;
-				await this.enforceDeleteAuthority(preimage, normalized, params);
-				await runDeleteGuardsAndHooks(preimage, normalized, db);
-				stagedCrdtOwner = await this.stageCrdtOwner(preimage);
-			}
-
 			// Use transaction for delete + version
 			await withTransaction(db, async (tx) => {
 				const txContext = { ...normalized, db: tx };
 				let currentExisting: OptimisticConcurrencyRecord;
 				let crdtFallbackOwner: OptimisticConcurrencyRecord;
+
+				// Legacy collections retain intent-hook semantics: hooks run before
+				// the write-time claim and row lock, but share the write transaction
+				// so a later denial rolls their database effects back.
+				if (!optimisticConcurrency) {
+					const [preimage] = await tx
+						.select()
+						.from(this.table)
+						.where(eq(getColumn(this.table, "id")!, id))
+						.limit(1);
+					if (
+						!preimage ||
+						(this.state.options.softDelete && preimage.deletedAt != null)
+					) {
+						if (await this.hasUnconditionalDeleteAuthority(txContext, params)) {
+							throw ApiError.notFound("Record", id);
+						}
+						this.throwNeutralWriteDenial("delete");
+					}
+					existing = preimage;
+					await this.enforceDeleteAuthority(preimage, txContext, params);
+					await runDeleteGuardsAndHooks(preimage, txContext, tx);
+					stagedCrdtOwner = await this.stageCrdtOwner(preimage);
+				}
 
 				if (optimisticConcurrency) {
 					const [lockedBeforeDelete] = await tx
@@ -3505,7 +3536,7 @@ export class CRUDGenerator<TState extends CollectionBuilderState> {
 					}
 					for (const row of locked) {
 						const update = params.updates.find((entry) => entry.id === row.id)!;
-						await this.enforceUpdateAuthority([row], normalized, update.data);
+						await this.enforceUpdateAuthority([row], txContext, update.data);
 					}
 					if (
 						locked.some(
@@ -3575,42 +3606,42 @@ export class CRUDGenerator<TState extends CollectionBuilderState> {
 				StagedCrdtOwnerActivation
 			>();
 
-			if (!optimisticConcurrency) {
-				const deleteBulkMeta = {
-					isBatch: true as const,
-					recordIds: records.map((record) => record.id),
-					records,
-					count: records.length,
-				};
-				for (const record of records) {
-					await this.enforceDeleteAuthority(record, normalized, params);
-					await this.executeCollectionHooksWithGlobal(
-						"beforeDelete",
-						this.state.hooks?.beforeDelete,
-						this.createHookContext({
-							data: record,
-							original: record,
-							operation: "delete",
-							context: normalized,
-							db,
-							bulk: deleteBulkMeta,
-						}),
-					);
-				}
-				await Promise.all(
-					records.map(async (record) => {
-						const staged = await this.stageCrdtOwner(record);
-						if (staged) stagedCrdtOwners.set(record.id, staged);
-					}),
-				);
-				expectedRevisions = this.assertExpectedRevisions(params, records);
-			}
-
 			// 3. Batched DELETE query
 			// Claim check inside the tx: only rows that STILL match the caller's
 			// where at delete time are deleted ("winners").
 			const winners = await withTransaction(db, async (tx) => {
 				const txContext = { ...normalized, db: tx };
+
+				if (!optimisticConcurrency) {
+					const deleteBulkMeta = {
+						isBatch: true as const,
+						recordIds: records.map((record) => record.id),
+						records,
+						count: records.length,
+					};
+					for (const record of records) {
+						await this.enforceDeleteAuthority(record, txContext, params);
+						await this.executeCollectionHooksWithGlobal(
+							"beforeDelete",
+							this.state.hooks?.beforeDelete,
+							this.createHookContext({
+								data: record,
+								original: record,
+								operation: "delete",
+								context: txContext,
+								db: tx,
+								bulk: deleteBulkMeta,
+							}),
+						);
+					}
+					await Promise.all(
+						records.map(async (record) => {
+							const staged = await this.stageCrdtOwner(record);
+							if (staged) stagedCrdtOwners.set(record.id, staged);
+						}),
+					);
+					expectedRevisions = this.assertExpectedRevisions(params, records);
+				}
 
 				let winnerIdList = await this.claimRecords({
 					tx,

--- a/packages/questpie/src/server/collection/crud/crud-generator.ts
+++ b/packages/questpie/src/server/collection/crud/crud-generator.ts
@@ -2687,7 +2687,6 @@ export class CRUDGenerator<TState extends CollectionBuilderState> {
 						txContext,
 						tx,
 					));
-
 				// Split localized vs non-localized fields
 				const { localized, nonLocalized, nestedLocalized } =
 					this.splitLocalizedFields(regularFields);
@@ -2701,6 +2700,21 @@ export class CRUDGenerator<TState extends CollectionBuilderState> {
 						originalRows: winners,
 					});
 				}
+				// Nested belongsTo operations materialize FK fields after the first
+				// access pass, so the final payload is the write-authority boundary.
+				for (const lockedRecord of lockedRecords) {
+					await this.validateFieldWriteAccess(
+						regularFields,
+						txContext,
+						"update",
+						lockedRecord,
+					);
+				}
+				await this.enforceUpdateAuthority(
+					lockedRecords,
+					txContext,
+					regularFields,
+				);
 
 				// Update main table
 				if (
@@ -3383,35 +3397,17 @@ export class CRUDGenerator<TState extends CollectionBuilderState> {
 			const existing = existingRows[0];
 
 			if (!existing) {
-				throw ApiError.notFound("Record", id);
+				if (
+					this.hasUnconditionalUpdateAuthority(normalized, { deletedAt: null })
+				) {
+					throw ApiError.notFound("Record", id);
+				}
+				this.throwNeutralWriteDenial("update");
 			}
 
-			const canUpdate = await this.enforceAccessControl(
-				"update",
-				normalized,
-				existing,
-				{ deletedAt: null },
-			);
-			if (canUpdate === false) {
-				throw ApiError.forbidden({
-					operation: "update",
-					resource: this.state.name,
-					reason: "User does not have permission to restore this record",
-				});
-			}
-			if (typeof canUpdate === "object") {
-				const matchesConditions = await this.checkAccessConditions(
-					canUpdate,
-					existing,
-				);
-				if (!matchesConditions) {
-					throw ApiError.forbidden({
-						operation: "update",
-						resource: this.state.name,
-						reason: "Record does not match access control conditions",
-					});
-				}
-			}
+			await this.enforceUpdateAuthority([existing], normalized, {
+				deletedAt: null,
+			});
 
 			if (!existing.deletedAt) {
 				return withTransaction(db, async (tx) => {
@@ -3422,7 +3418,14 @@ export class CRUDGenerator<TState extends CollectionBuilderState> {
 						.for("update");
 
 					if (!locked) {
-						throw ApiError.notFound("Record", id);
+						if (
+							this.hasUnconditionalUpdateAuthority(normalized, {
+								deletedAt: null,
+							})
+						) {
+							throw ApiError.notFound("Record", id);
+						}
+						this.throwNeutralWriteDenial("update");
 					}
 					this.assertExpectedRevision(params, [locked]);
 

--- a/packages/questpie/src/server/collection/crud/crud-generator.ts
+++ b/packages/questpie/src/server/collection/crud/crud-generator.ts
@@ -1719,21 +1719,7 @@ export class CRUDGenerator<TState extends CollectionBuilderState> {
 				},
 				async () => {
 					// Enforce access control
-					const canCreate = await this.enforceAccessControl(
-						"create",
-						normalized,
-						null,
-						input,
-					);
-					if (canCreate === false) {
-						this.throwNeutralWriteDenial("create");
-					}
-					if (
-						typeof canCreate === "object" &&
-						!(await matchesStrictAccessConditions(canCreate, input))
-					) {
-						this.throwNeutralWriteDenial("create");
-					}
+					await this.enforceCreateAuthority(normalized, input);
 
 					await this.executeHooks(
 						this.state.hooks?.beforeOperation,
@@ -1841,6 +1827,10 @@ export class CRUDGenerator<TState extends CollectionBuilderState> {
 									context,
 									tx,
 								));
+							await this.enforceCreateAuthority(
+								{ ...normalized, db: tx },
+								regularFields,
+							);
 
 							// Split localized vs non-localized fields
 							// Auto-detects { $i18n: value } wrappers in JSONB fields
@@ -2162,6 +2152,25 @@ export class CRUDGenerator<TState extends CollectionBuilderState> {
 			resource: this.state.name,
 			reason: "Access denied",
 		});
+	}
+
+	private async enforceCreateAuthority(
+		context: CRUDContext,
+		data: Record<string, unknown>,
+	): Promise<void> {
+		const canCreate = await this.enforceAccessControl(
+			"create",
+			context,
+			null,
+			data,
+		);
+		if (
+			canCreate === false ||
+			(typeof canCreate === "object" &&
+				!(await matchesStrictAccessConditions(canCreate, data)))
+		) {
+			this.throwNeutralWriteDenial("create");
+		}
 	}
 
 	private hasUnconditionalUpdateAuthority(
@@ -2575,13 +2584,18 @@ export class CRUDGenerator<TState extends CollectionBuilderState> {
 
 				const winnerIds = new Set(recordIds);
 				const winners = records.filter((r: any) => winnerIds.has(r.id));
+				const lockedRecords = await tx
+					.select()
+					.from(this.table)
+					.where(inArray(getColumn(this.table, "id")!, recordIds))
+					.for("update");
+				await this.enforceUpdateAuthority(
+					lockedRecords,
+					txContext,
+					regularFields,
+				);
 				const optimisticConcurrency = this.getOptimisticConcurrency();
 				if (optimisticConcurrency) {
-					const lockedRecords = await tx
-						.select()
-						.from(this.table)
-						.where(inArray(getColumn(this.table, "id")!, recordIds))
-						.for("update");
 					if (expectedRevisions) {
 						if (
 							lockedRecords.length !== expectedRevisions.size ||
@@ -2956,7 +2970,16 @@ export class CRUDGenerator<TState extends CollectionBuilderState> {
 					if (claimed.length === 0 || !existing) {
 						throw ApiError.notFound("Record", id);
 					}
-					currentExisting = existing;
+					const [lockedExisting] = await tx
+						.select()
+						.from(this.table)
+						.where(eq(getColumn(this.table, "id")!, id))
+						.for("update");
+					if (!lockedExisting) {
+						throw ApiError.notFound("Record", id);
+					}
+					await this.enforceDeleteAuthority(lockedExisting, txContext, params);
+					currentExisting = lockedExisting;
 					crdtFallbackOwner = existing;
 				}
 				existing = currentExisting;
@@ -3630,10 +3653,10 @@ export class CRUDGenerator<TState extends CollectionBuilderState> {
 						return [];
 					}
 				}
+				for (const record of lockedBeforeDelete) {
+					await this.enforceDeleteAuthority(record, txContext, params);
+				}
 				if (optimisticConcurrency) {
-					for (const record of lockedBeforeDelete) {
-						await this.enforceDeleteAuthority(record, txContext, params);
-					}
 					expectedRevisions = this.assertExpectedRevisions(
 						params,
 						lockedBeforeDelete,
@@ -3702,6 +3725,9 @@ export class CRUDGenerator<TState extends CollectionBuilderState> {
 						throw ApiError.conflict(
 							"Canonical rows changed during delete hooks",
 						);
+					}
+					for (const record of lockedBeforeDelete) {
+						await this.enforceDeleteAuthority(record, txContext, params);
 					}
 				}
 				const lockedById = new Map(

--- a/packages/questpie/test/collection/auth-credential-field-access.test.ts
+++ b/packages/questpie/test/collection/auth-credential-field-access.test.ts
@@ -130,7 +130,7 @@ describe("starter auth credential collections", () => {
 				},
 				userCtx,
 			),
-		).rejects.toThrow("permission to create");
+		).rejects.toThrow("Access denied");
 
 		await expect(
 			setup.app.collections.apikey.create(
@@ -142,7 +142,7 @@ describe("starter auth credential collections", () => {
 				},
 				userCtx,
 			),
-		).rejects.toThrow("permission to create");
+		).rejects.toThrow("Access denied");
 		await expect(
 			setup.app.collections.session.updateById(
 				{
@@ -151,10 +151,10 @@ describe("starter auth credential collections", () => {
 				},
 				userCtx,
 			),
-		).rejects.toThrow("permission to update");
+		).rejects.toThrow("Access denied");
 		await expect(
 			setup.app.collections.session.deleteById({ id: created.id }, userCtx),
-		).rejects.toThrow("permission to delete");
+		).rejects.toThrow("Access denied");
 		await expect(
 			setup.app.collections.session.deleteMany(
 				{ where: { userId: "user-1" } },

--- a/packages/questpie/test/collection/collection-crud.test.ts
+++ b/packages/questpie/test/collection/collection-crud.test.ts
@@ -194,7 +194,7 @@ describe("collection CRUD", () => {
 				},
 				createTestContext({ accessMode: "user" }),
 			),
-		).rejects.toThrow("User does not have permission to create records");
+		).rejects.toThrow("Access denied");
 
 		const created = await setup.app.collections.locked_products.create(
 			{

--- a/packages/questpie/test/collection/conditional-update-race.test.ts
+++ b/packages/questpie/test/collection/conditional-update-race.test.ts
@@ -10,8 +10,8 @@
  * pglite is single-connection, so true parallel transactions cannot
  * interleave here. Instead these tests mutate rows in the exact TOCTOU
  * window — `beforeChange`/`beforeDelete` hooks run after the pre-SELECT and
- * before the write transaction — via raw drizzle writes (autocommit), and
- * assert the semantic outcome: a row claimed in the window must NOT be
+ * before the row lock — via raw writes on the hook transaction, and assert
+ * the semantic outcome: a row claimed in the window must NOT be
  * double-claimed, losers are reported by the return value, and afterChange /
  * versioning fire for winners only.
  */
@@ -131,10 +131,10 @@ describe("atomic conditional writes (claim-checked)", () => {
 		afterChangeCount = 0;
 
 		// Steal the row AFTER the pre-SELECT (which saw owner = null) and
-		// BEFORE the write transaction — exactly the race window.
-		onBeforeChange = async () => {
+		// BEFORE the row lock — exactly the claim-check window.
+		onBeforeChange = async ({ db }) => {
 			const table = claimsTable();
-			await setup.app.db
+			await db
 				.update(table)
 				.set({ owner: "intruder" })
 				.where(eq(getColumn(table, "id")!, created.id));
@@ -181,11 +181,11 @@ describe("atomic conditional writes (claim-checked)", () => {
 
 		// Steal row B in the TOCTOU window (once)
 		let stolen = false;
-		onBeforeChange = async () => {
+		onBeforeChange = async ({ db }) => {
 			if (stolen) return;
 			stolen = true;
 			const table = claimsTable();
-			await setup.app.db
+			await db
 				.update(table)
 				.set({ status: "claimed" })
 				.where(eq(getColumn(table, "id")!, b.id));
@@ -232,9 +232,9 @@ describe("atomic conditional writes (claim-checked)", () => {
 		);
 
 		// A competing writer bumps the revision in the race window
-		onBeforeChange = async () => {
+		onBeforeChange = async ({ db }) => {
 			const table = claimsTable();
-			await setup.app.db
+			await db
 				.update(table)
 				.set({ revision: 2 })
 				.where(eq(getColumn(table, "id")!, created.id));
@@ -263,11 +263,9 @@ describe("atomic conditional writes (claim-checked)", () => {
 			ctx,
 		);
 
-		onBeforeChange = async () => {
+		onBeforeChange = async ({ db }) => {
 			const table = claimsTable();
-			await setup.app.db
-				.delete(table)
-				.where(eq(getColumn(table, "id")!, created.id));
+			await db.delete(table).where(eq(getColumn(table, "id")!, created.id));
 		};
 
 		await expect(
@@ -284,11 +282,9 @@ describe("atomic conditional writes (claim-checked)", () => {
 			ctx,
 		);
 
-		onBeforeDelete = async () => {
+		onBeforeDelete = async ({ db }) => {
 			const table = claimsTable();
-			await setup.app.db
-				.delete(table)
-				.where(eq(getColumn(table, "id")!, created.id));
+			await db.delete(table).where(eq(getColumn(table, "id")!, created.id));
 		};
 
 		await expect(
@@ -309,11 +305,11 @@ describe("atomic conditional writes (claim-checked)", () => {
 
 		// Revive row B in the TOCTOU window (once)
 		let revived = false;
-		onBeforeDelete = async () => {
+		onBeforeDelete = async ({ db }) => {
 			if (revived) return;
 			revived = true;
 			const table = claimsTable();
-			await setup.app.db
+			await db
 				.update(table)
 				.set({ status: "active" })
 				.where(eq(getColumn(table, "id")!, b.id));
@@ -348,10 +344,10 @@ describe("atomic conditional writes (claim-checked)", () => {
 		);
 
 		// Steal the en translation in the race window
-		onBeforeChange = async () => {
+		onBeforeChange = async ({ db }) => {
 			const i18nTable =
 				setup.app.collections.localized_claims["~internalI18nTable"];
-			await setup.app.db
+			await db
 				.update(i18nTable)
 				.set({ name: "Stolen" })
 				.where(

--- a/packages/questpie/test/collection/optimistic-concurrency.test.ts
+++ b/packages/questpie/test/collection/optimistic-concurrency.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 
 import { collection } from "../../src/exports/index.js";
 import { createFetchHandler } from "../../src/server/adapters/http.js";
+import { ApiError } from "../../src/server/errors/index.js";
 import { buildMockApp } from "../utils/mocks/mock-app-builder";
 import { createMockSession, createTestContext } from "../utils/test-context";
 import { runTestDbMigrations } from "../utils/test-db";
@@ -11,6 +12,8 @@ let onBeforeChange: (() => Promise<void>) | undefined;
 let onBeforeDelete: (() => Promise<void>) | undefined;
 let beforeTransitionFacts = 0;
 let observedDeleteRevision: number | undefined;
+let beforeOperationDeleteRuns = 0;
+let beforeDeleteRuns = 0;
 
 const optimisticTags = collection("optimistic_tags")
 	.fields(({ f }) => ({
@@ -41,6 +44,9 @@ const optimisticTags = collection("optimistic_tags")
 	})
 	.access({ introspect: true })
 	.hooks({
+		beforeOperation: ({ operation }) => {
+			if (operation === "delete") beforeOperationDeleteRuns++;
+		},
 		beforeChange: async ({ original, operation }) => {
 			if (operation === "update") {
 				observedOriginalRevision = original?.revision;
@@ -48,6 +54,7 @@ const optimisticTags = collection("optimistic_tags")
 			}
 		},
 		beforeDelete: async () => {
+			beforeDeleteRuns++;
 			await onBeforeDelete?.();
 		},
 		afterDelete: ({ data }) => {
@@ -88,6 +95,20 @@ const retainedTags = collection("retained_tags")
 		versioning: { maxVersions: 2 },
 		optimisticConcurrency: true,
 	});
+const guardedDocuments = collection("guarded_documents")
+	.fields(({ f }) => ({
+		tenantId: f.text().required(),
+		title: f.text().required(),
+	}))
+	.options({ optimisticConcurrency: true })
+	.access({
+		update: ({ session }) => ({
+			tenantId: session?.user.id ?? "__anonymous__",
+		}),
+		delete: ({ session }) => ({
+			tenantId: session?.user.id ?? "__anonymous__",
+		}),
+	});
 
 describe("generated CRUD optimistic concurrency", () => {
 	let setup: Awaited<ReturnType<typeof buildMockApp>>;
@@ -99,6 +120,8 @@ describe("generated CRUD optimistic concurrency", () => {
 		onBeforeDelete = undefined;
 		beforeTransitionFacts = 0;
 		observedDeleteRevision = undefined;
+		beforeOperationDeleteRuns = 0;
+		beforeDeleteRuns = 0;
 		setup = await buildMockApp({
 			collections: {
 				optimisticTags,
@@ -107,6 +130,7 @@ describe("generated CRUD optimistic concurrency", () => {
 				legacyTags,
 				tenantDocuments,
 				retainedTags,
+				guardedDocuments,
 			},
 		});
 		await runTestDbMigrations(setup.app);
@@ -124,6 +148,112 @@ describe("generated CRUD optimistic concurrency", () => {
 		expect(() => invalid.build()).toThrow(
 			'cannot declare framework-owned field "revision"',
 		);
+	});
+
+	it("hides guarded update and delete targets before revision checks", async () => {
+		const ownerId = crypto.randomUUID();
+		const strangerId = crypto.randomUUID();
+		const guarded = await setup.app.collections.guardedDocuments.create(
+			{ tenantId: ownerId, title: "Private" },
+			context,
+		);
+		const stranger = createTestContext({
+			accessMode: "user",
+			session: createMockSession({ id: strangerId }),
+		});
+
+		const capture = (promise: Promise<unknown>) =>
+			promise.catch((error: ApiError) => error) as Promise<ApiError>;
+		const foreignUpdate = await capture(
+			setup.app.collections.guardedDocuments.updateById(
+				{ id: guarded.id, expectedRevision: 999, data: { title: "Probe" } },
+				stranger,
+			),
+		);
+		const absentUpdate = await capture(
+			setup.app.collections.guardedDocuments.updateById(
+				{
+					id: crypto.randomUUID(),
+					expectedRevision: 999,
+					data: { title: "Probe" },
+				},
+				stranger,
+			),
+		);
+		expect(foreignUpdate.toJSON(false)).toEqual(absentUpdate.toJSON(false));
+
+		const foreignDelete = await capture(
+			setup.app.collections.guardedDocuments.deleteById(
+				{ id: guarded.id, expectedRevision: 999 },
+				stranger,
+			),
+		);
+		const absentDelete = await capture(
+			setup.app.collections.guardedDocuments.deleteById(
+				{ id: crypto.randomUUID(), expectedRevision: 999 },
+				stranger,
+			),
+		);
+		expect(foreignDelete.toJSON(false)).toEqual(absentDelete.toJSON(false));
+
+		const foreignBulkUpdate = await capture(
+			setup.app.collections.guardedDocuments.updateMany(
+				{
+					where: { tenantId: ownerId },
+					data: { title: "Probe" },
+					expectedRevisions: [{ id: guarded.id, expectedRevision: 999 }],
+				},
+				stranger,
+			),
+		);
+		const absentBulkUpdate = await capture(
+			setup.app.collections.guardedDocuments.updateMany(
+				{
+					where: { tenantId: crypto.randomUUID() },
+					data: { title: "Probe" },
+					expectedRevisions: [],
+				},
+				stranger,
+			),
+		);
+		expect(foreignBulkUpdate.toJSON(false)).toEqual(
+			absentBulkUpdate.toJSON(false),
+		);
+
+		const foreignBulkDelete = await capture(
+			setup.app.collections.guardedDocuments.deleteMany(
+				{
+					where: { tenantId: ownerId },
+					expectedRevisions: [{ id: guarded.id, expectedRevision: 999 }],
+				},
+				stranger,
+			),
+		);
+		const absentBulkDelete = await capture(
+			setup.app.collections.guardedDocuments.deleteMany(
+				{ where: { tenantId: crypto.randomUUID() }, expectedRevisions: [] },
+				stranger,
+			),
+		);
+		expect(foreignBulkDelete.toJSON(false)).toEqual(
+			absentBulkDelete.toJSON(false),
+		);
+	});
+
+	it("rejects a stale delete before running delete hooks", async () => {
+		const tag = await setup.app.collections.optimisticTags.create(
+			{ name: "Stale delete" },
+			context,
+		);
+
+		await expect(
+			setup.app.collections.optimisticTags.deleteById(
+				{ id: tag.id, expectedRevision: tag.revision + 1 },
+				context,
+			),
+		).rejects.toThrow("Optimistic concurrency conflict");
+		expect(beforeOperationDeleteRuns).toBe(0);
+		expect(beforeDeleteRuns).toBe(0);
 	});
 
 	it("creates revision 1 and advances it once from the expected revision", async () => {

--- a/packages/questpie/test/collection/optimistic-concurrency.test.ts
+++ b/packages/questpie/test/collection/optimistic-concurrency.test.ts
@@ -131,6 +131,37 @@ const guardedDocuments = collection("guarded_documents")
 			`);
 		},
 	});
+const guardedLegacyDocuments = collection("guarded_legacy_documents")
+	.fields(({ f }) => ({
+		tenantId: f.text().required(),
+		title: f.text().required(),
+	}))
+	.access({
+		update: ({ session }) => ({
+			tenantId: session?.user.id ?? "__anonymous__",
+		}),
+		delete: ({ session }) => ({
+			tenantId: session?.user.id ?? "__anonymous__",
+		}),
+	})
+	.hooks({
+		beforeChange: async ({ db, operation, original }) => {
+			if (operation !== "update" || guardedHookMode !== "update") return;
+			await db.execute(sql`
+				UPDATE guarded_legacy_documents
+				SET "tenantId" = ${guardedHookTenantId}
+				WHERE id = ${original.id}
+			`);
+		},
+		beforeDelete: async ({ db, original }) => {
+			if (guardedHookMode !== "delete") return;
+			await db.execute(sql`
+				UPDATE guarded_legacy_documents
+				SET "tenantId" = ${guardedHookTenantId}
+				WHERE id = ${original.id}
+			`);
+		},
+	});
 
 describe("generated CRUD optimistic concurrency", () => {
 	let setup: Awaited<ReturnType<typeof buildMockApp>>;
@@ -148,6 +179,7 @@ describe("generated CRUD optimistic concurrency", () => {
 		guardedHookTenantId = undefined;
 		setup = await buildMockApp({
 			collections: {
+				guardedLegacyDocuments,
 				optimisticTags,
 				optimisticGroups,
 				optimisticTagGroups,
@@ -343,6 +375,90 @@ describe("generated CRUD optimistic concurrency", () => {
 			context,
 		);
 		expect(unchanged).toMatchObject({ tenantId: ownerId, title: "Keep" });
+	});
+
+	it("rolls back legacy update hook writes after final authority denial", async () => {
+		const ownerId = crypto.randomUUID();
+		const guarded = await setup.app.collections.guardedLegacyDocuments.create(
+			{ tenantId: ownerId, title: "Original" },
+			context,
+		);
+		const owner = createTestContext({
+			accessMode: "user",
+			session: createMockSession({ id: ownerId }),
+		});
+		guardedHookMode = "update";
+		guardedHookTenantId = crypto.randomUUID();
+
+		await expect(
+			setup.app.collections.guardedLegacyDocuments.updateById(
+				{ id: guarded.id, data: { title: "Unauthorized" } },
+				owner,
+			),
+		).rejects.toThrow("Access denied");
+
+		expect(
+			await setup.app.collections.guardedLegacyDocuments.findOne(
+				{ where: { id: guarded.id } },
+				context,
+			),
+		).toMatchObject({ tenantId: ownerId, title: "Original" });
+	});
+
+	it("rolls back legacy deleteById hook writes after final authority denial", async () => {
+		const ownerId = crypto.randomUUID();
+		const guarded = await setup.app.collections.guardedLegacyDocuments.create(
+			{ tenantId: ownerId, title: "Keep by id" },
+			context,
+		);
+		const owner = createTestContext({
+			accessMode: "user",
+			session: createMockSession({ id: ownerId }),
+		});
+		guardedHookMode = "delete";
+		guardedHookTenantId = crypto.randomUUID();
+
+		await expect(
+			setup.app.collections.guardedLegacyDocuments.deleteById(
+				{ id: guarded.id },
+				owner,
+			),
+		).rejects.toThrow("Access denied");
+
+		expect(
+			await setup.app.collections.guardedLegacyDocuments.findOne(
+				{ where: { id: guarded.id } },
+				context,
+			),
+		).toMatchObject({ tenantId: ownerId, title: "Keep by id" });
+	});
+
+	it("rolls back legacy deleteMany hook writes after final authority denial", async () => {
+		const ownerId = crypto.randomUUID();
+		const guarded = await setup.app.collections.guardedLegacyDocuments.create(
+			{ tenantId: ownerId, title: "Keep in bulk" },
+			context,
+		);
+		const owner = createTestContext({
+			accessMode: "user",
+			session: createMockSession({ id: ownerId }),
+		});
+		guardedHookMode = "delete";
+		guardedHookTenantId = crypto.randomUUID();
+
+		await expect(
+			setup.app.collections.guardedLegacyDocuments.deleteMany(
+				{ where: { id: guarded.id } },
+				owner,
+			),
+		).rejects.toThrow("Access denied");
+
+		expect(
+			await setup.app.collections.guardedLegacyDocuments.findOne(
+				{ where: { id: guarded.id } },
+				context,
+			),
+		).toMatchObject({ tenantId: ownerId, title: "Keep in bulk" });
 	});
 
 	it("creates revision 1 and advances it once from the expected revision", async () => {

--- a/packages/questpie/test/collection/optimistic-concurrency.test.ts
+++ b/packages/questpie/test/collection/optimistic-concurrency.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 
+import { sql } from "drizzle-orm";
+
 import { collection } from "../../src/exports/index.js";
 import { createFetchHandler } from "../../src/server/adapters/http.js";
 import { ApiError } from "../../src/server/errors/index.js";
@@ -14,6 +16,8 @@ let beforeTransitionFacts = 0;
 let observedDeleteRevision: number | undefined;
 let beforeOperationDeleteRuns = 0;
 let beforeDeleteRuns = 0;
+let guardedHookMode: "update" | "delete" | undefined;
+let guardedHookTenantId: string | undefined;
 
 const optimisticTags = collection("optimistic_tags")
 	.fields(({ f }) => ({
@@ -108,6 +112,24 @@ const guardedDocuments = collection("guarded_documents")
 		delete: ({ session }) => ({
 			tenantId: session?.user.id ?? "__anonymous__",
 		}),
+	})
+	.hooks({
+		beforeChange: async ({ db, operation, original }) => {
+			if (operation !== "update" || guardedHookMode !== "update") return;
+			await db.execute(sql`
+				UPDATE guarded_documents
+				SET "tenantId" = ${guardedHookTenantId}
+				WHERE id = ${original.id}
+			`);
+		},
+		beforeDelete: async ({ db, original }) => {
+			if (guardedHookMode !== "delete") return;
+			await db.execute(sql`
+				UPDATE guarded_documents
+				SET "tenantId" = ${guardedHookTenantId}
+				WHERE id = ${original.id}
+			`);
+		},
 	});
 
 describe("generated CRUD optimistic concurrency", () => {
@@ -122,6 +144,8 @@ describe("generated CRUD optimistic concurrency", () => {
 		observedDeleteRevision = undefined;
 		beforeOperationDeleteRuns = 0;
 		beforeDeleteRuns = 0;
+		guardedHookMode = undefined;
+		guardedHookTenantId = undefined;
 		setup = await buildMockApp({
 			collections: {
 				optimisticTags,
@@ -254,6 +278,71 @@ describe("generated CRUD optimistic concurrency", () => {
 		).rejects.toThrow("Optimistic concurrency conflict");
 		expect(beforeOperationDeleteRuns).toBe(0);
 		expect(beforeDeleteRuns).toBe(0);
+	});
+
+	it("rechecks guarded updates after hooks mutate access fields", async () => {
+		const ownerId = crypto.randomUUID();
+		const foreignTenantId = crypto.randomUUID();
+		const guarded = await setup.app.collections.guardedDocuments.create(
+			{ tenantId: ownerId, title: "Original" },
+			context,
+		);
+		const owner = createTestContext({
+			accessMode: "user",
+			session: createMockSession({ id: ownerId }),
+		});
+		guardedHookMode = "update";
+		guardedHookTenantId = foreignTenantId;
+
+		await expect(
+			setup.app.collections.guardedDocuments.updateById(
+				{
+					id: guarded.id,
+					expectedRevision: guarded.revision,
+					data: { title: "Unauthorized" },
+				},
+				owner,
+			),
+		).rejects.toThrow("Access denied");
+
+		const unchanged = await setup.app.collections.guardedDocuments.findOne(
+			{ where: { id: guarded.id } },
+			context,
+		);
+		expect(unchanged).toMatchObject({ tenantId: ownerId, title: "Original" });
+	});
+
+	it("rechecks guarded bulk deletes after hooks mutate access fields", async () => {
+		const ownerId = crypto.randomUUID();
+		const foreignTenantId = crypto.randomUUID();
+		const guarded = await setup.app.collections.guardedDocuments.create(
+			{ tenantId: ownerId, title: "Keep" },
+			context,
+		);
+		const owner = createTestContext({
+			accessMode: "user",
+			session: createMockSession({ id: ownerId }),
+		});
+		guardedHookMode = "delete";
+		guardedHookTenantId = foreignTenantId;
+
+		await expect(
+			setup.app.collections.guardedDocuments.deleteMany(
+				{
+					where: { id: guarded.id },
+					expectedRevisions: [
+						{ id: guarded.id, expectedRevision: guarded.revision },
+					],
+				},
+				owner,
+			),
+		).rejects.toThrow("Access denied");
+
+		const unchanged = await setup.app.collections.guardedDocuments.findOne(
+			{ where: { id: guarded.id } },
+			context,
+		);
+		expect(unchanged).toMatchObject({ tenantId: ownerId, title: "Keep" });
 	});
 
 	it("creates revision 1 and advances it once from the expected revision", async () => {

--- a/packages/questpie/test/collection/transaction-bound-hooks-postgres.test.ts
+++ b/packages/questpie/test/collection/transaction-bound-hooks-postgres.test.ts
@@ -13,13 +13,14 @@ import { z } from "zod";
 
 import { channel } from "../../src/exports/channels.js";
 import { collection, withTransaction } from "../../src/exports/index.js";
+import { createFetchHandler } from "../../src/server/adapters/http.js";
 import { rowsOf } from "../../src/server/db/driver-result.js";
 import {
 	questpieChannelEventTable,
 	questpieRealtimeLogTable,
 } from "../../src/server/modules/core/integrated/realtime/collection.js";
 import { buildMockApp } from "../utils/mocks/mock-app-builder";
-import { createTestContext } from "../utils/test-context";
+import { createMockSession, createTestContext } from "../utils/test-context";
 import { runTestDbMigrations } from "../utils/test-db";
 
 const databaseUrl = process.env.QUESTPIE_TRANSACTION_LOCK_DATABASE_URL;
@@ -88,6 +89,54 @@ const postgresOptimisticAccessTargets = collection(
 		},
 	});
 
+const postgresNestedAccounts = collection("postgres_nested_accounts")
+	.fields(({ f }) => ({ name: f.text().required() }))
+	.access({ create: true });
+
+const postgresNestedAuthorityDocuments = collection(
+	"postgres_nested_authority_documents",
+)
+	.fields(({ f }) => ({
+		owner: f.relation("postgresNestedAccounts").required(),
+		title: f.text().required(),
+	}))
+	.options({ optimisticConcurrency: true })
+	.access({
+		update: ({ session, input }) => {
+			const nextOwner = (input as { owner?: unknown } | undefined)?.owner;
+			if (typeof nextOwner === "string" && nextOwner !== session?.user.id) {
+				return false;
+			}
+			return { owner: session?.user.id ?? "__anonymous__" };
+		},
+	});
+
+const postgresNestedFieldDocuments = collection(
+	"postgres_nested_field_documents",
+)
+	.fields(({ f }) => ({
+		owner: f
+			.relation("postgresNestedAccounts")
+			.required()
+			.access({ update: false }),
+		title: f.text().required(),
+	}))
+	.options({ optimisticConcurrency: true })
+	.access({ update: true });
+
+const postgresGuardedRestores = collection("postgres_guarded_restores")
+	.fields(({ f }) => ({
+		tenantId: f.text().required(),
+		title: f.text().required(),
+	}))
+	.options({ optimisticConcurrency: true, softDelete: true })
+	.access({
+		update: ({ session }) => ({
+			tenantId: session?.user.id ?? "__anonymous__",
+		}),
+		delete: true,
+	});
+
 describe.skipIf(!runPostgresContract)(
 	"transaction-bound hooks on PostgreSQL",
 	() => {
@@ -110,6 +159,10 @@ describe.skipIf(!runPostgresContract)(
 					collections: {
 						postgresEffectLogs,
 						postgresEffectTargets,
+						postgresGuardedRestores,
+						postgresNestedAccounts,
+						postgresNestedAuthorityDocuments,
+						postgresNestedFieldDocuments,
 						postgresOptimisticAccessTargets,
 					},
 				},
@@ -151,6 +204,125 @@ describe.skipIf(!runPostgresContract)(
 			expect(
 				new Set([...optimisticAccessTxids, ...optimisticHookTxids]).size,
 			).toBe(1);
+		});
+
+		it("rechecks materialized belongsTo authority and field access on PostgreSQL", async () => {
+			const owner = await setup.app.collections.postgresNestedAccounts.create(
+				{ name: "Owner" },
+				context,
+			);
+			const foreignOwner =
+				await setup.app.collections.postgresNestedAccounts.create(
+					{ name: "Foreign owner" },
+					context,
+				);
+			const authorityDocument =
+				await setup.app.collections.postgresNestedAuthorityDocuments.create(
+					{ owner: owner.id, title: "Authority guarded" },
+					context,
+				);
+			const ownerContext = createTestContext({
+				accessMode: "user",
+				session: createMockSession({ id: owner.id }),
+			});
+
+			await expect(
+				setup.app.collections.postgresNestedAuthorityDocuments.updateById(
+					{
+						id: authorityDocument.id,
+						expectedRevision: authorityDocument.revision,
+						data: { owner: { connect: { id: foreignOwner.id } } },
+					},
+					ownerContext,
+				),
+			).rejects.toMatchObject({ code: "FORBIDDEN" });
+			await expect(
+				setup.app.collections.postgresNestedAuthorityDocuments.findOne(
+					{ where: { id: authorityDocument.id } },
+					context,
+				),
+			).resolves.toMatchObject({
+				owner: owner.id,
+				revision: authorityDocument.revision,
+			});
+
+			const fieldDocument =
+				await setup.app.collections.postgresNestedFieldDocuments.create(
+					{ owner: owner.id, title: "Field guarded" },
+					context,
+				);
+			const accountCount =
+				await setup.app.collections.postgresNestedAccounts.count({}, context);
+			await expect(
+				setup.app.collections.postgresNestedFieldDocuments.updateById(
+					{
+						id: fieldDocument.id,
+						expectedRevision: fieldDocument.revision,
+						data: { owner: { create: { name: "Must roll back" } } },
+					},
+					ownerContext,
+				),
+			).rejects.toMatchObject({ code: "FORBIDDEN" });
+			expect(
+				await setup.app.collections.postgresNestedAccounts.count({}, context),
+			).toBe(accountCount);
+			await expect(
+				setup.app.collections.postgresNestedFieldDocuments.findOne(
+					{ where: { id: fieldDocument.id } },
+					context,
+				),
+			).resolves.toMatchObject({
+				owner: owner.id,
+				revision: fieldDocument.revision,
+			});
+		});
+
+		it("returns a neutral restore denial through HTTP on PostgreSQL", async () => {
+			const ownerId = crypto.randomUUID();
+			const strangerId = crypto.randomUUID();
+			const guarded =
+				await setup.app.collections.postgresGuardedRestores.create(
+					{ tenantId: ownerId, title: "Private tombstone" },
+					context,
+				);
+			const deletion =
+				await setup.app.collections.postgresGuardedRestores.deleteById(
+					{ id: guarded.id, expectedRevision: guarded.revision },
+					context,
+				);
+			const handler = createFetchHandler(setup.app, {
+				getSession: async () => createMockSession({ id: strangerId }),
+			});
+			const restore = (id: string) =>
+				handler(
+					new Request(
+						`http://localhost/postgresGuardedRestores/${id}/restore`,
+						{
+							method: "POST",
+							headers: { "content-type": "application/json" },
+							body: JSON.stringify({
+								expectedRevision: deletion.data.revision,
+							}),
+						},
+					),
+				);
+
+			const foreign = await restore(guarded.id);
+			const absent = await restore(crypto.randomUUID());
+			expect(foreign.status).toBe(403);
+			expect(absent.status).toBe(foreign.status);
+			expect(await absent.json()).toEqual(await foreign.json());
+
+			const unchanged =
+				await setup.app.collections.postgresGuardedRestores.findOne(
+					{ where: { id: guarded.id }, includeDeleted: true },
+					context,
+				);
+			expect(unchanged).toMatchObject({
+				tenantId: ownerId,
+				revision: deletion.data.revision,
+			});
+			expect(unchanged?.deletedAt).toBeInstanceOf(Date);
 		});
 
 		it("keeps optimistic updateBatch authority on its locked transaction", async () => {

--- a/packages/questpie/test/collection/transaction-bound-hooks-postgres.test.ts
+++ b/packages/questpie/test/collection/transaction-bound-hooks-postgres.test.ts
@@ -7,11 +7,13 @@ import {
 	it,
 } from "bun:test";
 
+import { sql } from "drizzle-orm";
 import pg from "pg";
 import { z } from "zod";
 
 import { channel } from "../../src/exports/channels.js";
 import { collection, withTransaction } from "../../src/exports/index.js";
+import { rowsOf } from "../../src/server/db/driver-result.js";
 import {
 	questpieChannelEventTable,
 	questpieRealtimeLogTable,
@@ -24,6 +26,15 @@ const databaseUrl = process.env.QUESTPIE_TRANSACTION_LOCK_DATABASE_URL;
 const runPostgresContract = Boolean(databaseUrl);
 
 let failUpdateEffect = false;
+let optimisticAccessTxids: string[] = [];
+let optimisticHookTxids: string[] = [];
+
+async function currentTransactionId(db: any): Promise<string> {
+	const result = await db.execute(sql`
+		SELECT pg_current_xact_id()::text AS txid
+	`);
+	return String(rowsOf<{ txid: string }>(result)[0]?.txid);
+}
 
 const postgresEffectsChannel = channel("postgres-effects-[targetId]").events({
 	applied: z.object({
@@ -58,11 +69,31 @@ const postgresEffectTargets = collection("postgres_effect_targets")
 		},
 	});
 
+const postgresOptimisticAccessTargets = collection(
+	"postgres_optimistic_access_targets",
+)
+	.fields(({ f }) => ({ name: f.text().required() }))
+	.options({ optimisticConcurrency: true })
+	.access({
+		update: async ({ db }) => {
+			optimisticAccessTxids.push(await currentTransactionId(db));
+			return true;
+		},
+	})
+	.hooks({
+		beforeChange: async ({ db, operation }) => {
+			if (operation === "update") {
+				optimisticHookTxids.push(await currentTransactionId(db));
+			}
+		},
+	});
+
 describe.skipIf(!runPostgresContract)(
 	"transaction-bound hooks on PostgreSQL",
 	() => {
 		let setup: Awaited<ReturnType<typeof buildMockApp>>;
 		const context = createTestContext();
+		const accessContext = createTestContext({ role: "user" });
 
 		beforeAll(async () => {
 			const pool = new pg.Pool({ connectionString: databaseUrl });
@@ -79,6 +110,7 @@ describe.skipIf(!runPostgresContract)(
 					collections: {
 						postgresEffectLogs,
 						postgresEffectTargets,
+						postgresOptimisticAccessTargets,
 					},
 				},
 				{ db: { url: databaseUrl!, pool: { max: 5 } } },
@@ -94,6 +126,68 @@ describe.skipIf(!runPostgresContract)(
 
 		beforeEach(() => {
 			failUpdateEffect = false;
+			optimisticAccessTxids = [];
+			optimisticHookTxids = [];
+		});
+
+		it("keeps optimistic update authority on the locked transaction", async () => {
+			const target =
+				await setup.app.collections.postgresOptimisticAccessTargets.create(
+					{ name: "Before" },
+					context,
+				);
+
+			await setup.app.collections.postgresOptimisticAccessTargets.updateById(
+				{
+					id: target.id,
+					expectedRevision: target.revision,
+					data: { name: "After" },
+				},
+				accessContext,
+			);
+
+			expect(optimisticAccessTxids.length).toBeGreaterThan(1);
+			expect(optimisticHookTxids).toHaveLength(1);
+			expect(
+				new Set([...optimisticAccessTxids, ...optimisticHookTxids]).size,
+			).toBe(1);
+		});
+
+		it("keeps optimistic updateBatch authority on its locked transaction", async () => {
+			const first =
+				await setup.app.collections.postgresOptimisticAccessTargets.create(
+					{ name: "First" },
+					context,
+				);
+			const second =
+				await setup.app.collections.postgresOptimisticAccessTargets.create(
+					{ name: "Second" },
+					context,
+				);
+
+			await setup.app.collections.postgresOptimisticAccessTargets.updateBatch(
+				{
+					updates: [
+						{
+							id: first.id,
+							expectedRevision: first.revision,
+							data: { name: "First updated" },
+						},
+						{
+							id: second.id,
+							expectedRevision: second.revision,
+							data: { name: "Second updated" },
+						},
+					],
+				},
+				accessContext,
+			);
+
+			expect(optimisticAccessTxids.length).toBeGreaterThan(2);
+			expect(optimisticHookTxids).toHaveLength(2);
+			expect(
+				new Set([...optimisticAccessTxids, ...optimisticHookTxids]).size,
+			).toBe(1);
 		});
 
 		it("rolls back row, channel, and realtime ledgers then commits once through a nested transaction", async () => {

--- a/packages/questpie/test/integration/error-handling.test.ts
+++ b/packages/questpie/test/integration/error-handling.test.ts
@@ -31,11 +31,39 @@ const errorTest = collection("error_test")
 		timestamps: true,
 	});
 
+let deniedCreateHooks = 0;
+const deniedCreateTest = collection("denied_create_test")
+	.fields(({ f }) => ({ title: f.text(100).required() }))
+	.access({ create: false })
+	.hooks({ beforeOperation: () => void (deniedCreateHooks += 1) });
+
+const scopedCreateTest = collection("scoped_create_test")
+	.fields(({ f }) => ({
+		tenantId: f.text().required(),
+		title: f.text().required(),
+	}))
+	.access({ create: () => ({ tenantId: "allowed" }) });
+
+const operatorCreateTest = collection("operator_create_test")
+	.fields(({ f }) => ({
+		tenantId: f.text().required(),
+		title: f.text().required(),
+	}))
+	.access({ create: () => ({ NOT: { tenantId: { eq: "foreign" } } }) });
+
 describe("error handling", () => {
 	let setup: Awaited<ReturnType<typeof buildMockApp>>;
 
 	beforeEach(async () => {
-		setup = await buildMockApp({ collections: { error_test: errorTest } });
+		deniedCreateHooks = 0;
+		setup = await buildMockApp({
+			collections: {
+				error_test: errorTest,
+				denied_create_test: deniedCreateTest,
+				scoped_create_test: scopedCreateTest,
+				operator_create_test: operatorCreateTest,
+			},
+		});
 		await runTestDbMigrations(setup.app);
 	});
 
@@ -89,15 +117,59 @@ describe("error handling", () => {
 				systemCtx,
 			);
 
-			await expect(
+			const update = (id: string) =>
 				setup.app.collections.error_test.updateById(
-					{
-						id: record.id,
-						data: { title: "Updated Title" },
-					},
+					{ id, data: { title: "Updated Title" } },
+					userCtx,
+				);
+			const known = await update(record.id).catch((error: ApiError) => error);
+			const absent = await update(crypto.randomUUID()).catch(
+				(error: ApiError) => error,
+			);
+
+			expect(known).toBeInstanceOf(ApiError);
+			expect(absent).toBeInstanceOf(ApiError);
+			expect(known.toJSON(false)).toEqual(absent.toJSON(false));
+			expect(known.context?.access?.reason).toBe("Access denied");
+		});
+
+		it("uses the neutral access reason for denied creates", async () => {
+			const userCtx = createTestContext({ accessMode: "user", role: "user" });
+
+			await expect(
+				setup.app.collections.denied_create_test.create(
+					{ id: crypto.randomUUID(), title: "Secret target" },
 					userCtx,
 				),
-			).rejects.toThrow("User does not have permission to update");
+			).rejects.toThrow("Access denied");
+			expect(deniedCreateHooks).toBe(0);
+		});
+
+		it("enforces create access predicates against the proposed row", async () => {
+			const userCtx = createTestContext({ accessMode: "user", role: "user" });
+
+			await expect(
+				setup.app.collections.scoped_create_test.create(
+					{ tenantId: "foreign", title: "Probe" },
+					userCtx,
+				),
+			).rejects.toThrow("Access denied");
+			const allowed = await setup.app.collections.scoped_create_test.create(
+				{ tenantId: "allowed", title: "Accepted" },
+				userCtx,
+			);
+			expect(allowed.title).toBe("Accepted");
+		});
+
+		it("fails closed for create predicates unsupported by the in-memory matcher", async () => {
+			const userCtx = createTestContext({ accessMode: "user", role: "user" });
+
+			await expect(
+				setup.app.collections.operator_create_test.create(
+					{ tenantId: "foreign", title: "Probe" },
+					userCtx,
+				),
+			).rejects.toThrow("Access denied");
 		});
 
 		it("should throw ApiError with field-level access violation", async () => {
@@ -124,7 +196,7 @@ describe("error handling", () => {
 					},
 					userCtx,
 				),
-			).rejects.toThrow("User does not have permission to update");
+			).rejects.toThrow("Access denied");
 		});
 
 		it("should throw ApiError for database constraint violation", async () => {


### PR DESCRIPTION
## Summary
- authorize generated collection writes before target existence, revision conflicts, or lifecycle hooks can disclose state
- return neutral access denials for conditional create, update, and delete policies
- preserve unconditional system/public missing-target semantics and fail closed for unsupported create predicates

## Proof
- 48 focused CRUD/error/optimistic-concurrency tests pass
- 67 related bulk-hook, race, transaction-hook, default-access, and core-hook tests pass
- questpie package typecheck passes
- targeted oxlint and diff checks pass
- independent adversarial review found no remaining P0-P2 findings