### PR TITLE
fix(crud): preserve update input provenance

### DIFF
--- a/.changeset/clean-pans-relate.md
+++ b/.changeset/clean-pans-relate.md
@@ -1,0 +1,5 @@
+---
+"questpie": patch
+---
+
+Preserve server-derived update fields while rechecking caller-authored nested relationship authority.

--- a/packages/questpie/src/server/collection/crud/crud-generator.ts
+++ b/packages/questpie/src/server/collection/crud/crud-generator.ts
@@ -36,6 +36,7 @@ type UpdateExecutionInternal = {
 	revisionPrelocked?: true;
 	legacyTransactionBound?: true;
 	returnBeforeOutputHooks?: true;
+	callerData?: Record<string, any>;
 };
 type UpdateExecutionParams =
 	| UpdateParams<any, any, string | number>
@@ -1628,9 +1629,10 @@ export class CRUDGenerator<TState extends CollectionBuilderState> {
 	): Promise<{
 		regularFields: Record<string, any>;
 		nestedRelations: Record<string, any>;
+		materializedFields: Record<string, any>;
 	}> {
 		if (!this.app || !this.state.relations) {
-			return { regularFields, nestedRelations };
+			return { regularFields, nestedRelations, materializedFields: {} };
 		}
 		return applyBelongsToRelations(
 			regularFields,
@@ -2322,6 +2324,9 @@ export class CRUDGenerator<TState extends CollectionBuilderState> {
 		const db = this.getDb(normalized);
 		const isBatch = "where" in params;
 		const data = params.data;
+		const callerData =
+			internal?.callerData ??
+			(normalized.accessMode === "system" ? data : structuredClone(data));
 		if (!this.getOptimisticConcurrency() && !internal?.legacyTransactionBound) {
 			const deferred = await withTransaction(db, (tx) =>
 				this._executeUpdate(
@@ -2329,6 +2334,7 @@ export class CRUDGenerator<TState extends CollectionBuilderState> {
 					{ ...normalized, db: tx },
 					{
 						...internal,
+						callerData,
 						legacyTransactionBound: true,
 						returnBeforeOutputHooks: true,
 					},
@@ -2444,6 +2450,7 @@ export class CRUDGenerator<TState extends CollectionBuilderState> {
 				}
 				return this._executeUpdate(params, txContext, {
 					...internal,
+					callerData,
 					revisionPrelocked: true,
 				});
 			});
@@ -2558,6 +2565,38 @@ export class CRUDGenerator<TState extends CollectionBuilderState> {
 				throw ApiError.badRequest(`Validation error: ${error.message}`);
 			}
 		}
+		const { nestedRelations: callerNestedRelations } =
+			this.separateNestedRelationsInternal(callerData);
+		const callerRelationInput = this.preApplyConnectOperations(
+			{},
+			callerNestedRelations,
+		);
+		const canonicalCallerFields =
+			normalized.accessMode === "system"
+				? regularFields
+				: structuredClone(regularFields);
+		const authorityFields = {
+			...canonicalCallerFields,
+			...callerRelationInput.regularFields,
+		};
+		const preMaterializedAuthorityInput = {
+			...authorityFields,
+			...callerRelationInput.nestedRelations,
+		};
+		const nestedFieldAccess = this.preApplyConnectOperations(
+			{},
+			nestedRelations,
+		);
+		const fieldAccessFields = {
+			...canonicalCallerFields,
+			...nestedFieldAccess.regularFields,
+			...nestedFieldAccess.nestedRelations,
+		};
+		await this.enforceUpdateAuthority(
+			records,
+			normalized,
+			preMaterializedAuthorityInput,
+		);
 
 		// 5. beforeChange hooks
 
@@ -2574,7 +2613,7 @@ export class CRUDGenerator<TState extends CollectionBuilderState> {
 		for (const existing of records) {
 			// Validate field-level write access
 			await this.validateFieldWriteAccess(
-				regularFields,
+				fieldAccessFields,
 				normalized,
 				"update",
 				existing,
@@ -2657,7 +2696,7 @@ export class CRUDGenerator<TState extends CollectionBuilderState> {
 				await this.enforceUpdateAuthority(
 					lockedRecords,
 					txContext,
-					regularFields,
+					preMaterializedAuthorityInput,
 				);
 				const optimisticConcurrency = this.getOptimisticConcurrency();
 				if (optimisticConcurrency) {
@@ -2680,13 +2719,14 @@ export class CRUDGenerator<TState extends CollectionBuilderState> {
 				}
 
 				// Apply belongsTo relations
-				({ regularFields, nestedRelations } =
-					await this.applyBelongsToRelationsInternal(
-						regularFields,
-						nestedRelations,
-						txContext,
-						tx,
-					));
+				const appliedBelongsTo = await this.applyBelongsToRelationsInternal(
+					regularFields,
+					nestedRelations,
+					txContext,
+					tx,
+				);
+				regularFields = appliedBelongsTo.regularFields;
+				nestedRelations = appliedBelongsTo.nestedRelations;
 				// Split localized vs non-localized fields
 				const { localized, nonLocalized, nestedLocalized } =
 					this.splitLocalizedFields(regularFields);
@@ -2700,21 +2740,20 @@ export class CRUDGenerator<TState extends CollectionBuilderState> {
 						originalRows: winners,
 					});
 				}
-				// Nested belongsTo operations materialize FK fields after the first
-				// access pass, so the final payload is the write-authority boundary.
+				// Nested belongsTo operations materialize caller-authored FK input after
+				// the first access pass. Hook-derived fields remain server-owned.
 				for (const lockedRecord of lockedRecords) {
 					await this.validateFieldWriteAccess(
-						regularFields,
+						appliedBelongsTo.materializedFields,
 						txContext,
 						"update",
 						lockedRecord,
 					);
 				}
-				await this.enforceUpdateAuthority(
-					lockedRecords,
-					txContext,
-					regularFields,
-				);
+				await this.enforceUpdateAuthority(lockedRecords, txContext, {
+					...authorityFields,
+					...appliedBelongsTo.materializedFields,
+				});
 
 				// Update main table
 				if (

--- a/packages/questpie/src/server/collection/crud/relation-mutations/nested-operations.ts
+++ b/packages/questpie/src/server/collection/crud/relation-mutations/nested-operations.ts
@@ -306,9 +306,11 @@ export async function applyBelongsToRelations(
 ): Promise<{
 	regularFields: Record<string, any>;
 	nestedRelations: Record<string, any>;
+	materializedFields: Record<string, any>;
 }> {
 	const updatedFields = { ...regularFields };
 	const remainingRelations = { ...nestedRelations };
+	const materializedFields: Record<string, any> = {};
 
 	for (const [relationName, operations] of Object.entries(nestedRelations)) {
 		const relation = relations[relationName];
@@ -392,6 +394,7 @@ export async function applyBelongsToRelations(
 				(target as Record<string, unknown> | undefined)?.[referenceKey] ??
 				target?.id;
 		}
+		materializedFields[foreignKeyField] = updatedFields[foreignKeyField];
 
 		delete remainingRelations[relationName];
 	}
@@ -399,6 +402,7 @@ export async function applyBelongsToRelations(
 	return {
 		regularFields: updatedFields,
 		nestedRelations: remainingRelations,
+		materializedFields,
 	};
 }
 

--- a/packages/questpie/test/collection/nested-relation-field-access.test.ts
+++ b/packages/questpie/test/collection/nested-relation-field-access.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+
+import { collection } from "../../src/exports/index.js";
+import { buildMockApp } from "../utils/mocks/mock-app-builder";
+import { createMockSession, createTestContext } from "../utils/test-context";
+import { runTestDbMigrations } from "../utils/test-db";
+
+let nestedCreateEffects = 0;
+
+const sideEffectAccounts = collection("side_effect_accounts")
+	.fields(({ f }) => ({ name: f.text().required() }))
+	.access({ read: true, create: true })
+	.hooks({
+		beforeChange: () => {
+			nestedCreateEffects += 1;
+		},
+	});
+
+const guardedRelationDocuments = collection("guarded_relation_documents")
+	.fields(({ f }) => ({
+		owner: f
+			.relation("sideEffectAccounts")
+			.required()
+			.access({ update: false }),
+		title: f.text().required(),
+	}))
+	.access({ read: true, create: true, update: true });
+
+describe("nested relation field access", () => {
+	let setup: Awaited<ReturnType<typeof buildMockApp>>;
+	const systemContext = createTestContext({ accessMode: "system" });
+	const userContext = createTestContext({
+		accessMode: "user",
+		session: createMockSession({ id: crypto.randomUUID() }),
+	});
+
+	beforeEach(async () => {
+		nestedCreateEffects = 0;
+		setup = await buildMockApp({
+			collections: { guardedRelationDocuments, sideEffectAccounts },
+		});
+		await runTestDbMigrations(setup.app);
+	});
+
+	afterEach(async () => {
+		await setup.cleanup();
+	});
+
+	it("denies fenced nested creation before target hooks can run", async () => {
+		const owner = await setup.app.collections.sideEffectAccounts.create(
+			{ name: "Owner" },
+			systemContext,
+		);
+		const document =
+			await setup.app.collections.guardedRelationDocuments.create(
+				{ owner: owner.id, title: "Before" },
+				systemContext,
+			);
+		nestedCreateEffects = 0;
+
+		await expect(
+			setup.app.collections.guardedRelationDocuments.updateById(
+				{
+					id: document.id,
+					data: { owner: { create: { name: "Must not run" } } },
+				},
+				userContext,
+			),
+		).rejects.toMatchObject({ code: "FORBIDDEN" });
+		expect(nestedCreateEffects).toBe(0);
+
+		await expect(
+			setup.app.collections.guardedRelationDocuments.updateById(
+				{
+					id: document.id,
+					data: {
+						owner: {
+							connectOrCreate: {
+								where: { name: "Missing" },
+								create: { name: "Must not run either" },
+							},
+						},
+					},
+				},
+				userContext,
+			),
+		).rejects.toMatchObject({ code: "FORBIDDEN" });
+		expect(nestedCreateEffects).toBe(0);
+	});
+
+	it("allows an unchanged connect and denies a different target", async () => {
+		const owner = await setup.app.collections.sideEffectAccounts.create(
+			{ name: "Owner" },
+			systemContext,
+		);
+		const foreignOwner = await setup.app.collections.sideEffectAccounts.create(
+			{ name: "Foreign owner" },
+			systemContext,
+		);
+		const document =
+			await setup.app.collections.guardedRelationDocuments.create(
+				{ owner: owner.id, title: "Before" },
+				systemContext,
+			);
+
+		await expect(
+			setup.app.collections.guardedRelationDocuments.updateById(
+				{
+					id: document.id,
+					data: {
+						owner: { connect: { id: owner.id } },
+						title: "Same owner",
+					},
+				},
+				userContext,
+			),
+		).resolves.toMatchObject({ owner: owner.id, title: "Same owner" });
+
+		await expect(
+			setup.app.collections.guardedRelationDocuments.updateById(
+				{
+					id: document.id,
+					data: { owner: { connect: { id: foreignOwner.id } } },
+				},
+				userContext,
+			),
+		).rejects.toMatchObject({ code: "FORBIDDEN" });
+		await expect(
+			setup.app.collections.guardedRelationDocuments.findOne(
+				{ where: { id: document.id } },
+				systemContext,
+			),
+		).resolves.toMatchObject({ owner: owner.id });
+	});
+});

--- a/packages/questpie/test/collection/update-authority-input.test.ts
+++ b/packages/questpie/test/collection/update-authority-input.test.ts
@@ -1,0 +1,345 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+
+import { collection } from "../../src/exports/index.js";
+import { buildMockApp } from "../utils/mocks/mock-app-builder";
+import { createMockSession, createTestContext } from "../utils/test-context";
+import { runTestDbMigrations } from "../utils/test-db";
+
+let authorityInputs: Array<Record<string, unknown>> = [];
+let normalizedAuthorityEffects = 0;
+
+const authorityAccounts = collection("authority_accounts")
+	.fields(({ f }) => ({ name: f.text().required() }))
+	.access({ read: true, create: true });
+
+const authorityDocuments = collection("authority_documents")
+	.fields(({ f }) => ({
+		owner: f.relation("authorityAccounts").required(),
+		title: f.text().required(),
+		derivedKey: f.text().required().access({ update: false }),
+	}))
+	.access({
+		read: true,
+		create: true,
+		update: ({ input, session }) => {
+			const authorityInput = (input ?? {}) as Record<string, unknown>;
+			authorityInputs.push({ ...authorityInput });
+			if (Object.hasOwn(authorityInput, "derivedKey")) return false;
+
+			const nextOwner = authorityInput.owner;
+			if (typeof nextOwner === "string" && nextOwner !== session?.user.id) {
+				return false;
+			}
+
+			return { owner: session?.user.id ?? "__anonymous__" };
+		},
+	})
+	.hooks({
+		beforeChange: ({ data, operation }) => {
+			if (operation === "update" && typeof data.title === "string") {
+				data.derivedKey = `server:${data.title.trim().toLowerCase()}`;
+			}
+		},
+	});
+
+const optimisticAuthorityDocuments = collection(
+	"optimistic_authority_documents",
+)
+	.fields(({ f }) => ({
+		owner: f.relation("authorityAccounts").required(),
+		title: f.text().required(),
+		derivedKey: f.text().required().access({ update: false }),
+	}))
+	.options({ optimisticConcurrency: true })
+	.access({
+		read: true,
+		create: true,
+		update: ({ input, session }) => {
+			const authorityInput = (input ?? {}) as Record<string, unknown>;
+			authorityInputs.push({ ...authorityInput });
+			if (Object.hasOwn(authorityInput, "derivedKey")) return false;
+
+			const nextOwner = authorityInput.owner;
+			if (typeof nextOwner === "string" && nextOwner !== session?.user.id) {
+				return false;
+			}
+
+			return { owner: session?.user.id ?? "__anonymous__" };
+		},
+	})
+	.hooks({
+		beforeChange: ({ data, operation }) => {
+			if (operation === "update" && typeof data.title === "string") {
+				data.derivedKey = `server:${data.title.trim().toLowerCase()}`;
+			}
+		},
+	});
+
+const normalizedAuthorityDocuments = collection(
+	"normalized_authority_documents",
+)
+	.fields(({ f }) => ({
+		role: f
+			.text()
+			.required()
+			.zod((schema) => schema.trim()),
+	}))
+	.access({
+		read: true,
+		create: true,
+		update: ({ input }) =>
+			(input as { role?: string } | undefined)?.role !== "admin",
+	})
+	.hooks({
+		beforeChange: ({ operation }) => {
+			if (operation === "update") normalizedAuthorityEffects += 1;
+		},
+	});
+
+describe("update authority input", () => {
+	let setup: Awaited<ReturnType<typeof buildMockApp>>;
+	const systemContext = createTestContext({ accessMode: "system" });
+
+	beforeEach(async () => {
+		authorityInputs = [];
+		normalizedAuthorityEffects = 0;
+		setup = await buildMockApp({
+			collections: {
+				authorityAccounts,
+				authorityDocuments,
+				normalizedAuthorityDocuments,
+				optimisticAuthorityDocuments,
+			},
+		});
+		await runTestDbMigrations(setup.app);
+	});
+
+	afterEach(async () => {
+		await setup.cleanup();
+	});
+
+	it("allows server-derived fenced fields while rechecking materialized belongsTo input", async () => {
+		const owner = await setup.app.collections.authorityAccounts.create(
+			{ name: "Owner" },
+			systemContext,
+		);
+		const document = await setup.app.collections.authorityDocuments.create(
+			{
+				owner: owner.id,
+				title: "Before",
+				derivedKey: "server:before",
+			},
+			systemContext,
+		);
+		const ownerContext = createTestContext({
+			accessMode: "user",
+			session: createMockSession({ id: owner.id }),
+		});
+
+		const updated = await setup.app.collections.authorityDocuments.updateById(
+			{
+				id: document.id,
+				data: {
+					title: " After ",
+					owner: { connect: { id: owner.id } },
+				},
+			},
+			ownerContext,
+		);
+
+		expect(updated).toMatchObject({
+			owner: owner.id,
+			title: " After ",
+			derivedKey: "server:after",
+		});
+		expect(
+			authorityInputs.some((input) => input.owner === owner.id),
+		).toBeTrue();
+		expect(
+			authorityInputs.every((input) => !("derivedKey" in input)),
+		).toBeTrue();
+	});
+
+	it("denies a client-authored nested belongsTo change rejected after materialization", async () => {
+		const owner = await setup.app.collections.authorityAccounts.create(
+			{ name: "Owner" },
+			systemContext,
+		);
+		const foreignOwner = await setup.app.collections.authorityAccounts.create(
+			{ name: "Foreign owner" },
+			systemContext,
+		);
+		const document = await setup.app.collections.authorityDocuments.create(
+			{
+				owner: owner.id,
+				title: "Before",
+				derivedKey: "server:before",
+			},
+			systemContext,
+		);
+		const ownerContext = createTestContext({
+			accessMode: "user",
+			session: createMockSession({ id: owner.id }),
+		});
+
+		await expect(
+			setup.app.collections.authorityDocuments.updateById(
+				{
+					id: document.id,
+					data: {
+						title: "Hijacked",
+						owner: { connect: { id: foreignOwner.id } },
+					},
+				},
+				ownerContext,
+			),
+		).rejects.toMatchObject({ code: "FORBIDDEN" });
+
+		await expect(
+			setup.app.collections.authorityDocuments.findOne(
+				{ where: { id: document.id } },
+				systemContext,
+			),
+		).resolves.toMatchObject({
+			owner: owner.id,
+			title: "Before",
+			derivedKey: "server:before",
+		});
+	});
+
+	it("keeps update:false fields closed to caller-authored values", async () => {
+		const owner = await setup.app.collections.authorityAccounts.create(
+			{ name: "Owner" },
+			systemContext,
+		);
+		const document = await setup.app.collections.authorityDocuments.create(
+			{
+				owner: owner.id,
+				title: "Before",
+				derivedKey: "server:before",
+			},
+			systemContext,
+		);
+		const ownerContext = createTestContext({
+			accessMode: "user",
+			session: createMockSession({ id: owner.id }),
+		});
+
+		await expect(
+			setup.app.collections.authorityDocuments.updateById(
+				{
+					id: document.id,
+					data: { derivedKey: "client:value" },
+				},
+				ownerContext,
+			),
+		).rejects.toMatchObject({ code: "FORBIDDEN" });
+		await expect(
+			setup.app.collections.authorityDocuments.findOne(
+				{ where: { id: document.id } },
+				systemContext,
+			),
+		).resolves.toMatchObject({ derivedKey: "server:before" });
+	});
+
+	it("allows server-derived fenced fields across every updateMany row", async () => {
+		const owner = await setup.app.collections.authorityAccounts.create(
+			{ name: "Owner" },
+			systemContext,
+		);
+		await setup.app.collections.authorityDocuments.create(
+			{ owner: owner.id, title: "First", derivedKey: "server:first" },
+			systemContext,
+		);
+		await setup.app.collections.authorityDocuments.create(
+			{ owner: owner.id, title: "Second", derivedKey: "server:second" },
+			systemContext,
+		);
+		const ownerContext = createTestContext({
+			accessMode: "user",
+			session: createMockSession({ id: owner.id }),
+		});
+
+		const updated = await setup.app.collections.authorityDocuments.updateMany(
+			{ where: { owner: owner.id }, data: { title: "Batch" } },
+			ownerContext,
+		);
+
+		expect(updated).toHaveLength(2);
+		expect(updated.map((document) => document.derivedKey)).toEqual([
+			"server:batch",
+			"server:batch",
+		]);
+	});
+
+	it("preserves caller provenance through optimistic prelock recursion", async () => {
+		const owner = await setup.app.collections.authorityAccounts.create(
+			{ name: "Owner" },
+			systemContext,
+		);
+		const document =
+			await setup.app.collections.optimisticAuthorityDocuments.create(
+				{
+					owner: owner.id,
+					title: "Before",
+					derivedKey: "server:before",
+				},
+				systemContext,
+			);
+		authorityInputs = [];
+
+		const updated =
+			await setup.app.collections.optimisticAuthorityDocuments.updateById(
+				{
+					id: document.id,
+					expectedRevision: document.revision,
+					data: {
+						title: "After",
+						owner: { connect: { id: owner.id } },
+					},
+				},
+				createTestContext({
+					accessMode: "user",
+					session: createMockSession({ id: owner.id }),
+				}),
+			);
+
+		expect(updated).toMatchObject({
+			owner: owner.id,
+			derivedKey: "server:after",
+			revision: document.revision + 1,
+		});
+		expect(
+			authorityInputs.some((input) => input.owner === owner.id),
+		).toBeTrue();
+		expect(
+			authorityInputs.every((input) => !("derivedKey" in input)),
+		).toBeTrue();
+	});
+
+	it("rechecks authority against schema-normalized caller fields", async () => {
+		const document =
+			await setup.app.collections.normalizedAuthorityDocuments.create(
+				{ role: "member" },
+				systemContext,
+			);
+		normalizedAuthorityEffects = 0;
+
+		await expect(
+			setup.app.collections.normalizedAuthorityDocuments.updateById(
+				{ id: document.id, data: { role: " admin " } },
+				createTestContext({
+					accessMode: "user",
+					session: createMockSession({ id: crypto.randomUUID() }),
+				}),
+			),
+		).rejects.toMatchObject({ code: "FORBIDDEN" });
+		expect(normalizedAuthorityEffects).toBe(0);
+		await expect(
+			setup.app.collections.normalizedAuthorityDocuments.findOne(
+				{ where: { id: document.id } },
+				systemContext,
+			),
+		).resolves.toMatchObject({ role: "member" });
+	});
+});


### PR DESCRIPTION
## Regression

The 3.28.7 authorization hardening rechecked the fully materialized update payload as though every field had been authored by the caller. Nested `belongsTo` handling can derive fenced foreign-key fields server-side, so legitimate updates were rejected and Autopilot's generated CRUD contract failed.

## Fix

- retain caller-authored update provenance through materialization and optimistic-prelock recursion
- authorize caller-authored fields while allowing server-derived fenced fields
- keep explicit client writes to `update: false` fields denied
- apply the same boundary to `updateMany`
- preserve nested relation target checks before hooks run

## Proof

- `bun test --max-concurrency=1 --timeout=60000 test/collection/update-authority-input.test.ts test/collection/nested-relation-field-access.test.ts` — 8 pass, 0 fail
- `bun run check-types` in `packages/questpie` — green
- API-created branch tree is byte-identical to local reviewed commit tree `a77cb9c281f428f2e494204a158a49106160b405`
